### PR TITLE
[GOBBLIN-1448] Send failed timer instead of success timer when job is cancelled

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -598,7 +598,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
               }
             });
 
-            if (jobState.getState() == JobState.RunningState.FAILED) {
+            if (jobState.getState() == JobState.RunningState.FAILED || jobState.getState() == JobState.RunningState.CANCELLED) {
               notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_FAILED, new JobListenerAction() {
                 @Override
                 public void apply(JobListener jobListener, JobContext jobContext)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1448


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently AbstractJobLauncher will default to sending a jobSucceededTimer if job state is anything other than FAILED. It probably makes more sense to send a jobFailedTimer instead in the case of CANCELLED status.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

