### PR TITLE
Assign a multi-task ID to each MultiWorkUnit

### DIFF
--- a/runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -224,15 +224,19 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     jobState.setStartTime(startTime);
     jobState.setState(JobState.RunningState.RUNNING);
 
-    // Populate job/task IDs
-    int sequence = 0;
+    // Add work units and assign task IDs to them
+    int taskIdSequence = 0;
+    int multiTaskIdSequence = 0;
     for (WorkUnit workUnit : workUnits.get()) {
       if (workUnit instanceof MultiWorkUnit) {
+        String multiTaskId = JobLauncherUtils.newMultiTaskId(jobId, multiTaskIdSequence++);
+        workUnit.setProp(ConfigurationKeys.TASK_ID_KEY, multiTaskId);
+        workUnit.setId(multiTaskId);
         for (WorkUnit innerWorkUnit : ((MultiWorkUnit) workUnit).getWorkUnits()) {
-          addWorkUnit(innerWorkUnit, jobState, sequence++);
+          addWorkUnit(innerWorkUnit, jobState, taskIdSequence++);
         }
       } else {
-        addWorkUnit(workUnit, jobState, sequence++);
+        addWorkUnit(workUnit, jobState, taskIdSequence++);
       }
     }
 

--- a/utility/src/main/java/gobblin/util/JobLauncherUtils.java
+++ b/utility/src/main/java/gobblin/util/JobLauncherUtils.java
@@ -21,7 +21,7 @@ public class JobLauncherUtils {
   /**
    * Create a new job ID.
    *
-   * @param jobName Job name
+   * @param jobName job name
    * @return new job ID
    */
   public static String newJobId(String jobName) {
@@ -34,10 +34,23 @@ public class JobLauncherUtils {
   /**
    * Create a new task ID for the job with the given job ID.
    *
-   * @param jobId Job ID
-   * @param sequence Task sequence number
+   * @param jobId job ID
+   * @param sequence task sequence number
+   * @return new task ID
    */
   public static String newTaskId(String jobId, int sequence) {
     return String.format("task_%s_%d", jobId.substring(jobId.indexOf('_') + 1), sequence);
+  }
+
+  /**
+   * Create an ID for a new multi-task (corresponding to a {@link gobblin.source.workunit.MultiWorkUnit})
+   * for the job with the given job ID.
+   *
+   * @param jobId job ID
+   * @param sequence multi-task sequence number
+   * @return new multi-task ID
+   */
+  public static String newMultiTaskId(String jobId, int sequence) {
+    return String.format("multitask_%s_%d", jobId.substring(jobId.indexOf('_') + 1), sequence);
   }
 }


### PR DESCRIPTION
Currently MultiWorkUnits do not have a task ID assigned to them. When the MRJobLauncher serializes a WorkUnit/MultiWorkUnit to a file, it uses the task ID assigned to the WorkUnit/MultiWorkUnit as the file name. Because a MultiWorkUnit does not have a task ID assigned to it, the file it gets serialized into does not have a proper file name. This commit fixes this by giving a MultiWorkUnit a so-called multi-task ID.

Signed-off-by: Yinan Li liyinan926@gmail.com
