### PR TITLE
[GOBBLIN-1402] Allow flow's requester list/owner to be updated

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.service;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -76,6 +75,8 @@ public class FlowConfigV2Test {
   private static final String TEST_FLOW_NAME_5 = "testFlow5";
   private static final String TEST_FLOW_NAME_6 = "testFlow6";
   private static final String TEST_FLOW_NAME_7 = "testFlow7";
+  private static final String TEST_FLOW_NAME_8 = "testFlow8";
+  private static final String TEST_FLOW_NAME_9 = "testFlow9";
   private static final String TEST_SCHEDULE = "0 1/0 * ? * *";
   private static final String TEST_TEMPLATE_URI = "FS:///templates/test.template";
 
@@ -299,6 +300,42 @@ public class FlowConfigV2Test {
     _client.createFlowConfig(flowConfig);
     testRequester.setName("testName3");
     _client.deleteFlowConfig(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7));
+  }
+
+
+  @Test (expectedExceptions = RestLiResponseException.class)
+  public void testGroupUpdateRejected() throws Exception {
+   ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
+   _requesterService.setRequester(testRequester);
+   Map<String, String> flowProperties = Maps.newHashMap();
+
+   FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_8))
+       .setTemplateUris(TEST_TEMPLATE_URI)
+       .setProperties(new StringMap(flowProperties))
+       .setOwningGroup("testGroup");
+
+   _client.createFlowConfig(flowConfig);
+
+   flowConfig.setOwningGroup("testGroup2");
+   _client.updateFlowConfig(flowConfig);
+  }
+
+  @Test (expectedExceptions = RestLiResponseException.class)
+  public void testRequesterUpdateRejected() throws Exception {
+    ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
+    ServiceRequester testRequester2 = new ServiceRequester("testName2", "USER_PRINCIPAL", "testFrom");
+    _requesterService.setRequester(testRequester);
+    Map<String, String> flowProperties = Maps.newHashMap();
+
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_9))
+        .setTemplateUris(TEST_TEMPLATE_URI)
+        .setProperties(new StringMap(flowProperties));
+
+    _client.createFlowConfig(flowConfig);
+
+    flowProperties.put(RequesterService.REQUESTER_LIST, RequesterService.serialize(Lists.newArrayList(testRequester2)));
+    flowConfig.setProperties(new StringMap(flowProperties));
+    _client.updateFlowConfig(flowConfig);
   }
 
   @AfterClass(alwaysRun = true)

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -55,7 +55,6 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.restli.EmbeddedRestliServer;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_store.FSSpecStore;
-import org.apache.gobblin.util.request_allocation.Request;
 
 
 @Test(groups = { "gobblin.service" }, singleThreaded = true)
@@ -78,7 +77,6 @@ public class FlowConfigV2Test {
   private static final String TEST_FLOW_NAME_7 = "testFlow7";
   private static final String TEST_FLOW_NAME_8 = "testFlow8";
   private static final String TEST_FLOW_NAME_9 = "testFlow9";
-  private static final String TEST_FLOW_NAME_10 = "testFlow10";
   private static final String TEST_SCHEDULE = "0 1/0 * ? * *";
   private static final String TEST_TEMPLATE_URI = "FS:///templates/test.template";
 
@@ -265,53 +263,13 @@ public class FlowConfigV2Test {
     }
   }
 
-  @Test(dependsOnMethods = {"testGroupRequesterRejected", "testGroupRequesterAllowed", "testGroupUpdateRejected", "testRequesterUpdate"})
-  public void testLocalGroupOwnershipUpdates() throws Exception {
-    try {
-      ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
-      _requesterService.setRequester(testRequester);
-      Map<String, String> flowProperties = Maps.newHashMap();
-
-      FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7))
-          .setTemplateUris(TEST_TEMPLATE_URI)
-          .setProperties(new StringMap(flowProperties))
-          .setOwningGroup("testGroup2");
-
-      _client.createFlowConfig(flowConfig);
-
-    } catch (RestLiResponseException e) {
-      Assert.assertEquals(e.getStatus(), HttpStatus.ORDINAL_401_Unauthorized);
-    }
-
-    String filePath = this.groupConfigFile.getAbsolutePath();
-    this.groupConfigFile.delete();
-    this.groupConfigFile = new File(filePath);
-    String groups ="{\"testGroup2\": \"testName,testName3\"}";
-    Files.write(groups.getBytes(), this.groupConfigFile);
-
-    ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
-    _requesterService.setRequester(testRequester);
-    Map<String, String> flowProperties = Maps.newHashMap();
-
-    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7))
-        .setTemplateUris(TEST_TEMPLATE_URI)
-        .setProperties(new StringMap(flowProperties))
-        .setOwningGroup("testGroup2");
-
-    // this should no longer fail as the localGroupOwnership service should have updated as the file changed
-    _client.createFlowConfig(flowConfig);
-    testRequester.setName("testName3");
-    _client.deleteFlowConfig(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7));
-  }
-
-
   @Test
   public void testGroupUpdateRejected() throws Exception {
    ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
    _requesterService.setRequester(testRequester);
    Map<String, String> flowProperties = Maps.newHashMap();
 
-   FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_8))
+   FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7))
        .setTemplateUris(TEST_TEMPLATE_URI)
        .setProperties(new StringMap(flowProperties))
        .setOwningGroup("testGroup");
@@ -335,7 +293,7 @@ public class FlowConfigV2Test {
     _requesterService.setRequester(testRequester);
     Map<String, String> flowProperties = Maps.newHashMap();
 
-    FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_9);
+    FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_8);
     FlowConfig flowConfig = new FlowConfig().setId(flowId)
         .setTemplateUris(TEST_TEMPLATE_URI)
         .setProperties(new StringMap(flowProperties))
@@ -362,7 +320,7 @@ public class FlowConfigV2Test {
     _requesterService.setRequester(testRequester);
     Map<String, String> flowProperties = Maps.newHashMap();
 
-    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_10))
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_9))
         .setTemplateUris(TEST_TEMPLATE_URI)
         .setProperties(new StringMap(flowProperties));
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
@@ -154,9 +154,12 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
           "flowName and flowGroup cannot be changed in update", null);
     }
 
-    // Carry forward the requester list property since it is added at time of creation
     FlowConfig originalFlowConfig = getFlowConfig(flowId);
-    flowConfig.getProperties().put(RequesterService.REQUESTER_LIST, originalFlowConfig.getProperties().get(RequesterService.REQUESTER_LIST));
+
+    if (!flowConfig.getProperties().containsKey(RequesterService.REQUESTER_LIST)) {
+      // Carry forward the requester list property if it is not being updated since it was added at time of creation
+      flowConfig.getProperties().put(RequesterService.REQUESTER_LIST, originalFlowConfig.getProperties().get(RequesterService.REQUESTER_LIST));
+    }
 
     if (isUnscheduleRequest(flowConfig)) {
       // flow config is not changed if it is just a request to un-schedule

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsResource.java
@@ -155,7 +155,7 @@ public class FlowConfigsResource extends ComplexKeyResourceTemplate<FlowId, Empt
    */
   public static void checkRequester(
       RequesterService requesterService, FlowConfig originalFlowConfig, List<ServiceRequester> requesterList) {
-    if (requesterList == null || requesterService.isRequesterWhitelisted(requesterList)) {
+    if (requesterService.isRequesterWhitelisted(requesterList)) {
       return;
     }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
@@ -235,7 +235,7 @@ public class FlowConfigsV2Resource extends ComplexKeyResourceTemplate<FlowId, Fl
    *    it to themselves.
    */
   public void checkPropertyUpdatesAllowed(List<ServiceRequester> requesterList, FlowConfig updatedFlowConfig) {
-    if (requesterList == null || this.requesterService.isRequesterWhitelisted(requesterList)) {
+    if (this.requesterService.isRequesterWhitelisted(requesterList)) {
       return;
     }
 
@@ -269,7 +269,7 @@ public class FlowConfigsV2Resource extends ComplexKeyResourceTemplate<FlowId, Fl
    * @param requesterList list of requesters for this request
    */
   public void checkRequester(FlowConfig originalFlowConfig, List<ServiceRequester> requesterList) {
-    if (requesterList == null || this.requesterService.isRequesterWhitelisted(requesterList)) {
+    if (this.requesterService.isRequesterWhitelisted(requesterList)) {
       return;
     }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
@@ -80,6 +80,13 @@ public abstract class RequesterService {
   protected abstract List<ServiceRequester> findRequesters(BaseResource resource);
 
   /**
+   * Return true if the requester is whitelisted to always be accepted
+   */
+  public boolean isRequesterWhitelisted(List<ServiceRequester> requesterList) {
+    return false;
+  }
+
+  /**
    * returns true if the requester is allowed to make this request.
    * This default implementation accepts all requesters.
    * @param originalRequesterList original requester list
@@ -87,7 +94,7 @@ public abstract class RequesterService {
    * @return true if the requester is allowed to make this request, false otherwise
    */
   protected boolean isRequesterAllowed(
-      List<ServiceRequester> originalRequesterList, List<ServiceRequester> currentRequesterList){
+      List<ServiceRequester> originalRequesterList, List<ServiceRequester> currentRequesterList) {
     return true;
   }
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/LocalGroupOwnershipServiceTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/LocalGroupOwnershipServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.io.Files;
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.config.ConfigBuilder;
+
+
+@Test(groups = { "gobblin.service" })
+public class LocalGroupOwnershipServiceTest {
+  private File _testDirectory;
+  private GroupOwnershipService groupOwnershipService;
+  private File groupConfigFile;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    _testDirectory = Files.createTempDir();
+
+    this.groupConfigFile = new File(_testDirectory + "/TestGroups.json");
+    String groups ="{\"testGroup\": \"testName,testName2\"}";
+    Files.write(groups.getBytes(), this.groupConfigFile);
+    Config groupServiceConfig = ConfigBuilder.create()
+        .addPrimitive(LocalGroupOwnershipService.GROUP_MEMBER_LIST, this.groupConfigFile.getAbsolutePath())
+        .build();
+
+    groupOwnershipService = new LocalGroupOwnershipService(groupServiceConfig);
+  }
+
+  @Test
+  public void testLocalGroupOwnershipUpdates() throws Exception {
+    List<ServiceRequester> testRequester = new ArrayList<>();
+    testRequester.add(new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom"));
+
+    Assert.assertFalse(this.groupOwnershipService.isMemberOfGroup(testRequester, "testGroup2"));
+
+    String filePath = this.groupConfigFile.getAbsolutePath();
+    this.groupConfigFile.delete();
+    this.groupConfigFile = new File(filePath);
+    String groups ="{\"testGroup2\": \"testName,testName3\"}";
+    Files.write(groups.getBytes(), this.groupConfigFile);
+
+    // this should return true now as the localGroupOwnership service should have updated as the file changed
+    Assert.assertTrue(this.groupOwnershipService.isMemberOfGroup(testRequester, "testGroup2"));
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    _testDirectory.delete();
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1402


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Make it possible to update the owner/requester list in a FlowConfig in some circumstances, and also refactoring/fixing some other related issues.

- In `FlowConfigResourceLocalHandler`, don't overwrite the previous requester list property (to allow it to be updated if it was specified by a user)
- Move whitelisted requester checking to an API in `RequesterService` to allow it to be used by handlers
- Add some checks to deprecated "flowconfigs" endpoint, since it was possible to set owning group to a group you were not part of through that endpoint
- Add checks as well to "flowconfigsV2" endpoint to avoid a similar way of updating the owning group, and to include the logic for when requester list is allowed to be updated

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated unit tests and tested locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

