### PR TITLE
[GOBBLIN-1474] Use jfrog for pegasus repository location as bintray was deactivated

### DIFF
--- a/gobblin-rest-service/gobblin-rest-api/build.gradle
+++ b/gobblin-rest-service/gobblin-rest-api/build.gradle
@@ -140,7 +140,7 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven {
-            url "https://linkedin.bintray.com/maven"
+            url "https://linkedin.jfrog.io/artifactory/open-source"
         }
     }
 

--- a/gobblin-rest-service/gobblin-rest-server/build.gradle
+++ b/gobblin-rest-service/gobblin-rest-server/build.gradle
@@ -56,7 +56,7 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven {
-            url "https://linkedin.bintray.com/maven"
+            url "https://linkedin.jfrog.io/artifactory/open-source/"
         }
     }
 

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -24,13 +24,10 @@ repositories {
     url "http://packages.confluent.io/maven/"
   }
   maven {
-    url "https://linkedin.bintray.com/maven"
-  }
-  maven {
     url "https://repository.apache.org/content/repositories/snapshots"
   }
   maven {
-    url "https://linkedin.jfrog.io/artifactory/"
+    url "https://linkedin.jfrog.io/artifactory/open-source/"
   }
   jcenter()
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

LinkedIn Bintray was closed down on 06/11 due to the service being sunset
On JFrog, the location of the migrated jars is linkedin.jfrog.io/artifactory/open-source/

Use this new location to fix pegasus dependency issues.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

