### PR TITLE
[GOBBLIN-1377] Adds functionality to create shards for target directories in hive distcp

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -210,7 +210,6 @@ public class ConfigurationKeys {
   public static final String MAXIMUM_JAR_COPY_RETRY_TIMES_KEY = JOB_JAR_FILES_KEY + ".uploading.retry.maximum";
   public static final String USER_DEFINED_STATIC_STAGING_DIR = "user.defined.static.staging.dir";
   public static final String USER_DEFINED_STAGING_DIR_FLAG = "user.defined.staging.dir.flag";
-  public static final String IS_DATASET_STAGING_DIR_USED = "dataset.staging.dir.used";
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;
@@ -1062,4 +1061,14 @@ public class ConfigurationKeys {
    */
   public static final String TASK_EVENT_METADATA_GENERATOR_CLASS_KEY = "gobblin.task.event.metadata.generator.class";
   public static final String DEFAULT_TASK_EVENT_METADATA_GENERATOR_CLASS_KEY = "nooptask";
+
+  /**
+   * Configuration for sharded directory files
+   */
+  public static final String USE_DATASET_LOCAL_WORK_DIR = "gobblin.useDatasetLocalWorkDir";
+  public static final String DESTINATION_DATASET_HANDLER_CLASS = "gobblin.destination.datasetHandlerClass";
+  public static final String DATASET_DESTINATION_PATH = "gobblin.dataset.destination.path";
+  public static final String STAGING_DIR_DEFAULT_SUFFIX = "/.temp/taskStaging";
+  public static final String OUTPUT_DIR_DEFAULT_SUFFIX = "/.temp/taskOutput";
+  public static final String ROW_LEVEL_ERR_FILE_DEFAULT_SUFFIX = "/err";
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
@@ -15,16 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.data.management.copy;
+package org.apache.gobblin.destination;
 
-import org.apache.gobblin.dataset.Dataset;
-import org.apache.hadoop.fs.Path;
-
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.gobblin.source.workunit.WorkUnit;
 
 /**
- * A common superinterface for {@link Dataset}s that can be operated on by distcp.
- * Concrete classes must implement a subinterface of this interface ({@link CopyableDataset} or {@link IterableCopyableDataset}).
+ * Performs work related to initializing the target environment before the files are written and published
  */
-public interface CopyableDatasetBase extends Dataset {
-  default String getDatasetPath() { return ""; }
+public interface DestinationDatasetHandler extends Closeable {
+
+  /**
+   * Handle destination setup before workunits are sent to writer and publisher
+   * @param workUnits
+   */
+  void handle(Collection<WorkUnit> workUnits) throws IOException;
+
+  /**
+   * Perform cleanup if needed
+   * @throws IOException
+   */
+  void close() throws IOException;
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.destination;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.util.ClassAliasResolver;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+
+
+public class DestinationDatasetHandlerFactory  {
+
+  public static DestinationDatasetHandler newInstance(String handlerTypeName, SourceState state, Boolean canCleanUp) {
+    try {
+      ClassAliasResolver<DestinationDatasetHandler> aliasResolver = new ClassAliasResolver<>(DestinationDatasetHandler.class);
+      DestinationDatasetHandler handler = GobblinConstructorUtils.invokeLongestConstructor(
+          aliasResolver.resolveClass(handlerTypeName), state, canCleanUp);
+      return handler;
+    } catch (ReflectiveOperationException rfe) {
+      throw new RuntimeException("Could not construct DestinationDatasetHandler " + handlerTypeName, rfe);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.destination;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
+import org.apache.gobblin.util.JobLauncherUtils;
+
+
+/**
+ * Initializes and runs handlers on workunits before writers are initialized
+ * Reads {@link ConfigurationKeys#DESTINATION_DATASET_HANDLER_CLASS} as a list
+ * of classes, separated by comma to initialize the handlers
+ */
+public class DestinationDatasetHandlerService implements Closeable {
+  List<DestinationDatasetHandler> handlers;
+
+  public DestinationDatasetHandlerService(SourceState jobState, Boolean canCleanUp, EventSubmitter eventSubmitter) {
+    this.handlers = new ArrayList<>();
+    if (jobState.contains(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS)) {
+      String[] handlerList = jobState.getProp(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS)
+          .replaceAll("\\s", "") // cleans out whitespace
+          .split(",");
+      for (String handlerClass : handlerList) {
+        this.handlers.add(DestinationDatasetHandlerFactory.newInstance(handlerClass, jobState, canCleanUp));
+      }
+    }
+  }
+
+  /**
+   * Executes handlers
+   * @param workUnitStream
+   */
+  public void executeHandlers(WorkUnitStream workUnitStream) {
+    if (handlers.size() > 0) {
+      if (workUnitStream.isSafeToMaterialize()) {
+        Collection<WorkUnit> workUnits = JobLauncherUtils.flattenWorkUnits(workUnitStream.getMaterializedWorkUnitCollection());
+          for (DestinationDatasetHandler handler : this.handlers) {
+            try {
+              handler.handle(workUnits);
+            } catch (IOException e) {
+              throw new RuntimeException(String.format("Handler %s failed to execute", handler.getClass().getName()), e);
+            }
+          }
+      } else {
+        throw new RuntimeException(DestinationDatasetHandlerService.class.getName() + " does not support work unit streams");
+      }
+    }
+  }
+
+
+  public void close() throws IOException {
+    for (DestinationDatasetHandler handler: this.handlers) {
+      handler.close();
+    }
+  }
+}

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
@@ -41,9 +41,7 @@ public class DestinationDatasetHandlerService implements Closeable {
   public DestinationDatasetHandlerService(SourceState jobState, Boolean canCleanUp, EventSubmitter eventSubmitter) {
     this.handlers = new ArrayList<>();
     if (jobState.contains(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS)) {
-      String[] handlerList = jobState.getProp(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS)
-          .replaceAll("\\s", "") // cleans out whitespace
-          .split(",");
+      List<String> handlerList = jobState.getPropAsList(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS);
       for (String handlerClass : handlerList) {
         this.handlers.add(DestinationDatasetHandlerFactory.newInstance(handlerClass, jobState, canCleanUp));
       }

--- a/gobblin-core/src/test/java/org/apache/gobblin/destination/DestinationDatasetHandlerServiceTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/destination/DestinationDatasetHandlerServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.destination;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import static org.mockito.Mockito.mock;
+
+
+public class DestinationDatasetHandlerServiceTest {
+
+  EventSubmitter eventSubmitter = null;
+
+  @BeforeSuite
+  void setup() {
+    this.eventSubmitter = mock(EventSubmitter.class);
+  }
+
+  @Test
+  void testSingleHandler() throws Exception {
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS, TestDestinationDatasetHandler.class.getName());
+    DestinationDatasetHandlerService service = new DestinationDatasetHandlerService(state, true, this.eventSubmitter);
+    List<WorkUnit> workUnits = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      WorkUnit wu = WorkUnit.createEmpty();
+      workUnits.add(wu);
+    }
+    WorkUnitStream workUnitStream = new BasicWorkUnitStream.Builder(workUnits).build();
+    service.executeHandlers(workUnitStream);
+
+    for (WorkUnit wu: workUnits) {
+      Assert.assertEquals(wu.getPropAsInt(TestDestinationDatasetHandler.TEST_COUNTER_KEY), 1);
+    }
+  }
+
+  @Test
+  void testMultipleHandlers() throws Exception {
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS,
+        TestDestinationDatasetHandler.class.getName() + "," + TestDestinationDatasetHandler.class.getName());
+    DestinationDatasetHandlerService service = new DestinationDatasetHandlerService(state, true, this.eventSubmitter);
+    List<WorkUnit> workUnits = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      WorkUnit wu = WorkUnit.createEmpty();
+      workUnits.add(wu);
+    }
+    WorkUnitStream workUnitStream = new BasicWorkUnitStream.Builder(workUnits).build();
+    service.executeHandlers(workUnitStream);
+
+    for (WorkUnit wu: workUnits) {
+      // there were 2 handlers, each should have added to counter
+      Assert.assertEquals(wu.getPropAsInt(TestDestinationDatasetHandler.TEST_COUNTER_KEY), 2);
+    }
+  }
+
+  @Test
+  void testMultipleHandlersWhitespace() throws Exception {
+    SourceState state = new SourceState();
+    // add whitespace in class list
+    state.setProp(ConfigurationKeys.DESTINATION_DATASET_HANDLER_CLASS,
+        TestDestinationDatasetHandler.class.getName() + "    ,      " + TestDestinationDatasetHandler.class.getName());
+    DestinationDatasetHandlerService service = new DestinationDatasetHandlerService(state, true, this.eventSubmitter);
+    List<WorkUnit> workUnits = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      WorkUnit wu = WorkUnit.createEmpty();
+      workUnits.add(wu);
+    }
+    WorkUnitStream workUnitStream = new BasicWorkUnitStream.Builder(workUnits).build();
+    service.executeHandlers(workUnitStream);
+
+    for (WorkUnit wu: workUnits) {
+      // there were 2 handlers, each should have added to counter
+      Assert.assertEquals(wu.getPropAsInt(TestDestinationDatasetHandler.TEST_COUNTER_KEY), 2);
+    }
+  }
+
+  @Test
+  // should not throw an exception
+  void testEmpty() throws Exception {
+    SourceState state = new SourceState();
+    DestinationDatasetHandlerService service = new DestinationDatasetHandlerService(state, true, this.eventSubmitter);
+    List<WorkUnit> workUnits = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      WorkUnit wu = WorkUnit.createEmpty();
+      workUnits.add(wu);
+    }
+    WorkUnitStream workUnitStream = new BasicWorkUnitStream.Builder(workUnits).build();
+    service.executeHandlers(workUnitStream);
+  }
+}

--- a/gobblin-core/src/test/java/org/apache/gobblin/destination/TestDestinationDatasetHandler.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/destination/TestDestinationDatasetHandler.java
@@ -15,16 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.data.management.copy;
+package org.apache.gobblin.destination;
 
-import org.apache.gobblin.dataset.Dataset;
-import org.apache.hadoop.fs.Path;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.workunit.WorkUnit;
 
 
-/**
- * A common superinterface for {@link Dataset}s that can be operated on by distcp.
- * Concrete classes must implement a subinterface of this interface ({@link CopyableDataset} or {@link IterableCopyableDataset}).
- */
-public interface CopyableDatasetBase extends Dataset {
-  default String getDatasetPath() { return ""; }
+public class TestDestinationDatasetHandler implements DestinationDatasetHandler {
+  public static String TEST_COUNTER_KEY = "counter";
+  private Boolean canCleanUp;
+  public TestDestinationDatasetHandler(SourceState state, Boolean canCleanUp){
+    this.canCleanUp = canCleanUp;
+  }
+
+  @Override
+  public void handle(Collection<WorkUnit> workUnits) {
+    for (WorkUnit wu: workUnits) {
+      wu.setProp(TEST_COUNTER_KEY, wu.getPropAsInt(TEST_COUNTER_KEY, 0) + 1);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {}
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableDatasetBase.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.data.management.copy;
 
 import org.apache.gobblin.dataset.Dataset;
-import org.apache.hadoop.fs.Path;
 
 
 /**

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -142,12 +142,6 @@ public class HiveCopyEntityHelper {
    * partitions with Path containing '/Hourly/' will be kept.
    */
   public static final String HIVE_PARTITION_EXTENDED_FILTER_TYPE = HiveDatasetFinder.HIVE_DATASET_PREFIX + ".extendedFilterType";
-
-
-  /**
-   * Config to specify class for ensuring that the target directory exists, generally for cloud providers
-   * */
-
   static final Gson gson = new Gson();
 
   private static final String source_client = "source_client";
@@ -315,9 +309,7 @@ public class HiveCopyEntityHelper {
         }
 
         Path targetPath = getTargetLocation(this.targetFs, this.dataset.table.getDataLocation(), Optional.<Partition>absent());
-        if (MapUtils.getBoolean(this.dataset.getProperties(), ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR, false)) {
-          this.dataset.datasetPath = targetPath.toUri().getRawPath();
-        }
+        this.dataset.setDatasetPath(targetPath.toUri().getRawPath());
 
         this.targetTable = getTargetTable(this.dataset.table, targetPath);
         HiveSpec tableHiveSpec = new SimpleHiveSpec.Builder<>(targetPath)

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -44,8 +44,10 @@ import lombok.Getter;
 import lombok.Singular;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gobblin.commit.CommitStep;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyEntity;
@@ -82,7 +84,6 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.mapred.InputFormat;
-import org.apache.hadoop.mapred.InvalidInputException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.thrift.TException;
 
@@ -142,6 +143,11 @@ public class HiveCopyEntityHelper {
    */
   public static final String HIVE_PARTITION_EXTENDED_FILTER_TYPE = HiveDatasetFinder.HIVE_DATASET_PREFIX + ".extendedFilterType";
 
+
+  /**
+   * Config to specify class for ensuring that the target directory exists, generally for cloud providers
+   * */
+
   static final Gson gson = new Gson();
 
   private static final String source_client = "source_client";
@@ -168,7 +174,7 @@ public class HiveCopyEntityHelper {
 
   private final HiveDataset dataset;
   private final CopyConfiguration configuration;
-  private final FileSystem targetFs;
+  private FileSystem targetFs;
 
   private final HiveMetastoreClientPool targetClientPool;
   private final String targetDatabase;
@@ -180,15 +186,14 @@ public class HiveCopyEntityHelper {
   private final ExistingEntityPolicy existingEntityPolicy;
   private final UnmanagedDataPolicy unmanagedDataPolicy;
   private final Optional<String> partitionFilter;
-  private Optional<? extends HivePartitionExtendedFilter> hivePartitionExtendedFilter;
+  private final Optional<? extends HivePartitionExtendedFilter> hivePartitionExtendedFilter;
   private final Optional<Predicate<HivePartitionFileSet>> fastPartitionSkip;
   private final Optional<Predicate<HiveCopyEntityHelper>> fastTableSkip;
-
   private final DeregisterFileDeleteMethod deleteMethod;
 
   private final Optional<CommitStep> tableRegistrationStep;
-  private final Map<List<String>, Partition> sourcePartitions;
-  private final Map<List<String>, Partition> targetPartitions;
+  private Map<List<String>, Partition> sourcePartitions;
+  private Map<List<String>, Partition> targetPartitions;
   private final boolean enforceFileSizeMatch;
   private final EventSubmitter eventSubmitter;
   @Getter
@@ -265,7 +270,6 @@ public class HiveCopyEntityHelper {
       this.dataset = dataset;
       this.configuration = configuration;
       this.targetFs = targetFs;
-
       this.targetPathHelper = new HiveTargetPathHelper(this.dataset);
       this.enforceFileSizeMatch = configuration.isEnforceFileLengthMatch();
       this.hiveRegProps = new HiveRegProps(new State(this.dataset.getProperties()));
@@ -287,58 +291,14 @@ public class HiveCopyEntityHelper {
           .valueOf(this.dataset.getProperties().getProperty(DELETE_FILES_ON_DEREGISTER).toUpperCase())
           : DEFAULT_DEREGISTER_DELETE_METHOD;
 
-      if (this.dataset.getProperties().containsKey(COPY_PARTITION_FILTER_GENERATOR)) {
-        try {
-          PartitionFilterGenerator generator = GobblinConstructorUtils.invokeFirstConstructor(
-              (Class<PartitionFilterGenerator>) Class
-                  .forName(this.dataset.getProperties().getProperty(COPY_PARTITION_FILTER_GENERATOR)),
-              Lists.<Object> newArrayList(this.dataset.getProperties()), Lists.newArrayList());
-          this.partitionFilter = Optional.of(generator.getFilter(this.dataset));
-          log.info(String.format("Dynamic partition filter for table %s: %s.", this.dataset.table.getCompleteName(),
-              this.partitionFilter.get()));
-        } catch (ReflectiveOperationException roe) {
-          throw new IOException(roe);
-        }
-      } else {
-        this.partitionFilter =
-            Optional.fromNullable(this.dataset.getProperties().getProperty(COPY_PARTITIONS_FILTER_CONSTANT));
-      }
-
-      // Initialize extended partition filter
-      if ( this.dataset.getProperties().containsKey(HIVE_PARTITION_EXTENDED_FILTER_TYPE)){
-        String filterType = dataset.getProperties().getProperty(HIVE_PARTITION_EXTENDED_FILTER_TYPE);
-        try {
-          Config config = ConfigFactory.parseProperties(this.dataset.getProperties());
-          this.hivePartitionExtendedFilter =
-              Optional.of(new ClassAliasResolver<>(HivePartitionExtendedFilterFactory.class).resolveClass(filterType).newInstance().createFilter(config));
-        } catch (ReflectiveOperationException roe) {
-          log.error("Error: Could not find filter with alias " + filterType);
-          closer.close();
-          throw new IOException(roe);
-        }
-      }
-      else {
-        this.hivePartitionExtendedFilter = Optional.absent();
-      }
-
       try {
-        this.fastPartitionSkip = this.dataset.getProperties().containsKey(FAST_PARTITION_SKIP_PREDICATE)
-            ? Optional.of(GobblinConstructorUtils.invokeFirstConstructor(
-            (Class<Predicate<HivePartitionFileSet>>) Class
-                .forName(this.dataset.getProperties().getProperty(FAST_PARTITION_SKIP_PREDICATE)),
-            Lists.<Object> newArrayList(this), Lists.newArrayList()))
-            : Optional.<Predicate<HivePartitionFileSet>> absent();
-
-        this.fastTableSkip = this.dataset.getProperties().containsKey(FAST_TABLE_SKIP_PREDICATE)
-            ? Optional.of(GobblinConstructorUtils.invokeFirstConstructor(
-            (Class<Predicate<HiveCopyEntityHelper>>) Class
-                .forName(this.dataset.getProperties().getProperty(FAST_TABLE_SKIP_PREDICATE)),
-            Lists.newArrayList()))
-            : Optional.<Predicate<HiveCopyEntityHelper>> absent();
-
-      } catch (ReflectiveOperationException roe) {
+        this.partitionFilter = this.initializePartitionFilter();
+        this.hivePartitionExtendedFilter = this.initializeExtendedPartitionFilter();
+        this.fastPartitionSkip = this.initializePartitionSkipper();
+        this.fastTableSkip = this.initializeTableSkipper();
+      } catch (ReflectiveOperationException e) {
         closer.close();
-        throw new IOException(roe);
+        throw new IOException(e);
       }
 
       Map<String, HiveMetastoreClientPool> namedPools =
@@ -354,13 +314,16 @@ public class HiveCopyEntityHelper {
           this.existingTargetTable = Optional.absent();
         }
 
-        // Constructing CommitStep object for table registration
-        Path targetPath = getTargetLocation(this.dataset.fs, this.targetFs, this.dataset.table.getDataLocation(),
-            Optional.<Partition> absent());
+        Path targetPath = getTargetLocation(this.targetFs, this.dataset.table.getDataLocation(), Optional.<Partition>absent());
+        if (MapUtils.getBoolean(this.dataset.getProperties(), ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR, false)) {
+          this.dataset.datasetPath = targetPath.toUri().getRawPath();
+        }
+
         this.targetTable = getTargetTable(this.dataset.table, targetPath);
         HiveSpec tableHiveSpec = new SimpleHiveSpec.Builder<>(targetPath)
             .withTable(HiveMetaStoreUtils.getHiveTable(this.targetTable.getTTable())).build();
 
+        // Constructing CommitStep object for table registration
         CommitStep tableRegistrationStep =
             new HiveRegisterStep(this.targetMetastoreURI, tableHiveSpec, this.hiveRegProps);
         this.tableRegistrationStep = Optional.of(tableRegistrationStep);
@@ -368,27 +331,98 @@ public class HiveCopyEntityHelper {
         if (this.existingTargetTable.isPresent() && this.existingTargetTable.get().isPartitioned()) {
           checkPartitionedTableCompatibility(this.targetTable, this.existingTargetTable.get());
         }
-        if (this.dataset.table.isPartitioned()) {
-          this.sourcePartitions = HiveUtils.getPartitionsMap(multiClient.getClient(source_client), this.dataset.table,
-              this.partitionFilter, this.hivePartitionExtendedFilter);
-          HiveAvroCopyEntityHelper.updatePartitionAttributesIfAvro(this.targetTable, this.sourcePartitions, this);
-
-          // Note: this must be mutable, so we copy the map
-          this.targetPartitions =
-              this.existingTargetTable.isPresent() ? Maps.newHashMap(
-                  HiveUtils.getPartitionsMap(multiClient.getClient(target_client),
-                      this.existingTargetTable.get(), this.partitionFilter, this.hivePartitionExtendedFilter))
-                  : Maps.<List<String>, Partition> newHashMap();
-        } else {
-          this.sourcePartitions = Maps.newHashMap();
-          this.targetPartitions = Maps.newHashMap();
-        }
+        initializeSourceAndTargetTablePartitions(multiClient);
 
       } catch (TException te) {
         closer.close();
         throw new IOException("Failed to generate work units for table " + dataset.table.getCompleteName(), te);
       }
     }
+  }
+
+  /**
+   * Checks {@value COPY_PARTITION_FILTER_GENERATOR} in configuration to determine which class to use for hive filtering
+   * Default is to filter based on {@value COPY_PARTITIONS_FILTER_CONSTANT}, a constant regex
+   * @throws ReflectiveOperationException if the generator class in the configuration is not found
+   */
+  private Optional<String> initializePartitionFilter() throws ReflectiveOperationException {
+    if (this.dataset.getProperties().containsKey(COPY_PARTITION_FILTER_GENERATOR)) {
+      PartitionFilterGenerator generator = GobblinConstructorUtils.invokeFirstConstructor(
+          (Class<PartitionFilterGenerator>) Class.forName(
+              this.dataset.getProperties().getProperty(COPY_PARTITION_FILTER_GENERATOR)),
+          Lists.<Object>newArrayList(this.dataset.getProperties()), Lists.newArrayList());
+      Optional<String> partitionFilter = Optional.of(generator.getFilter(this.dataset));
+      log.info(String.format("Dynamic partition filter for table %s: %s.", this.dataset.table.getCompleteName(),
+          partitionFilter.get()));
+      return partitionFilter;
+    } else {
+      return Optional.fromNullable(this.dataset.getProperties().getProperty(COPY_PARTITIONS_FILTER_CONSTANT));
+    }
+  }
+
+  /**
+   * Checks {@value HIVE_PARTITION_EXTENDED_FILTER_TYPE} in configuration to initialize more granular filtering class
+   * Default is to use none
+   * @throws ReflectiveOperationException if the filter class in the configuration is not found
+   */
+  private Optional<HivePartitionExtendedFilter> initializeExtendedPartitionFilter() throws IOException, ReflectiveOperationException {
+    if (this.dataset.getProperties().containsKey(HIVE_PARTITION_EXTENDED_FILTER_TYPE)){
+      String filterType = dataset.getProperties().getProperty(HIVE_PARTITION_EXTENDED_FILTER_TYPE);
+      Config config = ConfigFactory.parseProperties(this.dataset.getProperties());
+      return Optional.of(new ClassAliasResolver<>(HivePartitionExtendedFilterFactory.class).resolveClass(filterType).newInstance().createFilter(config));
+    } else {
+      return Optional.absent();
+    }
+  }
+
+  /**
+   * Checks {@value FAST_PARTITION_SKIP_PREDICATE} in configuration to determine the class used to find which hive partitions to skip
+   * Default is to skip none
+   * @throws ReflectiveOperationException if class in configuration is not found
+   */
+  private Optional<Predicate<HivePartitionFileSet>> initializePartitionSkipper() throws ReflectiveOperationException {
+    return this.dataset.getProperties().containsKey(FAST_PARTITION_SKIP_PREDICATE)
+        ? Optional.of(GobblinConstructorUtils.invokeFirstConstructor(
+        (Class<Predicate<HivePartitionFileSet>>) Class
+            .forName(this.dataset.getProperties().getProperty(FAST_PARTITION_SKIP_PREDICATE)),
+        Lists.<Object> newArrayList(this), Lists.newArrayList()))
+        : Optional.<Predicate<HivePartitionFileSet>> absent();
+  }
+
+  /**
+   * Checks {@value FAST_TABLE_SKIP_PREDICATE} in configuration to determine the class used to find which hive tables to skip
+   * Default is to skip none
+   * @throws ReflectiveOperationException if class in configuration is not found
+   */
+  private Optional<Predicate<HiveCopyEntityHelper>> initializeTableSkipper() throws ReflectiveOperationException {
+    return this.dataset.getProperties().containsKey(FAST_TABLE_SKIP_PREDICATE)
+        ? Optional.of(GobblinConstructorUtils.invokeFirstConstructor(
+        (Class<Predicate<HiveCopyEntityHelper>>) Class
+            .forName(this.dataset.getProperties().getProperty(FAST_TABLE_SKIP_PREDICATE)),
+        Lists.newArrayList()))
+        : Optional.<Predicate<HiveCopyEntityHelper>> absent();
+  }
+
+  /**
+   * Initializes the corresponding source and target partitions after applying the hive partition filters
+   * @param multiClient a map of {@link IMetaStoreClient}
+   * @throws IOException if encountering a hive error when determining partitions
+   */
+  private void initializeSourceAndTargetTablePartitions(HiveMetastoreClientPool.MultiClient multiClient) throws IOException {
+    if (this.dataset.table.isPartitioned()) {
+      this.sourcePartitions = HiveUtils.getPartitionsMap(multiClient.getClient(source_client), this.dataset.table, this.partitionFilter,
+          this.hivePartitionExtendedFilter);
+      HiveAvroCopyEntityHelper.updatePartitionAttributesIfAvro(this.targetTable, this.sourcePartitions, this);
+
+      // Note: this must be mutable, so we copy the map
+      this.targetPartitions = this.existingTargetTable.isPresent() ? Maps.newHashMap(
+          HiveUtils.getPartitionsMap(multiClient.getClient(target_client), this.existingTargetTable.get(), this.partitionFilter,
+              this.hivePartitionExtendedFilter))
+          : Maps.<List<String>, Partition>newHashMap();
+    } else {
+        this.sourcePartitions = Maps.newHashMap();
+        this.targetPartitions = Maps.newHashMap();
+      }
   }
 
   /**
@@ -639,7 +673,7 @@ public class HiveCopyEntityHelper {
     Map<Path, FileStatus> desiredTargetExistingPaths;
     try {
       desiredTargetExistingPaths = desiredTargetLocation.getPaths();
-    } catch (InvalidInputException ioe) {
+    } catch (IOException ioe) {
       // Thrown if inputFormat cannot find location in target. Since location doesn't exist, this set is empty.
       desiredTargetExistingPaths = Maps.newHashMap();
     }
@@ -791,14 +825,12 @@ public class HiveCopyEntityHelper {
 
   /**
    * Compute the target location for a Hive location.
-   * @param sourceFs Source {@link FileSystem}.
    * @param path source {@link Path} in Hive location.
    * @param partition partition these paths correspond to.
    * @return transformed location in the target.
    * @throws IOException if cannot generate a single target location.
    */
-  Path getTargetLocation(FileSystem sourceFs, FileSystem targetFs, Path path, Optional<Partition> partition)
-      throws IOException {
+  Path getTargetLocation(FileSystem targetFs, Path path, Optional<Partition> partition) {
     return getTargetPathHelper().getTargetPath(path, targetFs, partition, false);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -93,6 +94,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public static final String LOGICAL_DB_TOKEN = "$LOGICAL_DB";
   public static final String LOGICAL_TABLE_TOKEN = "$LOGICAL_TABLE";
 
+  @Getter
+  @Setter
   private String datasetPath;
 
   // Will not be serialized/de-serialized
@@ -335,12 +338,4 @@ public class HiveDataset implements PrioritizedCopyableDataset {
     return true;
   }
 
-  @Override
-  public String getDatasetPath() {
-    return datasetPath;
-  }
-
-  public void setDatasetPath(String path) {
-    this.datasetPath = path;
-  }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -86,13 +86,14 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public static final String DATASET_NAME_PATTERN_KEY = "hive.datasetNamePattern";
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
-  public static final String DATASET_STAGING_PATH = "dataset.staging.path";
 
   public static final String DATABASE_TOKEN = "$DB";
   public static final String TABLE_TOKEN = "$TABLE";
 
   public static final String LOGICAL_DB_TOKEN = "$LOGICAL_DB";
   public static final String LOGICAL_TABLE_TOKEN = "$LOGICAL_TABLE";
+
+  public String datasetPath;
 
   // Will not be serialized/de-serialized
   @Getter
@@ -128,11 +129,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
         Optional.fromNullable(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
-    Path tableLocation = this.table.getPath();
-    if (!(this.properties.isEmpty())) {
-      String datasetStagingDir = this.properties.getProperty(COPY_TARGET_TABLE_PREFIX_REPLACEMENT) + "/" + tableLocation.getName();
-      properties.setProperty(DATASET_STAGING_PATH,datasetStagingDir);
-    }
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());
@@ -337,5 +333,10 @@ public class HiveDataset implements PrioritizedCopyableDataset {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String getDatasetPath() {
+    return datasetPath;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -339,4 +339,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public String getDatasetPath() {
     return datasetPath;
   }
+
+  public void setDatasetPath(String path) {
+    this.datasetPath = path;
+  }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -93,7 +93,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public static final String LOGICAL_DB_TOKEN = "$LOGICAL_DB";
   public static final String LOGICAL_TABLE_TOKEN = "$LOGICAL_TABLE";
 
-  public String datasetPath;
+  private String datasetPath;
 
   // Will not be serialized/de-serialized
   @Getter

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
@@ -85,7 +85,7 @@ public class HivePartitionFileSet extends HiveFileSet {
       stepPriority = hiveCopyEntityHelper.addSharedSteps(copyEntities, fileSet, stepPriority);
 
       multiTimer.nextStage(HiveCopyEntityHelper.Stages.COMPUTE_TARGETS);
-      Path targetPath = hiveCopyEntityHelper.getTargetLocation(hiveCopyEntityHelper.getDataset().fs, hiveCopyEntityHelper.getTargetFs(),
+      Path targetPath = hiveCopyEntityHelper.getTargetLocation(hiveCopyEntityHelper.getTargetFs(),
           this.partition.getDataLocation(), Optional.of(this.partition));
       Partition targetPartition = getTargetPartition(this.partition, targetPath);
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -84,8 +84,6 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
-  public static final String STAGING_DIR_SUFFIX = "/taskStaging";
-  public static final String DATASET_STAGING_DIR_PATH = "dataset.staging.dir.path";
 
   protected final AtomicLong bytesWritten = new AtomicLong();
   protected final AtomicLong filesWritten = new AtomicLong();
@@ -146,20 +144,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       this.fs = FileSystem.get(uri, conf);
     }
     this.fileContext = FileContext.getFileContext(uri, conf);
-
-    /**
-     * The staging directory defines the path of staging folder.
-     * USER_DEFINED_STATIC_STAGING_DIR_FLAG shall be set to true when user wants to specify the staging folder and the directory can be fetched through USER_DEFINED_STATIC_STAGING_DIR property.
-     * IS_DATASET_STAGING_DIR_USED when true creates the staging folder within a dataset location for dataset copying.
-     * Else system will calculate the staging directory automatically.
-     */
     if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
       this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
-    } else if ((state.getPropAsBoolean(ConfigurationKeys.IS_DATASET_STAGING_DIR_USED,false))) {
-      String stgDir = state.getProp(DATASET_STAGING_DIR_PATH) + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
-      state.setProp(ConfigurationKeys.WRITER_STAGING_DIR,stgDir);
-      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
-          : WriterUtils.getWriterStagingDir(state, numBranches, branchId);
     } else {
       this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
           : WriterUtils.getWriterStagingDir(state, numBranches, branchId);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/MockHiveDatasetFinder.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/MockHiveDatasetFinder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.data.management.copy.hive.HiveDataset;
+import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
+import org.apache.gobblin.data.management.copy.hive.HiveTargetPathHelper;
+import org.apache.gobblin.hive.HiveMetastoreClientPool;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+
+public class MockHiveDatasetFinder extends HiveDatasetFinder {
+
+  Path tempDirRoot;
+  SourceState state;
+
+  public MockHiveDatasetFinder(LocalFileSystem fs, Properties properties,
+      EventSubmitter eventSubmitter) throws IOException {
+    super(fs, properties, eventSubmitter);
+    this.tempDirRoot = new Path(properties.getProperty("tempDirRoot"));
+  }
+
+  public Collection<DbAndTable> getTables() throws IOException {
+    List<DbAndTable> tables = Lists.newArrayList();
+
+    for (int i = 0; i < 3; i++) {
+      tables.add(new DbAndTable("testDB", "table" + i));
+    }
+
+    return tables;
+  }
+
+  @Override
+  public Iterator<HiveDataset> getDatasetsIterator() throws IOException {
+
+    return new AbstractIterator<HiveDataset>() {
+      private Iterator<DbAndTable> tables = getTables().iterator();
+
+      @Override
+      protected HiveDataset computeNext() {
+        try {
+          while (this.tables.hasNext()) {
+            DbAndTable dbAndTable = this.tables.next();
+            File dbPath = new File(tempDirRoot + "/testPath/testDB/" + dbAndTable.getTable());
+            fs.mkdirs(new Path(dbPath.getAbsolutePath()));
+            Properties hiveProperties = new Properties();
+            hiveProperties.setProperty(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR, "true");
+            hiveProperties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED, tempDirRoot + "/testPath");
+            hiveProperties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_REPLACEMENT, tempDirRoot + "/targetPath");
+            Table table = new Table(Table.getEmptyTable(dbAndTable.getDb(), dbAndTable.getTable()));
+            table.setDataLocation(new Path(dbPath.getPath()));
+            HiveMetastoreClientPool pool = HiveMetastoreClientPool.get(new Properties(), Optional.absent());
+            HiveDataset dataset = new HiveDataset(new LocalFileSystem(), pool, table, hiveProperties);
+            return dataset;
+          }
+        } catch (IOException e) {
+          Throwables.propagate(e);
+        }
+        return endOfData();
+      }
+    };
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -34,6 +34,10 @@ import org.apache.gobblin.data.management.copy.entities.PostPublishStep;
 import org.apache.gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
 import org.apache.gobblin.hive.HiveRegProps;
 import org.apache.gobblin.metrics.event.MultiTimingEvent;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.data.management.copy.CopyConfiguration;
+import org.apache.gobblin.hive.HiveMetastoreClientPool;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
@@ -359,6 +363,73 @@ public class HiveCopyEntityHelperTest {
     meta_table.getSd().getSerdeInfo().setParameters(storageParams);
     HiveCopyEntityHelper.addMetadataToTargetTable(meta_table, new Path("newPath"), "testDB", 10L);
     Assert.assertFalse(meta_table.getSd().getSerdeInfo().getParameters().containsKey("path"));
+  }
+
+  @Test
+  public void testGetTargetLocationDefault() throws Exception {
+
+    Properties copyProperties = new Properties();
+    copyProperties.put(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/target");
+    Path testPath = new Path("/testPath");
+    Properties hiveProperties = new Properties();
+    Table table =  new Table(Table.getEmptyTable("testDB", "testTable"));
+    table.setDataLocation(testPath);
+    HiveMetastoreClientPool pool = HiveMetastoreClientPool.get(new Properties(), Optional.absent());
+    HiveDataset dataset = new HiveDataset(new LocalFileSystem(), pool, table, hiveProperties);
+
+    HiveCopyEntityHelper helper = new HiveCopyEntityHelper(dataset,
+        CopyConfiguration.builder(FileSystem.getLocal(new Configuration()), copyProperties).build(),
+        new LocalFileSystem()
+    );
+
+    FileSystem fs = new LocalFileSystem();
+    // test that by default, the input path is the same as the output path
+    Path path = helper.getTargetLocation(fs, testPath, Optional.<Partition>absent());
+    Assert.assertEquals(testPath.toUri().getRawPath(), path.toUri().getRawPath());
+  }
+
+  @Test
+  public void testSetsDatasetShardPath() throws Exception {
+
+    Properties copyProperties = new Properties();
+    copyProperties.put(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/target");
+    Path testPath = new Path("/testPath/db/table");
+    Properties hiveProperties = new Properties();
+    hiveProperties.setProperty(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR, "true");
+    Table table =  new Table(Table.getEmptyTable("testDB", "testTable"));
+    table.setDataLocation(testPath);
+    HiveMetastoreClientPool pool = HiveMetastoreClientPool.get(new Properties(), Optional.absent());
+    HiveDataset dataset = new HiveDataset(new LocalFileSystem(), pool, table, hiveProperties);
+
+    HiveCopyEntityHelper helper = new HiveCopyEntityHelper(dataset,
+        CopyConfiguration.builder(FileSystem.getLocal(new Configuration()), copyProperties).build(),
+        new LocalFileSystem()
+    );
+
+    Assert.assertEquals(helper.getDataset().datasetPath, "/testPath/db/table");
+  }
+
+  @Test
+  public void testSetsDatasetShardPathWithReplacement() throws Exception {
+
+    Properties copyProperties = new Properties();
+    copyProperties.put(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/target");
+    Path testPath = new Path("/testPath/db/table");
+    Properties hiveProperties = new Properties();
+    hiveProperties.setProperty(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR, "true");
+    hiveProperties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED, "/testPath");
+    hiveProperties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_REPLACEMENT, "/targetPath");
+    Table table =  new Table(Table.getEmptyTable("testDB", "testTable"));
+    table.setDataLocation(testPath);
+    HiveMetastoreClientPool pool = HiveMetastoreClientPool.get(new Properties(), Optional.absent());
+    HiveDataset dataset = new HiveDataset(new LocalFileSystem(), pool, table, hiveProperties);
+
+    HiveCopyEntityHelper helper = new HiveCopyEntityHelper(dataset,
+        CopyConfiguration.builder(FileSystem.getLocal(new Configuration()), copyProperties).build(),
+        new LocalFileSystem()
+    );
+
+    Assert.assertEquals(helper.getDataset().datasetPath, "/targetPath/db/table");
   }
 
   private boolean containsPath(Collection<FileStatus> statuses, Path path) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -406,7 +406,7 @@ public class HiveCopyEntityHelperTest {
         new LocalFileSystem()
     );
 
-    Assert.assertEquals(helper.getDataset().datasetPath, "/testPath/db/table");
+    Assert.assertEquals(helper.getDataset().getDatasetPath(), "/testPath/db/table");
   }
 
   @Test
@@ -429,7 +429,7 @@ public class HiveCopyEntityHelperTest {
         new LocalFileSystem()
     );
 
-    Assert.assertEquals(helper.getDataset().datasetPath, "/targetPath/db/table");
+    Assert.assertEquals(helper.getDataset().getDatasetPath(), "/targetPath/db/table");
   }
 
   private boolean containsPath(Collection<FileStatus> statuses, Path path) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisherTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisherTest.java
@@ -236,11 +236,12 @@ public class CopyDataPublisherTest {
     private Path targetPath;
     private FileSystem fs;
     private CopyEntity copyEntity;
+    State state;
 
     private void createDatasetFiles() throws IOException {
       // Create writer output files
       Path datasetWriterOutputPath =
-          new Path(writerOutputPath, copyEntity.getDatasetAndPartition(this.metadata).identifier());
+          new Path(writerOutputPath + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY), copyEntity.getDatasetAndPartition(this.metadata).identifier());
       Path outputPathWithCurrentDirectory = new Path(datasetWriterOutputPath,
           PathUtils.withoutLeadingSeparator(this.targetPath));
       for (String path : relativeFilePaths) {
@@ -259,7 +260,7 @@ public class CopyDataPublisherTest {
       this.metadata = new CopyableDatasetMetadata(this.copyableDataset);
       this.relativeFilePaths = relativeFilePaths;
       this.writerOutputPath = new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR));
-
+      this.state = state;
       this.targetPath = new Path(testMethodTempPath, datasetTargetPath);
 
       FileStatus file = new FileStatus(0, false, 0, 0, 0, new Path("/file"));
@@ -277,6 +278,7 @@ public class CopyDataPublisherTest {
       List<WorkUnitState> workUnitStates =
           Lists.newArrayList(new WorkUnitState(), new WorkUnitState(), new WorkUnitState());
       for (WorkUnitState wus : workUnitStates) {
+        wus.addAll(this.state); // propagate job state into work unit state, this is always done in copysource workunit generation
         CopySource.serializeCopyableDataset(wus, metadata);
         CopySource.serializeCopyEntity(wus, this.copyEntity);
       }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/publisher/DeletingCopyDataPublisherTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/publisher/DeletingCopyDataPublisherTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.data.management.copy.publisher;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.configuration.WorkUnitState.WorkingState;
@@ -72,7 +73,10 @@ public class DeletingCopyDataPublisherTest {
     CopySource.serializeCopyEntity(wus, cf);
 
     Assert.assertTrue(fs.exists(new Path(testMethodTempPath, "test.txt")));
-
+    // these 2 properties should already be set before the publisher is called
+    wus.setProp(ConfigurationKeys.WRITER_STAGING_DIR, testMethodTempPath + "/" + ConfigurationKeys.STAGING_DIR_DEFAULT_SUFFIX);
+    wus.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, testMethodTempPath + "/task-output");
+    wus.setProp(ConfigurationKeys.JOB_ID_KEY, "jobid");
     wus.setWorkingState(WorkingState.SUCCESSFUL);
 
     copyDataPublisher.publishData(ImmutableList.of(wus));

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.gobblin.destination.DestinationDatasetHandlerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -438,6 +439,10 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           return;
         }
 
+        // Perform work needed before writing is done
+        Boolean canCleanUp = this.canCleanStagingData(this.jobContext.getJobState());
+        closer.register(new DestinationDatasetHandlerService(jobState, canCleanUp, this.eventSubmitter))
+            .executeHandlers(workUnitStream);
         //Initialize writer and converter(s)
         closer.register(WriterInitializerFactory.newInstace(jobState, workUnitStream)).initialize();
         closer.register(ConverterInitializerFactory.newInstance(jobState, workUnitStream)).initialize();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/JobLauncherUtils.java
@@ -132,10 +132,9 @@ public class JobLauncherUtils {
    * @param logger a {@link Logger} used for logging
    */
   public static void cleanJobStagingData(State state, Logger logger) throws IOException {
-    Preconditions.checkArgument(state.contains(ConfigurationKeys.WRITER_STAGING_DIR),
-        "Missing required property " + ConfigurationKeys.WRITER_STAGING_DIR);
-    Preconditions.checkArgument(state.contains(ConfigurationKeys.WRITER_OUTPUT_DIR),
-        "Missing required property " + ConfigurationKeys.WRITER_OUTPUT_DIR);
+    if (!state.contains(ConfigurationKeys.WRITER_STAGING_DIR) || !state.contains(ConfigurationKeys.WRITER_OUTPUT_DIR)) {
+      return;
+    }
 
     String writerFsUri = state.getProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, ConfigurationKeys.LOCAL_FS_URI);
     FileSystem fs = getFsWithProxy(state, writerFsUri, WriterUtils.getFsConfiguration(state));
@@ -267,7 +266,7 @@ public class JobLauncherUtils {
    * @return
    * @throws IOException
    */
-  private static FileSystem getFsWithProxy(final State state, final String fsUri, final Configuration conf) throws IOException {
+  public static FileSystem getFsWithProxy(final State state, final String fsUri, final Configuration conf) throws IOException {
     if (!state.getPropAsBoolean(ConfigurationKeys.SHOULD_FS_PROXY_AS_USER,
         ConfigurationKeys.DEFAULT_SHOULD_FS_PROXY_AS_USER)) {
       return FileSystem.get(URI.create(fsUri), conf);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1377


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

This PR allows Gobblin to have an entrypoint to create shards on cloud environments before copying. Notable changes include
1) A configuration `gobblin.useDatasetLocalWorkDir` to enable dataset-local temporary directories for the writer and error files instead of a storing these on the job level.
2) Refactoring of `HiveCopyEntityHelper` for code cleanup
3) Hive Dataset unit tests for `CopySource`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

