### PR TITLE
Added a LoggingUncaughtExceptionHandler and used it in all thread pools

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the
 License at  http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied.
@@ -52,3 +52,6 @@ This product includes/uses TestNG (http://testng.org/)
 Copyright (c) 2004 Cedric Beust
 License: Apache 2.0
 
+This product includes/uses Mockito (http://mockito.org/)
+Copyright (c) 2007 Mockito contributors
+License: MIT

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ ext.externalDependency = [
     "javaxInject": "javax.inject:javax.inject:1",
     "guice": "com.google.inject:guice:3.0",
     "derby": "org.apache.derby:derby:10.11.1.1",
+    "mockito": "org.mockito:mockito-core:1.10.19",
     "pegasus" : [
         "data" : "com.linkedin.pegasus:data:"+pegasusVersion,
         "generator" : "com.linkedin.pegasus:generator:"+pegasusVersion,

--- a/runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
+++ b/runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
@@ -19,11 +19,13 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.JobMetrics;
+import gobblin.util.ExecutorsUtils;
 
 
 /**
@@ -43,7 +45,8 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
     Preconditions.checkArgument(maxThreadPoolSize >= coreThreadPoolSize,
         "Maximum thread pool size must not be smaller than the core thread pool size for the "
             + "task metrics updater executor");
-    this.taskMetricsUpdaterExecutor = new ScheduledThreadPoolExecutor(coreThreadPoolSize);
+    this.taskMetricsUpdaterExecutor =
+        new ScheduledThreadPoolExecutor(coreThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(logger)));
     this.taskMetricsUpdaterExecutor.setMaximumPoolSize(maxThreadPoolSize);
     this.logger = logger;
   }

--- a/runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -22,10 +22,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.JobMetrics;
+import gobblin.util.ExecutorsUtils;
 
 
 /**
@@ -54,7 +56,8 @@ public class TaskExecutor extends AbstractIdleService {
 
     // Currently a fixed-size thread pool is used to execute tasks.
     // We probably need to revisit this later.
-    this.executor = Executors.newFixedThreadPool(taskExecutorThreadPoolSize);
+    this.executor =
+        Executors.newFixedThreadPool(taskExecutorThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(LOG)));
 
     // Using a separate thread pool for task retries to achieve isolation
     // between normal task execution and task retries

--- a/runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
+++ b/runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.AbstractIdleService;
 
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.ExecutorsUtils;
 
 
 /**
@@ -41,6 +42,7 @@ import gobblin.source.workunit.WorkUnit;
  *
  * @author ynli
  */
+@Deprecated
 public class WorkUnitManager extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(WorkUnitManager.class);
@@ -60,7 +62,7 @@ public class WorkUnitManager extends AbstractIdleService {
     // need a priority queue to support priority-based execution of
     // work units.
     this.workUnitQueue = Queues.newLinkedBlockingQueue();
-    this.executorService = Executors.newSingleThreadExecutor();
+    this.executorService = Executors.newSingleThreadExecutor(ExecutorsUtils.newThreadFactory(Optional.of(LOG)));
     this.workUnitHandler = new WorkUnitHandler(this.workUnitQueue, taskExecutor, taskStateTracker);
   }
 

--- a/scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -42,6 +42,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -56,6 +57,7 @@ import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobLauncherFactory;
 import gobblin.runtime.JobListener;
 import gobblin.runtime.RunOnceJobListener;
+import gobblin.util.ExecutorsUtils;
 import gobblin.util.JobLauncherUtils;
 import gobblin.util.SchedulerUtils;
 
@@ -112,12 +114,13 @@ public class JobScheduler extends AbstractIdleService {
     this.scheduler = new StdSchedulerFactory().getScheduler();
 
     this.jobExecutor = Executors.newFixedThreadPool(Integer.parseInt(properties
-            .getProperty(ConfigurationKeys.JOB_EXECUTOR_THREAD_POOL_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_JOB_EXECUTOR_THREAD_POOL_SIZE)));
+        .getProperty(ConfigurationKeys.JOB_EXECUTOR_THREAD_POOL_SIZE_KEY,
+            ConfigurationKeys.DEFAULT_JOB_EXECUTOR_THREAD_POOL_SIZE)),
+        ExecutorsUtils.newThreadFactory(Optional.of(LOG)));
 
     this.jobConfigFileExtensions = Sets.newHashSet(Splitter.on(",").omitEmptyStrings().split(this.properties
-                .getProperty(ConfigurationKeys.JOB_CONFIG_FILE_EXTENSIONS_KEY,
-                    ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_EXTENSIONS)));
+        .getProperty(ConfigurationKeys.JOB_CONFIG_FILE_EXTENSIONS_KEY,
+            ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_EXTENSIONS)));
 
     long pollingInterval = Long.parseLong(this.properties
         .getProperty(ConfigurationKeys.JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY,

--- a/scheduler/src/main/java/gobblin/scheduler/Worker.java
+++ b/scheduler/src/main/java/gobblin/scheduler/Worker.java
@@ -23,6 +23,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
@@ -32,6 +33,7 @@ import gobblin.runtime.TaskStateTracker;
 import gobblin.runtime.WorkUnitManager;
 import gobblin.runtime.local.LocalJobManager;
 import gobblin.runtime.local.LocalTaskStateTracker;
+import gobblin.util.ExecutorsUtils;
 
 
 /**
@@ -89,7 +91,7 @@ public class Worker {
             service.failureCause().toString()));
         System.exit(1);
       }
-    }, Executors.newSingleThreadExecutor());
+    }, Executors.newSingleThreadExecutor(ExecutorsUtils.newThreadFactory(Optional.of(LOG))));
 
     // Add a shutdown hook so the task scheduler gets properly shutdown
     Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -1,9 +1,9 @@
 // (c) 2014 LinkedIn Corp. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at  http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ dependencies {
   compile externalDependency.avro
 
   testCompile externalDependency.testng
+  testCompile externalDependency.mockito
 }
 
 configurations {

--- a/utility/src/main/java/gobblin/util/ExecutorsUtils.java
+++ b/utility/src/main/java/gobblin/util/ExecutorsUtils.java
@@ -1,0 +1,57 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.concurrent.ThreadFactory;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * A utility class to use with {@link java.util.concurrent.Executors} in cases such as when creating new thread pools.
+ *
+ * @author ynli
+ */
+public class ExecutorsUtils {
+
+  private static final ThreadFactory DEFAULT_THREAD_FACTORY = newThreadFactory(Optional.<Logger>absent());
+
+  /**
+   * Get a default {@link java.util.concurrent.ThreadFactory}.
+   *
+   * @return the default {@link java.util.concurrent.ThreadFactory}
+   */
+  public static ThreadFactory defaultThreadFactory() {
+    return DEFAULT_THREAD_FACTORY;
+  }
+
+  /**
+   * Get a new {@link java.util.concurrent.ThreadFactory} that uses a {@link LoggingUncaughtExceptionHandler}
+   * to handle uncaught exceptions.
+   *
+   * @param logger an {@link com.google.common.base.Optional} wrapping the {@link org.slf4j.Logger} that the
+   *               {@link LoggingUncaughtExceptionHandler} uses to log uncaught exceptions thrown in threads
+   * @return a new {@link java.util.concurrent.ThreadFactory}
+   */
+  public static ThreadFactory newThreadFactory(final Optional<Logger> logger) {
+    return new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable runnable) {
+        Thread thread = new Thread(runnable);
+        thread.setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler(logger));
+        return thread;
+      }
+    };
+  }
+}

--- a/utility/src/main/java/gobblin/util/ForkOperatorUtils.java
+++ b/utility/src/main/java/gobblin/util/ForkOperatorUtils.java
@@ -11,6 +11,8 @@
 
 package gobblin.util;
 
+import com.google.common.base.Preconditions;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 
@@ -26,11 +28,12 @@ public class ForkOperatorUtils {
    * Get a branch name for the given branch.
    *
    * @param state       a {@link State} object carrying configuration properties
-   * @param index       branch index
+   * @param index       branch index (non-negative)
    * @param defaultName default branch name
    * @return a branch name
    */
   public static String getBranchName(State state, int index, String defaultName) {
+    Preconditions.checkArgument(index >= 0, "index is expected to be non-negative");
     return state.getProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + "." + index, defaultName);
   }
 
@@ -38,11 +41,13 @@ public class ForkOperatorUtils {
    * Get a new property key from an original one with branch index (if applicable).
    *
    * @param key      property key
-   * @param branches number of branches
-   * @param index    branch index
+   * @param branches number of branches (non-negative)
+   * @param index    branch index (non-negative)
    * @return a new property key
    */
   public static String getPropertyNameForBranch(String key, int branches, int index) {
+    Preconditions.checkArgument(index >= 0, "index is expected to be non-negative");
+    Preconditions.checkArgument(branches >= 0, "branches is expected to be non-negative");
     return branches > 1 ? key + "." + index : key;
   }
 
@@ -62,10 +67,11 @@ public class ForkOperatorUtils {
    * Get a new path with the given branch name as a sub directory.
    *
    * @param branchName branch name
-   * @param branches   number of branches
+   * @param branches   number of branches (non-negative)
    * @return a new path
    */
   public static String getPathForBranch(String path, String branchName, int branches) {
+    Preconditions.checkArgument(branches >= 0, "branches is expected to be non-negative");
     return branches > 1 ? path + "/" + branchName : path;
   }
 }

--- a/utility/src/main/java/gobblin/util/LoggingUncaughtExceptionHandler.java
+++ b/utility/src/main/java/gobblin/util/LoggingUncaughtExceptionHandler.java
@@ -1,0 +1,41 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * A type of {@link java.lang.Thread.UncaughtExceptionHandler} that logs uncaught exceptions.
+ *
+ * @author ynli
+ */
+public class LoggingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+  private final Logger logger;
+
+  public LoggingUncaughtExceptionHandler(Optional<Logger> logger) {
+    if (logger.isPresent()) {
+      this.logger = logger.get();
+    } else {
+      this.logger = LoggerFactory.getLogger(LoggingUncaughtExceptionHandler.class);
+    }
+  }
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    this.logger.error(String.format("Thread %s threw an uncaught exception: %s", t, e), e);
+  }
+}

--- a/utility/src/test/java/gobblin/util/ExecutorsUtilsTest.java
+++ b/utility/src/test/java/gobblin/util/ExecutorsUtilsTest.java
@@ -1,0 +1,49 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.concurrent.ThreadFactory;
+
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * Unit tests for {@link ExecutorsUtils}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.util"})
+public class ExecutorsUtilsTest {
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testNewThreadFactory() throws InterruptedException {
+    Logger logger = Mockito.mock(Logger.class);
+
+    ThreadFactory threadFactory = ExecutorsUtils.newThreadFactory(Optional.of(logger));
+    final RuntimeException runtimeException = new RuntimeException();
+    Thread thread = threadFactory.newThread(new Runnable() {
+      @Override
+      public void run() {
+        throw runtimeException;
+      }
+    });
+    thread.setName("foo");
+    String errorMessage = String.format("Thread %s threw an uncaught exception: %s", thread, runtimeException);
+    Mockito.doThrow(runtimeException).when(logger).error(errorMessage, runtimeException);
+
+    thread.run();
+  }
+}

--- a/utility/src/test/java/gobblin/util/ForkOperatorUtilsTest.java
+++ b/utility/src/test/java/gobblin/util/ForkOperatorUtilsTest.java
@@ -1,0 +1,68 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+
+/**
+ * Unit tests for {@link ForkOperatorUtils}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.util"})
+public class ForkOperatorUtilsTest {
+
+  private static final String FORK_BRANCH_NAME_0 = "fork_foo_0";
+  private static final String FORK_BRANCH_NAME_1 = "fork_foo_1";
+  private static final String PROPERTY_FOO = "foo";
+  private static final String PATH_FOO = "foo";
+
+  @Test
+  public void testGetBranchName() {
+    State state = new State();
+    state.setProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + ".0", FORK_BRANCH_NAME_0);
+    state.setProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + ".1", FORK_BRANCH_NAME_1);
+    Assert.assertEquals(ForkOperatorUtils.getBranchName(state, 0, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + 0),
+        FORK_BRANCH_NAME_0);
+    Assert.assertEquals(ForkOperatorUtils.getBranchName(state, 1, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + 1),
+        FORK_BRANCH_NAME_1);
+    Assert.assertEquals(ForkOperatorUtils.getBranchName(state, 2, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + 2),
+        ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + 2);
+  }
+
+  @Test
+  public void testGetPropertyNameForBranch() {
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, -1), PROPERTY_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 0), PROPERTY_FOO + ".0");
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 1), PROPERTY_FOO + ".1");
+
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 0, 0), PROPERTY_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 1, 0), PROPERTY_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 2, 0), PROPERTY_FOO + ".0");
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(PROPERTY_FOO, 2, 1), PROPERTY_FOO + ".1");
+  }
+
+  @Test
+  public void testGetPathForBranch() {
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 0), PATH_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 1), PATH_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 2),
+        PATH_FOO + "/" + FORK_BRANCH_NAME_0);
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_1, 2),
+        PATH_FOO + "/" + FORK_BRANCH_NAME_1);
+  }
+}

--- a/utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
+++ b/utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
@@ -1,0 +1,49 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.regex.Pattern;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link JobLauncherUtils}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.util"})
+public class JobLauncherUtilsTest {
+
+  private static final String JOB_NAME = "foo";
+  private static final Pattern PATTERN = Pattern.compile("job_" + JOB_NAME + "_\\d+");
+  private String jobId;
+
+  @Test
+  public void testNewJobId() {
+    this.jobId = JobLauncherUtils.newJobId(JOB_NAME);
+    Assert.assertTrue(PATTERN.matcher(this.jobId).matches());
+  }
+
+  @Test(dependsOnMethods = "testNewJobId")
+  public void testNewTaskId() {
+    Assert.assertEquals(JobLauncherUtils.newTaskId(this.jobId, 0), this.jobId.replace("job", "task") + "_0");
+    Assert.assertEquals(JobLauncherUtils.newTaskId(this.jobId, 1), this.jobId.replace("job", "task") + "_1");
+  }
+
+  @Test(dependsOnMethods = "testNewJobId")
+  public void testNewMultiTaskId() {
+    Assert.assertEquals(JobLauncherUtils.newMultiTaskId(this.jobId, 0), this.jobId.replace("job", "multitask") + "_0");
+    Assert.assertEquals(JobLauncherUtils.newMultiTaskId(this.jobId, 1), this.jobId.replace("job", "multitask") + "_1");
+  }
+}

--- a/utility/src/test/java/gobblin/util/LoggingUncaughtExceptionHandlerTest.java
+++ b/utility/src/test/java/gobblin/util/LoggingUncaughtExceptionHandlerTest.java
@@ -1,0 +1,42 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * Unit tests for {@link LoggingUncaughtExceptionHandler}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.util"})
+public class LoggingUncaughtExceptionHandlerTest {
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testUncaughtException() {
+    Logger logger = Mockito.mock(Logger.class);
+
+    Thread thread = new Thread();
+    thread.setName("foo");
+    RuntimeException runtimeException = new RuntimeException();
+    String errorMessage = String.format("Thread %s threw an uncaught exception: %s", thread, runtimeException);
+    Mockito.doThrow(runtimeException).when(logger).error(errorMessage, runtimeException);
+
+    Thread.UncaughtExceptionHandler uncaughtExceptionHandler = new LoggingUncaughtExceptionHandler(Optional.of(logger));
+    uncaughtExceptionHandler.uncaughtException(thread, runtimeException);
+  }
+}


### PR DESCRIPTION
The LoggingUncaughtExceptionHandler logs uncaught exceptions using a SLF4J logger and is used as the default UncaughtExceptionHandler. This commit also added more unit tests for some classes under the utility module.

Signed-off-by: Yinan Li liyinan926@gmail.com
