### PR TITLE
[GOBBLIN-1419]Error handling for compaction pipeline on GMCE emitted error

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1053,6 +1053,7 @@ public class ConfigurationKeys {
   /**
    * Configuration and constant vale for GobblinMetadataChangeEvent
    */
+  public static final String GOBBLIN_METADATA_CHANGE_EVENT_ENABLED = "GobblinMetadataChangeEvent.enabled";
   public static final String LIST_DELIMITER_KEY = ",";
   public static final String RANGE_DELIMITER_KEY = "-";
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
@@ -167,6 +167,10 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
         compactionState.setProp(DUPLICATE_COUNT_TOTAL + Long.toString(executionCount),
             compactionState.getProp(DUPLICATE_COUNT_TOTAL, "null"));
       }
+      if(state.getPropAsBoolean(ConfigurationKeys.GOBBLIN_METADATA_CHANGE_EVENT_ENABLED, false)) {
+        //GMCE enabled, set the key to be false to indicate that GMCE has not been sent yet
+        compactionState.setProp(CompactionGMCEPublishingAction.GMCE_EMITTED_KEY, false);
+      }
       compactionState.setProp(CompactionSlaEventHelper.RECORD_COUNT_TOTAL, Long.toString(newTotalRecords));
       compactionState.setProp(CompactionSlaEventHelper.EXEC_COUNT_TOTAL, Long.toString(executionCount + 1));
       compactionState.setProp(CompactionSlaEventHelper.MR_JOB_ID,

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Job;
 
-import static org.apache.gobblin.compaction.event.CompactionSlaEventHelper.DUPLICATE_COUNT_TOTAL;
+import static org.apache.gobblin.compaction.event.CompactionSlaEventHelper.*;
 
 
 /**
@@ -66,14 +66,18 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
   private EventSubmitter eventSubmitter;
   private FileSystem fs;
 
-  public CompactionCompleteFileOperationAction(State state, CompactionJobConfigurator configurator) {
+  public CompactionCompleteFileOperationAction(State state, CompactionJobConfigurator configurator, InputRecordCountHelper helper) {
     if (!(state instanceof WorkUnitState)) {
       throw new UnsupportedOperationException(this.getClass().getName() + " only supports workunit state");
     }
     this.state = (WorkUnitState) state;
-    this.helper = new InputRecordCountHelper(state);
+    this.helper = helper;
     this.configurator = configurator;
     this.fs = configurator.getFs();
+  }
+
+  public CompactionCompleteFileOperationAction(State state, CompactionJobConfigurator configurator) {
+    this(state, configurator, new InputRecordCountHelper(state));
   }
 
   /**
@@ -127,8 +131,10 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
         newTotalRecords = this.configurator.getFileNameRecordCount();
       } else {
         if (state.getPropAsBoolean(ConfigurationKeys.RECOMPACTION_WRITE_TO_NEW_FOLDER, false)) {
-          Path oldFilePath = PathUtils.mergePaths(dstPath, new Path(String.format(COMPACTION_DIRECTORY_FORMAT, executionCount)));
-          dstPath = PathUtils.mergePaths(dstPath, new Path(String.format(COMPACTION_DIRECTORY_FORMAT, executionCount + 1)));
+          Path oldFilePath =
+              PathUtils.mergePaths(dstPath, new Path(String.format(COMPACTION_DIRECTORY_FORMAT, executionCount)));
+          dstPath =
+              PathUtils.mergePaths(dstPath, new Path(String.format(COMPACTION_DIRECTORY_FORMAT, executionCount + 1)));
           this.configurator.getOldFiles().add(this.fs.makeQualified(oldFilePath).toString());
           //Write to a new path, no need to delete the old path
         } else {
@@ -167,7 +173,7 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
         compactionState.setProp(DUPLICATE_COUNT_TOTAL + Long.toString(executionCount),
             compactionState.getProp(DUPLICATE_COUNT_TOTAL, "null"));
       }
-      if(state.getPropAsBoolean(ConfigurationKeys.GOBBLIN_METADATA_CHANGE_EVENT_ENABLED, false)) {
+      if (state.getPropAsBoolean(ConfigurationKeys.GOBBLIN_METADATA_CHANGE_EVENT_ENABLED, false)) {
         //GMCE enabled, set the key to be false to indicate that GMCE has not been sent yet
         compactionState.setProp(CompactionGMCEPublishingAction.GMCE_EMITTED_KEY, false);
       }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionGMCEPublishingAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionGMCEPublishingAction.java
@@ -65,14 +65,18 @@ public class CompactionGMCEPublishingAction implements CompactionCompleteAction<
   private InputRecordCountHelper helper;
   private EventSubmitter eventSubmitter;
 
-  public CompactionGMCEPublishingAction(State state, CompactionJobConfigurator configurator) {
+  public CompactionGMCEPublishingAction(State state, CompactionJobConfigurator configurator, InputRecordCountHelper helper) {
     if (!(state instanceof WorkUnitState)) {
       throw new UnsupportedOperationException(this.getClass().getName() + " only supports workunit state");
     }
     this.state = state;
     this.configurator = configurator;
     this.conf = HadoopUtils.getConfFromState(state);
-    this.helper = new InputRecordCountHelper(state);
+    this.helper = helper;
+  }
+
+  public CompactionGMCEPublishingAction(State state, CompactionJobConfigurator configurator) {
+    this(state, configurator, new InputRecordCountHelper(state));
   }
 
   public void onCompactionJobComplete(FileSystemDataset dataset) throws IOException {

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionGMCEPublishingAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionGMCEPublishingAction.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.compaction.mapreduce.CompactionJobConfigurator;
 import org.apache.gobblin.compaction.parser.CompactionPathParser;
+import org.apache.gobblin.compaction.verify.InputRecordCountHelper;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -57,9 +58,11 @@ public class CompactionGMCEPublishingAction implements CompactionCompleteAction<
 
   public static final String ICEBERG_ID_ATTRIBUTE = "iceberg.id";
   public static final String ICEBERG_REQUIRED_ATTRIBUTE = "iceberg.required";
+  public final static String GMCE_EMITTED_KEY = "GMCE.emitted";
   private final State state;
   private final CompactionJobConfigurator configurator;
   private final Configuration conf;
+  private InputRecordCountHelper helper;
   private EventSubmitter eventSubmitter;
 
   public CompactionGMCEPublishingAction(State state, CompactionJobConfigurator configurator) {
@@ -69,20 +72,24 @@ public class CompactionGMCEPublishingAction implements CompactionCompleteAction<
     this.state = state;
     this.configurator = configurator;
     this.conf = HadoopUtils.getConfFromState(state);
+    this.helper = new InputRecordCountHelper(state);
   }
 
   public void onCompactionJobComplete(FileSystemDataset dataset) throws IOException {
     if (dataset.isVirtual()) {
       return;
     }
+    CompactionPathParser.CompactionParserResult result = new CompactionPathParser(state).parse(dataset);
+    String datasetDir = Joiner.on("/").join(result.getDstBaseDir(), result.getDatasetName());
+    state.setProp(ConfigurationKeys.DATA_PUBLISHER_DATASET_DIR, datasetDir);
     try (GobblinMCEProducer producer = GobblinMCEProducer.getGobblinMCEProducer(state)) {
-
-      CompactionPathParser.CompactionParserResult result = new CompactionPathParser(state).parse(dataset);
-      String datasetDir = Joiner.on("/").join(result.getDstBaseDir(), result.getDatasetName());
-      state.setProp(ConfigurationKeys.DATA_PUBLISHER_DATASET_DIR, datasetDir);
       producer.sendGMCE(getNewFileMetrics(result), null, Lists.newArrayList(this.configurator.getOldFiles()), null,
           OperationType.rewrite_files, SchemaSource.NONE);
     }
+    State compactionState = helper.loadState(new Path(result.getDstAbsoluteDir()));
+    //Set the prop to be true to indicate that gmce has been emitted
+    compactionState.setProp(GMCE_EMITTED_KEY, true);
+    helper.saveState(new Path(result.getDstAbsoluteDir()), compactionState);
     //clear old files to release memory
     this.configurator.getOldFiles().clear();
   }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/suite/CompactionSuiteBaseWithConfigurableCompleteAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/suite/CompactionSuiteBaseWithConfigurableCompleteAction.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.gobblin.compaction.action.CompactionCompleteAction;
+import org.apache.gobblin.compaction.verify.InputRecordCountHelper;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.dataset.FileSystemDataset;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
@@ -54,7 +55,7 @@ public class CompactionSuiteBaseWithConfigurableCompleteAction extends Compactio
     try {
       for (String s : state.getPropAsList(COMPACTION_COMPLETE_ACTIONS)) {
         compactionCompleteActionsList.add((CompactionCompleteAction<FileSystemDataset>) GobblinConstructorUtils.invokeLongestConstructor(
-            Class.forName(s), state, getConfigurator()));
+            Class.forName(s), state, getConfigurator(), new InputRecordCountHelper(state)));
       }
     } catch (ReflectiveOperationException e) {
       throw new IOException(e);

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionThresholdVerifier.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionThresholdVerifier.java
@@ -17,24 +17,20 @@
 
 package org.apache.gobblin.compaction.verify;
 
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.gobblin.compaction.action.CompactionGMCEPublishingAction;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.hadoop.fs.Path;
-
-import com.google.common.collect.Lists;
-
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.compaction.conditions.RecompactionConditionBasedOnRatio;
 import org.apache.gobblin.compaction.mapreduce.MRCompactor;
 import org.apache.gobblin.compaction.parser.CompactionPathParser;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.dataset.FileSystemDataset;
+import org.apache.hadoop.fs.Path;
 
 
 /**
@@ -88,10 +84,9 @@ public class CompactionThresholdVerifier implements CompactionVerifier<FileSyste
       if (oldRecords == 0) {
         return new Result(true, "");
       }
-      if(state.getPropAsBoolean(ConfigurationKeys.GOBBLIN_METADATA_CHANGE_EVENT_ENABLED, false)) {
-        if (!datasetState.getPropAsBoolean(CompactionGMCEPublishingAction.GMCE_EMITTED_KEY, true)) {
-          return new Result(true, "GMCE has not sent, need re-compact");
-        }
+      if (state.getPropAsBoolean(ConfigurationKeys.GOBBLIN_METADATA_CHANGE_EVENT_ENABLED, false)
+          && !datasetState.getPropAsBoolean(CompactionGMCEPublishingAction.GMCE_EMITTED_KEY, true)) {
+        return new Result(true, "GMCE has not sent, need re-compact");
       }
       if (newRecords < oldRecords) {
         return new Result(false, "Illegal state: Current records count should old be smaller.");
@@ -102,8 +97,8 @@ public class CompactionThresholdVerifier implements CompactionVerifier<FileSyste
         return new Result(true, "");
       }
 
-      return new Result(false, String
-          .format("%s is failed for dataset %s. Prev=%f, Cur=%f, not reaching to threshold %f", this.getName(),
+      return new Result(false,
+          String.format("%s is failed for dataset %s. Prev=%f, Cur=%f, not reaching to threshold %f", this.getName(),
               result.getDatasetName(), oldRecords, newRecords, threshold));
     } catch (IOException e) {
       return new Result(false, ExceptionUtils.getFullStackTrace(e));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1419


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
No compaction publish file and emit GMCE are happening separately. If file rename succeed but emit GMCE fails, we will end up with not emit GMCE for the compaction. So need  a strategy to do error handling for compaction that when emit GMCE fails, next job will treat the previous compaction as fail and re-compact the data.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

