### PR TITLE
GOBBLIN-1483: Handle null valued ConsumerRecords in Kafka Streaming Extractor

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -87,7 +87,8 @@ import static org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.
 public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableKafkaRecord> {
   public static final String DATASET_KEY = "dataset";
   public static final String DATASET_PARTITION_KEY = "datasetPartition";
-  private static final Long MAX_LOG_DECODING_ERRORS = 5L;
+  private static final Long MAX_LOG_ERRORS = 100L;
+
   private static final String KAFKA_EXTRACTOR_STATS_REPORTING_INTERVAL_MINUTES_KEY =
       "gobblin.kafka.extractor.statsReportingIntervalMinutes";
   private static final Long DEFAULT_KAFKA_EXTRACTOR_STATS_REPORTING_INTERVAL_MINUTES = 1L;
@@ -350,20 +351,33 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
     this.readStartTime = System.nanoTime();
     long fetchStartTime = System.nanoTime();
     try {
-      while (this.messageIterator == null || !this.messageIterator.hasNext()) {
-        Long currentTime = System.currentTimeMillis();
-        //it's time to flush, so break the while loop and directly return null
-        if ((currentTime - timeOfLastFlush) > this.flushIntervalMillis) {
-          return new FlushRecordEnvelope();
+      DecodeableKafkaRecord kafkaConsumerRecord;
+      while(true) {
+        while (this.messageIterator == null || !this.messageIterator.hasNext()) {
+          Long currentTime = System.currentTimeMillis();
+          //it's time to flush, so break the while loop and directly return null
+          if ((currentTime - timeOfLastFlush) > this.flushIntervalMillis) {
+            return new FlushRecordEnvelope();
+          }
+          try {
+            fetchStartTime = System.nanoTime();
+            this.messageIterator = this.kafkaConsumerClient.consume();
+          } catch (Exception e) {
+            log.error("Failed to consume from Kafka", e);
+          }
         }
-        try {
-          fetchStartTime = System.nanoTime();
-          this.messageIterator = this.kafkaConsumerClient.consume();
-        } catch (Exception e) {
-          log.error("Failed to consume from Kafka", e);
+        kafkaConsumerRecord = (DecodeableKafkaRecord) this.messageIterator.next();
+        if (kafkaConsumerRecord.getValue() != null) {
+          break;
+        } else {
+          //Filter the null-valued records early, so that they do not break the pipeline downstream.
+          if (shouldLogError()) {
+            log.error("Encountered a null-valued record at offset: {}, partition: {}", kafkaConsumerRecord.getOffset(),
+                kafkaConsumerRecord.getPartition());
+          }
+          this.statsTracker.onNullRecord(this.partitionIdToIndexMap.get(kafkaConsumerRecord.getPartition()));
         }
       }
-      DecodeableKafkaRecord kafkaConsumerRecord = (DecodeableKafkaRecord) this.messageIterator.next();
 
       int partitionIndex = this.partitionIdToIndexMap.get(kafkaConsumerRecord.getPartition());
       this.statsTracker.onFetchNextMessageBuffer(partitionIndex, fetchStartTime);
@@ -395,7 +409,7 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
   }
 
   private boolean shouldLogError() {
-    return this.statsTracker.getUndecodableMessageCount() <= MAX_LOG_DECODING_ERRORS;
+    return (this.statsTracker.getUndecodableMessageCount() + this.statsTracker.getNullRecordCount()) <= MAX_LOG_ERRORS;
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTrackerTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTrackerTest.java
@@ -74,6 +74,23 @@ public class KafkaExtractorStatsTrackerTest {
   }
 
   @Test
+  public void testOnNullRecord() {
+    //Ensure that counters are initialized correctly
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(0).longValue(), -1);
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(0).longValue(), -1);
+
+    //Ensure that counters are updated correctly after 1st call to KafkaExtractorStatsTracker#onNullRecord()
+    this.extractorStatsTracker.onNullRecord(0);
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(0).longValue(), 1);
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(1).longValue(), -1);
+
+    //Ensure that counters are updated correctly after 2nd call to KafkaExtractorStatsTracker#onUndecodeableRecord()
+    this.extractorStatsTracker.onNullRecord(0);
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(0).longValue(), 2);
+    Assert.assertEquals(this.extractorStatsTracker.getNullRecordCount(1).longValue(), -1);
+  }
+
+  @Test
   public void testResetStartFetchEpochTime() {
     long currentTime = System.currentTimeMillis();
     this.extractorStatsTracker.resetStartFetchEpochTime(1);

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
@@ -26,9 +26,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.publisher.DataPublisher;
 import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.extract.FlushingExtractor;
+import org.apache.gobblin.stream.RecordEnvelope;
+import org.apache.gobblin.stream.StreamEntity;
 
 
 public class KafkaStreamingExtractorTest {
@@ -37,9 +40,9 @@ public class KafkaStreamingExtractorTest {
 
   @BeforeClass
   public void setUp() {
-    WorkUnitState state = KafkaExtractorUtils.getWorkUnitState("testTopic", numPartitions);
-    state.setProp(FlushingExtractor.FLUSH_DATA_PUBLISHER_CLASS, TestDataPublisher.class.getName());
-    this.streamingExtractor = new KafkaStreamingExtractor(state);
+    WorkUnitState state1 = KafkaExtractorUtils.getWorkUnitState("testTopic", numPartitions);
+    state1.setProp(FlushingExtractor.FLUSH_DATA_PUBLISHER_CLASS, TestDataPublisher.class.getName());
+    this.streamingExtractor = new KafkaStreamingExtractor(state1);
   }
 
   @Test
@@ -48,17 +51,17 @@ public class KafkaStreamingExtractorTest {
     MultiLongWatermark highWatermark1 = new MultiLongWatermark(this.streamingExtractor.highWatermark);
 
     //Read 3 records
-    this.streamingExtractor.readStreamEntityImpl();
+    StreamEntity<DecodeableKafkaRecord> streamEntity = this.streamingExtractor.readStreamEntityImpl();
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 0L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 0L);
 
-    streamingExtractor.readStreamEntityImpl();
+    this.streamingExtractor.readStreamEntityImpl();
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 1L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 0L);
 
-    streamingExtractor.readStreamEntityImpl();
+    this.streamingExtractor.readStreamEntityImpl();
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(0), 1L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(1), 1L);
     Assert.assertEquals(this.streamingExtractor.nextWatermark.get(2), 1L);
@@ -103,11 +106,27 @@ public class KafkaStreamingExtractorTest {
   }
 
   @Test
-  public void testGenerateAdditionalTagHelper() throws Exception {
+  public void testGenerateAdditionalTagHelper() {
     // Verifying that produce rate has been added.
     Map<KafkaPartition, Map<String, String>> result = this.streamingExtractor.getAdditionalTagsHelper();
     for (Map<String, String> entry: result.values()) {
       Assert.assertTrue(entry.containsKey(KafkaProduceRateTracker.KAFKA_PARTITION_PRODUCE_RATE_KEY));
+    }
+  }
+
+  @Test
+  public void testReadRecordEnvelopeImpl()
+      throws IOException {
+    WorkUnitState state = KafkaExtractorUtils.getWorkUnitState("testTopic", numPartitions);
+    state.setProp(FlushingExtractor.FLUSH_DATA_PUBLISHER_CLASS, TestDataPublisher.class.getName());
+    //Enable config that allows underlying KafkaConsumerClient to return null-valued Kafka records.
+    state.setProp(KafkaStreamTestUtils.MockKafkaConsumerClient.CAN_RETURN_NULL_VALUED_RECORDS, "true");
+    KafkaStreamingExtractor streamingExtractorWithNulls = new KafkaStreamingExtractor(state);
+
+    //Extract 4 records. Ensure each record returned by readRecordEnvelopeImpl() is a non-null valued record.
+    for (int i = 0; i < 4; i++) {
+      RecordEnvelope<DecodeableKafkaRecord> recordEnvelope = streamingExtractorWithNulls.readRecordEnvelopeImpl();
+      Assert.assertNotNull(recordEnvelope.getRecord().getValue() != null);
     }
   }
 
@@ -131,8 +150,7 @@ public class KafkaStreamingExtractorTest {
     }
 
     @Override
-    public void close()
-        throws IOException {
+    public void close() {
 
     }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1483


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, null-valued ConsumerRecords returned by the Kafka consumer are passed down the construct chain and can result in irrecoverable failures. Null valued records should be filtered out early in the pipeline so as to avoid such errors.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

