### PR TITLE
[GOBBLIN-1454] Fixing NPE when trying to fetch delegation tokens for multiple remote namenodes

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/hadoop/TokenUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/hadoop/TokenUtils.java
@@ -424,11 +424,13 @@ public class TokenUtils {
     Path[] ps = new Path[remoteNamenodesList.size()];
     for (int i = 0; i < ps.length; i++) {
       ps[i] = new Path(remoteNamenodesList.get(i).trim());
-      FileSystem otherNameNodeFS = ps[i].getFileSystem(conf);
+    }
 
-      if (StringUtils.isEmpty(renewer)) {
-        TokenCache.obtainTokensForNamenodes(cred, ps, conf);
-      } else {
+    if (StringUtils.isEmpty(renewer)) {
+      TokenCache.obtainTokensForNamenodes(cred, ps, conf);
+    } else {
+      for(Path p: ps) {
+        FileSystem otherNameNodeFS = p.getFileSystem(conf);
         final Token<?>[] tokens = otherNameNodeFS.addDelegationTokens(renewer, cred);
         if (tokens != null) {
           for (Token<?> token : tokens) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1454


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
       When the application tries to fetch delegation tokens for multiple remote namenodes, the current implementation of 
       getRemoteFSTokenFromURI method doesn't wait for initialization of all the elements of path ("ps") array before calling
       obtainTokensForNamenodes leading to NPE when the fileSystem of an initialized path is accessed.   


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

