### PR TITLE
Fixed packaging of Gobblin in gobblin-distribution

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -37,12 +37,12 @@ task build(type: Tar, overwrite: true) {
     from configurations.runtime
   }
   into("gobblin-dist")
-  
+
   doLast {
     copy {
-      from buildDir.path + '/distributions/distribution.tar.gz'
+      from buildDir.path + '/distributions/gobblin-distribution.tar.gz'
       into project.rootDir.path
-      rename ('distribution.tar.gz', 'gobblin-dist.tar.gz')
+      rename ('gobblin-distribution.tar.gz', 'gobblin-dist.tar.gz')
     }
   }
 }


### PR DESCRIPTION
After the module restructuring changes, Gobblin packaging in gobblin-distribution is not working. This commit fixed it so gobblin-dist.tar.gz is created as part of gradle build.

Signed-off-by: Yinan Li liyinan926@gmail.com
