### PR TITLE
[GOBBLIN-1423] Add config to Event reporter to control queue capacity…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/KafkaReportingFormats.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/KafkaReportingFormats.java
@@ -82,12 +82,13 @@ public enum KafkaReportingFormats {
       builder.withPusherClassName(pusherClassName);
 
       Config allConfig = ConfigUtils.propertiesToConfig(properties);
+      builder.withConfig(allConfig);
       // the kafka configuration is composed of the metrics reporting specific keys with a fallback to the shared
       // kafka config
       Config kafkaConfig = ConfigUtils.getConfigOrEmpty(allConfig, PusherUtils.METRICS_REPORTING_KAFKA_CONFIG_PREFIX)
           .withFallback(ConfigUtils.getConfigOrEmpty(allConfig, ConfigurationKeys.SHARED_KAFKA_CONFIG_PREFIX));
 
-      builder.withConfig(kafkaConfig);
+      builder.withKafkaConfig(kafkaConfig);
 
       return builder.build(brokers, topic);
     }
@@ -124,12 +125,13 @@ public enum KafkaReportingFormats {
       builder.withPusherClassName(pusherClassName);
 
       Config allConfig = ConfigUtils.propertiesToConfig(properties);
+      builder.withConfig(allConfig);
       // the kafka configuration is composed of the metrics reporting specific keys with a fallback to the shared
       // kafka config
       Config kafkaConfig = ConfigUtils.getConfigOrEmpty(allConfig, PusherUtils.METRICS_REPORTING_KAFKA_CONFIG_PREFIX)
           .withFallback(ConfigUtils.getConfigOrEmpty(allConfig, ConfigurationKeys.SHARED_KAFKA_CONFIG_PREFIX));
 
-      builder.withConfig(kafkaConfig);
+      builder.withKafkaConfig(kafkaConfig);
 
       return builder.build(brokers, topic);
     }
@@ -153,12 +155,13 @@ public enum KafkaReportingFormats {
       builder.withPusherClassName(pusherClassName);
 
       Config allConfig = ConfigUtils.propertiesToConfig(properties);
+      builder.withConfig(allConfig);
       // the kafka configuration is composed of the metrics reporting specific keys with a fallback to the shared
       // kafka config
       Config kafkaConfig = ConfigUtils.getConfigOrEmpty(allConfig, PusherUtils.METRICS_REPORTING_KAFKA_CONFIG_PREFIX)
           .withFallback(ConfigUtils.getConfigOrEmpty(allConfig, ConfigurationKeys.SHARED_KAFKA_CONFIG_PREFIX));
 
-      builder.withConfig(kafkaConfig);
+      builder.withKafkaConfig(kafkaConfig);
 
       return builder.build(brokers, topic);
     }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
@@ -33,7 +33,6 @@ import org.apache.gobblin.metrics.reporter.util.AvroSerializer;
 import org.apache.gobblin.metrics.reporter.util.FixedSchemaVersionWriter;
 import org.apache.gobblin.metrics.reporter.util.SchemaVersionWriter;
 
-
 /**
  * Reports {@link GobblinTrackingEvent} to a Kafka topic serialized as JSON.
  */

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
@@ -52,7 +52,7 @@ public class KafkaEventReporter extends EventReporter {
       this.kafkaPusher = builder.kafkaPusher.get();
     } else {
         String pusherClassName = builder.pusherClassName.or(PusherUtils.DEFAULT_KAFKA_PUSHER_CLASS_NAME);
-        this.kafkaPusher = PusherUtils.getPusher(pusherClassName, builder.brokers, builder.topic, builder.config);
+        this.kafkaPusher = PusherUtils.getPusher(pusherClassName, builder.brokers, builder.topic, builder.kafkaConfig);
     }
     this.closer.register(this.kafkaPusher);
   }
@@ -122,7 +122,7 @@ public class KafkaEventReporter extends EventReporter {
     protected String brokers;
     protected String topic;
     protected Optional<Pusher> kafkaPusher;
-    protected Optional<Config> config = Optional.absent();
+    protected Optional<Config> kafkaConfig = Optional.absent();
     protected Optional<String> pusherClassName = Optional.absent();
 
     protected Builder(MetricContext context) {
@@ -141,8 +141,8 @@ public class KafkaEventReporter extends EventReporter {
     /**
      * Set additional configuration.
      */
-    public T withConfig(Config config) {
-      this.config = Optional.of(config);
+    public T withKafkaConfig(Config config) {
+      this.kafkaConfig = Optional.of(config);
       return self();
     }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
@@ -63,7 +63,7 @@ public class KeyValueEventObjectReporter extends EventReporter {
   public KeyValueEventObjectReporter(Builder builder) {
     super(builder);
 
-    Config config = builder.config.get();
+    Config config = builder.config;
     Config pusherConfig = ConfigUtils.getConfigOrEmpty(config, PUSHER_CONFIG).withFallback(config);
     String pusherClassName =
         ConfigUtils.getString(config, PUSHER_CLASS, PusherUtils.DEFAULT_KEY_VALUE_PUSHER_CLASS_NAME);
@@ -132,7 +132,6 @@ public class KeyValueEventObjectReporter extends EventReporter {
 
     protected String brokers;
     protected String topic;
-    protected Optional<Config> config = Optional.absent();
     protected Optional<Map<String, String>> namespaceOverride = Optional.absent();
 
     public Builder(MetricContext context) {
@@ -142,14 +141,6 @@ public class KeyValueEventObjectReporter extends EventReporter {
     @Override
     protected Builder self() {
       return this;
-    }
-
-    /**
-     * Set additional configuration.
-     */
-    public Builder withConfig(Config config) {
-      this.config = Optional.of(config);
-      return self();
     }
 
     public Builder namespaceOverride(Optional<Map<String, String>> namespaceOverride) {

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KafkaEventReporterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KafkaEventReporterTest.java
@@ -57,7 +57,6 @@ public class KafkaEventReporterTest {
 
     MockKafkaPusher pusher = new MockKafkaPusher();
     KafkaEventReporter kafkaReporter = getBuilder(context, pusher).build("localhost:0000", "topic");
-    kafkaReporter.getQueueCapacity();
     String namespace = "gobblin.metrics.test";
     String eventName = "testEvent";
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KafkaEventReporterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KafkaEventReporterTest.java
@@ -24,7 +24,10 @@ import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.MetricContext;
@@ -54,7 +57,7 @@ public class KafkaEventReporterTest {
 
     MockKafkaPusher pusher = new MockKafkaPusher();
     KafkaEventReporter kafkaReporter = getBuilder(context, pusher).build("localhost:0000", "topic");
-
+    kafkaReporter.getQueueCapacity();
     String namespace = "gobblin.metrics.test";
     String eventName = "testEvent";
 
@@ -134,6 +137,27 @@ public class KafkaEventReporterTest {
     Assert.assertEquals(retrievedEvent.getMetadata().size(), 4);
     Assert.assertEquals(retrievedEvent.getMetadata().get(tag1), metadataValue1);
     Assert.assertEquals(retrievedEvent.getMetadata().get(tag2), value2);
+  }
+
+  @Test
+  public void testEventReporterConfigs() throws IOException {
+
+    MetricContext context = MetricContext.builder("context").build();
+
+    MockKafkaPusher pusher = new MockKafkaPusher();
+    KafkaEventReporter kafkaReporter = getBuilder(context, pusher).build("localhost:0000", "topic");
+    Assert.assertEquals(kafkaReporter.getQueueCapacity(), EventReporter.DEFAULT_QUEUE_CAPACITY);
+    Assert.assertEquals(kafkaReporter.getQueueOfferTimeoutSecs(), EventReporter.DEFAULT_QUEUE_OFFER_TIMEOUT_SECS);
+
+    Config config = ConfigFactory.parseMap(
+        ImmutableMap.<String, Object>builder()
+            .put(EventReporter.QUEUE_CAPACITY_KEY, 200)
+            .put(EventReporter.QUEUE_OFFER_TIMOUT_SECS_KEY, 5)
+            .build());
+
+    kafkaReporter = getBuilder(context, pusher).withConfig(config).build("localhost:0000", "topic");
+    Assert.assertEquals(kafkaReporter.getQueueCapacity(), 200);
+    Assert.assertEquals(kafkaReporter.getQueueOfferTimeoutSecs(), 5);
   }
 
   /**


### PR DESCRIPTION
… and offer timeout

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1423] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1423


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- Added reference to Config in EventReporter
- pass config to reporters via user configs
- Control queue capacity and queue offer timeout via configs

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added testEventReporterConfigs 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

