### PR TITLE
[GOBBLIN-1412] Escape single backslash in avro ORC schema conversion

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -888,13 +888,13 @@ public class AvroUtils {
   }
 
   /**
-   * Escaping ";" and "'" character in the schema string when it is being used in DDL.
+   * Escaping "\", """, ";" and "'" character in the schema string when it is being used in DDL.
    * These characters are not allowed to show as part of column name but could possibly appear in documentation field.
    * Therefore the escaping behavior won't cause correctness issues.
    */
   public static String sanitizeSchemaString(String schemaString) {
-    return schemaString.replace("\\\"", "\\\\\\\"").replace(";",  "\\;")
-        .replace("'", "\\'");
+    return schemaString.replace("\\\\", "\\\\\\\\").replace("\\\"", "\\\\\\\"")
+        .replace(";",  "\\;").replace("'", "\\'");
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -299,6 +299,11 @@ public class AvroUtilsTest {
     expectedString = "abc\\\\\\\"";
     Assert.assertEquals(actualString, expectedString);
     Assert.assertEquals(actualString.length(), invalidStringWithSlash.length() + 2);
+
+    String stringWithBackslash = "\\\\d+";
+    actualString = AvroUtils.sanitizeSchemaString(stringWithBackslash);
+    Assert.assertEquals(actualString, "\\\\\\\\d+");
+    Assert.assertEquals(actualString.length(), stringWithBackslash.length() + 2);
   }
 
   public static List<GenericRecord> getRecordFromFile(String path)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1412


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

The single backslash character (which is represented by `\\` in a schema string) should also be escaped in avro to orc conversion by changing to a double backslash (`\\\\`)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

