### PR TITLE
GOBBLIN-1449: Correctly parse topic name from topic partition string if topic name has hyphens

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -23,7 +23,9 @@ import org.apache.gobblin.configuration.WorkUnitState;
 
 import java.util.List;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class KafkaUtils {
+
+  private static final String TOPIC_PARTITION_DELIMITER = "-";
 
   /**
    * Get topic name from a {@link State} object. The {@link State} should contain property
@@ -182,4 +186,15 @@ public class KafkaUtils {
     return Long.parseLong(workUnitState.contains(key) ? workUnitState.getProp(key)
         : workUnitState.getProp(KafkaUtils.getPartitionPropName(key, partitionId), "0"));
   }
+
+  /**
+   * Get topic name from a topic partition
+   * @param topicPartition
+   */
+  public static String getTopicNameFromTopicPartition(String topicPartition) {
+    Preconditions.checkArgument(topicPartition.contains(TOPIC_PARTITION_DELIMITER));
+    List<String> parts = Splitter.on(TOPIC_PARTITION_DELIMITER).splitToList(topicPartition);
+    return Joiner.on(TOPIC_PARTITION_DELIMITER).join(parts.subList(0, parts.size() - 1));
+  }
+
 }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.gobblin.source.extractor.extract.kafka;
 
 import org.testng.Assert;

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtilsTest.java
@@ -1,0 +1,14 @@
+package org.apache.gobblin.source.extractor.extract.kafka;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class KafkaUtilsTest {
+
+  @Test
+  public void testGetTopicNameFromTopicPartition() {
+    Assert.assertEquals(KafkaUtils.getTopicNameFromTopicPartition("topic-1"), "topic");
+    Assert.assertEquals(KafkaUtils.getTopicNameFromTopicPartition("topic-foo-bar-1"), "topic-foo-bar");
+  }
+}


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1449


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In KafkaTopicGroupingWorkUnitPacker, the extraction of topic name from topic partition string currently does not handle the hyphens in the topic name correctly.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

