### PR TITLE
[GOBBLIN-1386]Increase the timeout setting for Gobblin Partitioned DataWriter to write a record

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -82,8 +82,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
   // in incorrect behavior.
   public static final String PARTITIONED_WRITER_CACHE_TTL_SECONDS = "partitionedDataWriter.cache.ttl.seconds";
   public static final Long DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS = Long.MAX_VALUE;
-  public static final String PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS = "partitionedDataWriter.write.timeout.seconds";
-  public static final Long DEFAULT_PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS = 480L;
+  public static final String PARTITIONED_WRITER_WRITE_TIMEOUT_SECONDS = "partitionedDataWriter.write.timeout.seconds";
+  public static final Long DEFAULT_PARTITIONED_WRITER_WRITE_TIMEOUT_SECONDS = 480L;
 
   private static final GenericRecord NON_PARTITIONED_WRITER_KEY =
       new GenericData.Record(SchemaBuilder.record("Dummy").fields().endRecord());
@@ -132,7 +132,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       this.state.setProp(WRITER_LATEST_SCHEMA, builder.getSchema());
     }
     long cacheExpiryInterval = this.state.getPropAsLong(PARTITIONED_WRITER_CACHE_TTL_SECONDS, DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS);
-    this.writeTimeoutInterval = this.state.getPropAsLong(PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS, DEFAULT_PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS);
+    this.writeTimeoutInterval = this.state.getPropAsLong(PARTITIONED_WRITER_WRITE_TIMEOUT_SECONDS,
+        DEFAULT_PARTITIONED_WRITER_WRITE_TIMEOUT_SECONDS);
     // Bound the timeout value to avoid data loss when slow write happening
     this.writeTimeoutInterval = Math.min(this.writeTimeoutInterval, cacheExpiryInterval / 3 * 2);
     log.debug("PartitionedDataWriter: Setting cache expiry interval to {} seconds", cacheExpiryInterval);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -82,6 +82,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
   // in incorrect behavior.
   public static final String PARTITIONED_WRITER_CACHE_TTL_SECONDS = "partitionedDataWriter.cache.ttl.seconds";
   public static final Long DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS = Long.MAX_VALUE;
+  public static final String PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS = "partitionedDataWriter.write.timeout.seconds";
+  public static final Long DEFAULT_PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS = 480L;
 
   private static final GenericRecord NON_PARTITIONED_WRITER_KEY =
       new GenericData.Record(SchemaBuilder.record("Dummy").fields().endRecord());
@@ -130,8 +132,9 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       this.state.setProp(WRITER_LATEST_SCHEMA, builder.getSchema());
     }
     long cacheExpiryInterval = this.state.getPropAsLong(PARTITIONED_WRITER_CACHE_TTL_SECONDS, DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS);
-    // Increase the timeout value to make it less sensitive to HDFS slow writer
-    this.writeTimeoutInterval = cacheExpiryInterval / 3 * 2;
+    this.writeTimeoutInterval = this.state.getPropAsLong(PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS, DEFAULT_PARTITIONED_WRITER_WRITER_TIMEOUT_SECONDS);
+    // Bound the timeout value to avoid data loss when slow write happening
+    this.writeTimeoutInterval = Math.min(this.writeTimeoutInterval, cacheExpiryInterval / 3 * 2);
     log.debug("PartitionedDataWriter: Setting cache expiry interval to {} seconds", cacheExpiryInterval);
 
     this.partitionWriters = CacheBuilder.newBuilder()

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -130,7 +130,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       this.state.setProp(WRITER_LATEST_SCHEMA, builder.getSchema());
     }
     long cacheExpiryInterval = this.state.getPropAsLong(PARTITIONED_WRITER_CACHE_TTL_SECONDS, DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS);
-    this.writeTimeoutInterval = cacheExpiryInterval / 3;
+    // Increase the timeout value to make it less sensitive to HDFS slow writer
+    this.writeTimeoutInterval = cacheExpiryInterval / 3 * 2;
     log.debug("PartitionedDataWriter: Setting cache expiry interval to {} seconds", cacheExpiryInterval);
 
     this.partitionWriters = CacheBuilder.newBuilder()


### PR DESCRIPTION
…taWriter to write a record

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1386


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Increase the timeout setting for Gobblin Partitioned DataWriter to write a record to make it less sensitive to the slow HDFS writer

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Small change, run unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

