### PR TITLE
Report all metric counters as Hadoop counters in MR mode

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -11,7 +11,6 @@
 
 package gobblin.runtime.mapreduce;
 
-import gobblin.runtime.JobState;
 import java.io.BufferedWriter;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -65,6 +64,7 @@ import gobblin.runtime.FileBasedJobLock;
 import gobblin.runtime.JobException;
 import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobLock;
+import gobblin.runtime.JobState;
 import gobblin.runtime.Task;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskState;
@@ -336,7 +336,6 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
       // Serialize each work unit into a file named after the task ID
       for (WorkUnit workUnit : workUnits) {
-
         Closer workUnitFileCloser = Closer.create();
         try {
           Path workUnitFile =
@@ -353,6 +352,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           workUnitFileCloser.close();
         }
       }
+
       return jobInputFile;
     } catch (Throwable t) {
       throw closer.rethrow(t);


### PR DESCRIPTION
Currently only the four built-in counters (records and bytes at the job- and task-level) are reported as Hadoop counters. Since tracking-purger will be having its own custom counters soon, those counters should also be reported as Hadoop counters so they can be collected upon job completion.

Signed-off-by: Yinan Li liyinan926@gmail.com
