### PR TITLE
[GOBBLIN-1426] let child classes use SalesforceConnector code

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConnector.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConnector.java
@@ -115,7 +115,7 @@ public class SalesforceConnector extends RestApiConnector {
     }
   }
 
-  static boolean isPasswordGrant(State state) {
+  protected static boolean isPasswordGrant(State state) {
     String userName = state.getProp(ConfigurationKeys.SOURCE_CONN_USERNAME);
     String securityToken = state.getProp(ConfigurationKeys.SOURCE_CONN_SECURITY_TOKEN);
     return (userName != null &&  securityToken != null);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1426


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Static method `isPasswordGrant` in SalesforceConnector is private, so child classes cannot use it.
This PR will make it protected so child classes can use it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
very trivial changes; do not require unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

