### PR TITLE
[GOBBLIN-1427] Handle MountPointNotFoundException when determining files in target for File Distcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -179,7 +179,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
     try {
       return FileListUtils
           .listFilesToCopyAtPath(fs, path, fileFilter, applyFilterToDirectories, includeEmptyDirectories);
-    } catch (FileNotFoundException fnfe) {
+    } catch (IOException e) {
       return Lists.newArrayList();
     }
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.data.management.copy;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.data.management.copy.entities.PrePublishStep;
 import org.apache.gobblin.data.management.dataset.DatasetUtils;
@@ -47,6 +48,7 @@ import com.google.common.collect.Maps;
  * Implementation of {@link CopyableDataset} that creates a {@link CopyableFile} for every file that is a descendant if
  * the root directory.
  */
+@Slf4j
 public class RecursiveCopyableDataset implements CopyableDataset, FileSystemDataset {
 
   private static final String CONFIG_PREFIX = CopyConfiguration.COPY_PREFIX + ".recursive";
@@ -180,6 +182,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
       return FileListUtils
           .listFilesToCopyAtPath(fs, path, fileFilter, applyFilterToDirectories, includeEmptyDirectories);
     } catch (IOException e) {
+      log.info(String.format("Could not find any files on target path due to %s. Returning an empty list of files.", e.getClass().getCanonicalName()));
       return Lists.newArrayList();
     }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1427


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

When files on target directory do not exist on viewfs, MountPointNotFoundException is raised instead of FileNotFoundException. This causes the code to error out when it should be returning an empty list of files at the target location.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

