### PR TITLE
[GOBBLIN-1475] merge currentAttempt correctly when processing GTE

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -39,6 +39,7 @@ import org.apache.gobblin.util.ConfigUtils;
 public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker {
   public static final String EVENT_NAME_FIELD = "eventName";
   public static final String NA_KEY = "NA";
+  public static final String TIMESTAMP_FIELD = "timestamp";
 
   @Getter
   protected final MetricContext metricContext;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -115,6 +115,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
     }
     Properties properties = new Properties();
     properties.putAll(event.getMetadata());
+    properties.put(JobStatusRetriever.TIMESTAMP_FIELD, event.getTimestamp().toString());
 
     switch (event.getName()) {
       case TimingEvent.FlowTimings.FLOW_COMPILED:


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@jack-moseley @Will-Lo please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1475


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When a lower order event (orchestrated) having higher count of `currentAttempts` (1) arrives later than a higher order event (flow running) having smaller count of `currentAttempt` (0) , we store 0 as a new `currentAttempt`. This is wrong, because we should take a max of currentAttempt and not blindly give precedence of all the higher order event's properties
over the lower order event's properties

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a couple of tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

