### PR TITLE
GOBBLIN-1247: Disable flaky unit tests causing intermittent build failures

### DIFF
--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
@@ -146,7 +146,7 @@ public class ClusterIntegrationTest {
    *   We confirm the execution by again inspecting the zNode and ensuring its TargetState is START. </li>
    * </ul>
    */
-  @Test (dependsOnMethods = { "testJobShouldGetCancelled" }, groups = {"disabledOnTravis"})
+  @Test (enabled = false, dependsOnMethods = { "testJobShouldGetCancelled" }, groups = {"disabledOnTravis"})
   public void testJobRestartViaSpec() throws Exception {
     Config jobConfigOverrides = ClusterIntegrationTestUtils.buildSleepingJob(IntegrationJobCancelSuite.JOB_ID,
         IntegrationJobCancelSuite.TASK_STATE_FILE);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
@@ -286,7 +286,7 @@ public class GobblinHelixJobLauncherTest {
     Assert.assertEquals(testListener.getCompletes().get() == 1, true);
   }
 
-  @Test(dependsOnMethods = {"testLaunchJob", "testLaunchMultipleJobs"})
+  @Test(enabled = false, dependsOnMethods = {"testLaunchJob", "testLaunchMultipleJobs"})
   public void testJobCleanup() throws Exception {
     final ConcurrentHashMap<String, Boolean> runningMap = new ConcurrentHashMap<>();
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/HOCONInputStreamFlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/HOCONInputStreamFlowTemplate.java
@@ -28,7 +28,6 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
 
-import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.JobTemplate;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
@@ -39,9 +38,8 @@ import org.apache.gobblin.util.ConfigUtils;
 /**
  * A {@link FlowTemplate} that loads a HOCON file as a {@link StaticFlowTemplate}.
  */
-@Alpha
 public class HOCONInputStreamFlowTemplate extends StaticFlowTemplate {
-  public static final String VERSION_KEY = "gobblin.flow.template.version";
+  private static final String VERSION_KEY = "gobblin.flow.template.version";
   private static final String DEFAULT_VERSION = "1";
 
   public HOCONInputStreamFlowTemplate(InputStream inputStream, URI flowTemplateDirUri, FlowCatalogWithTemplates catalog)
@@ -52,7 +50,7 @@ public class HOCONInputStreamFlowTemplate extends StaticFlowTemplate {
 
   public HOCONInputStreamFlowTemplate(Config config, URI flowTemplateDirUri, FlowCatalogWithTemplates catalog)
       throws SpecNotFoundException, IOException, JobTemplate.TemplateException, URISyntaxException {
-    super(flowTemplateDirUri, config.hasPath(VERSION_KEY) ? config.getString(VERSION_KEY) : DEFAULT_VERSION,
+    super(flowTemplateDirUri, ConfigUtils.getString(config, VERSION_KEY, DEFAULT_VERSION),
         config.hasPath(ConfigurationKeys.FLOW_DESCRIPTION_KEY) ? config
             .getString(ConfigurationKeys.FLOW_DESCRIPTION_KEY) : "", config, catalog);
   }

--- a/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
+++ b/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
@@ -24,6 +24,17 @@ import java.util.Properties;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.jboss.byteman.contrib.bmunit.BMNGRunner;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -42,16 +53,6 @@ import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.retry.RetryerFactory;
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
-import org.jboss.byteman.contrib.bmunit.BMNGRunner;
-import org.jboss.byteman.contrib.bmunit.BMRule;
-import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TIMES;
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TYPE;
@@ -131,7 +132,7 @@ public class TaskErrorIntegrationTest extends BMNGRunner {
    * and does not hang
    * @throws Exception
    */
-  @Test
+  @Test (enabled = false)
   @BMRule(name = "testErrorDuringSubmission", targetClass = "org.apache.gobblin.runtime.TaskExecutor",
       targetMethod = "submit(Task)", targetLocation = "AT ENTRY", condition = "true",
       action = "throw new RuntimeException(\"Exception for testErrorDuringSubmission\")")


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1247


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This task disables the following unit tests that fail intermittently on local build:

ClusterIntegrationTest#testJobRestartViaSpec
TaskErrorIntegrationTest#testErrorDuringSubmission()
GobblinHelixJobLauncherTest#testJobCleanup()
In addition, this task also fixes a findbugsMain failure in HOCONInputStreamFlowTemplate caused by usage of a ternary operator in the constructor. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Full local build.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

