### PR TITLE
[GOBBLIN-1472] toggle to control compaction MR output dir

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1074,7 +1074,8 @@ public class ConfigurationKeys {
   public static final String USE_DATASET_LOCAL_WORK_DIR = "gobblin.useDatasetLocalWorkDir";
   public static final String DESTINATION_DATASET_HANDLER_CLASS = "gobblin.destination.datasetHandlerClass";
   public static final String DATASET_DESTINATION_PATH = "gobblin.dataset.destination.path";
-  public static final String STAGING_DIR_DEFAULT_SUFFIX = "/.temp/taskStaging";
-  public static final String OUTPUT_DIR_DEFAULT_SUFFIX = "/.temp/taskOutput";
+  public static final String TMP_DIR = ".temp";
+  public static final String STAGING_DIR_DEFAULT_SUFFIX = "/" + TMP_DIR + "/taskStaging";
+  public static final String OUTPUT_DIR_DEFAULT_SUFFIX = "/" + TMP_DIR + "/taskOutput";
   public static final String ROW_LEVEL_ERR_FILE_DEFAULT_SUFFIX = "/err";
 }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
@@ -241,6 +241,7 @@ public abstract class CompactionJobConfigurator {
    * a directory containing one or more files.
    *
    */
+
   protected boolean configureInputAndOutputPaths(Job job, FileSystemDataset dataset) throws IOException {
     boolean emptyDirectoryFlag = false;
 
@@ -249,6 +250,11 @@ public abstract class CompactionJobConfigurator {
     CompactionPathParser.CompactionParserResult rst = parser.parse(dataset);
     this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(), rst.getDstSubDir(), rst.getTimeString());
 
+    if(this.state.contains(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR)) {
+      mrOutputBase = this.state.getProp(MRCompactor.COMPACTION_DEST_DIR);
+      String tmpDir = ".temp";
+      this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(), tmpDir, rst.getDstSubDir(), rst.getTimeString());
+    }
     log.info("Cleaning temporary MR output directory: " + mrOutputPath);
     this.fs.delete(mrOutputPath, true);
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
@@ -241,7 +241,6 @@ public abstract class CompactionJobConfigurator {
    * a directory containing one or more files.
    *
    */
-
   protected boolean configureInputAndOutputPaths(Job job, FileSystemDataset dataset) throws IOException {
     boolean emptyDirectoryFlag = false;
 
@@ -252,7 +251,8 @@ public abstract class CompactionJobConfigurator {
 
     if(this.state.contains(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR)) {
       mrOutputBase = this.state.getProp(MRCompactor.COMPACTION_DEST_DIR);
-      this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(), ConfigurationKeys.TMP_DIR, rst.getDstSubDir(), rst.getTimeString());
+      this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(),
+          ConfigurationKeys.TMP_DIR, rst.getDstSubDir(), rst.getTimeString());
     }
     log.info("Cleaning temporary MR output directory: " + mrOutputPath);
     this.fs.delete(mrOutputPath, true);

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionJobConfigurator.java
@@ -252,8 +252,7 @@ public abstract class CompactionJobConfigurator {
 
     if(this.state.contains(ConfigurationKeys.USE_DATASET_LOCAL_WORK_DIR)) {
       mrOutputBase = this.state.getProp(MRCompactor.COMPACTION_DEST_DIR);
-      String tmpDir = ".temp";
-      this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(), tmpDir, rst.getDstSubDir(), rst.getTimeString());
+      this.mrOutputPath = concatPaths(mrOutputBase, rst.getDatasetName(), ConfigurationKeys.TMP_DIR, rst.getDstSubDir(), rst.getTimeString());
     }
     log.info("Cleaning temporary MR output directory: " + mrOutputPath);
     this.fs.delete(mrOutputPath, true);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1472] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1472


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- For Azure migration, MR output directories need to reside inside the dataset directory
- used 'gobblin.useDatasetLocalWorkDir' to toggle between the job dir and dataset directory to maintain backward compatibility

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

