### PR TITLE
[GOBBLIN-1469]Fix Issue that hive registration cannot process when schema.literal is not set

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -227,7 +227,8 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   @VisibleForTesting
   protected void updateSchema(HiveSpec spec, Table table, HiveTable existingTable) throws IOException{
 
-    if (this.schemaRegistry.isPresent()) {
+    if (this.schemaRegistry.isPresent() && existingTable.getSerDeProps().getProp(
+        AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()) != null) {
       try (Timer.Context context = this.metricContext.timer(GET_AND_SET_LATEST_SCHEMA).time()) {
         Schema existingTableSchema = new Schema.Parser().parse(existingTable.getSerDeProps().getProp(
             AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1469


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
We have noticed two instances where the streaming topics were having Missing/Orphan hive partition issues. After investigating, it's because the schema.literal is missing when creating the table, and thus the following partition registration in ingestion job are all fail which cause the hourly partition missing. So create this ticket to make it able to proceed hive registration even if schema.literal is missing.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

