### PR TITLE
[GOBBLIN-1388] Fix bug when comparing partition type

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/FSDatasetPartitionConfig.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/FSDatasetPartitionConfig.java
@@ -133,7 +133,7 @@ public class FSDatasetPartitionConfig {
       return false;
     }
     return ((DatasetDescriptorConfigKeys.DATASET_DESCRIPTOR_CONFIG_ANY.equalsIgnoreCase(getPartitionType())
-        || this.getPartitionType().equalsIgnoreCase(partitionType)))
+        || this.getPartitionType().equalsIgnoreCase(other.getPartitionType())))
         && ((DatasetDescriptorConfigKeys.DATASET_DESCRIPTOR_CONFIG_ANY.equalsIgnoreCase(getPartitionPattern())
         || this.getPartitionPattern().equalsIgnoreCase(other.getPartitionPattern())));
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1388


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In this `FSDatasetPartitionConfig` method, there is a bug where `this.partitionType` is just being compared to itself (always returning true), instead of compared to `other.partitionType`.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

