### PR TITLE
[GOBBLIN-1441] separate delete and cancel specs in KafkaJobMonitor

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
@@ -55,6 +55,8 @@ public interface SpecExecutor {
    * a consumer on the physical executor side. */
   Future<? extends SpecProducer<Spec>> getProducer();
 
+  String VERB_KEY = "Verb";
+
   public static enum Verb {
     ADD(1, "add"),
     UPDATE(2, "update"),

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -379,10 +379,6 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
    * Build the {@link JobConfigurationManager} for the Application Master.
    */
   private JobConfigurationManager buildJobConfigurationManager(Config config) {
-    return create(config);
-  }
-
-  private JobConfigurationManager create(Config config) {
     try {
       List<Object> argumentList = (this.jobCatalog != null)? ImmutableList.of(this.eventBus, config, this.jobCatalog, this.fs) :
           ImmutableList.of(this.eventBus, config, this.fs);

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobMonitorTest.java
@@ -57,7 +57,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new NoopSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 1);
     Assert.assertEquals(monitor.events.size(), 1);
     Assert.assertEquals(monitor.events.get(0), event);
@@ -76,7 +76,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(MetricReport.SCHEMA$, new NoopSchemaVersionWriter());
 
     MetricReport event = new MetricReport(Maps.<String, String>newHashMap(), 0L, Lists.<Metric>newArrayList());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
 
     Assert.assertEquals(results.size(), 0);
     Assert.assertEquals(monitor.events.size(), 0);
@@ -96,7 +96,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new FixedSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 1);
     Assert.assertEquals(monitor.events.size(), 1);
     Assert.assertEquals(monitor.events.get(0), event);
@@ -114,7 +114,7 @@ public class KafkaAvroJobMonitorTest {
         new AvroBinarySerializer<>(GobblinTrackingEvent.SCHEMA$, new FixedSchemaVersionWriter());
 
     GobblinTrackingEvent event = new GobblinTrackingEvent(0L, "namespace", "event", Maps.<String, String>newHashMap());
-    Collection<Either<JobSpec, URI>> results = monitor.parseJobSpec(serializer.serializeRecord(event));
+    Collection<JobSpec> results = monitor.parseJobSpec(serializer.serializeRecord(event));
     Assert.assertEquals(results.size(), 0);
     Assert.assertEquals(monitor.events.size(), 0);
     Assert.assertEquals(monitor.getMessageParseFailures().getCount(), 1);
@@ -132,9 +132,9 @@ public class KafkaAvroJobMonitorTest {
     }
 
     @Override
-    public Collection<Either<JobSpec, URI>> parseJobSpec(GobblinTrackingEvent message) {
+    public Collection<JobSpec> parseJobSpec(GobblinTrackingEvent message) {
       this.events.add(message);
-      return Lists.newArrayList(Either.<JobSpec, URI>left(JobSpec.builder(message.getName()).build()));
+      return Lists.newArrayList(JobSpec.builder(message.getName()).build());
     }
 
     @Override

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/SLAEventKafkaJobMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/SLAEventKafkaJobMonitorTest.java
@@ -68,10 +68,10 @@ public class SLAEventKafkaJobMonitorTest {
 
     GobblinTrackingEvent event = createSLAEvent("DatasetPublish", new URI("/data/myDataset"),
         ImmutableMap.of("metadataKey1","value1","key1","value2"));
-    Collection<Either<JobSpec, URI>> jobSpecs = monitor.parseJobSpec(event);
+    Collection<JobSpec> jobSpecs = monitor.parseJobSpec(event);
 
     Assert.assertEquals(jobSpecs.size(), 1);
-    JobSpec jobSpec = (JobSpec) jobSpecs.iterator().next().get();
+    JobSpec jobSpec = jobSpecs.iterator().next();
     Assert.assertEquals(jobSpec.getUri(), new URI("/base/URI/data/myDataset"));
     Assert.assertEquals(jobSpec.getTemplateURI().get(), templateURI);
     // should insert configuration from metadata
@@ -92,7 +92,7 @@ public class SLAEventKafkaJobMonitorTest {
     monitor.buildMetricsContextAndMetrics();
 
     GobblinTrackingEvent event;
-    Collection<Either<JobSpec, URI>> jobSpecs;
+    Collection<JobSpec> jobSpecs;
 
     event = createSLAEvent("acceptthis", new URI("/data/myDataset"), Maps.<String, String>newHashMap());
     jobSpecs = monitor.parseJobSpec(event);
@@ -123,7 +123,7 @@ public class SLAEventKafkaJobMonitorTest {
     monitor.buildMetricsContextAndMetrics();
 
     GobblinTrackingEvent event;
-    Collection<Either<JobSpec, URI>> jobSpecs;
+    Collection<JobSpec> jobSpecs;
 
     event = createSLAEvent("event", new URI("/accept/myDataset"), Maps.<String, String>newHashMap());
     jobSpecs = monitor.parseJobSpec(event);

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecConsumer.java
@@ -62,7 +62,6 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 import org.apache.gobblin.util.CompletedFuture;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.apache.gobblin.service.SimpleKafkaSpecExecutor.VERB_KEY;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -193,10 +192,10 @@ public class SimpleKafkaSpecConsumer implements SpecConsumer<Spec>, Closeable {
             jobSpecBuilder.withTemplate(new URI(record.getTemplateUri()));
           }
 
-          String verbName = record.getMetadata().get(VERB_KEY);
+          String verbName = record.getMetadata().get(SpecExecutor.VERB_KEY);
           SpecExecutor.Verb verb = SpecExecutor.Verb.valueOf(verbName);
 
-          changesSpecs.add(new ImmutablePair<SpecExecutor.Verb, Spec>(verb, jobSpecBuilder.build()));
+          changesSpecs.add(new ImmutablePair<>(verb, jobSpecBuilder.build()));
         } catch (Throwable t) {
           log.error("Could not decode record at partition " + this.currentPartitionIdx +
               " offset " + nextValidMessage.getOffset());
@@ -204,7 +203,7 @@ public class SimpleKafkaSpecConsumer implements SpecConsumer<Spec>, Closeable {
       }
     }
 
-    return new CompletedFuture(changesSpecs, null);
+    return new CompletedFuture<>(changesSpecs, null);
   }
 
   private void initializeWatermarks() {

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
@@ -39,9 +39,6 @@ import org.apache.gobblin.util.CompletedFuture;
 public class SimpleKafkaSpecExecutor extends AbstractSpecExecutor {
   public static final String SPEC_KAFKA_TOPICS_KEY = "spec.kafka.topics";
 
-
-  protected static final String VERB_KEY = "Verb";
-
   private SpecProducer<Spec> specProducer;
 
   public SimpleKafkaSpecExecutor(Config config, Optional<Logger> log) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -51,7 +51,6 @@ import org.apache.gobblin.util.filters.HiddenFilter;
 @Slf4j
 public class FsSpecConsumer implements SpecConsumer<Spec> {
   public static final String SPEC_PATH_KEY = "gobblin.cluster.specConsumer.path";
-  public static final String VERB_KEY = "Verb";
 
   private final Path specDirPath;
   private final FileSystem fs;
@@ -125,7 +124,7 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
           continue;
         }
 
-        String verbName = avroJobSpec.getMetadata().get(VERB_KEY);
+        String verbName = avroJobSpec.getMetadata().get(SpecExecutor.VERB_KEY);
         SpecExecutor.Verb verb = SpecExecutor.Verb.valueOf(verbName);
 
         JobSpec jobSpec = jobSpecBuilder.build();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -52,8 +52,6 @@ import org.apache.gobblin.util.HadoopUtils;
  */
 @Slf4j
 public class FsSpecProducer implements SpecProducer<Spec> {
-  protected static final String VERB_KEY = "Verb";
-
   private Path specConsumerPath;
   private FileSystem fs;
 
@@ -107,7 +105,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
   @Override
   public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
     AvroJobSpec avroJobSpec = AvroJobSpec.newBuilder().setUri(deletedSpecURI.toString())
-        .setMetadata(ImmutableMap.of(VERB_KEY, SpecExecutor.Verb.DELETE.name()))
+        .setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.DELETE.name()))
         .setProperties(Maps.fromProperties(headers)).build();
     try {
       writeAvroJobSpec(avroJobSpec);
@@ -131,7 +129,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
         setTemplateUri("FS:///").
         setDescription(jobSpec.getDescription()).
         setVersion(jobSpec.getVersion()).
-        setMetadata(ImmutableMap.of(VERB_KEY, verb.name())).build();
+        setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, verb.name())).build();
   }
 
   private void writeAvroJobSpec(AvroJobSpec jobSpec) throws IOException {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobSpec.java
@@ -78,7 +78,6 @@ public class JobSpec implements Configurable, Spec {
   Map<String, String> metadata;
 
   /** A Verb identifies if the Spec is for Insert/Update/Delete */
-  public static final String VERB_KEY = "Verb";
   private static final String IN_MEMORY_TEMPLATE_URI = "inmemory";
 
   public static Builder builder(URI jobSpecUri) {
@@ -344,7 +343,7 @@ public class JobSpec implements Configurable, Spec {
 
     public Map getDefaultMetadata() {
       log.debug("Job Spec Verb is not provided, using type 'UNKNOWN'.");
-      return ImmutableMap.of(VERB_KEY, SpecExecutor.Verb.UNKNOWN.name());
+      return ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.UNKNOWN.name());
     }
 
     public Map getMetadata() {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/AvroJobSpecKafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/AvroJobSpecKafkaJobMonitor.java
@@ -58,7 +58,6 @@ public class AvroJobSpecKafkaJobMonitor extends KafkaAvroJobMonitor<AvroJobSpec>
   public static final String CONFIG_PREFIX = "gobblin.jobMonitor.avroJobSpec";
   public static final String TOPIC_KEY = "topic";
   public static final String SCHEMA_VERSION_READER_CLASS = "versionReaderClass";
-  protected static final String VERB_KEY = "Verb";
   private static final Config DEFAULTS = ConfigFactory.parseMap(ImmutableMap.of(
       SCHEMA_VERSION_READER_CLASS, FixedSchemaVersionWriter.class.getName()));
 
@@ -108,10 +107,10 @@ public class AvroJobSpecKafkaJobMonitor extends KafkaAvroJobMonitor<AvroJobSpec>
   /**
    * Creates a {@link JobSpec} or {@link URI} from the {@link AvroJobSpec} record.
    * @param record the record as an {@link AvroJobSpec}
-   * @return a {@link JobSpec} or {@link URI} wrapped in a {@link Collection} of {@link Either}
+   * @return a {@link JobSpec}
    */
   @Override
-  public Collection<Either<JobSpec, URI>> parseJobSpec(AvroJobSpec record) {
+  public Collection<JobSpec> parseJobSpec(AvroJobSpec record) {
     JobSpec.Builder jobSpecBuilder = JobSpec.builder(record.getUri());
 
     Properties props = new Properties();
@@ -127,17 +126,10 @@ public class AvroJobSpecKafkaJobMonitor extends KafkaAvroJobMonitor<AvroJobSpec>
       }
     }
 
-    String verbName = record.getMetadata().get(VERB_KEY);
-    SpecExecutor.Verb verb = SpecExecutor.Verb.valueOf(verbName);
-
     JobSpec jobSpec = jobSpecBuilder.build();
 
     log.info("Parsed job spec " + jobSpec.toString());
 
-    if (verb == Verb.ADD || verb == Verb.UPDATE) {
-      return Lists.newArrayList(Either.left(jobSpec));
-    } else {
-      return Lists.newArrayList(Either.right(jobSpec.getUri()));
-    }
+    return Lists.newArrayList(jobSpec);
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaAvroJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaAvroJobMonitor.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
@@ -37,13 +36,11 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.reporter.util.SchemaVersionWriter;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.metrics.RuntimeMetrics;
-import org.apache.gobblin.util.Either;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -102,7 +99,7 @@ public abstract class KafkaAvroJobMonitor<T> extends KafkaJobMonitor {
   }
 
   @Override
-  public Collection<Either<JobSpec, URI>> parseJobSpec(byte[] message)
+  public Collection<JobSpec> parseJobSpec(byte[] message)
       throws IOException {
 
     InputStream is = new ByteArrayInputStream(message);
@@ -126,5 +123,5 @@ public abstract class KafkaAvroJobMonitor<T> extends KafkaJobMonitor {
   /**
    * Extract {@link JobSpec}s from the Kafka message.
    */
-  public abstract Collection<Either<JobSpec, URI>> parseJobSpec(T message);
+  public abstract Collection<JobSpec> parseJobSpec(T message);
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/SLAEventKafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/SLAEventKafkaJobMonitor.java
@@ -172,7 +172,7 @@ public class SLAEventKafkaJobMonitor extends KafkaAvroJobMonitor<GobblinTracking
   }
 
   @Override
-  public Collection<Either<JobSpec, URI>> parseJobSpec(GobblinTrackingEvent event) {
+  public Collection<JobSpec> parseJobSpec(GobblinTrackingEvent event) {
 
     if (!acceptEvent(event)) {
       this.rejectedEvents.inc();
@@ -192,7 +192,7 @@ public class SLAEventKafkaJobMonitor extends KafkaAvroJobMonitor<GobblinTracking
 
     JobSpec jobSpec = JobSpec.builder(jobSpecURI).withTemplate(this.template).withConfig(jobConfig).build();
 
-    return Lists.newArrayList(Either.<JobSpec, URI>left(jobSpec));
+    return Lists.newArrayList(jobSpec);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1441


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
make KafkaJobMonitor s parseJobSpec() method return the entire JobSpec, so that the caller method processMessage() - can distinguish between a DELETE FLOW and CANCEL JOB requests and take appropriate actions. jobs are identified by the VERB in the spec.
to achieve this I had to change the signature of parseJobSpec method and most of the diffs in this PR are because of this signature change.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
just refactoring changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

