### PR TITLE
[GOBBLIN-1481] Throw failure in concurrency mode when allocating files

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/request_allocation/PriorityIterableBasedRequestAllocator.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/request_allocation/PriorityIterableBasedRequestAllocator.java
@@ -91,7 +91,8 @@ public abstract class PriorityIterableBasedRequestAllocator<T extends Request<T>
 
       try {
         List<Either<Void, ExecutionException>> results = executor.executeAndGetResults();
-        IteratorExecutor.logFailures(results, log, 10);
+        // Throw runtime failure if an exception occurs during execution to fail the job
+        IteratorExecutor.logAndThrowFailures(results, log, 10);
       } catch (InterruptedException ie) {
         log.error("Request allocation was interrupted.");
         return new AllocatedRequestsIteratorBase<>(


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1481


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  When generating workunits, there are scenarios where the underlying file system can throw errors when attempting to collect files to allocate them into workunits. The behavior for single threaded workunit generation is to throw the error, so we should make the multithreaded configuration also throw errors and fail loudly instead of logging and marking the job as successful (although there would still be 0 workunits).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

