### PR TITLE
GOBBLIN-1417: Make row batch size in ORC Mapreduce writer configurable

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyCompactorOutputFormat.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyCompactorOutputFormat.java
@@ -18,8 +18,7 @@
 package org.apache.gobblin.compaction.mapreduce.orc;
 
 import java.io.IOException;
-import org.apache.gobblin.compaction.mapreduce.CompactionJobConfigurator;
-import org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.OutputCommitter;
@@ -32,14 +31,19 @@ import org.apache.orc.Writer;
 import org.apache.orc.mapreduce.OrcMapreduceRecordWriter;
 import org.apache.orc.mapreduce.OrcOutputFormat;
 
-import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.*;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter;
+import org.apache.gobblin.writer.GobblinOrcWriter;
+
+import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.COMPACTION_OUTPUT_EXTENSION;
 
 
 /**
  * Extension of {@link OrcOutputFormat} for customized {@link CompactorOutputCommitter}
  */
+@Slf4j
 public class OrcKeyCompactorOutputFormat extends OrcOutputFormat {
-
   private FileOutputCommitter committer = null;
 
   @Override
@@ -65,6 +69,8 @@ public class OrcKeyCompactorOutputFormat extends OrcOutputFormat {
     Path filename = getDefaultWorkFile(taskAttemptContext, extension);
     Writer writer = OrcFile.createWriter(filename,
         org.apache.orc.mapred.OrcOutputFormat.buildOptions(conf));
-    return new OrcMapreduceRecordWriter(writer);
+    int rowBatchSize = conf.getInt(GobblinOrcWriter.ORC_WRITER_BATCH_SIZE, GobblinOrcWriter.DEFAULT_ORC_WRITER_BATCH_SIZE);
+    log.info("Creating OrcMapreduceRecordWriter with row batch size = {}", rowBatchSize);
+    return new OrcMapreduceRecordWriter(writer, rowBatchSize);
   }
 }

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriter.java
@@ -59,8 +59,8 @@ import static org.apache.gobblin.writer.AvroOrcSchemaConverter.getOrcSchema;
 @Slf4j
 public class GobblinOrcWriter extends FsDataWriter<GenericRecord> {
   static final String ORC_WRITER_PREFIX = "orcWriter.";
-  private static final String ORC_WRITER_BATCH_SIZE = ORC_WRITER_PREFIX + "batchSize";
-  private static final int DEFAULT_ORC_WRITER_BATCH_SIZE = 1000;
+  public static final String ORC_WRITER_BATCH_SIZE = ORC_WRITER_PREFIX + "batchSize";
+  public static final int DEFAULT_ORC_WRITER_BATCH_SIZE = 1000;
 
   private static final String CONTAINER_MEMORY_MBS = ORC_WRITER_PREFIX + "jvm.memory.mbs";
   private static final int DEFAULT_CONTAINER_MEMORY_MBS = 4096;

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -180,9 +180,9 @@ ext.externalDependency = [
     /**
      * Avoiding conflicts with Hive 1.x versions existed in the classpath
      */
-    "orcMapreduce":"org.apache.orc:orc-mapreduce:1.6.5:nohive",
-    "orcCore": "org.apache.orc:orc-core:1.6.5:nohive",
-    "orcTools":"org.apache.orc:orc-tools:1.6.5",
+    "orcMapreduce":"org.apache.orc:orc-mapreduce:1.6.8-SNAPSHOT:nohive",
+    "orcCore": "org.apache.orc:orc-core:1.6.8-SNAPSHOT:nohive",
+    "orcTools":"org.apache.orc:orc-tools:1.6.8-SNAPSHOT",
     'parquet': 'org.apache.parquet:parquet-hadoop:1.11.0',
     'parquetAvro': 'org.apache.parquet:parquet-avro:1.11.0',
     'parquetProto': 'org.apache.parquet:parquet-protobuf:1.11.0',

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -26,6 +26,9 @@ repositories {
   maven {
     url "https://linkedin.bintray.com/maven"
   }
+  maven {
+    url "https://repository.apache.org/content/repositories/snapshots"
+  }
   jcenter()
 }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1417


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current behavior enforces the default row batch size of 1024. To prevent OOMs during writes, this config may need to be overridden.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested with a MR job and ensuring the config is overridden.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

