### PR TITLE
[GOBBLIN-1411] Rename staging file name with record count before movi…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -70,7 +70,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   protected final String fileName;
   protected final FileSystem fs;
   protected final FileContext fileContext;
-  protected final Path stagingFile;
+  protected Path stagingFile;
   protected final String partitionKey;
   private final GlobalMetadata defaultMetadata;
   protected Path outputFile;
@@ -256,18 +256,18 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
 
     this.bytesWritten = Optional.of(Long.valueOf(stagingFileStatus.getLen()));
 
+    // Rename staging file to add record count before copying to output file
+    if (this.shouldIncludeRecordCountInFileName) {
+      String filePathWithRecordCount = addRecordCountToStagingFile();
+      this.stagingFile = new Path(filePathWithRecordCount);
+      this.outputFile = new Path(this.outputFile.getParent().toString(), new Path(filePathWithRecordCount).getName());
+    }
+
     LOG.info(String.format("Moving data from %s to %s", this.stagingFile, this.outputFile));
     // For the same reason as deleting the staging file if it already exists, overwrite
     // the output file if it already exists to prevent task retry from being blocked.
     HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile, true);
-
-    // The staging file is moved to the output path in commit, so rename to add record count after that
-    if (this.shouldIncludeRecordCountInFileName) {
-      String filePathWithRecordCount = addRecordCountToFileName();
-      this.properties.appendToSetProp(this.allOutputFilesPropName, filePathWithRecordCount);
-    } else {
-      this.properties.appendToSetProp(this.allOutputFilesPropName, getOutputFilePath());
-    }
+    this.properties.appendToSetProp(this.allOutputFilesPropName, this.outputFile.toString());
 
     FsWriterMetrics metrics = new FsWriterMetrics(
         this.id,
@@ -301,13 +301,12 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     this.closer.close();
   }
 
-  private synchronized String addRecordCountToFileName()
+  private synchronized String addRecordCountToStagingFile()
       throws IOException {
-    String filePath = getOutputFilePath();
+    String filePath = this.stagingFile.toString();
     String filePathWithRecordCount = IngestionRecordCountProvider.constructFilePath(filePath, recordsWritten());
     LOG.info("Renaming " + filePath + " to " + filePathWithRecordCount);
     HadoopUtils.renamePath(this.fs, new Path(filePath), new Path(filePathWithRecordCount), true);
-    this.outputFile = new Path(filePathWithRecordCount);
     return filePathWithRecordCount;
   }
 


### PR DESCRIPTION
…ng to task output

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1411] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1411


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Renaming /tmp/gobblin-kafka-streaming-vbohra/kafka-streaming-on-yarn/task-staging/KafkaHdfsStreamingTrackingOrcTest/job_KafkaHdfsStreamingTrackingOrcTest_1616125750983/PageViewEvent/GobblinYarnTaskRunner_380/hourly/2021/03/17/21/part.task_KafkaHdfsStreamingTrackingOrcTest_1616125750983_221_1616125834250_1.orc to /tmp/gobblin-kafka-streaming-vbohra/kafka-streaming-on-yarn/task-staging/KafkaHdfsStreamingTrackingOrcTest/job_KafkaHdfsStreamingTrackingOrcTest_1616125750983/PageViewEvent/GobblinYarnTaskRunner_380/hourly/2021/03/17/21/part.task_KafkaHdfsStreamingTrackingOrcTest_1616125750983_221_1616125834250_1.1552921.orc
Moving data from /tmp/gobblin-kafka-streaming-vbohra/kafka-streaming-on-yarn/task-staging/KafkaHdfsStreamingTrackingOrcTest/job_KafkaHdfsStreamingTrackingOrcTest_1616125750983/PageViewEvent/GobblinYarnTaskRunner_380/hourly/2021/03/17/21/part.task_KafkaHdfsStreamingTrackingOrcTest_1616125750983_221_1616125834250_1.1552921.orc to /tmp/gobblin-kafka-streaming-vbohra/kafka-streaming-on-yarn/task-output/KafkaHdfsStreamingTrackingOrcTest/job_KafkaHdfsStreamingTrackingOrcTest_1616125750983/221/PageViewEvent/hourly/2021/03/17/21/part.task_KafkaHdfsStreamingTrackingOrcTest_1616125750983_221_1616125834250_1.1552921.orc


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

