### PR TITLE
[GOBBLIN-1433] Bump up sql connector version

### DIFF
--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -110,7 +110,7 @@ ext.externalDependency = [
     "jdo2": "javax.jdo:jdo2-api:2.1",
     "azkaban": "com.linkedin.azkaban:azkaban:2.5.0",
     "commonsVfs": "org.apache.commons:commons-vfs2:2.0",
-    "mysqlConnector": "mysql:mysql-connector-java:8.0.16",
+    "mysqlConnector": "mysql:mysql-connector-java:8.0.24",
     "javaxInject": "javax.inject:javax.inject:1",
     "guice": "com.google.inject:guice:4.0",
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1433


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Tests involving SQL break on the latest version of Java 1.8, 1.8.291 which was released April 20, 2021.
Error is caused by 
`Caused by:
                    javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
                        at sun.security.ssl.HandshakeContext.<init>(HandshakeContext.java:171)`
                        
Recommended solution is to bump up SQL connector version to use compatible encryption methods

### Tests
-  [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

