### PR TITLE
[GOBBLIN-1408] Uses empty password on local test runs

### DIFF
--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
@@ -152,10 +152,12 @@ class TestMetastoreDatabaseServer implements Closeable {
   }
 
   private MySqlJdbcUrl getInformationSchemaJdbcUrl() throws URISyntaxException {
+    // embedded mysql has an empty password by default
+    String password =  this.embeddedMysqlEnabled ? "" : ROOT_PASSWORD;
     return getBaseJdbcUrl()
         .setPath(INFORMATION_SCHEMA)
         .setUser(ROOT_USER)
-        .setPassword(ROOT_PASSWORD);
+        .setPassword(password);
   }
 
   private Optional<Connection> getConnector(MySqlJdbcUrl jdbcUrl) throws SQLException {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1408


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
MySQL Unit tests are broken as they use password "password" instead of "" for embedded mysql runs.
They should use an empty password as that is the default mysql configuration for local.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

