### PR TITLE
[GOBBLIN-1482] Move verify dependencies test to after build step to fix pegasus error

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -55,9 +55,6 @@ jobs:
           # Only rebuild cache if build.gradle is changed
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Verify Dependencies
-        run: |
-          eval ./gradlew assemble
       - name: Build repository
         run: |
           ./gradlew --no-daemon clean build -x test -x javadoc -x findbugsMain -x findbugsTest -x checkstyleMain -x checkstyleJmh -x checkstyleTest -Dorg.gradle.parallel=true

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -58,6 +58,10 @@ jobs:
       - name: Build repository
         run: |
           ./gradlew --no-daemon clean build -x test -x javadoc -x findbugsMain -x findbugsTest -x checkstyleMain -x checkstyleJmh -x checkstyleTest -Dorg.gradle.parallel=true
+      - name: Verify Dependencies
+        run: |
+          # Since dependencies are cached, check after building if they are valid or not
+          eval ./gradlew assemble
 
   static_checks:
     name: Run static checks

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Verify Dependencies
         run: |
           # Since dependencies are cached, check after building if they are valid or not
-          eval ./gradlew assemble
+          eval ./gradlew --no-daemon assemble -x javadoc -Dorg.gradle.parallel=true
 
   static_checks:
     name: Run static checks


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1482
    - 


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

The issue is caused by the `./gradlew assemble` step conflicting with the build step and not including all the classes needed for some of the build tasks, if it’s done before the build step.

`./gradlew assemble` is still needed to verify the dependencies, as `./gradlew build` caches the dependencies between runs as an optimization

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

