### PR TITLE
[GOBBLIN-1438] Only load failed dags at time of resume

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.service.modules.orchestration;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -188,7 +189,6 @@ public class DagManager extends AbstractIdleService {
   private final int defaultQuota;
   private final Map<String, Integer> perUserQuota;
   private final long failedDagRetentionTime;
-  private final Map<String, Dag<JobExecutionPlan>> failedDags = new ConcurrentHashMap<>();
 
   private volatile boolean isActive = false;
 
@@ -372,16 +372,17 @@ public class DagManager extends AbstractIdleService {
         //Initializing state store for persisting Dags.
         this.dagStateStore = createDagStateStore(config, topologySpecMap);
         this.failedDagStateStore = createDagStateStore(ConfigUtils.getConfigOrEmpty(config, FAILED_DAG_STATESTORE_PREFIX).withFallback(config), topologySpecMap);
+        List<String> failedDagIds = Collections.synchronizedList(this.failedDagStateStore.getDagIds());
 
         //On startup, the service creates DagManagerThreads that are scheduled at a fixed rate.
         this.dagManagerThreads = new DagManagerThread[numThreads];
         for (int i = 0; i < numThreads; i++) {
           DagManagerThread dagManagerThread = new DagManagerThread(jobStatusRetriever, dagStateStore, failedDagStateStore,
-              queue[i], cancelQueue[i], resumeQueue[i], instrumentationEnabled, defaultQuota, perUserQuota, failedDags);
+              queue[i], cancelQueue[i], resumeQueue[i], instrumentationEnabled, defaultQuota, perUserQuota, failedDagIds);
           this.dagManagerThreads[i] = dagManagerThread;
           this.scheduledExecutorPool.scheduleAtFixedRate(dagManagerThread, 0, this.pollingInterval, TimeUnit.SECONDS);
         }
-        FailedDagRetentionThread failedDagRetentionThread = new FailedDagRetentionThread(failedDagStateStore, failedDags, failedDagRetentionTime);
+        FailedDagRetentionThread failedDagRetentionThread = new FailedDagRetentionThread(failedDagStateStore, failedDagIds, failedDagRetentionTime);
         this.scheduledExecutorPool.scheduleAtFixedRate(failedDagRetentionThread, 0, retentionPollingInterval, TimeUnit.MINUTES);
         List<Dag<JobExecutionPlan>> dags = dagStateStore.getDags();
         log.info("Loading " + dags.size() + " dags from dag state store");
@@ -416,7 +417,7 @@ public class DagManager extends AbstractIdleService {
     private static final Map<String, Integer> proxyUserToJobCount = new ConcurrentHashMap<>();
     private static final Map<String, Integer> requesterToJobCount = new ConcurrentHashMap<>();
     private final Map<String, Dag<JobExecutionPlan>> dags = new HashMap<>();
-    private Map<String, Dag<JobExecutionPlan>> failedDags;
+    private List<String> failedDagIds;
     private final Map<String, Dag<JobExecutionPlan>> resumingDags = new HashMap<>();
     // dagToJobs holds a map of dagId to running jobs of that dag
     final Map<String, LinkedList<DagNode<JobExecutionPlan>>> dagToJobs = new HashMap<>();
@@ -443,18 +444,11 @@ public class DagManager extends AbstractIdleService {
      */
     DagManagerThread(JobStatusRetriever jobStatusRetriever, DagStateStore dagStateStore, DagStateStore failedDagStateStore,
         BlockingQueue<Dag<JobExecutionPlan>> queue, BlockingQueue<String> cancelQueue, BlockingQueue<String> resumeQueue,
-        boolean instrumentationEnabled, int defaultQuota, Map<String, Integer> perUserQuota, Map<String, Dag<JobExecutionPlan>> failedDags) {
+        boolean instrumentationEnabled, int defaultQuota, Map<String, Integer> perUserQuota, List<String> failedDagIds) {
       this.jobStatusRetriever = jobStatusRetriever;
       this.dagStateStore = dagStateStore;
       this.failedDagStateStore = failedDagStateStore;
-      try {
-        this.failedDags = failedDags;
-        for (Dag<JobExecutionPlan> dag : failedDagStateStore.getDags()) {
-          this.failedDags.put(DagManagerUtils.generateDagId(dag), dag);
-        }
-      } catch (IOException e) {
-        log.error("Failed to load previously failed dags into memory", e);
-      }
+      this.failedDagIds = failedDagIds;
       this.queue = queue;
       this.cancelQueue = cancelQueue;
       this.resumeQueue = resumeQueue;
@@ -524,10 +518,14 @@ public class DagManager extends AbstractIdleService {
      * Begin resuming a dag by setting the status of both the dag and the failed/cancelled dag nodes to {@link ExecutionStatus#PENDING_RESUME},
      * and also sending events so that this status will be reflected in the job status state store.
      */
-    private void beginResumingDag(String dagId) {
-      Dag<JobExecutionPlan> dag = this.failedDags.get(dagId);
-      if (dag == null) {
+    private void beginResumingDag(String dagId) throws IOException {
+      if (!this.failedDagIds.contains(dagId)) {
         log.warn("No dag found with dagId " + dagId + ", so cannot resume flow");
+        return;
+      }
+      Dag<JobExecutionPlan> dag = this.failedDagStateStore.getDag(dagId);
+      if (dag == null) {
+        log.error("Dag " + dagId + " was found in memory but not found in failed dag state store");
         return;
       }
 
@@ -575,7 +573,7 @@ public class DagManager extends AbstractIdleService {
         if (dagReady) {
           this.dagStateStore.writeCheckpoint(dag.getValue());
           this.failedDagStateStore.cleanUp(dag.getValue());
-          this.failedDags.remove(dag.getKey());
+          this.failedDagIds.remove(dag.getKey());
           this.resumingDags.remove(dag.getKey());
           initialize(dag.getValue());
         }
@@ -1190,7 +1188,7 @@ public class DagManager extends AbstractIdleService {
       } catch (IOException e) {
         log.error("Failed to add dag " + dagId + " to failed dag state store", e);
       }
-      this.failedDags.put(dagId, this.dags.get(dagId));
+      this.failedDagIds.add(dagId);
     }
 
     /**
@@ -1229,12 +1227,12 @@ public class DagManager extends AbstractIdleService {
    */
   public static class FailedDagRetentionThread implements Runnable {
     private final DagStateStore failedDagStateStore;
-    private final Map<String, Dag<JobExecutionPlan>> failedDags;
+    private final List<String> failedDagIds;
     private final long failedDagRetentionTime;
 
-    FailedDagRetentionThread(DagStateStore failedDagStateStore, Map<String, Dag<JobExecutionPlan>> failedDags, long failedDagRetentionTime) {
+    FailedDagRetentionThread(DagStateStore failedDagStateStore, List<String> failedDagIds, long failedDagRetentionTime) {
       this.failedDagStateStore = failedDagStateStore;
-      this.failedDags = failedDags;
+      this.failedDagIds = failedDagIds;
       this.failedDagRetentionTime = failedDagRetentionTime;
     }
 
@@ -1243,20 +1241,20 @@ public class DagManager extends AbstractIdleService {
       try {
         log.info("Cleaning failed dag state store");
         long startTime = System.currentTimeMillis();
-        List<String> dagKeysToClean = new ArrayList<>();
+        List<String> dagIdsToClean = new ArrayList<>();
 
-        for (Map.Entry<String, Dag<JobExecutionPlan>> entry : this.failedDags.entrySet()) {
-          if (this.failedDagRetentionTime > 0L && startTime > DagManagerUtils.getFlowExecId(entry.getValue()) + this.failedDagRetentionTime) {
-            this.failedDagStateStore.cleanUp(entry.getValue());
-            dagKeysToClean.add(entry.getKey());
+        for (String dagId : this.failedDagIds) {
+          if (this.failedDagRetentionTime > 0L && startTime > DagManagerUtils.getFlowExecId(dagId) + this.failedDagRetentionTime) {
+            this.failedDagStateStore.cleanUp(dagId);
+            dagIdsToClean.add(dagId);
           }
         }
 
-        for (String key : dagKeysToClean) {
-          this.failedDags.remove(key);
+        for (String dagId : dagIdsToClean) {
+          this.failedDagIds.remove(dagId);
         }
 
-      log.info("Cleaned " + dagKeysToClean.size() + " from the failed dag state store");
+      log.info("Cleaned " + dagIdsToClean.size() + " dags from the failed dag state store");
       } catch (Exception e) {
         log.error("Failed to run retention on failed dag state store", e);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
-import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
@@ -60,14 +59,6 @@ public class DagManagerUtils {
     return new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
   }
 
-  static FlowId getFlowId(String dagId) {
-    List<String> splitDagId = Splitter.on("_").splitToList(dagId);
-    if (splitDagId.size() != 3) {
-      throw new IllegalArgumentException(dagId + " is not a valid dagId, expected format group_name_id");
-    }
-    return new FlowId().setFlowGroup(splitDagId.get(0)).setFlowName(splitDagId.get(1));
-  }
-
   static long getFlowExecId(Dag<JobExecutionPlan> dag) {
     return getFlowExecId(dag.getStartNodes().get(0));
   }
@@ -81,11 +72,7 @@ public class DagManagerUtils {
   }
 
   static long getFlowExecId(String dagId) {
-    List<String> splitDagId = Splitter.on("_").splitToList(dagId);
-    if (splitDagId.size() != 3) {
-      throw new IllegalArgumentException(dagId + " is not a valid dagId, expected format group_name_id");
-    }
-    return Long.parseLong(splitDagId.get(2));
+    return Long.parseLong(dagId.substring(dagId.lastIndexOf('_') + 1));
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
@@ -59,6 +60,14 @@ public class DagManagerUtils {
     return new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
   }
 
+  static FlowId getFlowId(String dagId) {
+    List<String> splitDagId = Splitter.on("_").splitToList(dagId);
+    if (splitDagId.size() != 3) {
+      throw new IllegalArgumentException(dagId + " is not a valid dagId, expected format group_name_id");
+    }
+    return new FlowId().setFlowGroup(splitDagId.get(0)).setFlowName(splitDagId.get(1));
+  }
+
   static long getFlowExecId(Dag<JobExecutionPlan> dag) {
     return getFlowExecId(dag.getStartNodes().get(0));
   }
@@ -69,6 +78,14 @@ public class DagManagerUtils {
 
   static long getFlowExecId(JobSpec jobSpec) {
     return jobSpec.getConfig().getLong(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+  }
+
+  static long getFlowExecId(String dagId) {
+    List<String> splitDagId = Splitter.on("_").splitToList(dagId);
+    if (splitDagId.size() != 3) {
+      throw new IllegalArgumentException(dagId + " is not a valid dagId, expected format group_name_id");
+    }
+    return Long.parseLong(splitDagId.get(2));
   }
 
   /**
@@ -94,18 +111,6 @@ public class DagManagerUtils {
 
   static String generateDagId(String flowGroup, String flowName, long flowExecutionId) {
     return Joiner.on("_").join(flowGroup, flowName, flowExecutionId);
-  }
-
-  /**
-   * Generate a FlowId from the given {@link Dag} instance.
-   * FlowId, comparing to DagId, doesn't contain FlowExecutionId so different {@link Dag} could possibly have same
-   * {@link FlowId}.
-   * @param dag
-   * @return
-   */
-  static String generateFlowIdInString(Dag<JobExecutionPlan> dag) {
-    FlowId flowId = getFlowId(dag);
-    return Joiner.on("_").join(flowId.getFlowGroup(), flowId.getFlowName());
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStore.java
@@ -47,9 +47,26 @@ public interface DagStateStore {
   void cleanUp(Dag<JobExecutionPlan> dag) throws IOException;
 
   /**
+   * Delete the {@link Dag} from the backing store, typically upon completion of execution.
+   * @param dagId The ID of the dag to clean up.
+   */
+  void cleanUp(String dagId) throws IOException;
+
+  /**
    * Load all currently running {@link Dag}s from the underlying store. Typically, invoked when a new {@link DagManager}
    * takes over or on restart of service.
    * @return a {@link List} of currently running {@link Dag}s.
    */
   List<Dag<JobExecutionPlan>> getDags() throws IOException;
+
+  /**
+   * Return a single dag from the dag state store.
+   * @param dagId The ID of the dag to load.
+   */
+  Dag<JobExecutionPlan> getDag(String dagId) throws IOException;
+
+  /**
+   * Return a list of all dag IDs contained in the dag state store.
+   */
+  List<String> getDagIds() throws IOException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStore.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
@@ -68,5 +69,5 @@ public interface DagStateStore {
   /**
    * Return a list of all dag IDs contained in the dag state store.
    */
-  List<String> getDagIds() throws IOException;
+  Set<String> getDagIds() throws IOException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStore.java
@@ -21,8 +21,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -157,8 +159,8 @@ public class FSDagStateStore implements DagStateStore {
    * {@inheritDoc}
    */
   @Override
-  public List<String> getDagIds() {
-    List<String> dagIds = Lists.newArrayList();
+  public Set<String> getDagIds() {
+    Set<String> dagIds = new HashSet<>();
     File dagCheckpointFolder = new File(this.dagCheckpointDir);
 
     for (File file : dagCheckpointFolder.listFiles((dir, name) -> name.endsWith(DAG_FILE_EXTENSION))) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -83,7 +83,7 @@ public class DagManagerTest {
     this.cancelQueue = new LinkedBlockingQueue<>();
     this.resumeQueue = new LinkedBlockingQueue<>();
     this._dagManagerThread = new DagManager.DagManagerThread(_jobStatusRetriever, _dagStateStore, _dagStateStore, queue, cancelQueue,
-        resumeQueue, true, 5, new HashMap<>(), new ConcurrentHashMap<>());
+        resumeQueue, true, 5, new HashMap<>(), new ArrayList<>());
 
     Field jobToDagField = DagManager.DagManagerThread.class.getDeclaredField("jobToDag");
     jobToDagField.setAccessible(true);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -23,15 +23,16 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.gobblin.metrics.event.TimingEvent;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -69,7 +70,7 @@ public class DagManagerTest {
   private Map<DagNode<JobExecutionPlan>, Dag<JobExecutionPlan>> jobToDag;
   private Map<String, LinkedList<DagNode<JobExecutionPlan>>> dagToJobs;
   private Map<String, Dag<JobExecutionPlan>> dags;
-  private Map<String, Dag<JobExecutionPlan>> failedDags;
+  private Set<String> failedDagIds;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -78,12 +79,13 @@ public class DagManagerTest {
         .withValue(FSDagStateStore.DAG_STATESTORE_DIR, ConfigValueFactory.fromAnyRef(this.dagStateStoreDir));
 
     this._dagStateStore = new FSDagStateStore(config, new HashMap<>());
+    DagStateStore failedDagStateStore = new InMemoryDagStateStore();
     this._jobStatusRetriever = Mockito.mock(JobStatusRetriever.class);
     this.queue = new LinkedBlockingQueue<>();
     this.cancelQueue = new LinkedBlockingQueue<>();
     this.resumeQueue = new LinkedBlockingQueue<>();
-    this._dagManagerThread = new DagManager.DagManagerThread(_jobStatusRetriever, _dagStateStore, _dagStateStore, queue, cancelQueue,
-        resumeQueue, true, 5, new HashMap<>(), new ArrayList<>());
+    this._dagManagerThread = new DagManager.DagManagerThread(_jobStatusRetriever, _dagStateStore, failedDagStateStore, queue, cancelQueue,
+        resumeQueue, true, 5, new HashMap<>(), new HashSet<>());
 
     Field jobToDagField = DagManager.DagManagerThread.class.getDeclaredField("jobToDag");
     jobToDagField.setAccessible(true);
@@ -97,9 +99,9 @@ public class DagManagerTest {
     dagsField.setAccessible(true);
     this.dags = (Map<String, Dag<JobExecutionPlan>>) dagsField.get(this._dagManagerThread);
 
-    Field failedDagsField = DagManager.DagManagerThread.class.getDeclaredField("failedDags");
-    failedDagsField.setAccessible(true);
-    this.failedDags = (Map<String, Dag<JobExecutionPlan>>) failedDagsField.get(this._dagManagerThread);
+    Field failedDagIdsField = DagManager.DagManagerThread.class.getDeclaredField("failedDagIds");
+    failedDagIdsField.setAccessible(true);
+    this.failedDagIds = (Set<String>) failedDagIdsField.get(this._dagManagerThread);
   }
 
   /**
@@ -335,7 +337,7 @@ public class DagManagerTest {
   }
 
   @Test (dependsOnMethods = "testFailedDag")
-  public void testResumeDag() throws URISyntaxException, IOException {
+  public void testResumeDag() throws URISyntaxException {
     long flowExecutionId = System.currentTimeMillis();
     String flowGroupId = "0";
     String flowGroup = "group" + flowGroupId;
@@ -394,19 +396,19 @@ public class DagManagerTest {
       this._dagManagerThread.run();
     }
 
-    Assert.assertTrue(this.failedDags.containsKey(dagId));
+    Assert.assertTrue(this.failedDagIds.contains(dagId));
 
     // Resume dag
     this.resumeQueue.offer(dagId);
 
     // Job2 rerunning
     this._dagManagerThread.run();
-    Assert.assertFalse(this.failedDags.containsKey(dagId));
+    Assert.assertFalse(this.failedDagIds.contains(dagId));
     Assert.assertTrue(this.dags.containsKey(dagId));
 
     // Job2 complete
     this._dagManagerThread.run();
-    Assert.assertFalse(this.failedDags.containsKey(dagId));
+    Assert.assertFalse(this.failedDagIds.contains(dagId));
     Assert.assertFalse(this.dags.containsKey(dagId));
   }
 
@@ -618,25 +620,52 @@ public class DagManagerTest {
     this.cancelQueue.offer(dagId);
 
     this._dagManagerThread.run();
-    Assert.assertTrue(this.failedDags.containsKey(dagId));
-    Assert.assertTrue((this.failedDags.get(dagId).getFlowEvent() == null));
+    Assert.assertTrue(this.failedDagIds.contains(dagId));
 
     // Resume dag
     this.resumeQueue.offer(dagId);
 
     // Job2 rerunning
     this._dagManagerThread.run();
-    Assert.assertFalse(this.failedDags.containsKey(dagId));
+    Assert.assertFalse(this.failedDagIds.contains(dagId));
     Assert.assertTrue(this.dags.containsKey(dagId));
 
     // Job2 complete
     this._dagManagerThread.run();
-    Assert.assertFalse(this.failedDags.containsKey(dagId));
+    Assert.assertFalse(this.failedDagIds.contains(dagId));
     Assert.assertFalse(this.dags.containsKey(dagId));
   }
 
   @AfterClass
   public void cleanUp() throws Exception {
     FileUtils.deleteDirectory(new File(this.dagStateStoreDir));
+  }
+
+  public static class InMemoryDagStateStore implements DagStateStore {
+    private final Map<String, Dag<JobExecutionPlan>> dags = new ConcurrentHashMap<>();
+
+    public void writeCheckpoint(Dag<JobExecutionPlan> dag) {
+      dags.put(DagManagerUtils.generateDagId(dag), dag);
+    }
+
+    public void cleanUp(Dag<JobExecutionPlan> dag) {
+      cleanUp(DagManagerUtils.generateDagId(dag));
+    }
+
+    public void cleanUp(String dagId) {
+      dags.remove(dagId);
+    }
+
+    public List<Dag<JobExecutionPlan>> getDags() {
+      return new ArrayList<>(dags.values());
+    }
+
+    public Dag<JobExecutionPlan> getDag(String dagId) {
+      return dags.get(dagId);
+    }
+
+    public Set<String> getDagIds() {
+      return dags.keySet();
+    }
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
@@ -141,7 +142,7 @@ public class FSDagStateStoreTest {
       Assert.assertTrue(Boolean.parseBoolean(dag.getNodes().get(1).getValue().getJobFuture().get().get().toString()));
     }
 
-    List<String> dagIds = this._dagStateStore.getDagIds();
+    Set<String> dagIds = this._dagStateStore.getDagIds();
     Assert.assertEquals(dagIds.size(), 2);
     for (Dag<JobExecutionPlan> dag: dags) {
       Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag)));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
@@ -108,6 +108,11 @@ public class FSDagStateStoreTest {
     Assert.assertTrue(dagFile.exists());
     this._dagStateStore.cleanUp(dag);
     Assert.assertFalse(dagFile.exists());
+
+    this._dagStateStore.writeCheckpoint(dag);
+    Assert.assertTrue(dagFile.exists());
+    this._dagStateStore.cleanUp(DagManagerUtils.generateDagId(dag));
+    Assert.assertFalse(dagFile.exists());
   }
 
   @Test (dependsOnMethods = "testCleanUp")
@@ -123,6 +128,8 @@ public class FSDagStateStoreTest {
 
     List<Dag<JobExecutionPlan>> dags = this._dagStateStore.getDags();
     Assert.assertEquals(dags.size(), 2);
+    Dag<JobExecutionPlan> singleDag = this._dagStateStore.getDag(DagManagerUtils.generateDagId(dags.get(0)));
+    dags.add(singleDag);
     for (Dag<JobExecutionPlan> dag: dags) {
       Assert.assertEquals(dag.getNodes().size(), 2);
       Assert.assertEquals(dag.getStartNodes().size(), 1);
@@ -132,6 +139,12 @@ public class FSDagStateStoreTest {
       Assert.assertEquals(dag.getNodes().get(1).getValue().getSpecExecutor().getUri(), specExecURI);
       Assert.assertTrue(Boolean.parseBoolean(dag.getNodes().get(0).getValue().getJobFuture().get().get().toString()));
       Assert.assertTrue(Boolean.parseBoolean(dag.getNodes().get(1).getValue().getJobFuture().get().get().toString()));
+    }
+
+    List<String> dagIds = this._dagStateStore.getDagIds();
+    Assert.assertEquals(dagIds.size(), 2);
+    for (Dag<JobExecutionPlan> dag: dags) {
+      Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag)));
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.dbcp.BasicDataSource;
 import org.testng.Assert;
@@ -80,10 +81,11 @@ public class MysqlDagStateStoreTest {
 
     // Verify get one dag
     Dag<JobExecutionPlan> dag = _dagStateStore.getDag(DagManagerUtils.generateDagId(dag_0));
-    Assert.assertEquals(dag, dag_0);
+    Assert.assertEquals(dag.getNodes().get(0), dag_0.getNodes().get(0));
+    Assert.assertEquals(dag.getNodes().get(1), dag_0.getNodes().get(1));
 
     // Verify get dagIds
-    List<String> dagIds = _dagStateStore.getDagIds();
+    Set<String> dagIds = _dagStateStore.getDagIds();
     Assert.assertEquals(dagIds.size(), 2);
     Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag_0)));
     Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag_1)));
@@ -132,7 +134,7 @@ public class MysqlDagStateStoreTest {
     }
   }
 
-  @Test (dependsOnMethods = "testWriteCheckpointAndGetAll")
+  @Test (dependsOnMethods = "testWriteCheckpointAndGet")
   public void testCleanUp() throws Exception {
     Dag<JobExecutionPlan> dag_0 = DagTestUtils.buildDag("random_0", 123L);
     Dag<JobExecutionPlan> dag_1 = DagTestUtils.buildDag("random_1", 456L);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
@@ -72,12 +72,23 @@ public class MysqlDagStateStoreTest {
 
 
   @Test
-  public void testWriteCheckpointAndGetAll() throws Exception{
+  public void testWriteCheckpointAndGet() throws Exception{
     Dag<JobExecutionPlan> dag_0 = DagTestUtils.buildDag("random_0", 123L);
     Dag<JobExecutionPlan> dag_1 = DagTestUtils.buildDag("random_1", 456L);
     _dagStateStore.writeCheckpoint(dag_0);
     _dagStateStore.writeCheckpoint(dag_1);
 
+    // Verify get one dag
+    Dag<JobExecutionPlan> dag = _dagStateStore.getDag(DagManagerUtils.generateDagId(dag_0));
+    Assert.assertEquals(dag, dag_0);
+
+    // Verify get dagIds
+    List<String> dagIds = _dagStateStore.getDagIds();
+    Assert.assertEquals(dagIds.size(), 2);
+    Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag_0)));
+    Assert.assertTrue(dagIds.contains(DagManagerUtils.generateDagId(dag_1)));
+
+    // Verify get all dags
     List<Dag<JobExecutionPlan>> dags = _dagStateStore.getDags();
     Assert.assertEquals(dags.size(), 2);
 
@@ -132,7 +143,7 @@ public class MysqlDagStateStoreTest {
     Assert.assertEquals(dags.size(), 2);
 
     _dagStateStore.cleanUp(dags.get(0));
-    _dagStateStore.cleanUp(dags.get(1));
+    _dagStateStore.cleanUp(DagManagerUtils.generateDagId(dags.get(1)));
 
     dags = _dagStateStore.getDags();
     Assert.assertEquals(dags.size(), 0);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1438


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This PR changes failed dags to only be loaded if resume is called (and only the dag that was resumed is loaded) to avoid keeping all failed dags in memory at all times, since this can cause memory issues.

Changes for this:
- In `DagManager`, keep a list of failed dagIds instead of a map of all failed dags. This list is still needed to know which dags to clean up, and also allows us to avoid calling the dag store for dags that aren't there.
- Add an API in `DagStateStore` to load only one dag, because previously the only option was to load all dags at once, which would still cause memory issues.
- Add an API  in `DagStateStore` to get all dag IDs

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated unit tests and tested resuming locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

