### PR TITLE
[GOBBLIN-1434]Make the maxWaitMills to get a hive client be configurable

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
@@ -153,6 +153,7 @@ public class HiveMetastoreClientPool {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(this.hiveRegProps.getNumThreads());
     config.setMaxIdle(this.hiveRegProps.getNumThreads());
+    config.setMaxWaitMillis(this.hiveRegProps.getMaxWaitMillisBorrowingClient());
 
     String extraConfigTarget = properties.getProperty(POOL_HIVE_ADDITIONAL_CONFIG_TARGET, "");
 

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegProps.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegProps.java
@@ -44,6 +44,8 @@ public class HiveRegProps extends State {
 
   public static final String HIVE_DB_ROOT_DIR = "hive.db.root.dir";
   public static final String HIVE_REGISTER_THREADS = "hive.register.threads";
+  public static final String HIVE_MAX_WAIT_MILLS_BORROW_CLIENT = "hive.register.maxWaitMills.borrow.client";
+  public static final long DEFAULT_HIVE_MAX_WAIT_MILLS_BORROW_CLIENT = -1L;
   public static final int DEFAULT_HIVE_REGISTER_THREADS = 20;
   public static final String HIVE_TABLE_PARTITION_PROPS = "hive.table.partition.props";
   public static final String HIVE_STORAGE_PROPS = "hive.storage.props";
@@ -149,5 +151,12 @@ public class HiveRegProps extends State {
    */
   public int getNumThreads() {
     return getPropAsInt(HIVE_REGISTER_THREADS, DEFAULT_HIVE_REGISTER_THREADS);
+  }
+  /**
+   * Get max wait mills when borrow a hive client from pool from {@link #HIVE_MAX_WAIT_MILLS_BORROW_CLIENT}, with a default value of
+   * {@link #DEFAULT_HIVE_MAX_WAIT_MILLS_BORROW_CLIENT}.
+   */
+  public long getMaxWaitMillisBorrowingClient() {
+    return getPropAsLong(HIVE_MAX_WAIT_MILLS_BORROW_CLIENT, DEFAULT_HIVE_MAX_WAIT_MILLS_BORROW_CLIENT);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1434


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
By default, maxWaitMills to get a hive client in HiveMetastoreClientPool is set to be -1L, and in this case, the get call will wait for the client object forever if there is no available one. This ticket is to make maxWaitMills configurable, so that after maxWaitMills, it will throw timeout exception. But still, the default value will be -1L.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

