### PR TITLE
[GOBBLIN-1478] Fix concurrency issue when iterating failedDagIds

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -1275,20 +1275,18 @@ public class DagManager extends AbstractIdleService {
       try {
         log.info("Cleaning failed dag state store");
         long startTime = System.currentTimeMillis();
-        List<String> dagIdsToClean = new ArrayList<>();
+        int numCleaned = 0;
 
-        for (String dagId : this.failedDagIds) {
+        Set<String> failedDagIdsCopy = new HashSet<>(this.failedDagIds);
+        for (String dagId : failedDagIdsCopy) {
           if (this.failedDagRetentionTime > 0L && startTime > DagManagerUtils.getFlowExecId(dagId) + this.failedDagRetentionTime) {
             this.failedDagStateStore.cleanUp(dagId);
-            dagIdsToClean.add(dagId);
+            this.failedDagIds.remove(dagId);
+            numCleaned++;
           }
         }
 
-        for (String dagId : dagIdsToClean) {
-          this.failedDagIds.remove(dagId);
-        }
-
-      log.info("Cleaned " + dagIdsToClean.size() + " dags from the failed dag state store");
+      log.info("Cleaned " + numCleaned + " dags from the failed dag state store");
       } catch (Exception e) {
         log.error("Failed to run retention on failed dag state store", e);
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1478


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

`failedDagIds` is a `synchronizedSet`, but as per [the doc](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedSet(java.util.Set)), it is still not thread safe to iterate over it which the retention thread does, so we saw concurrent modification exceptions related to this. This PR fixes it by creating a copy set and iterating that instead.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

