### PR TITLE
[GOBBLIN-1459] correct column length in MysqlSpecStore, MysqlDagStore, MysqlJobStatu…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -135,6 +135,8 @@ public class ServiceConfigKeys {
 
   public static final int MAX_FLOW_NAME_LENGTH = 128; // defined in FlowId.pdl
   public static final int MAX_FLOW_GROUP_LENGTH = 128; // defined in FlowId.pdl
+  public static final int MAX_JOB_NAME_LENGTH = 374;
+  public static final int MAX_JOB_GROUP_LENGTH = 374;
   public static final String STATE_STORE_TABLE_SUFFIX = "gst";
   public static final String STATE_STORE_KEY_SEPARATION_CHARACTER = ".";
   public static final String DAG_STORE_KEY_SEPARATION_CHARACTER = "_";

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -132,4 +132,11 @@ public class ServiceConfigKeys {
   // Group Membership authentication service
   public static final String GROUP_OWNERSHIP_SERVICE_CLASS = GOBBLIN_SERVICE_PREFIX + "groupOwnershipService.class";
   public static final String DEFAULT_GROUP_OWNERSHIP_SERVICE = "org.apache.gobblin.service.NoopGroupOwnershipService";
+
+  public static final int MAX_FLOW_NAME = 128; // defined in FlowId.pdl
+  public static final int MAX_FLOW_GROUP = 128; // defined in FlowId.pdl
+  public static final String STATE_STORE_TABLE_SUFFIX = "gst";
+  public static final String STATE_STORE_KEY_SEPARATION_CHARACTER = ".";
+  public static final String DAG_STORE_KEY_SEPARATION_CHARACTER = "_";
+
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -133,8 +133,8 @@ public class ServiceConfigKeys {
   public static final String GROUP_OWNERSHIP_SERVICE_CLASS = GOBBLIN_SERVICE_PREFIX + "groupOwnershipService.class";
   public static final String DEFAULT_GROUP_OWNERSHIP_SERVICE = "org.apache.gobblin.service.NoopGroupOwnershipService";
 
-  public static final int MAX_FLOW_NAME = 128; // defined in FlowId.pdl
-  public static final int MAX_FLOW_GROUP = 128; // defined in FlowId.pdl
+  public static final int MAX_FLOW_NAME_LENGTH = 128; // defined in FlowId.pdl
+  public static final int MAX_FLOW_GROUP_LENGTH = 128; // defined in FlowId.pdl
   public static final String STATE_STORE_TABLE_SUFFIX = "gst";
   public static final String STATE_STORE_KEY_SEPARATION_CHARACTER = ".";
   public static final String DAG_STORE_KEY_SEPARATION_CHARACTER = "_";

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/MysqlDagStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/MysqlDagStore.java
@@ -50,8 +50,8 @@ public class MysqlDagStore<T extends State> extends MysqlStateStore<T> {
 
   @Override
   protected String getCreateJobStateTableTemplate() {
-    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
-        + ServiceConfigKeys.MAX_FLOW_GROUP;
+    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME_LENGTH + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
+        + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
     int maxTableName = 13; // length of flowExecutionId which is epoch timestamp
 
     return "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(" + maxStoreName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/MysqlDagStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/MysqlDagStore.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin;
+
+import java.io.IOException;
+
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metastore.MysqlStateStore;
+import org.apache.gobblin.service.ServiceConfigKeys;
+
+
+@Slf4j
+/**
+ * An implementation of {@link MysqlStateStore} backed by MySQL to store Dag.
+ *
+ * @param <T> state object type
+ **/
+public class MysqlDagStore<T extends State> extends MysqlStateStore<T> {
+  /**
+   * Manages the persistence and retrieval of {@link State} in a MySQL database
+   * @param dataSource the {@link DataSource} object for connecting to MySQL
+   * @param stateStoreTableName the table for storing the state in rows keyed by two levels (store_name, table_name)
+   * @param compressedValues should values be compressed for storage?
+   * @param stateClass class of the {@link State}s stored in this state store
+   * @throws IOException in case of failures
+   */
+  public MysqlDagStore(DataSource dataSource, String stateStoreTableName, boolean compressedValues,
+      Class<T> stateClass)
+      throws IOException {
+    super(dataSource, stateStoreTableName, compressedValues, stateClass);
+  }
+
+  @Override
+  protected String getCreateJobStateTableTemplate() {
+    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
+        + ServiceConfigKeys.MAX_FLOW_GROUP;
+    int maxTableName = 13; // length of flowExecutionId which is epoch timestamp
+
+    return "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(" + maxStoreName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"
+        + "table_name varchar(" + maxTableName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"
+        + " modified_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
+        + " state longblob, primary key(store_name, table_name))";
+  }
+}

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlDagStateStoreFactory.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlDagStateStoreFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.metastore;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.MysqlDagStore;
+import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+public class MysqlDagStateStoreFactory extends MysqlStateStoreFactory {
+  @Override
+  public <T extends State> MysqlDagStore<T> createStateStore(Config config, Class<T> stateClass) {
+    String stateStoreTableName = ConfigUtils.getString(config, ConfigurationKeys.STATE_STORE_DB_TABLE_KEY,
+        ConfigurationKeys.DEFAULT_STATE_STORE_DB_TABLE);
+    boolean compressedValues = ConfigUtils.getBoolean(config, ConfigurationKeys.STATE_STORE_COMPRESSED_VALUES_KEY,
+        ConfigurationKeys.DEFAULT_STATE_STORE_COMPRESSED_VALUES);
+
+    try {
+      BasicDataSource basicDataSource = MysqlDataSourceFactory.get(config,
+          SharedResourcesBrokerFactory.getImplicitBroker());
+
+      return new MysqlDagStore<>(basicDataSource, stateStoreTableName, compressedValues, stateClass);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create MysqlDagStore with factory", e);
+    }
+  }
+}

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
@@ -73,11 +73,11 @@ public class MysqlJobStatusStateStore<T extends State> extends MysqlStateStore<T
 
   @Override
   protected String getCreateJobStateTableTemplate() {
-    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
-        + ServiceConfigKeys.MAX_FLOW_GROUP;
+    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME_LENGTH + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
+        + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
     int maxTableName = 13 // length of flowExecutionId which is epoch timestamp
-        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_NAME
-        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_GROUP
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_NAME_LENGTH
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH
         + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.STATE_STORE_TABLE_SUFFIX.length();
 
     return "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(" + maxStoreName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
@@ -36,6 +36,7 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.metadata.DatasetStateStoreEntryManager;
 import org.apache.gobblin.metastore.predicates.StateStorePredicate;
 import org.apache.gobblin.metastore.predicates.StoreNamePredicate;
+import org.apache.gobblin.service.ServiceConfigKeys;
 
 
 @Slf4j
@@ -68,6 +69,21 @@ public class MysqlJobStatusStateStore<T extends State> extends MysqlStateStore<T
    */
   public List<T> getAll(String storeName, long flowExecutionId) throws IOException {
     return getAll(storeName, flowExecutionId + "%", true);
+  }
+
+  @Override
+  protected String getCreateJobStateTableTemplate() {
+    int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
+        + ServiceConfigKeys.MAX_FLOW_GROUP;
+    int maxTableName = 13 // length of flowExecutionId which is epoch timestamp
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_NAME
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_GROUP
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.STATE_STORE_TABLE_SUFFIX.length();
+
+    return "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(" + maxStoreName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"
+        + "table_name varchar(" + maxTableName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"
+        + " modified_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
+        + " state longblob, primary key(store_name, table_name))";
   }
 
   @Override

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlJobStatusStateStore.java
@@ -76,8 +76,8 @@ public class MysqlJobStatusStateStore<T extends State> extends MysqlStateStore<T
     int maxStoreName = ServiceConfigKeys.MAX_FLOW_NAME_LENGTH + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length()
         + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
     int maxTableName = 13 // length of flowExecutionId which is epoch timestamp
-        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_NAME_LENGTH
-        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_JOB_NAME_LENGTH
+        + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.MAX_JOB_GROUP_LENGTH
         + ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER.length() + ServiceConfigKeys.STATE_STORE_TABLE_SUFFIX.length();
 
     return "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(" + maxStoreName + ") CHARACTER SET latin1 COLLATE latin1_bin not null,"

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
@@ -162,13 +162,17 @@ public class MysqlStateStore<T extends State> implements StateStore<T> {
     SELECT_METADATA_SQL = SELECT_METADATA_TEMPLATE.replace("$TABLE$", stateStoreTableName);
 
     // create table if it does not exist
-    String createJobTable = CREATE_JOB_STATE_TABLE_TEMPLATE.replace("$TABLE$", stateStoreTableName);
+    String createJobTable = getCreateJobStateTableTemplate().replace("$TABLE$", stateStoreTableName);
     try (Connection connection = dataSource.getConnection();
         PreparedStatement createStatement = connection.prepareStatement(createJobTable)) {
       createStatement.executeUpdate();
     } catch (SQLException e) {
       throw new IOException("Failure creation table " + stateStoreTableName, e);
     }
+  }
+
+  protected String getCreateJobStateTableTemplate() {
+    return CREATE_JOB_STATE_TABLE_TEMPLATE;
   }
 
   /**

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -337,6 +337,36 @@ public class FlowConfigV2Test {
     }
   }
 
+  @Test
+  public void testInvalidFlowId() throws Exception {
+    Map<String, String> flowProperties = Maps.newHashMap();
+    flowProperties.put("param1", "value1");
+    StringBuilder sb1 = new StringBuilder();
+    StringBuilder sb2 = new StringBuilder();
+    int maxFlowNameLength = ServiceConfigKeys.MAX_FLOW_NAME_LENGTH;
+    int maxFlowGroupLength = ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
+    while(maxFlowGroupLength-- >= 0) {
+      sb1.append("A");
+    }
+    while(maxFlowNameLength-- >= 0) {
+      sb2.append("A");
+    }
+    String TOO_LONG_FLOW_GROUP = sb1.toString();
+    String TOO_LONG_FLOW_NAME = sb2.toString();
+
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TOO_LONG_FLOW_GROUP).setFlowName(TOO_LONG_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties));
+    try {
+      _client.createFlowConfig(flowConfig);
+    } catch (RestLiResponseException e) {
+      Assert.assertEquals(e.getStatus(), HttpStatus.ORDINAL_422_Unprocessable_Entity);
+      Assert.assertTrue(e.getMessage().contains("is out of range"));
+      return;
+    }
+
+    Assert.fail();
+  }
+
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
     if (_client != null) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -47,6 +47,7 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.service.FlowConfig;
 import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.Schedule;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.util.ConfigUtils;
 
 
@@ -466,6 +467,11 @@ public class FlowSpec implements Configurable, Spec {
           .setFlowGroup(flowProps.getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
           .setFlowName(flowProps.getProperty(ConfigurationKeys.FLOW_NAME_KEY)))
           .setProperties(flowPropsAsStringMap);
+    }
+
+    public static int maxFlowSpecUri() {
+      return URI_SCHEME.length() + ":".length() // URI separator
+        + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_NAME + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_GROUP;
     }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -469,9 +469,9 @@ public class FlowSpec implements Configurable, Spec {
           .setProperties(flowPropsAsStringMap);
     }
 
-    public static int maxFlowSpecUri() {
+    public static int maxFlowSpecUriLength() {
       return URI_SCHEME.length() + ":".length() // URI separator
-        + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_NAME + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_GROUP;
+        + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_NAME_LENGTH + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
     }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
@@ -110,9 +110,9 @@ public class MysqlSpecStore extends InstrumentedSpecStore {
   }
 
   protected String getCreateJobStateTableTemplate() {
-    return "CREATE TABLE IF NOT EXISTS " + this.tableName + " (spec_uri VARCHAR(" + FlowSpec.Utils.maxFlowSpecUri()
-        + ") NOT NULL, flow_group VARCHAR(" + ServiceConfigKeys.MAX_FLOW_GROUP + "), flow_name VARCHAR("
-        + ServiceConfigKeys.MAX_FLOW_GROUP + "), " + "template_uri VARCHAR(128), user_to_proxy VARCHAR(128), "
+    return "CREATE TABLE IF NOT EXISTS " + this.tableName + " (spec_uri VARCHAR(" + FlowSpec.Utils.maxFlowSpecUriLength()
+        + ") NOT NULL, flow_group VARCHAR(" + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH + "), flow_name VARCHAR("
+        + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH + "), " + "template_uri VARCHAR(128), user_to_proxy VARCHAR(128), "
         + "source_identifier VARCHAR(128), " + "destination_identifier VARCHAR(128), schedule VARCHAR(128), "
         + "tag VARCHAR(128) NOT NULL, modified_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE "
         + "CURRENT_TIMESTAMP, isRunImmediately BOOLEAN, timezone VARCHAR(128), owning_group VARCHAR(128), spec LONGBLOB, "

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStore.java
@@ -26,13 +26,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metastore.MysqlDagStateStoreFactory;
 import org.apache.gobblin.metastore.MysqlStateStore;
 import org.apache.gobblin.metastore.MysqlStateStoreEntryManager;
-import org.apache.gobblin.metastore.MysqlStateStoreFactory;
 import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.metastore.predicates.StateStorePredicate;
 import org.apache.gobblin.runtime.api.TopologySpec;
 import org.apache.gobblin.runtime.spec_serde.GsonSerDe;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
@@ -97,7 +98,7 @@ public class MysqlDagStateStore implements DagStateStore {
    */
   protected StateStore<State> createStateStore(Config config) {
     try {
-      return (MysqlStateStoreFactory.class.newInstance()).createStateStore(config, State.class);
+      return (MysqlDagStateStoreFactory.class.newInstance()).createStateStore(config, State.class);
     } catch (ReflectiveOperationException rfoe) {
       throw new RuntimeException("A MySQL StateStore cannot be correctly initialized due to:", rfoe);
     }
@@ -148,21 +149,21 @@ public class MysqlDagStateStore implements DagStateStore {
    * e.g. storeName = group1_name1, tableName = 1234 gives dagId group1_name1_1234
    */
   private String entryToDagId(String storeName, String tableName) {
-    return Joiner.on("_").join(storeName, tableName);
+    return Joiner.on(ServiceConfigKeys.DAG_STORE_KEY_SEPARATION_CHARACTER).join(storeName, tableName);
   }
 
   /**
    * Return a storeName given a dagId. Store name is defined as flowGroup_flowName.
    */
   private String getStoreNameFromDagId(String dagId) {
-    return dagId.substring(0, dagId.lastIndexOf('_'));
+    return dagId.substring(0, dagId.lastIndexOf(ServiceConfigKeys.DAG_STORE_KEY_SEPARATION_CHARACTER));
   }
 
   /**
    * Return a tableName given a dagId. Table name is defined as the flowExecutionId.
    */
   private String getTableNameFromDagId(String dagId) {
-    return dagId.substring(dagId.lastIndexOf('_') + 1);
+    return dagId.substring(dagId.lastIndexOf(ServiceConfigKeys.DAG_STORE_KEY_SEPARATION_CHARACTER) + 1);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -50,6 +50,7 @@ import org.apache.gobblin.runtime.TaskContext;
 import org.apache.gobblin.runtime.kafka.HighLevelConsumer;
 import org.apache.gobblin.runtime.retention.DatasetCleanerTask;
 import org.apache.gobblin.service.ExecutionStatus;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -64,8 +65,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
   static final String JOB_STATUS_MONITOR_PREFIX = "jobStatusMonitor";
   //We use table suffix that is different from the Gobblin job state store suffix of jst to avoid confusion.
   //gst refers to the state store suffix for GaaS-orchestrated Gobblin jobs.
-  public static final String STATE_STORE_TABLE_SUFFIX = "gst";
-  public static final String STATE_STORE_KEY_SEPARATION_CHARACTER = ".";
   public static final String GET_AND_SET_JOB_STATUS = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
       JOB_STATUS_MONITOR_PREFIX,  "getAndSetJobStatus");
 
@@ -218,7 +217,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
   }
 
   public static String jobStatusTableName(String flowExecutionId, String jobGroup, String jobName) {
-    return Joiner.on(STATE_STORE_KEY_SEPARATION_CHARACTER).join(flowExecutionId, jobGroup, jobName, STATE_STORE_TABLE_SUFFIX);
+    return Joiner.on(ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER).join(flowExecutionId, jobGroup, jobName, ServiceConfigKeys.STATE_STORE_TABLE_SUFFIX);
   }
 
   public static String jobStatusTableName(long flowExecutionId, String jobGroup, String jobName) {
@@ -226,11 +225,11 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
   }
 
   public static String jobStatusStoreName(String flowGroup, String flowName) {
-    return Joiner.on(STATE_STORE_KEY_SEPARATION_CHARACTER).join(flowGroup, flowName);
+    return Joiner.on(ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER).join(flowGroup, flowName);
   }
 
   public static long getExecutionIdFromTableName(String tableName) {
-    return Long.parseLong(Splitter.on(STATE_STORE_KEY_SEPARATION_CHARACTER).splitToList(tableName).get(0));
+    return Long.parseLong(Splitter.on(ServiceConfigKeys.STATE_STORE_KEY_SEPARATION_CHARACTER).splitToList(tableName).get(0));
   }
 
   public abstract org.apache.gobblin.configuration.State parseJobStatus(DecodeableKafkaRecord<byte[],byte[]> message);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
@@ -18,15 +18,24 @@
 package org.apache.gobblin.service.monitoring;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Properties;
 
+import com.google.common.base.Strings;
+
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.MysqlJobStatusStateStore;
 import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
 import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.service.ExecutionStatus;
+import org.apache.gobblin.service.ServiceConfigKeys;
 
 
 public class MysqlJobStatusRetrieverTest extends JobStatusRetrieverTest {
@@ -73,6 +82,50 @@ public class MysqlJobStatusRetrieverTest extends JobStatusRetrieverTest {
   @Test (dependsOnMethods = "testGetJobStatusesForFlowExecution1")
   public void testGetLatestExecutionIdsForFlow() throws Exception {
     super.testGetLatestExecutionIdsForFlow();
+  }
+
+  @Test
+  public void testMaxColumnName() throws Exception {
+    Properties properties = new Properties();
+    long flowExecutionId = 12340L;
+    String flowGroup = Strings.repeat("A", ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH);
+    String flowName = Strings.repeat("B", ServiceConfigKeys.MAX_FLOW_NAME_LENGTH);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, flowGroup);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, flowName);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, String.valueOf(flowExecutionId));
+    properties.setProperty(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, Strings.repeat("C", ServiceConfigKeys.MAX_JOB_NAME_LENGTH));
+    properties.setProperty(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
+    properties.setProperty(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, Strings.repeat("D", ServiceConfigKeys.MAX_JOB_GROUP_LENGTH));
+    State jobStatus = new State(properties);
+
+    KafkaJobStatusMonitor.addJobStatusToStateStore(jobStatus, this.jobStatusRetriever.getStateStore());
+    Iterator<JobStatus>
+        jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId);
+    Assert.assertTrue(jobStatusIterator.hasNext());
+    Assert.assertEquals(jobStatusIterator.next().getFlowGroup(), flowGroup);
+  }
+
+  @Test
+  public void testInvalidColumnName() {
+    Properties properties = new Properties();
+    long flowExecutionId = 12340L;
+    String flowGroup = Strings.repeat("A", ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH + 1);
+    String flowName = Strings.repeat("B", ServiceConfigKeys.MAX_FLOW_NAME_LENGTH);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, flowGroup);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, flowName);
+    properties.setProperty(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, String.valueOf(flowExecutionId));
+    properties.setProperty(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, Strings.repeat("C", ServiceConfigKeys.MAX_JOB_NAME_LENGTH));
+    properties.setProperty(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
+    properties.setProperty(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, Strings.repeat("D", ServiceConfigKeys.MAX_JOB_GROUP_LENGTH));
+    State jobStatus = new State(properties);
+
+    try {
+      KafkaJobStatusMonitor.addJobStatusToStateStore(jobStatus, this.jobStatusRetriever.getStateStore());
+    } catch (IOException e) {
+      Assert.assertTrue(e.getCause().getMessage().contains("Data too long"));
+      return;
+    }
+    Assert.fail();
   }
 
   @Override


### PR DESCRIPTION
…sStore

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@Will-Lo @jack-moseley  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1459


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
  -some column length in MysqlSpecStore, MysqlDagStore, MysqlJobStatusStore are incorrect. limit on these column lengths is decided by the limit on flow group and flow name limits.
  - MysqlDagStateStore uses an internal MysqlStateStore. This PR will change it to use MysqlDagStore which just extends MysqlStateStore so that it can use override create table statement

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a few tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

