### PR TITLE
[GOBBLIN-1398] load system specific hive config to support multiple h…

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConfFactory.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConfFactory.java
@@ -18,16 +18,15 @@
 package org.apache.gobblin.hive;
 
 import java.io.IOException;
-import java.util.Map;
 
-import com.google.common.collect.Multimap;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.apache.gobblin.util.ConfigUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Multimap;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.ResourceInstance;
@@ -38,6 +37,7 @@ import org.apache.gobblin.broker.iface.ScopedConfigView;
 import org.apache.gobblin.broker.iface.SharedResourceFactory;
 import org.apache.gobblin.broker.iface.SharedResourceFactoryResponse;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.util.ConfigUtils;
 
 import static org.apache.gobblin.hive.HiveMetaStoreClientFactory.HIVE_METASTORE_TOKEN_SIGNATURE;
 
@@ -64,7 +64,8 @@ public class HiveConfFactory<S extends ScopeType<S>> implements SharedResourceFa
     if (!sharedHiveConfKey.hiveConfUri.equals(SharedHiveConfKey.INSTANCE.toConfigurationKey()) && StringUtils
         .isNotEmpty(sharedHiveConfKey.hiveConfUri)) {
       // match the uri with gobblin_sync_system config and load appropriate config
-      Multimap<String, String> sysConfigFiles = ConfigUtils.getSystemConfigForMetastore(sharedHiveConfKey.hiveConfUri, null);
+      Multimap<String, String> sysConfigFiles =
+          ConfigUtils.getSystemConfigForMetastore(sharedHiveConfKey.hiveConfUri, null);
       if (sysConfigFiles.size() == 0) {
         log.warn("no additional config specified for metastore {} to load as HiveConf()", sharedHiveConfKey.hiveConfUri);
       } else {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.util;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
@@ -31,28 +30,30 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
-
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.*;
-import com.typesafe.config.*;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.opencsv.CSVReader;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
 
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.password.PasswordManager;
@@ -615,7 +616,8 @@ public class ConfigUtils {
    * @return ConfigObject ( config in tree ) of the {@link ConfigUtils#GOBBLIN_SYNC_SYSTEMS_KEY}
    */
   public static ConfigObject getAllSystemConfig(Config config) {
-    return (config.hasPath(GOBBLIN_SYNC_SYSTEMS_KEY) ? config.getObject(GOBBLIN_SYNC_SYSTEMS_KEY) : getInstance().root() );
+    return (config.hasPath(GOBBLIN_SYNC_SYSTEMS_KEY) ? config.getObject(GOBBLIN_SYNC_SYSTEMS_KEY)
+        : getInstance().root());
   }
 
   /**
@@ -627,11 +629,12 @@ public class ConfigUtils {
     ConfigObject allSysConfig = getAllSystemConfig(config);
     Map<String, ConfigObject> secureSystems = new HashMap<>();
 
-    if (allSysConfig == null) return secureSystems;
+    if (allSysConfig == null) {
+      return secureSystems;
+    }
 
     for (String systemName : allSysConfig.keySet()) {
       ConfigObject sysConfig = allSysConfig.atPath(systemName).root();
-      sysConfig.get(IS_SECURE_KEY);
       if (ConfigUtils.getBoolean(sysConfig.toConfig(), IS_SECURE_KEY, false)) {
         secureSystems.put(systemName, sysConfig);
       }
@@ -648,10 +651,11 @@ public class ConfigUtils {
 
     Multimap<String, String> allSysConfFiles = LinkedHashMultimap.create();
 
-    getAllSystemConfig(config).entrySet();
     ConfigObject allSysConfig = getAllSystemConfig(config);
 
-    if (allSysConfig == null) return allSysConfFiles;
+    if (allSysConfig == null) {
+      return allSysConfFiles;
+    }
 
     for (Map.Entry<String, ConfigValue> sysConfig : allSysConfig.entrySet()) {
 
@@ -681,7 +685,9 @@ public class ConfigUtils {
 
     for (String systemName : config.getObject(GOBBLIN_SYNC_SYSTEMS_KEY).keySet()){
       Config sysConfig = config.getConfig(GOBBLIN_SYNC_SYSTEMS_KEY).getConfig(systemName);
-      if(ConfigUtils.getBoolean(sysConfig, IS_SECURE_KEY, false) && ConfigUtils.getBoolean(sysConfig, IS_TOKEN_MGMT_ENABLED_KEY, false) && sysConfig.hasPath(HIVE_SYSTEM_KEY)){
+      if(ConfigUtils.getBoolean(sysConfig, IS_SECURE_KEY, false) &&
+          ConfigUtils.getBoolean(sysConfig, IS_TOKEN_MGMT_ENABLED_KEY, false) &&
+          sysConfig.hasPath(HIVE_SYSTEM_KEY)){
         secureSystems.put(systemName, sysConfig);
       }
     }
@@ -703,7 +709,9 @@ public class ConfigUtils {
 
     ConfigObject allSysConfig = getAllSystemConfig(config);
 
-    if (allSysConfig == null) return sysConfFiles;
+    if (allSysConfig == null) {
+      return sysConfFiles;
+    }
 
     for (Map.Entry<String, ConfigValue> sysConfig : allSysConfig.entrySet()) {
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -65,7 +65,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String CONTAINER_JARS_KEY = GOBBLIN_YARN_PREFIX + "container.jars";
   public static final String CONTAINER_FILES_LOCAL_KEY = GOBBLIN_YARN_PREFIX + "container.files.local";
   public static final String CONTAINER_FILES_REMOTE_KEY = GOBBLIN_YARN_PREFIX + "container.files.remote";
-  public static final String CONTAINER_COPY_SYSTEM_CONFIGS = GOBBLIN_YARN_PREFIX + "container.copy_sync_system_configs";
+  public static final String CONTAINER_COPY_SYSTEM_CONFIGS = GOBBLIN_YARN_PREFIX + "container.copySyncSystemConfigs";
   public static final String CONTAINER_ZIPS_REMOTE_KEY = GOBBLIN_YARN_PREFIX + "container.zips.remote";
   public static final String CONTAINER_WORK_DIR_NAME = "container";
   public static final String CONTAINER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "container.jvm.args";

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -65,6 +65,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String CONTAINER_JARS_KEY = GOBBLIN_YARN_PREFIX + "container.jars";
   public static final String CONTAINER_FILES_LOCAL_KEY = GOBBLIN_YARN_PREFIX + "container.files.local";
   public static final String CONTAINER_FILES_REMOTE_KEY = GOBBLIN_YARN_PREFIX + "container.files.remote";
+  public static final String CONTAINER_COPY_SYSTEM_CONFIGS = GOBBLIN_YARN_PREFIX + "container.copy_sync_system_configs";
   public static final String CONTAINER_ZIPS_REMOTE_KEY = GOBBLIN_YARN_PREFIX + "container.zips.remote";
   public static final String CONTAINER_WORK_DIR_NAME = "container";
   public static final String CONTAINER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "container.jvm.args";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1398


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

GOBBLIN-1308 takes care of ability to connect to remote and secure hive metastore, but it still requires the management of hive-site to be provided to be container local file. 

When it comes to multiple hive clusters this manual management approach would not work, and requires special feature of providing system specific hive-site.xml without namespace collision.

This ticket aims to do following things
1) define a way to provide remote system configuration ( keep giving flat config is more cumbersome )
2) based on system config and feature flag, copy config files to container local path automatically.
3) when creating metastoreClient, pick up the right config for the requested system ( identified by the metastore URI )

 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Needs to add unit test once reviewed.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

