### PR TITLE
[GOBBLIN-1460] Fix NPE in DagManager cleanup

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -1102,7 +1102,8 @@ public class DagManager extends AbstractIdleService {
     }
 
     private boolean hasRunningJobs(String dagId) {
-      return !this.dagToJobs.get(dagId).isEmpty();
+      List<DagNode<JobExecutionPlan>> dagNodes = this.dagToJobs.get(dagId);
+      return dagNodes != null && !dagNodes.isEmpty();
     }
 
     private ContextAwareCounter getRunningJobsCounter(DagNode<JobExecutionPlan> dagNode) {


### PR DESCRIPTION
Under certain conditions, we can get a null list when checking if
dag has running job. This is a quickfix to address that.

https://issues.apache.org/jira/browse/GOBBLIN-1460
