### PR TITLE
Added a tool for state store migration

### DIFF
--- a/bin/state-store-utils.sh
+++ b/bin/state-store-utils.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+ACTION=$1
+shift
+PARAMETERS=$@
+
+FWDIR="$(cd `dirname $0`/..; pwd)"
+
+GOBBLIN_JARS=""
+for jar in $(ls -d $FWDIR/lib/*); do
+  if [ "$GOBBLIN_JARS" != "" ]; then
+    GOBBLIN_JARS+=":$jar"
+  else
+    GOBBLIN_JARS=$jar
+  fi
+done
+
+CLASSPATH=$GOBBLIN_JARS
+CLASSPATH+=":$FWDIR/conf"
+
+usage() {
+  echo "Usage: state-store-utils.sh migrate <fs uri> <src store root dir> <dest store root dir>"
+  echo "  OR"
+  echo "Usage: state-store-utils.sh check -p <gobblin system configuration file> -n <job name> -i <job ID> [-a] [-kc]"
+}
+
+migrate() {
+  echo "Running command:"
+  echo "java -cp $CLASSPATH gobblin.runtime.util.StateStoreMigrationUtil $PARAMETERS"
+  java -cp $CLASSPATH gobblin.runtime.util.StateStoreMigrationUtil $PARAMETERS
+}
+
+check() {
+  echo "Running command:"
+  echo "java -cp $CLASSPATH gobblin.runtime.util.JobStateToJsonConverter $PARAMETERS"
+  java -cp $CLASSPATH gobblin.runtime.util.JobStateToJsonConverter $PARAMETERS
+}
+
+case $ACTION in
+  "help")
+    usage
+    ;;
+  "migrate")
+    migrate
+    ;;
+  "check")
+    check
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/common-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/common-api/src/main/java/gobblin/configuration/SourceState.java
@@ -72,7 +72,7 @@ public class SourceState extends State {
    * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run
    */
   public List<WorkUnitState> getPreviousWorkUnitStates() {
-    return ImmutableList.<WorkUnitState>builder().addAll(this.previousTaskStates).build();
+    return this.previousTaskStates;
   }
 
   /**

--- a/common-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/common-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -75,7 +75,7 @@ public class WorkUnitState extends State {
    * @return an {@link ImmutableWorkUnit} that wraps the internal {@link WorkUnit}
    */
   public WorkUnit getWorkunit() {
-    return new ImmutableWorkUnit(workunit);
+    return this.workunit;
   }
 
   /**

--- a/runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/runtime/src/main/java/gobblin/runtime/JobState.java
@@ -11,6 +11,7 @@
 
 package gobblin.runtime;
 
+import com.google.common.collect.Lists;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -247,7 +248,7 @@ public class JobState extends SourceState {
    * @return {@link TaskState}s of {@link Task}s of this job
    */
   public List<TaskState> getTaskStates() {
-    return ImmutableList.<TaskState>builder().addAll(this.taskStates.values()).build();
+    return Lists.newArrayList(this.taskStates.values());
   }
 
   /**


### PR DESCRIPTION
Due to the package renaming, the package names of TaskState and JobState changed. Because the current state store uses SequenceFiles that store the fully-qualified class names of the key and value classes in the metafile, Gobblin won't be able to read the state store using the new TaskState and JobState classes unless we migrate the state store to use the new classes. This commit adds a utility for doing the migration.

Signed-off-by: Yinan Li liyinan926@gmail.com
