### PR TITLE
[GOBBLIN-1424] Fix flakiness in Github Actions network port binding

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -103,7 +103,7 @@ jobs:
           ./gradlew --no-daemon -x javadoc findbugsMain checkstyleMain checkstyleTest checkstyleJmh
 
   run_tests:
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       GOBBLIN_GRADLE_OPTS: "--no-daemon -Dgobblin.metastore.testing.embeddedMysqlEnabled=false -PusePreinstalledMysql=true"
     strategy:
@@ -130,6 +130,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      # Fix for bug where Github tests are failing port address binding.
+      - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+        run: |
+          echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - name: Verify mysql connection
         run: |
             sudo apt-get install -y mysql-client
@@ -160,5 +164,5 @@ jobs:
             else
               exit 1
             fi
-            sleep 10
+            sleep 30
           done


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1424


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Github CI is flaky due to the issue described here https://github.community/t/github-action-and-oserror-errno-99-cannot-assign-requested-address/173973. This fix adds a step to add hosts for reverse lookup to not fail, as well as some timeout improvements for flakiness.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

