### PR TITLE
[GOBBLIN-1451] Log better error messages from mappers

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -311,11 +311,12 @@ public class GobblinMultiTaskAttempt {
     }
 
     if (hasTaskFailure) {
-      String errorMsg ="";
+      String errorMsg = String.format("Tasks in container %s failed", containerIdOptional.or(""));
       for (Task task : tasks) {
         if (task.getTaskState().contains(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY)) {
-          errorMsg = String.format("Task %s failed due to exception: %s", task.getTaskId(),
-              task.getTaskState().getProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY));
+          errorMsg = String.format("Task failed: %s (Gobblin task id %s, container id %s)",
+                                   task.getTaskState().getProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY),
+                                   task.getTaskId(), containerIdOptional.or(""));
         }
 
         // If there are task failures then the tasks may be reattempted. Save a copy of the task state that is used
@@ -327,9 +328,7 @@ public class GobblinMultiTaskAttempt {
         }
       }
 
-      throw new IOException(
-          String.format("Not all tasks running in container %s completed successfully, last recorded exception[%s]",
-              containerIdOptional.or(""), errorMsg));
+      throw new IOException(errorMsg);
     }
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -80,6 +80,7 @@ import org.apache.gobblin.runtime.fork.AsynchronousFork;
 import org.apache.gobblin.runtime.fork.Fork;
 import org.apache.gobblin.runtime.fork.SynchronousFork;
 import org.apache.gobblin.runtime.task.TaskIFace;
+import org.apache.gobblin.runtime.util.ExceptionCleanupUtils;
 import org.apache.gobblin.runtime.util.TaskMetrics;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
@@ -379,11 +380,15 @@ public class Task implements TaskIFace {
             filter(not(Fork::isSucceeded)).map(x -> x.getIndex()).collect(Collectors.toList());
         ForkThrowableHolder holder = Task.getForkThrowableHolder(this.taskState.getTaskBroker());
 
-        Exception e = null;
+        Throwable e = null;
         if (!holder.isEmpty()) {
-          e = holder.getAggregatedException(failedForksId, this.taskId);
+          if (failedForksId.size() == 1 && holder.getThrowable(failedForksId.get(0)).isPresent()) {
+            e = holder.getThrowable(failedForksId.get(0)).get();
+          }else{
+            e = holder.getAggregatedException(failedForksId, this.taskId);
+          }
         }
-        throw e == null ? new RuntimeException("Some forks failed") : new RuntimeException("Forks failed with exception:", e);
+        throw e == null ? new RuntimeException("Some forks failed") : e;
       }
 
       //TODO: Move these to explicit shutdown phase
@@ -561,13 +566,16 @@ public class Task implements TaskIFace {
   }
 
   protected void failTask(Throwable t) {
-    LOG.error(String.format("Task %s failed", this.taskId), t);
+    Throwable cleanedException = ExceptionCleanupUtils.removeEmptyWrappers(t);
+
+    LOG.error(String.format("Task %s failed", this.taskId), cleanedException);
     this.taskState.setWorkingState(WorkUnitState.WorkingState.FAILED);
-    this.taskState.setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, Throwables.getStackTraceAsString(t));
+    this.taskState
+        .setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, Throwables.getStackTraceAsString(cleanedException));
 
     // Send task failure event
     FailureEventBuilder failureEvent = new FailureEventBuilder(FAILED_TASK_EVENT);
-    failureEvent.setRootCause(t);
+    failureEvent.setRootCause(cleanedException);
     failureEvent.addMetadata(TASK_STATE, this.taskState.toString());
     failureEvent.addAdditionalMetadata(this.taskEventMetadataGenerator.getMetadata(this.taskState, failureEvent.getName()));
     failureEvent.submit(taskContext.getTaskMetrics().getMetricContext());
@@ -923,11 +931,16 @@ public class Task implements TaskIFace {
         if (this.taskState.getWorkingState() != WorkUnitState.WorkingState.FAILED) {
           this.taskState.setWorkingState(WorkUnitState.WorkingState.SUCCESSFUL);
         }
-      } else {
+      }
+      else {
         ForkThrowableHolder holder = Task.getForkThrowableHolder(this.taskState.getTaskBroker());
         LOG.info("Holder for this task {} is {}", this.taskId, holder);
         if (!holder.isEmpty()) {
-          failTask(holder.getAggregatedException(failedForkIds, this.taskId));
+          if (failedForkIds.size() == 1 && holder.getThrowable(failedForkIds.get(0)).isPresent()) {
+            failTask(holder.getThrowable(failedForkIds.get(0)).get());
+          } else {
+            failTask(holder.getAggregatedException(failedForkIds, this.taskId));
+          }
         } else {
           // just in case there are some corner cases where Fork throw an exception but doesn't add into holder
           failTask(new ForkException("Fork branches " + failedForkIds + " failed for task " + this.taskId));

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/ExceptionCleanupUtils.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/ExceptionCleanupUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.util;
+
+public final class ExceptionCleanupUtils {
+
+  private ExceptionCleanupUtils() {
+  }
+
+  /**
+   * Removes exceptions that were wrapping another exception without providing a message of their own.
+   *
+   * When a checked exception is defined on the interface, and one of the implementations want to propagate a
+   * different type of exception, that implementation can wrap the original exception. For example, Gobblin
+   * codebase frequently wraps exception into new IOException(cause). As a result, users see large stack traces
+   * where real error is hidden below several wrappers. This method will remove the wrappers to provide users with
+   * better error messages.
+   * */
+  public static Throwable removeEmptyWrappers(Throwable exception) {
+    if (exception == null) {
+      return null;
+    }
+
+    if (exception.getCause() != null && exception.getCause().toString().equals(exception.getMessage())) {
+      return removeEmptyWrappers(exception.getCause());
+    }
+
+    return exception;
+  }
+}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/util/ExceptionCleanupUtilsTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/util/ExceptionCleanupUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.util;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+@Test(groups = {"gobblin.runtime"})
+public class ExceptionCleanupUtilsTest {
+
+  @Test
+  public void canRemoveEmptyWrapper() {
+    Exception exception = new IOException(new IllegalArgumentException("root cause"));
+    Throwable rootCause = ExceptionCleanupUtils.removeEmptyWrappers(exception);
+    assertEquals(rootCause.getClass(), IllegalArgumentException.class);
+  }
+
+  @Test
+  public void canRemoveMultipleEmptyWrappers() {
+    Exception exception = new IOException(new IOException(new IllegalArgumentException("root cause")));
+    Throwable unwrapped = ExceptionCleanupUtils.removeEmptyWrappers(exception);
+    assertEquals(unwrapped.getClass(), IllegalArgumentException.class);
+  }
+
+  @Test
+  public void willNotRemoveExceptionWithMessage() {
+    Exception exception = new IOException("test message", new IllegalArgumentException("root cause"));
+    Throwable unwrapped = ExceptionCleanupUtils.removeEmptyWrappers(exception);
+    assertEquals(unwrapped.getClass(), IOException.class);
+  }
+}


### PR DESCRIPTION
Previously, the root cause of the problems were wrapped in several
container exceptions that added little value in troubleshooting and
confused the users. They frequently reported that the job failed with
"RetryException" without looking at the root cause of it.

With this change, we'll unwrap the exceptions from tasks and show
the possible root cause at the top of the error message.

https://issues.apache.org/jira/browse/GOBBLIN-1451
