### PR TITLE
[GOBBLIN-1440] move cancel job logic from job catalog listeners to kafkajob monitor

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
@@ -55,6 +55,8 @@ public interface SpecExecutor {
    * a consumer on the physical executor side. */
   Future<? extends SpecProducer<Spec>> getProducer();
 
+  String VERB_KEY = "Verb";
+
   public static enum Verb {
     ADD(1, "add"),
     UPDATE(2, "update"),

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
@@ -114,9 +114,6 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
           this.jobCatalogOptional.get().remove(jobSpec.getUri());
         }
         postDeleteJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
-      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
-          // Handle cancel
-          postCancelJobConfigArrival(jobSpec.getUri().toString());
       }
 
       try {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -379,10 +379,6 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
    * Build the {@link JobConfigurationManager} for the Application Master.
    */
   private JobConfigurationManager buildJobConfigurationManager(Config config) {
-    return create(config);
-  }
-
-  private JobConfigurationManager create(Config config) {
     try {
       List<Object> argumentList = (this.jobCatalog != null)? ImmutableList.of(this.eventBus, config, this.jobCatalog, this.fs) :
           ImmutableList.of(this.eventBus, config, this.fs);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -62,6 +62,8 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.job_catalog.JobConfigArrivalEvent;
 import org.apache.gobblin.runtime.listeners.JobListener;
 import org.apache.gobblin.scheduler.JobScheduler;
 import org.apache.gobblin.scheduler.SchedulerService;
@@ -370,9 +372,15 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
   }
 
   @Subscribe
-  public void handleCancelJobConfigArrival(CancelJobConfigArrivalEvent cancelJobArrival)
+  public void handleJobConfigArrival(JobConfigArrivalEvent jobArrival)
       throws InterruptedException {
-    String jobUri = cancelJobArrival.getJoburi();
+    String jobUri = jobArrival.uri.toString();
+
+    if (jobArrival.verb != SpecExecutor.Verb.CANCEL) {
+      LOGGER.info("Received {} event for job uri {}. Taking no action.", jobArrival.verb, jobUri);
+      return;
+    }
+
     LOGGER.info("Received cancel for job configuration of job " + jobUri);
     Optional<String> distributedJobMode;
     Optional<String> planningJob = Optional.empty();

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
@@ -161,9 +161,4 @@ public class JobConfigurationManager extends AbstractIdleService implements Stan
     LOGGER.info(String.format("Posting delete JobConfig with name: %s and config: %s", jobName, jobConfig));
     this.eventBus.post(new DeleteJobConfigArrivalEvent(jobName, jobConfig));
   }
-
-  protected void postCancelJobConfigArrival(String jobUri) {
-    LOGGER.info(String.format("Posting cancel JobConfig with name: %s", jobUri));
-    this.eventBus.post(new CancelJobConfigArrivalEvent(jobUri));
-  }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ScheduledJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ScheduledJobConfigurationManager.java
@@ -140,11 +140,7 @@ public class ScheduledJobConfigurationManager extends JobConfigurationManager {
         Spec anonymousSpec = (Spec) entry.getValue();
         postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), new Properties());
         jobSpecs.remove(entry.getValue().getUri());
-      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
-        // Handle cancel
-        Spec anonymousSpec = entry.getValue();
-        postCancelJobConfigArrival(anonymousSpec.getUri().toString());
-        }
+      }
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
@@ -88,6 +88,7 @@ public class StreamingJobConfigurationManager extends JobConfigurationManager {
 
       this.specConsumer = (SpecConsumer) GobblinConstructorUtils.invokeFirstConstructor(
           Class.forName(aliasResolver.resolve(specExecutorInstanceConsumerClassName)),
+          ImmutableList.<Object>of(config, jobCatalog, Optional.of(eventBus)),
           ImmutableList.<Object>of(config, jobCatalog),
           ImmutableList.<Object>of(config));
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
@@ -160,9 +161,6 @@ public class StreamingJobConfigurationManager extends JobConfigurationManager {
         // Handle delete
         Spec anonymousSpec = entry.getValue();
         postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), new Properties());
-      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
-        Spec anonymousSpec = entry.getValue();
-        postCancelJobConfigArrival(anonymousSpec.getUri().toString());
       }
     }
   }

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobMonitorTest.java
@@ -57,7 +57,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new NoopSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 1);
     Assert.assertEquals(monitor.events.size(), 1);
     Assert.assertEquals(monitor.events.get(0), event);
@@ -76,7 +76,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(MetricReport.SCHEMA$, new NoopSchemaVersionWriter());
 
     MetricReport event = new MetricReport(Maps.<String, String>newHashMap(), 0L, Lists.<Metric>newArrayList());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
 
     Assert.assertEquals(results.size(), 0);
     Assert.assertEquals(monitor.events.size(), 0);
@@ -96,7 +96,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new FixedSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 1);
     Assert.assertEquals(monitor.events.size(), 1);
     Assert.assertEquals(monitor.events.get(0), event);
@@ -114,7 +114,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new FixedSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 0);
     Assert.assertEquals(monitor.events.size(), 0);
     Assert.assertEquals(monitor.getMessageParseFailures().getCount(), 1);
@@ -132,9 +132,9 @@ public class KafkaAvroJobMonitorTest {
     }
 
     @Override
-    public Collection<Either<JobSpec, URI>> parseJobSpec(GobblinTrackingEvent message) {
+    public Collection<JobSpec> parseJobSpec(GobblinTrackingEvent message) {
       this.events.add(message);
-      return Lists.newArrayList(Either.<JobSpec, URI>left(JobSpec.builder(message.getName()).build()));
+      return Lists.newArrayList(JobSpec.builder(message.getName()).build());
     }
 
     @Override

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/SLAEventKafkaJobMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/SLAEventKafkaJobMonitorTest.java
@@ -68,10 +68,10 @@ public class SLAEventKafkaJobMonitorTest {
 
     GobblinTrackingEvent event = createSLAEvent("DatasetPublish", new URI("/data/myDataset"),
         ImmutableMap.of("metadataKey1","value1","key1","value2"));
-    Collection<Either<JobSpec, URI>> jobSpecs = monitor.parseJobSpec(event);
+    Collection<JobSpec> jobSpecs = monitor.parseJobSpec(event);
 
     Assert.assertEquals(jobSpecs.size(), 1);
-    JobSpec jobSpec = (JobSpec) jobSpecs.iterator().next().get();
+    JobSpec jobSpec = jobSpecs.iterator().next();
     Assert.assertEquals(jobSpec.getUri(), new URI("/base/URI/data/myDataset"));
     Assert.assertEquals(jobSpec.getTemplateURI().get(), templateURI);
     // should insert configuration from metadata
@@ -92,7 +92,7 @@ public class SLAEventKafkaJobMonitorTest {
     monitor.buildMetricsContextAndMetrics();
 
     GobblinTrackingEvent event;
-    Collection<Either<JobSpec, URI>> jobSpecs;
+    Collection<JobSpec> jobSpecs;
 
     event = createSLAEvent("acceptthis", new URI("/data/myDataset"), Maps.<String, String>newHashMap());
     jobSpecs = monitor.parseJobSpec(event);
@@ -123,7 +123,7 @@ public class SLAEventKafkaJobMonitorTest {
     monitor.buildMetricsContextAndMetrics();
 
     GobblinTrackingEvent event;
-    Collection<Either<JobSpec, URI>> jobSpecs;
+    Collection<JobSpec> jobSpecs;
 
     event = createSLAEvent("event", new URI("/accept/myDataset"), Maps.<String, String>newHashMap());
     jobSpecs = monitor.parseJobSpec(event);

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecConsumer.java
@@ -62,7 +62,6 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 import org.apache.gobblin.util.CompletedFuture;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.apache.gobblin.service.SimpleKafkaSpecExecutor.VERB_KEY;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -193,10 +192,10 @@ public class SimpleKafkaSpecConsumer implements SpecConsumer<Spec>, Closeable {
             jobSpecBuilder.withTemplate(new URI(record.getTemplateUri()));
           }
 
-          String verbName = record.getMetadata().get(VERB_KEY);
+          String verbName = record.getMetadata().get(SpecExecutor.VERB_KEY);
           SpecExecutor.Verb verb = SpecExecutor.Verb.valueOf(verbName);
 
-          changesSpecs.add(new ImmutablePair<SpecExecutor.Verb, Spec>(verb, jobSpecBuilder.build()));
+          changesSpecs.add(new ImmutablePair<>(verb, jobSpecBuilder.build()));
         } catch (Throwable t) {
           log.error("Could not decode record at partition " + this.currentPartitionIdx +
               " offset " + nextValidMessage.getOffset());
@@ -204,7 +203,7 @@ public class SimpleKafkaSpecConsumer implements SpecConsumer<Spec>, Closeable {
       }
     }
 
-    return new CompletedFuture(changesSpecs, null);
+    return new CompletedFuture<>(changesSpecs, null);
   }
 
   private void initializeWatermarks() {

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
@@ -39,9 +39,6 @@ import org.apache.gobblin.util.CompletedFuture;
 public class SimpleKafkaSpecExecutor extends AbstractSpecExecutor {
   public static final String SPEC_KAFKA_TOPICS_KEY = "spec.kafka.topics";
 
-
-  protected static final String VERB_KEY = "Verb";
-
   private SpecProducer<Spec> specProducer;
 
   public SimpleKafkaSpecExecutor(Config config, Optional<Logger> log) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -51,7 +51,6 @@ import org.apache.gobblin.util.filters.HiddenFilter;
 @Slf4j
 public class FsSpecConsumer implements SpecConsumer<Spec> {
   public static final String SPEC_PATH_KEY = "gobblin.cluster.specConsumer.path";
-  public static final String VERB_KEY = "Verb";
 
   private final Path specDirPath;
   private final FileSystem fs;
@@ -125,7 +124,7 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
           continue;
         }
 
-        String verbName = avroJobSpec.getMetadata().get(VERB_KEY);
+        String verbName = avroJobSpec.getMetadata().get(SpecExecutor.VERB_KEY);
         SpecExecutor.Verb verb = SpecExecutor.Verb.valueOf(verbName);
 
         JobSpec jobSpec = jobSpecBuilder.build();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -52,8 +52,6 @@ import org.apache.gobblin.util.HadoopUtils;
  */
 @Slf4j
 public class FsSpecProducer implements SpecProducer<Spec> {
-  protected static final String VERB_KEY = "Verb";
-
   private Path specConsumerPath;
   private FileSystem fs;
 
@@ -107,7 +105,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
   @Override
   public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
     AvroJobSpec avroJobSpec = AvroJobSpec.newBuilder().setUri(deletedSpecURI.toString())
-        .setMetadata(ImmutableMap.of(VERB_KEY, SpecExecutor.Verb.DELETE.name()))
+        .setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.DELETE.name()))
         .setProperties(Maps.fromProperties(headers)).build();
     try {
       writeAvroJobSpec(avroJobSpec);
@@ -131,7 +129,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
         setTemplateUri("FS:///").
         setDescription(jobSpec.getDescription()).
         setVersion(jobSpec.getVersion()).
-        setMetadata(ImmutableMap.of(VERB_KEY, verb.name())).build();
+        setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, verb.name())).build();
   }
 
   private void writeAvroJobSpec(AvroJobSpec jobSpec) throws IOException {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalogListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalogListener.java
@@ -37,9 +37,6 @@ public interface JobCatalogListener {
    */
   public void onDeleteJob(URI deletedJobURI, String deletedJobVersion);
 
-  default void onCancelJob(URI cancelledJobURI) {
-  }
-
   /**
    * Invoked when the contents of a JobSpec gets updated in the catalog.
    */
@@ -75,21 +72,6 @@ public interface JobCatalogListener {
 
     @Override public Void apply(JobCatalogListener listener) {
       listener.onDeleteJob(_deletedJobURI, _deletedJobVersion);
-      return null;
-    }
-  }
-
-  public static class CancelJobCallback extends Callback<JobCatalogListener, Void> {
-    private final URI _cancelledJobURI;
-
-    public CancelJobCallback(URI cancelledJobURI) {
-      super(Objects.toStringHelper("onCancelJob").add("cancelJob", cancelledJobURI).toString());
-      _cancelledJobURI = cancelledJobURI;
-    }
-
-    @Override
-    public Void apply(JobCatalogListener listener) {
-      listener.onCancelJob(_cancelledJobURI);
       return null;
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobSpec.java
@@ -78,7 +78,6 @@ public class JobSpec implements Configurable, Spec {
   Map<String, String> metadata;
 
   /** A Verb identifies if the Spec is for Insert/Update/Delete */
-  public static final String VERB_KEY = "Verb";
   private static final String IN_MEMORY_TEMPLATE_URI = "inmemory";
 
   public static Builder builder(URI jobSpecUri) {
@@ -344,7 +343,7 @@ public class JobSpec implements Configurable, Spec {
 
     public Map getDefaultMetadata() {
       log.debug("Job Spec Verb is not provided, using type 'UNKNOWN'.");
-      return ImmutableMap.of(VERB_KEY, SpecExecutor.Verb.UNKNOWN.name());
+      return ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.UNKNOWN.name());
     }
 
     public Map getMetadata() {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableJobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableJobCatalog.java
@@ -17,16 +17,12 @@
 package org.apache.gobblin.runtime.api;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.gobblin.annotation.Alpha;
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.metrics.ContextAwareMetric;
 import org.apache.gobblin.metrics.ContextAwareTimer;
-import org.apache.gobblin.util.ConfigUtils;
 
 import com.google.common.base.Optional;
 import com.typesafe.config.Config;
@@ -47,10 +43,6 @@ public interface MutableJobCatalog extends JobCatalog {
    * it will be replaced.
    * */
   public void put(JobSpec jobSpec);
-
-  default void remove(URI uri, boolean alwaysTriggerListeners) {
-    throw new UnsupportedOperationException("Method not implemented by " + this.getClass());
-  }
 
   /**
    * Removes an existing JobSpec with the given URI. A no-op if such JobSpec does not exist.

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobCatalogListenersList.java
@@ -99,17 +99,6 @@ public class JobCatalogListenersList implements JobCatalogListener, JobCatalogLi
   }
 
   @Override
-  public synchronized void onCancelJob(URI cancelledJobURI) {
-    Preconditions.checkNotNull(cancelledJobURI);
-
-    try {
-      _disp.execCallbacks(new CancelJobCallback(cancelledJobURI));
-    } catch (InterruptedException e) {
-      getLog().warn("onCancelJob interrupted.");
-    }
-  }
-
-  @Override
   public void close()
       throws IOException {
     _disp.close();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobConfigArrivalEvent.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobConfigArrivalEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.job_catalog;
+
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import java.net.URI;
+
+public class JobConfigArrivalEvent {
+  public final URI uri;
+  public final SpecExecutor.Verb verb;
+
+  public JobConfigArrivalEvent(URI uri, SpecExecutor.Verb verb) {
+    this.uri = uri;
+    this.verb = verb;
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/NonObservingFSJobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/NonObservingFSJobCatalog.java
@@ -102,10 +102,6 @@ public class NonObservingFSJobCatalog extends FSJobCatalog {
    */
   @Override
   public synchronized void remove(URI jobURI) {
-      remove(jobURI, false);
-  }
-
-  public synchronized void remove(URI jobURI, boolean alwaysTriggerListeners) {
     Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
     try {
       long startTime = System.currentTimeMillis();
@@ -123,12 +119,6 @@ public class NonObservingFSJobCatalog extends FSJobCatalog {
       throw new RuntimeException("When removing a JobConf. file, issues unexpected happen:" + e.getMessage());
     } catch (SpecNotFoundException e) {
       LOGGER.warn("No file with URI:" + jobURI + " is found. Deletion failed.");
-    } finally {
-      // HelixRetriggeringJobCallable deletes the job file after submitting it to helix,
-      // so we will have to trigger listeners regardless the existence of job file to cancel the job
-      if (alwaysTriggerListeners) {
-        this.listeners.onCancelJob(jobURI);
-      }
     }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaAvroJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaAvroJobMonitor.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
@@ -35,15 +34,14 @@ import org.apache.avro.specific.SpecificDatumReader;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.reporter.util.SchemaVersionWriter;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.metrics.RuntimeMetrics;
-import org.apache.gobblin.util.Either;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -68,7 +66,12 @@ public abstract class KafkaAvroJobMonitor<T> extends KafkaJobMonitor {
 
   public KafkaAvroJobMonitor(String topic, MutableJobCatalog catalog, Config config, Schema schema,
       SchemaVersionWriter<?> versionWriter) {
-    super(topic, catalog, config);
+    this(topic, catalog, config, schema, versionWriter, Optional.absent());
+  }
+
+  public KafkaAvroJobMonitor(String topic, MutableJobCatalog catalog, Config config, Schema schema,
+        SchemaVersionWriter<?> versionWriter, Optional<EventBus> eventBus) {
+    super(topic, catalog, eventBus, config);
 
     this.schema = schema;
     this.decoder = new ThreadLocal<BinaryDecoder>() {
@@ -102,7 +105,7 @@ public abstract class KafkaAvroJobMonitor<T> extends KafkaJobMonitor {
   }
 
   @Override
-  public Collection<Either<JobSpec, URI>> parseJobSpec(byte[] message)
+  public Collection<JobSpec> parseJobSpec(byte[] message)
       throws IOException {
 
     InputStream is = new ByteArrayInputStream(message);
@@ -126,5 +129,5 @@ public abstract class KafkaAvroJobMonitor<T> extends KafkaJobMonitor {
   /**
    * Extract {@link JobSpec}s from the Kafka message.
    */
-  public abstract Collection<Either<JobSpec, URI>> parseJobSpec(T message);
+  public abstract Collection<JobSpec> parseJobSpec(T message);
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/SLAEventKafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/SLAEventKafkaJobMonitor.java
@@ -172,7 +172,7 @@ public class SLAEventKafkaJobMonitor extends KafkaAvroJobMonitor<GobblinTracking
   }
 
   @Override
-  public Collection<Either<JobSpec, URI>> parseJobSpec(GobblinTrackingEvent event) {
+  public Collection<JobSpec> parseJobSpec(GobblinTrackingEvent event) {
 
     if (!acceptEvent(event)) {
       this.rejectedEvents.inc();
@@ -192,7 +192,7 @@ public class SLAEventKafkaJobMonitor extends KafkaAvroJobMonitor<GobblinTracking
 
     JobSpec jobSpec = JobSpec.builder(jobSpecURI).withTemplate(this.template).withConfig(jobConfig).build();
 
-    return Lists.newArrayList(Either.<JobSpec, URI>left(jobSpec));
+    return Lists.newArrayList(jobSpec);
   }
 
   /**


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1440


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- make KafkaJobMonitor s parseJobSpec() method return the entire JobSpec, so that the caller method processMessage() can distinguish between a DELETE FLOW and CANCEL JOB requests and take appropriate actions. 
- move cancel job logic from job catalog listeners to kafkajob monitor and remove dead code around job catalog cancel job feature mainly introduced in PR 3155
-some minor refactoring

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
existing test cases

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

