### PR TITLE
[GOBBLIN-1443]Make iceberg metadata root location include db name

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -96,7 +96,9 @@ public class GobblinMCEPublisher extends DataPublisher {
       if (newFiles.isEmpty()) {
         // There'll be only one dummy file here. This file is parsed for DB and table name calculation.
         newFiles = computeDummyFile(state);
-        this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
+        if (!newFiles.isEmpty()) {
+          this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
+        }
       } else {
         this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
       }
@@ -150,7 +152,9 @@ public class GobblinMCEPublisher extends DataPublisher {
       //
       PriorityQueue<FileStatus> fileStatuses =
           new PriorityQueue<>((x, y) -> Long.compare(y.getModificationTime(), x.getModificationTime()));
-      fileStatuses.add(fs.getFileStatus(path));
+      if (fs.exists(path)) {
+        fileStatuses.add(fs.getFileStatus(path));
+      }
       // Only register files
       while (!fileStatuses.isEmpty()) {
         FileStatus fileStatus = fileStatuses.poll();

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -120,7 +120,7 @@ import org.joda.time.format.PeriodFormatterBuilder;
 public class IcebergMetadataWriter implements MetadataWriter {
 
   public static final String USE_DATA_PATH_AS_TABLE_LOCATION = "use.data.path.as.table.location";
-  public static final String TABLE_LOCATION_SUFFIX = "/_iceberg_metadata";
+  public static final String TABLE_LOCATION_SUFFIX = "/_iceberg_metadata/%s";
   public static final String GMCE_HIGH_WATERMARK_KEY = "gmce.high.watermark.%s";
   public static final String GMCE_LOW_WATERMARK_KEY = "gmce.low.watermark.%s";
   private final static String EXPIRE_SNAPSHOTS_LOOKBACK_TIME = "gobblin.iceberg.dataset.expire.snapshots.lookBackTime";
@@ -409,7 +409,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
     Table icebergTable = null;
     String tableLocation = null;
     if (useDataLoacationAsTableLocation) {
-      tableLocation = gmce.getDatasetIdentifier().getNativeName() + TABLE_LOCATION_SUFFIX;
+      tableLocation = gmce.getDatasetIdentifier().getNativeName() + String.format(TABLE_LOCATION_SUFFIX, table.getDbName());
       //Set the path permission
       Path tablePath = new Path(tableLocation);
       WriterUtils.mkdirsWithRecursivePermission(tablePath.getFileSystem(conf), tablePath, permission);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1443] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1443


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Make iceberg metadata root location include db name, this is to enable create different iceberg tables under different db for same data
Also add simple fix for the GMCE emitting issue when there is no data existed

Options

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Change unit test for this feature

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

