### PR TITLE
[GOBBLIN-1410] Bump lombok to 1.18.16 for compatibility with Java 11

### DIFF
--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -123,7 +123,7 @@ ext.externalDependency = [
     "influxdbJava": "org.influxdb:influxdb-java:2.1",
     "kryo": "com.esotericsoftware.kryo:kryo:2.22",
     "libthrift":"org.apache.thrift:libthrift:0.9.3",
-    "lombok":"org.projectlombok:lombok:1.16.8",
+    "lombok":"org.projectlombok:lombok:1.18.16",
     "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",
     "xerces":"xerces:xercesImpl:2.11.0",
     "typesafeConfig": "com.typesafe:config:1.2.1",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1410


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Lombok version 1.18.10 is required for compatibility with Java 11, so bumping it because there are downstream consumers of gobblin that are migrating to java 11 that require it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`./gradlew` build passed

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

