### PR TITLE
GOBBLIN-1462: Ensure FsSpecConsumer handles config keys which are prefixes of other keys

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
 import org.apache.gobblin.util.CompletedFuture;
+import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.filters.HiddenFilter;
 
 
@@ -112,8 +113,11 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
         JobSpec.Builder jobSpecBuilder = new JobSpec.Builder(avroJobSpec.getUri());
         Properties props = new Properties();
         props.putAll(avroJobSpec.getProperties());
-        jobSpecBuilder.withJobCatalogURI(avroJobSpec.getUri()).withVersion(avroJobSpec.getVersion())
-            .withDescription(avroJobSpec.getDescription()).withConfigAsProperties(props);
+        jobSpecBuilder.withJobCatalogURI(avroJobSpec.getUri())
+            .withVersion(avroJobSpec.getVersion())
+            .withDescription(avroJobSpec.getDescription())
+            .withConfigAsProperties(props)
+            .withConfig(ConfigUtils.propertiesToConfig(props));
 
         try {
           if (!avroJobSpec.getTemplateUri().isEmpty()) {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
@@ -34,6 +34,8 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
+import org.apache.gobblin.util.ConfigUtils;
+
 
 public class FsSpecProducerTest {
   private FsSpecProducer _fsSpecProducer;
@@ -50,10 +52,17 @@ public class FsSpecProducerTest {
   }
 
   private JobSpec createTestJobSpec() throws URISyntaxException {
-    JobSpec jobSpec = JobSpec.builder("testJob").withConfig(ConfigFactory.empty().
-        withValue("key1", ConfigValueFactory.fromAnyRef("val1")).
-        withValue("key2", ConfigValueFactory.fromAnyRef("val2"))).
-        withVersion("1").withDescription("").withTemplate(new URI("FS:///")).build();
+    Properties properties = new Properties();
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    properties.put("key3.1", "val3");
+    properties.put("key3.1.1", "val4");
+
+    JobSpec jobSpec = JobSpec.builder("testJob")
+        .withConfig(ConfigUtils.propertiesToConfig(properties))
+        .withVersion("1")
+        .withDescription("")
+        .withTemplate(new URI("FS:///")).build();
     return jobSpec;
   }
 
@@ -68,6 +77,8 @@ public class FsSpecProducerTest {
     Assert.assertEquals(jobSpecs.get(0).getRight().getUri().toString(), "testJob");
     Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key1"), "val1");
     Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key2"), "val2");
+    Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key3.1" + ConfigUtils.STRIP_SUFFIX), "val3");
+    Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key3.1.1"), "val4");
   }
 
   @Test (dependsOnMethods = "testAddSpec")
@@ -80,6 +91,8 @@ public class FsSpecProducerTest {
     Assert.assertEquals(jobSpecs.get(0).getRight().getUri().toString(), "testJob");
     Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key1"), "val1");
     Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key2"), "val2");
+    Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key3.1" + ConfigUtils.STRIP_SUFFIX), "val3");
+    Assert.assertEquals(((JobSpec) jobSpecs.get(0).getRight()).getConfig().getString("key3.1.1"), "val4");
   }
 
   @Test (dependsOnMethods = "testUpdateSpec")

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
@@ -55,6 +55,7 @@ public class FsSpecProducerTest {
     Properties properties = new Properties();
     properties.put("key1", "val1");
     properties.put("key2", "val2");
+    //Introduce a key which is a prefix of another key and ensure it is correctly handled in the code
     properties.put("key3.1", "val3");
     properties.put("key3.1.1", "val4");
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1462


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, the FsSpecConsumer fails when building a JobSpec if the configuration contains keys which are prefixes of other keys, which is not allowed in typesafe config. In practice, this constraint may be violated particularly when loading system properties which are outside application's control. To ensure these properties are safely handled, the FsSpecConsumer should use the proertiesToConfig() method in PropertiesUtils which adds a suffix to the root properties.  


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Modified unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

