### PR TITLE
[GOBBLIN-1387] Add function for jobcontext to access datasetstate failures

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -546,5 +547,19 @@ public class JobContext implements Closeable {
   public String toString() {
     return Objects.toStringHelper(JobContext.class.getSimpleName()).add("jobName", getJobName())
         .add("jobId", getJobId()).add("jobState", getJobState()).toString();
+  }
+
+  /**
+   * Get all of the failures from the datasetStates stored in the jobContext to determine if
+   * email notification should be sent or not. Previously job context only looked at jobStates, where
+   * failures from datasetStates were not propagated from
+   * Failures are tracked using {@link ConfigurationKeys#JOB_FAILURES_KEY}
+   */
+  public int getDatasetStateFailures() {
+    int totalFailures = 0;
+    for (Map.Entry<String, JobState.DatasetState> datasetState: this.getDatasetStatesByUrns().entrySet()) {
+      totalFailures += datasetState.getValue().getJobFailures();
+    }
+    return totalFailures;
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
@@ -48,7 +48,7 @@ public class EmailNotificationJobListener extends AbstractJobListener {
 
     // Send out alert email if the maximum number of consecutive failures is reached
     if (jobState.getState() == JobState.RunningState.FAILED) {
-      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0);
+      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0) + jobContext.getDatasetStateFailures();
       int maxFailures =
           jobState.getPropAsInt(ConfigurationKeys.JOB_MAX_FAILURES_KEY, ConfigurationKeys.DEFAULT_JOB_MAX_FAILURES);
       if (alertEmailEnabled && failures >= maxFailures) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1387


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Email notifications look into JOB_FAILURES_KEY, which is set by DatasetState.
JobContext's reference to it's own jobState is misleading here as it does not track dataset state failures (in terms of amounts, only if it is passed/failed).

Add a function to track the dataset state failures from jobContext

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests in JobContextTests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

