### PR TITLE
[GOBBLIN-1392] Replacing unsafe File.createTempfile to java nio's Files.createTempFile

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -19,10 +19,10 @@ package org.apache.gobblin.azkaban;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +43,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
@@ -182,7 +181,7 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
         LOG.info(
             "Job type " + props.getProperty(JOB_TYPE) + " did not provide Hadoop token in the environment variable " + HADOOP_TOKEN_FILE_LOCATION + ". Negotiating Hadoop tokens.");
 
-        File tokenFile = File.createTempFile("mr-azkaban", ".token");
+        File tokenFile = Files.createTempFile("mr-azkaban", ".token").toFile();
         TokenUtils.getHadoopTokens(new State(props), Optional.of(tokenFile), new Credentials());
 
         System.setProperty(HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/DownloadUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/DownloadUtils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
@@ -108,7 +109,7 @@ public class DownloadUtils {
     }
 
     // Create temporary Ivy settings file.
-    ivySettingsFile = File.createTempFile("ivy.settings", ".xml");
+    ivySettingsFile = Files.createTempFile("ivy.settings", ".xml").toFile();
     ivySettingsFile.deleteOnExit();
 
     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(ivySettingsFile))) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1392] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1392


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Replacing unsafe File.createTempfile to java nio's Files.createTempFile

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

