### PR TITLE
[GOBBLIN-1394] Add stacktrace to error log callback dispatcher

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/callbacks/CallbacksDispatcher.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/callbacks/CallbacksDispatcher.java
@@ -171,7 +171,7 @@ public class CallbacksDispatcher<L> implements Closeable {
         res.cancellations.put(listener, cr);
       }
       else if (cr.hasFailed()) {
-        _log.error("Callback error: " + callbacks.get(i) + " on " + listener + ":" + cr.getError());
+        _log.error("Callback error: " + callbacks.get(i) + " on " + listener + ":" + cr.getError(), cr.getError());
         res.failures.put(listener, cr);
       }
       else {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1394


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
CallbackDispatcher error logs cast the error to a string, removing the stacktrace. This makes it difficult to debug the issue when an exception is thrown.
PR uses the logging library's Throwable argument to print the exception stacktrace.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

