### PR TITLE
[GOBBLIN-1458] Add endpoint to trigger a flow in GaaS

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
@@ -79,7 +79,12 @@
       } ]
     } ],
     "entity" : {
-      "path" : "/flowconfigsV2/{id}"
+      "path" : "/flowconfigsV2/{id}",
+      "actions" : [ {
+        "name" : "runImmediately",
+        "doc" : "Trigger a new execution of an existing flow",
+        "returns" : "string"
+      } ]
     }
   }
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowconfigsV2.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowconfigsV2.snapshot.json
@@ -180,7 +180,12 @@
         } ]
       } ],
       "entity" : {
-        "path" : "/flowconfigsV2/{id}"
+        "path" : "/flowconfigsV2/{id}",
+        "actions" : [ {
+          "name" : "runImmediately",
+          "doc" : "Trigger a new execution of an existing flow",
+          "returns" : "string"
+        } ]
       }
     }
   }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowConfigV2Client.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowConfigV2Client.java
@@ -36,6 +36,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.ActionRequest;
 import com.linkedin.restli.client.CreateIdEntityRequest;
 import com.linkedin.restli.client.DeleteRequest;
 import com.linkedin.restli.client.FindRequest;
@@ -253,6 +254,19 @@ public class FlowConfigV2Client implements Closeable {
     ResponseFuture<EmptyRecord> response = _restClient.get().sendRequest(deleteRequest);
 
     response.getResponse();
+  }
+
+  public String runImmediately(FlowId flowId)
+      throws RemoteInvocationException {
+    LOG.debug("runImmediately with groupName " + flowId.getFlowGroup() + " flowName " + flowId.getFlowName());
+
+    ActionRequest<String> runImmediatelyRequest = _flowconfigsV2RequestBuilders.actionRunImmediately()
+        .id(new ComplexResourceKey<>(flowId, new FlowStatusId())).build();
+
+    Response<String> response = (Response<String>) FlowClientUtils.sendRequestWithRetry(_restClient.get(), runImmediatelyRequest,
+        FlowconfigsV2RequestBuilders.getPrimaryResource());
+
+    return response.getEntity();
   }
 
   @Override

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -46,7 +46,6 @@ import com.linkedin.restli.client.RestLiResponseException;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.internal.server.util.DataMapUtils;
 import com.linkedin.restli.server.resources.BaseResource;
-import com.linkedin.restli.server.util.PatchApplier;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -84,6 +83,9 @@ public class FlowConfigV2Test {
   private static final String TEST_FLOW_NAME_9 = "testFlow9";
   private static final String TEST_SCHEDULE = "0 1/0 * ? * *";
   private static final String TEST_TEMPLATE_URI = "FS:///templates/test.template";
+
+  private static final ServiceRequester TEST_REQUESTER = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
+  private static final ServiceRequester TEST_REQUESTER2 = new ServiceRequester("testName2", "USER_PRINCIPAL", "testFrom");
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -168,6 +170,7 @@ public class FlowConfigV2Test {
   @Test
   public void testPartialUpdate() throws Exception {
     FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_3);
+    _requesterService.setRequester(TEST_REQUESTER);
 
     Map<String, String> flowProperties = Maps.newHashMap();
     flowProperties.put("param1", "value1");
@@ -187,9 +190,7 @@ public class FlowConfigV2Test {
     DataMap dataMap = DataMapUtils.readMap(IOUtils.toInputStream(patchJson));
     PatchRequest<FlowConfig> flowConfigPatch = PatchRequest.createFromPatchDocument(dataMap);
 
-    PatchApplier.applyPatch(flowConfig, flowConfigPatch);
-
-    _client.updateFlowConfig(flowConfig);
+    _client.partialUpdateFlowConfig(flowId, flowConfigPatch);
 
     FlowConfig retrievedFlowConfig = _client.getFlowConfig(flowId);
 
@@ -273,8 +274,7 @@ public class FlowConfigV2Test {
 
   @Test
   public void testGroupUpdateRejected() throws Exception {
-   ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
-   _requesterService.setRequester(testRequester);
+   _requesterService.setRequester(TEST_REQUESTER);
    Map<String, String> flowProperties = Maps.newHashMap();
 
    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_7))
@@ -296,9 +296,7 @@ public class FlowConfigV2Test {
 
   @Test
   public void testRequesterUpdate() throws Exception {
-    ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
-    ServiceRequester testRequester2 = new ServiceRequester("testName2", "USER_PRINCIPAL", "testFrom");
-    _requesterService.setRequester(testRequester);
+    _requesterService.setRequester(TEST_REQUESTER);
     Map<String, String> flowProperties = Maps.newHashMap();
 
     FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_8);
@@ -310,22 +308,20 @@ public class FlowConfigV2Test {
     _client.createFlowConfig(flowConfig);
 
     // testName2 takes ownership of the flow
-    flowProperties.put(RequesterService.REQUESTER_LIST, RequesterService.serialize(Lists.newArrayList(testRequester2)));
+    flowProperties.put(RequesterService.REQUESTER_LIST, RequesterService.serialize(Lists.newArrayList(TEST_REQUESTER2)));
     flowConfig.setProperties(new StringMap(flowProperties));
-    _requesterService.setRequester(testRequester2);
+    _requesterService.setRequester(TEST_REQUESTER2);
     _client.updateFlowConfig(flowConfig);
 
     // Check that the requester list was actually updated
     FlowConfig updatedFlowConfig = _client.getFlowConfig(flowId);
     Assert.assertEquals(RequesterService.deserialize(updatedFlowConfig.getProperties().get(RequesterService.REQUESTER_LIST)),
-        Lists.newArrayList(testRequester2));
+        Lists.newArrayList(TEST_REQUESTER2));
   }
 
   @Test
   public void testRequesterUpdateRejected() throws Exception {
-    ServiceRequester testRequester = new ServiceRequester("testName", "USER_PRINCIPAL", "testFrom");
-    ServiceRequester testRequester2 = new ServiceRequester("testName2", "USER_PRINCIPAL", "testFrom");
-    _requesterService.setRequester(testRequester);
+    _requesterService.setRequester(TEST_REQUESTER);
     Map<String, String> flowProperties = Maps.newHashMap();
 
     FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME_9))
@@ -335,7 +331,7 @@ public class FlowConfigV2Test {
     _client.createFlowConfig(flowConfig);
 
     // Update should be rejected because testName is not allowed to update the owner to testName2
-    flowProperties.put(RequesterService.REQUESTER_LIST, RequesterService.serialize(Lists.newArrayList(testRequester2)));
+    flowProperties.put(RequesterService.REQUESTER_LIST, RequesterService.serialize(Lists.newArrayList(TEST_REQUESTER2)));
     flowConfig.setProperties(new StringMap(flowProperties));
     try {
       _client.updateFlowConfig(flowConfig);
@@ -373,6 +369,29 @@ public class FlowConfigV2Test {
     }
 
     Assert.fail();
+  }
+
+  @Test
+  public void testRunFlow() throws Exception {
+    String flowName = "testRunFlow";
+    FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(flowName);
+    _requesterService.setRequester(TEST_REQUESTER);
+
+    Map<String, String> flowProperties = Maps.newHashMap();
+    flowProperties.put("param1", "value1");
+
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(flowName))
+        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).setRunImmediately(false))
+        .setProperties(new StringMap(flowProperties));
+
+    // Create initial flowConfig
+    _client.createFlowConfig(flowConfig);
+
+    // Trigger flow
+    _client.runImmediately(flowId);
+
+    // Verify runImmediately was changed to true
+    Assert.assertTrue(_client.getFlowConfig(flowId).getSchedule().isRunImmediately());
   }
 
   @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1458


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Previously the way to manually trigger an execution of a scheduled flow is to send a partial update that sets the flow's `runImmediately` property to true. This PR improves the API by adding a restli action that sends the same partial update. With this, flows can be triggered through the URL: `/flowconfigsV2/(flowGroup:test1,flowName:test1)?action=trigger`

Also copied the implementation of `partialUpdateFlowConfig` to `FlowConfigV2ResourceLocalHandler` for testing convenience (normally when running the service `GobblinServiceFlowConfigResourceHandler` would be used, but for tests it is `FlowConfigV2ResourceLocalHandler`).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated unit test and tested in local gaas

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

