### PR TITLE
[Gobblin-1422] Publish to artifactory instead of bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ env:
     - RUN_TEST_GROUP=group1
     - RUN_TEST_GROUP=coverage
   global:
-    - secure: U72nmzXq7kXcIabiwvrTF+WkNFQxov2ACd8oPxWSHsyzRsfVJN42vT7gS3dLbH5G5claXG2p+rur4ueVffzYSwJ8B9OP6gTB8sNJnGr9zyxni4OJchyKqOYuj+UBpEQC/7qXKMCKnuJndsf1OvndDh/V1SH0DSSUuA6mDtgO/eM=
-    - secure: WiK7tyFV68xdkIfUlWreUHgEGGjaCBd73O4SbjE9AsbqqF7D+Iu8iRo1OhKQj+6eajUH9Eoev9rVN74FQgUfeNzrOkYsgDysXmyZ7+UxFokijFcATJmIBompA3dySGU2qXeKbJMNuUjXgrRIludaV6h2ahL6Fji42cgK4I3s2qs=
     - secure: TihDMhhcX3K1BXV1zCgHYfAa/wxpVOxnMZXbvAoCiA6vbUCd/94bPQaAhABKkZdWUqsgto9YxYyqcQM2XntDXs2K3A8AdW2PUgb9ynf782zFsfG8O2fasW1UQxg4QQ5TQw+P34s7HjUNz0dDfRyl1gurN9yPOPvAxv+paB9FDfE=
     - secure: K/d6ce/NOHkcNfQvFopU5jVkCPwbj8xWTu1vgZiHMOeIB3cU9lZzxQESOZw5zd1aqYDMmTYXU62I/fn0CWTUvfL1TdKFQ4iN0OW31uFr2cFtnCRhxALsRoXYHvApHmssOxuQdp76jAavoHt+CLxcwG/FGZ3GEaczbZC1ZU/pjbQ=
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
       env: RUN_TEST_GROUP=none
       install: skip
       script:
-        - travis_retry ./travis/bintrayDeploy.sh
+        - travis_retry ./travis/artifactoryDeploy.sh
 
 env:
   jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ env:
   global:
     - secure: U72nmzXq7kXcIabiwvrTF+WkNFQxov2ACd8oPxWSHsyzRsfVJN42vT7gS3dLbH5G5claXG2p+rur4ueVffzYSwJ8B9OP6gTB8sNJnGr9zyxni4OJchyKqOYuj+UBpEQC/7qXKMCKnuJndsf1OvndDh/V1SH0DSSUuA6mDtgO/eM=
     - secure: WiK7tyFV68xdkIfUlWreUHgEGGjaCBd73O4SbjE9AsbqqF7D+Iu8iRo1OhKQj+6eajUH9Eoev9rVN74FQgUfeNzrOkYsgDysXmyZ7+UxFokijFcATJmIBompA3dySGU2qXeKbJMNuUjXgrRIludaV6h2ahL6Fji42cgK4I3s2qs=
-
+    - secure: TihDMhhcX3K1BXV1zCgHYfAa/wxpVOxnMZXbvAoCiA6vbUCd/94bPQaAhABKkZdWUqsgto9YxYyqcQM2XntDXs2K3A8AdW2PUgb9ynf782zFsfG8O2fasW1UQxg4QQ5TQw+P34s7HjUNz0dDfRyl1gurN9yPOPvAxv+paB9FDfE=
+    - secure: K/d6ce/NOHkcNfQvFopU5jVkCPwbj8xWTu1vgZiHMOeIB3cU9lZzxQESOZw5zd1aqYDMmTYXU62I/fn0CWTUvfL1TdKFQ4iN0OW31uFr2cFtnCRhxALsRoXYHvApHmssOxuQdp76jAavoHt+CLxcwG/FGZ3GEaczbZC1ZU/pjbQ=
 jdk:
   - openjdk8

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,10 @@ buildscript {
     classpath 'org.apache.ant:ant:1.9.4'
     classpath 'gradle.plugin.org.inferred:gradle-processors:1.1.2'
     classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:1.0.2'
-    classpath 'io.spring.gradle:dependency-management-plugin:0.6.0.RELEASE'
+    classpath 'io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.20.0'
   }
 
   repositories {
@@ -132,7 +132,7 @@ apply from: 'gradle/scripts/sourcesJar.gradle'
 
 apply from: 'gradle/scripts/mavenPublishing.gradle'
 apply from: 'gradle/scripts/nexusPublishing.gradle'
-apply from: 'gradle/scripts/bintrayPublishing.gradle'
+apply from: 'gradle/scripts/artifactoryPublishing.gradle'
 apply from: 'gradle/scripts/javaVersionCheck.gradle'
 
 apply from: 'gradle/scripts/rat.gradle'

--- a/gobblin-cluster/build.gradle
+++ b/gobblin-cluster/build.gradle
@@ -93,7 +93,14 @@ project.publishing.publications {
     pom.withXml addRuntimeDependenciesToPom
   }
 }
-addPublicationToBintray("testsPub")
+
+artifactory {
+  publish {
+    defaults {
+      publications('mavenJava', 'testsPub')
+    }
+  }
+}
 
 test {
   workingDir rootProject.rootDir

--- a/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
+++ b/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
@@ -65,5 +65,13 @@ publishing.publications {
     pom.withXml addRuntimeDependenciesToPom
   }
 }
-project.bintray.publications = ["shadowPub"]
+
+artifactory {
+    publish {
+        defaults {
+            publications('shadowPub')
+        }
+    }
+}
+
 ext.classification="library"

--- a/gobblin-modules/gobblin-orc-dep/build.gradle
+++ b/gobblin-modules/gobblin-orc-dep/build.gradle
@@ -79,6 +79,13 @@ publishing.publications {
       pom.withXml addRuntimeDependenciesToPom
     }
 }
-project.bintray.publications = ["shadowPub"]
+
+artifactory {
+    publish {
+        defaults {
+            publications('shadowPub')
+        }
+    }
+}
 
 ext.classification="library"

--- a/gobblin-rest-service/gobblin-rest-api/build.gradle
+++ b/gobblin-rest-service/gobblin-rest-api/build.gradle
@@ -126,8 +126,14 @@ publishing.publications {
       pom.withXml addRuntimeDependenciesToPom
     }
 }
-addPublicationToBintray("dataTemplate")
-addPublicationToBintray("restClient")
+artifactory {
+    contextUrl = 'https://linkedin.jfrog.io/artifactory/'
+    publish {
+        defaults {
+            publications ('mavenJava', 'restClient', 'dataTemplate')
+        }
+    }
+}
 
 buildscript {
     repositories {

--- a/gobblin-restli/api.gradle
+++ b/gobblin-restli/api.gradle
@@ -68,7 +68,9 @@ artifacts {
   archives mainDataTemplateJar, dataTemplateSourcesJar, dataTemplateJavadocJar
 }
 
-if (file("${project.projectDir}/src/main/idl").exists()) {
+def generateRestClient = file("${project.projectDir}/src/main/idl").exists()
+
+if (generateRestClient) {
 
   // Configure sources and javadoc jars for the rest client  library
   def restClientName = project.name + "-rest-client"
@@ -103,7 +105,6 @@ if (file("${project.projectDir}/src/main/idl").exists()) {
         pom.withXml addRuntimeDependenciesToPom
       }
   }
-  addPublicationToBintray("restClient")
 }
 
 install {
@@ -142,4 +143,15 @@ publishing.publications {
       pom.withXml addRuntimeDependenciesToPom
     }
 }
-addPublicationToBintray("dataTemplate")
+
+artifactory {
+  publish {
+    defaults {
+      if (generateRestClient) {
+        publications('mavenJava', 'restClient', 'dataTemplate')
+      } else {
+        publications('mavenJava', 'dataTemplate')
+      }
+    }
+  }
+}

--- a/gradle/scripts/artifactoryPublishing.gradle
+++ b/gradle/scripts/artifactoryPublishing.gradle
@@ -104,7 +104,7 @@ subprojects{
     }
   }
 
-  // Using gradle bintray plugin to publish artifacts to Jfrog bintray
+  // Using gradle artifactory plugin to publish artifacts to Jfrog Artifactory
   artifactory {
     contextUrl = 'https://linkedin.jfrog.io/artifactory/'
     publish {

--- a/gradle/scripts/artifactoryPublishing.gradle
+++ b/gradle/scripts/artifactoryPublishing.gradle
@@ -42,6 +42,7 @@ ext.pomAttributes = {
 // Uses maven-publish plugin and generates the default jar, sources, javadoc
 // and pom file (https://docs.gradle.org/current/userguide/publishing_maven.html)
 subprojects{
+  apply plugin: "com.jfrog.artifactory"
   plugins.withType(JavaPlugin) {
     plugins.apply('maven-publish')
     publishing {
@@ -104,45 +105,22 @@ subprojects{
   }
 
   // Using gradle bintray plugin to publish artifacts to Jfrog bintray
-  plugins.apply('com.jfrog.bintray')
-  bintray {
-    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
-    publications = ["mavenJava"]
-    publish = true
-    override = project.hasProperty("bintray.override") //[Default: false]
-    dryRun = project.hasProperty("bintray.dryRun") //[Default: false]
-    pkg {
-      repo = 'maven'
-      name = 'gobblin-github'
-      userOrg = 'linkedin'
-      licenses = ['Apache-2.0']
-      vcsUrl = 'https://github.com/apache/incubator-gobblin.git'
-      version {
-        name = project.version
-        desc = 'Apache Gobblin'
-        released = new Date()
-        // disable gpg signing to speed up publishing
-        gpg {
-          sign = false
-        }
-        // disable upload to maven central
-        mavenCentralSync {
-          sync = false
-        }
+  artifactory {
+    contextUrl = 'https://linkedin.jfrog.io/artifactory/'
+    publish {
+      repository {
+        repoKey = 'gobblin-github'
+        username = project.hasProperty('artifactoryUser') ? project.property('artifactoryUser') : System.getenv('ARTIFACTORY_USER')
+        password = project.hasProperty('artifactoryApiKey') ? project.property('artifactoryApiKey') : System.getenv('ARTIFACTORY_API_KEY')
+      }
+      defaults {
+        publications ('mavenJava')
       }
     }
   }
 
-  tasks.bintrayUpload {
-    doFirst {
-      println "Running bintrayUpload for $project.name, publications: $project.bintray.publications"
-    }
-    dependsOn publishToMavenLocal
-  }
-
-  ext.addPublicationToBintray = { pubName ->
-    project.bintray.publications += pubName
+  tasks.artifactoryPublish {
+      dependsOn publishToMavenLocal
   }
 
   ext.addRuntimeDependenciesToPom = {

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -26,6 +26,9 @@ repositories {
   maven {
     url "https://linkedin.bintray.com/maven"
   }
+  maven {
+    url "https://linkedin.jfrog.com/artifactory/"
+  }
   jcenter()
 }
 

--- a/travis/artifactoryDeploy.sh
+++ b/travis/artifactoryDeploy.sh
@@ -35,5 +35,5 @@ echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
     echo "Uploading artifacts to bintray for version $BUILD_VERSION"
-    ./gradlew bintrayUpload -Pversion=$BUILD_VERSION -Pbintray.override
+    ./gradlew artifactoryPublish -Pversion=$BUILD_VERSION
 fi


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1422

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Based on Bintray's sunset https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/ publishing to bintray can no longer be done by May 1st. We will need to publish jars to an alternative source, such as JFrog's Artifactory.
This PR changes the publishing location to artifactory instead of bintray.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

