### PR TITLE
[GOBBLIN-1447] Fix url for linkedin jfrog, add pentaho dependency link

### DIFF
--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -18,6 +18,9 @@
 repositories {
   mavenCentral()
   maven {
+    url "http://nexus.pentaho.org/content/groups/omni"
+  }
+  maven {
     url "https://plugins.gradle.org/m2/"
   }
   maven {
@@ -30,7 +33,7 @@ repositories {
     url "https://repository.apache.org/content/repositories/snapshots"
   }
   maven {
-    url "https://linkedin.jfrog.com/artifactory/"
+    url "https://linkedin.jfrog.io/artifactory/"
   }
   jcenter()
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1447


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

We have a dependency on Calcite, which has a dependency on pentaho. Due to either a moved repository or broken link it can no longer be resolved without adding a repository that points to the dependency.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

