### PR TITLE
[GOBBLIN-1413]-Emit-GMCE-as-long-as-watermark-moved

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -18,21 +18,23 @@
 package org.apache.gobblin.iceberg.publisher;
 
 import com.google.common.io.Closer;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.iceberg.GobblinMCEProducer;
-import org.apache.gobblin.iceberg.Utils.IcebergUtils;
-import org.apache.gobblin.metadata.OperationType;
-import org.apache.gobblin.metadata.SchemaSource;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.iceberg.GobblinMCEProducer;
+import org.apache.gobblin.iceberg.Utils.IcebergUtils;
+import org.apache.gobblin.iceberg.writer.GobblinMCEWriter;
+import org.apache.gobblin.metadata.OperationType;
+import org.apache.gobblin.metadata.SchemaSource;
 import org.apache.gobblin.publisher.DataPublisher;
 import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.filters.HiddenFilter;
@@ -92,9 +94,12 @@ public class GobblinMCEPublisher extends DataPublisher {
       Map<Path, Metrics> newFiles = computeFileMetrics(state);
       Map<String, String> offsetRange = getPartitionOffsetRange(OFFSET_RANGE_KEY);
       if (newFiles.isEmpty()) {
-        return;
+        // There'll be only one dummy file here. This file is parsed for DB and table name calculation.
+        newFiles = computeDummyFile(state);
+        this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
+      } else {
+        this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
       }
-      this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
     }
   }
 
@@ -132,13 +137,44 @@ public class GobblinMCEPublisher extends DataPublisher {
     return newFiles;
   }
 
+  /**
+   * Choose the latest file from the work unit state. There will be no modification to the file.
+   * It's used in GMCE writer {@link GobblinMCEWriter} merely for getting the DB and table name.
+   * @throws IOException
+   */
+  private Map<Path, Metrics> computeDummyFile(State state) throws IOException {
+    Map<Path, Metrics> newFiles = new HashMap<>();
+    FileSystem fs = FileSystem.get(conf);
+    for (final String pathString : state.getPropAsList(ConfigurationKeys.DATA_PUBLISHER_DATASET_DIR, "")) {
+      Path path = new Path(pathString);
+      //
+      PriorityQueue<FileStatus> fileStatuses =
+          new PriorityQueue<>((x, y) -> Long.compare(y.getModificationTime(), x.getModificationTime()));
+      fileStatuses.add(fs.getFileStatus(path));
+      // Only register files
+      while (!fileStatuses.isEmpty()) {
+        FileStatus fileStatus = fileStatuses.poll();
+        if (fileStatus.isDirectory()) {
+          fileStatuses.addAll(Arrays.asList(fs.listStatus(fileStatus.getPath(), HIDDEN_FILES_FILTER)));
+        } else {
+          Path filePath = fileStatus.getPath();
+          newFiles.put(filePath, null);
+          // Only one concrete file from the path is needed
+          return newFiles;
+        }
+      }
+    }
+    return newFiles;
+  }
+
   protected NameMapping getNameMapping() {
     String writerSchema = state.getProp(PartitionedDataWriter.WRITER_LATEST_SCHEMA);
     if (writerSchema == null) {
       return null;
     }
     try {
-      org.apache.iceberg.shaded.org.apache.avro.Schema avroSchema = new org.apache.iceberg.shaded.org.apache.avro.Schema.Parser().parse(writerSchema);
+      org.apache.iceberg.shaded.org.apache.avro.Schema avroSchema =
+          new org.apache.iceberg.shaded.org.apache.avro.Schema.Parser().parse(writerSchema);
       Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
       //This conversion is to make sure the schema has the iceberg id setup
       state.setProp(AVRO_SCHEMA_WITH_ICEBERG_ID, AvroSchemaUtil.convert(icebergSchema.asStruct()).toString());

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
@@ -143,7 +143,8 @@
           "symbols": [
             "add_files",
             "drop_files",
-            "rewrite_files"
+            "rewrite_files",
+            "change_property"
           ]
         },
         "doc": "This is the operation type which indicates change for the specific files, for purger we don't need to do hive registration",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1413] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1413


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Emit GMCE(Gobblin Metadata Change Event) as long as watermark moved on streaming pipeline. 

Currently the GMCE won't be triggered within streaming pipeline if no new file being generated. This causes problem if watermarks moved, while no file being generated(for example, data been filtered out by quality checker), GMCE will be missed.

Change GMCE publisher to produce GMCE when no file generated. Change IcebergMetadataWriter to correctly update watermark. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

