### PR TITLE
GOBBLIN-1384: Fix task cancellation to ensure task commit is invoked …

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
@@ -95,7 +94,7 @@ public class GobblinMultiTaskAttemptTest {
   @Test
   public void testRunWithTaskStatsTrackerNotScheduledFailure()
       throws Exception {
-    TaskStateTracker stateTracker = new FailingTestStateTracker(new Properties(), log);
+    TaskStateTracker stateTracker = new DummyTestStateTracker(new Properties(), log);
     // Preparing Instance of TaskAttempt with designed failure on task creation
     WorkUnit tmpWU = new WorkUnit();
     // Put necessary attributes in workunit
@@ -122,8 +121,8 @@ public class GobblinMultiTaskAttemptTest {
     Assert.fail();
   }
 
-  public static class FailingTestStateTracker extends AbstractTaskStateTracker {
-    public FailingTestStateTracker(Properties properties, Logger logger) {
+  public static class DummyTestStateTracker extends AbstractTaskStateTracker {
+    public DummyTestStateTracker(Properties properties, Logger logger) {
       super(properties, logger);
     }
 
@@ -134,7 +133,7 @@ public class GobblinMultiTaskAttemptTest {
 
     @Override
     public void onTaskRunCompletion(Task task) {
-
+      task.markTaskCompletion();
     }
 
     @Override


### PR DESCRIPTION
…only after task completes

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1384


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Per the current behavior, the task is marked as completed as soon as task cancellation is invoked, which interrupts the task, and immediately decrements a latch counting the number of running tasks. This implies that GobblinMultiTaskAttempt which monitors this countdown latch, can invoke task commit before the task has completed. This can lead to incorrect behavior in batch mode and potential resource leak in the streaming mode where commit failures potentially leaves some resources open.  

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests in TaskTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

