### PR TITLE
Commit watermarks to state store for quiet topics with no data

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaProduceRateTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaProduceRateTracker.java
@@ -256,14 +256,10 @@ public class KafkaProduceRateTracker {
           (KafkaStreamingExtractor.KafkaWatermark) lastCommittedWatermarks.get(partition.toString());
       KafkaStreamingExtractor.KafkaWatermark unacknowledgedWatermark =
           (KafkaStreamingExtractor.KafkaWatermark) unacknowledgedWatermarks.get(partition.toString());
-      if (unacknowledgedWatermark == null && kafkaWatermark == null) {
-        //If there is no previously committed watermark for the topic partition and no records in current time window, no further
-        //processing needed for the topic partition.
-        continue;
-      }
+
       if (kafkaWatermark == null) {
         //If there is no previously committed watermark for the topic partition, create a dummy watermark for computing stats
-        kafkaWatermark = new KafkaStreamingExtractor.KafkaWatermark(partition, new LongWatermark(0L));
+        kafkaWatermark = new KafkaStreamingExtractor.KafkaWatermark(partition, new LongWatermark(maxOffset >= 0? maxOffset : 0L));
       }
       long avgRecordSize = this.statsTracker.getAvgRecordSize(partitionIndex);
       long previousMaxOffset = highWatermark.get(partitionIndex++);

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
@@ -47,16 +47,21 @@ public class KafkaStreamingExtractorTest {
       throws IOException, DataRecordException {
     MultiLongWatermark highWatermark1 = new MultiLongWatermark(this.streamingExtractor.highWatermark);
 
-    //Read 2 records
+    //Read 3 records
     this.streamingExtractor.readStreamEntityImpl();
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(0), 1L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(1), 0L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(2), 0L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 0L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 0L);
 
-    this.streamingExtractor.readStreamEntityImpl();
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(0), 1L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(1), 1L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(2), 0L);
+    streamingExtractor.readStreamEntityImpl();
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 0L);
+
+    streamingExtractor.readStreamEntityImpl();
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 1L);
 
     //Checkpoint watermarks
     this.streamingExtractor.onFlushAck();
@@ -70,13 +75,13 @@ public class KafkaStreamingExtractorTest {
     MultiLongWatermark highWatermark2 = new MultiLongWatermark(this.streamingExtractor.highWatermark);
     //Read 1 more record
     this.streamingExtractor.readStreamEntityImpl();
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(0), 1L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(1), 1L);
-    Assert.assertEquals( this.streamingExtractor.nextWatermark.get(2), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 2L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 1L);
+    Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 1L);
 
-    Assert.assertEquals( this.streamingExtractor.lowWatermark.get(0), 1L);
-    Assert.assertEquals( this.streamingExtractor.lowWatermark.get(1), 1L);
-    Assert.assertEquals( this.streamingExtractor.lowWatermark.get(2), 0L);
+    Assert.assertEquals(this.streamingExtractor.lowWatermark.get(0), 1L);
+    Assert.assertEquals(this.streamingExtractor.lowWatermark.get(1), 1L);
+    Assert.assertEquals(this.streamingExtractor.lowWatermark.get(2), 1L);
 
     //Checkpoint watermarks
     this.streamingExtractor.onFlushAck();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1470


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, quiet topics which see no data during a flush interval will not commit watermark to state store. This can result in quiet topics not having any prior stats resulting in an excess number of workunits for such topics. The correct behavior should be to have watermarks with produce rates set to 0.  


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

