### PR TITLE
[GOBBLIN-1456] do not remove spec on update

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -377,11 +377,6 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
     }
 
     try {
-      onDeleteSpec(updatedSpec.getUri(), updatedSpec.getVersion());
-    } catch (Exception e) {
-      _log.error("Failed to update Spec: " + updatedSpec, e);
-    }
-    try {
       onAddSpec(updatedSpec);
     } catch (Exception e) {
       _log.error("Failed to update Spec: " + updatedSpec, e);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@jack-moseley @Will-Lo  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1456


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
GobblinServiceJobScheduler update logic first deletes the spec and then adds it back. I think it is unnecessary and also create an issue. During delete spec it calls Orchestrator remove code and that sends a delete call to spec executor, which is wrong, because flow spec is actually not intended to be deleted. On cluster side, it is forcing a state store deletion.
This PR will remove the delete part.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes. tested locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

