### PR TITLE
[GOBBLIN-1389] Ensuring exception being propagated in Hive-Reg code path

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -278,6 +278,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           log.info(String.format("Created Hive table %s in db %s", tableName, dbName));
           return true;
         } catch (AlreadyExistsException e) {
+          log.debug("Table {}.{} already existed", table.getDbName(), table.getTableName());
         }
       }catch (TException e) {
         log.error(
@@ -377,7 +378,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           }
         });
       } catch (ExecutionException ee) {
-        throw new IOException("Database existence checking throwing execution exception.");
+        throw new IOException("Database existence checking throwing execution exception.", ee);
       }
       return retVal;
     } else {
@@ -476,7 +477,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           }
         });
       } catch (ExecutionException ee) {
-        throw new IOException("Table existence checking throwing execution exception.");
+        throw new IOException("Table existence checking throwing execution exception.", ee);
       }
     } else {
       this.ensureHiveTableExistenceBeforeAlternation(tableName, dbName, client, table, spec);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1389


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

This small PR just ensures the exception occurred while hive-registration will be propagated as it is so that users/developers would be able to learn the root cause easily. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

