### PR TITLE
[GOBBLIN-1463] Remove pentaho dependency

### DIFF
--- a/gobblin-binary-management/build.gradle
+++ b/gobblin-binary-management/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 configurations {
     compile {
         transitive = true
+        exclude group: "org.pentaho"
     }
     archives
 }

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -80,6 +80,7 @@ configurations {
   // HADOOP-5254 and MAPREDUCE-5664
   all*.exclude group: 'xml-apis'
   all*.exclude group: 'xerces'
+  all*.exclude group: "org.pentaho"
 }
 
 test {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableMysqlDatasetStoreDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableMysqlDatasetStoreDatasetTest.java
@@ -50,7 +50,7 @@ import org.apache.gobblin.util.ConfigUtils;
 /**
  * Unit test for cleaning {@link MysqlStateStore} and {@link MysqlDatasetStateStore}
  */
-@Test(singleThreaded = true)
+@Test(singleThreaded = true, groups = {"disabledOnCI"})
 public class CleanableMysqlDatasetStoreDatasetTest {
   private static final String TEST_STATE_STORE = "TestStateStore";
   private static final String TEST_JOB_NAME1 = "TestJob1";
@@ -173,7 +173,7 @@ public class CleanableMysqlDatasetStoreDatasetTest {
   /**
    * Test cleanup of the dataset state store. This test uses the combined selection policy to test that the newest 2
    * entries are retained even when the timestamp is old.
-   * 
+   *
    * @throws IOException
    */
   @Test

--- a/gobblin-hive-registration/build.gradle
+++ b/gobblin-hive-registration/build.gradle
@@ -45,3 +45,9 @@ dependencies {
 }
 
 ext.classification="library"
+
+configurations {
+  compile {
+    exclude group: "org.pentaho"
+  }
+}

--- a/gobblin-iceberg/build.gradle
+++ b/gobblin-iceberg/build.gradle
@@ -55,4 +55,10 @@ dependencies {
     testCompile externalDependency.mockito
 }
 
+configurations {
+    compile {
+        exclude group: "org.pentaho"
+    }
+}
+
 ext.classification="library"

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -134,7 +134,7 @@ ext.externalDependency = [
     "bcprovJdk15on": "org.bouncycastle:bcprov-jdk15on:1.52",
     "calciteCore": "org.apache.calcite:calcite-core:1.16.0",
     "calciteAvatica": "org.apache.calcite:calcite-avatica:1.13.0",
-    "jhyde": "org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde",
+    "jhyde": "net.hydromatic:aggdesigner-algorithm:6.0",
     "curatorFramework": "org.apache.curator:curator-framework:2.10.0",
     "curatorRecipes": "org.apache.curator:curator-recipes:2.10.0",
     "curatorClient": "org.apache.curator:curator-client:2.10.0",

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -18,9 +18,6 @@
 repositories {
   mavenCentral()
   maven {
-    url "http://nexus.pentaho.org/content/groups/omni"
-  }
-  maven {
     url "https://plugins.gradle.org/m2/"
   }
   maven {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1463


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Pentaho's library for aggdesigner is used in tests. https://mvnrepository.com/artifact/org.pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde However, the nexus repository frequently goes down and is unreliable.

Proposal to move to a newer version of aggdesigner hosted on maven central, similar to calcite https://issues.apache.org/jira/browse/CALCITE-1474.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

