### PR TITLE
GOBBLIN-1416: Fix a race condition caused by Helix task cancellation being invoked before Gobblin task creation

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -161,8 +161,10 @@ public class GobblinMultiTaskAttempt {
     Pair<List<Task>, Boolean> executionResult = runWorkUnits(countDownLatch);
     this.tasks = executionResult.getFirst();
 
+    // The task attempt has already been stopped and the task list is empty. This indicates that a cancel has been
+    // invoked prior to creation of underlying Gobblin tasks. In a normal scenario, where a cancel is invoked after
+    // successful task creation, the task list is guaranteed to be non-empty and we shouldn't enter the following block.
     if (this.tasks.isEmpty() && this.stopped.get()) {
-      //The task attempt has already been stopped.
       return;
     }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
 import org.mockito.Mockito;
@@ -65,7 +66,7 @@ public class GobblinMultiTaskAttemptTest {
   public void testRunWithTaskCreationFailure()
       throws Exception {
     // Preparing Instance of TaskAttempt with designed failure on task creation
-    WorkUnit tmpWU = new WorkUnit();
+    WorkUnit tmpWU = WorkUnit.createEmpty();
     // Put necessary attributes in workunit
     tmpWU.setProp(ConfigurationKeys.TASK_ID_KEY, "task_test");
     List<WorkUnit> workUnit = ImmutableList.of(tmpWU);
@@ -96,7 +97,7 @@ public class GobblinMultiTaskAttemptTest {
       throws Exception {
     TaskStateTracker stateTracker = new DummyTestStateTracker(new Properties(), log);
     // Preparing Instance of TaskAttempt with designed failure on task creation
-    WorkUnit tmpWU = new WorkUnit();
+    WorkUnit tmpWU = WorkUnit.createEmpty();
     // Put necessary attributes in workunit
     tmpWU.setProp(ConfigurationKeys.TASK_ID_KEY, "task_test");
     List<WorkUnit> workUnit = ImmutableList.of(tmpWU);
@@ -120,6 +121,31 @@ public class GobblinMultiTaskAttemptTest {
     // Should never reach here.
     Assert.fail();
   }
+
+  @Test
+  public void testRunAfterCancellation() throws Exception {
+    WorkUnit tmpWU = WorkUnit.createEmpty();
+    // Put necessary attributes in workunit
+    tmpWU.setProp(ConfigurationKeys.TASK_ID_KEY, "task_test");
+    List<WorkUnit> workUnit = ImmutableList.of(tmpWU);
+    JobState jobState = new JobState();
+    // Limit the number of times of retry in task-creation.
+    jobState.setProp(RETRY_TIME_OUT_MS, 1000);
+    jobState.setProp(ConfigurationKeys.SOURCE_CLASS_KEY, DatasetStateStoreTest.DummySource.class.getName());
+
+    TaskStateTracker stateTrackerMock = Mockito.mock(TaskStateTracker.class);
+
+    taskAttempt =
+        new GobblinMultiTaskAttempt(workUnit.iterator(), "testJob1", jobState, stateTrackerMock, taskExecutorMock,
+            Optional.absent(), Optional.absent(), jobBroker);
+
+    //Call shutdown() before creation of underlying Gobblin tasks.
+    taskAttempt.shutdownTasks();
+    taskAttempt.runAndOptionallyCommitTaskAttempt(GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE);
+    Assert.assertEquals(taskAttempt.getNumTasksCreated(), 0);
+    Assert.assertTrue(taskAttempt.getStopped().get());
+  }
+
 
   public static class DummyTestStateTracker extends AbstractTaskStateTracker {
     public DummyTestStateTracker(Properties properties, Logger logger) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1416


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Invocation of Gobblin Helix task cancellation before underlying Gobblin tasks have been created or submitted to the task executor results in GobblinHelixTask#cancel() returning successfully, but without preventing future submission of Gobblin tasks to the executor. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

