### PR TITLE
GOBBLIN-1455: Limit gobblin.kafka.minContainersForTopic config to the number of partitions of the topic

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
@@ -282,7 +282,8 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
    * @return the minimum workunit size.
    */
   private Double getMinWorkUnitSize(WorkUnit workUnit) {
-    int minContainersForTopic = workUnit.getPropAsInt(MIN_CONTAINERS_FOR_TOPIC, -1);
+    int minContainersForTopic = Math.min(workUnit.getPropAsInt(MIN_CONTAINERS_FOR_TOPIC, -1),
+        workUnit.getPropAsInt(KafkaSource.NUM_TOPIC_PARTITIONS));
     if (minContainersForTopic == -1) {
       //No minimum configured? Return lower bound for workunit size to be 0.
       return 0.0;


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1455


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We need to upper bound the config gobblin.kafka.minContainersForTopic so as not to exceed the number of partitions for the topic. When this config value exceeds the number of partitions, current behavior incorrectly estimates the work unit size in KafkaTopicGroupingWorkUnitPacker.  


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

