### PR TITLE
[GOBBLIN-1485]Enable feature to get schema from writer schema when do hive registration

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
@@ -149,9 +149,9 @@ public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitCompar
   private State extractSchemaVersion(State state) {
     State newState = new State(state);
     String schemaFromState = state.getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
-    if (Strings.isNullOrEmpty(schemaFromState)) {
+    if (!Strings.isNullOrEmpty(schemaFromState)) {
       String schemaVersion = AvroUtils.getSchemaCreationTime(new Schema.Parser().parse(schemaFromState));
-      if (Strings.isNullOrEmpty(schemaVersion)) {
+      if (!Strings.isNullOrEmpty(schemaVersion)) {
          newState.removeProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
          newState.setProp("schema.creationTime", schemaVersion);
       }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
  */
 @Alpha
 public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitComparator<?>> {
+  private static String SCHEMA_CREATION_TIME = "schema.creationTime";
 
   protected final HiveRegistrationUnit existingUnit;
   protected final HiveRegistrationUnit newUnit;
@@ -147,13 +148,15 @@ public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitCompar
   }
 
   private State extractSchemaVersion(State state) {
+    //FIXME: This is a temp fix for special character in schema string, need to investigate the root
+    //cause of why we see different encoding here and have a permanent fix for this
     State newState = new State(state);
     String schemaFromState = state.getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
     if (!Strings.isNullOrEmpty(schemaFromState)) {
       String schemaVersion = AvroUtils.getSchemaCreationTime(new Schema.Parser().parse(schemaFromState));
       if (!Strings.isNullOrEmpty(schemaVersion)) {
          newState.removeProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
-         newState.setProp("schema.creationTime", schemaVersion);
+         newState.setProp(SCHEMA_CREATION_TIME, schemaVersion);
       }
     }
     return newState;

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.hive;
 
+import com.google.common.base.Strings;
 import java.util.Set;
 
 import org.apache.avro.Schema;
@@ -148,9 +149,9 @@ public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitCompar
   private State extractSchemaVersion(State state) {
     State newState = new State(state);
     String schemaFromState = state.getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
-    if (schemaFromState != null && !schemaFromState.isEmpty()) {
+    if (Strings.isNullOrEmpty(schemaFromState)) {
       String schemaVersion = AvroUtils.getSchemaCreationTime(new Schema.Parser().parse(schemaFromState));
-      if (schemaVersion != null && !schemaVersion.isEmpty()) {
+      if (Strings.isNullOrEmpty(schemaVersion)) {
          newState.removeProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
          newState.setProp("schema.creationTime", schemaVersion);
       }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnitComparator.java
@@ -17,10 +17,8 @@
 
 package org.apache.gobblin.hive;
 
-import java.util.Map;
 import java.util.Set;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.gobblin.util.AvroUtils;
 import org.apache.hadoop.fs.Path;
@@ -70,7 +68,6 @@ import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
  * @author Ziyang Liu
  */
 @Alpha
-@Slf4j
 public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitComparator<?>> {
 
   protected final HiveRegistrationUnit existingUnit;

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/orc/HiveOrcSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/orc/HiveOrcSerDeManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.hive.orc;
 
+import com.google.common.base.Strings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.avro.AvroObjectInspectorGenerator;
+import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
@@ -78,16 +80,11 @@ public class HiveOrcSerDeManager extends HiveSerDeManager {
   public static final String DEFAULT_SERDE_TYPE = "ORC";
   public static final String INPUT_FORMAT_CLASS_KEY = "hiveOrcSerdeManager.inputFormatClass";
   public static final String DEFAULT_INPUT_FORMAT_CLASS = OrcInputFormat.class.getName();
-  public static final String WRITER_LATEST_SCHEMA = "writer.latest.schema";
 
   public static final String OUTPUT_FORMAT_CLASS_KEY = "hiveOrcSerdeManager.outputFormatClass";
   public static final String DEFAULT_OUTPUT_FORMAT_CLASS = OrcOutputFormat.class.getName();
 
   public static final String HIVE_SPEC_SCHEMA_READING_TIMER = "hiveOrcSerdeManager.schemaReadTimer";
-
-  public static final String HIVE_SPEC_SCHEMA_FROM_WRITER = "hiveOrcSerdeManager.getSchemaFromWriterSchema";
-  public static final boolean DEFAULT_HIVE_SPEC_SCHEMA_FROM_WRITER = false;
-
 
   public static final String ENABLED_ORC_TYPE_CHECK = "hiveOrcSerdeManager.enableFormatCheck";
   public static final boolean DEFAULT_ENABLED_ORC_TYPE_CHECK = false;
@@ -273,10 +270,9 @@ public class HiveOrcSerDeManager extends HiveSerDeManager {
    */
   protected void addSchemaPropertiesHelper(Path path, HiveRegistrationUnit hiveUnit) throws IOException {
     TypeInfo schema;
-    if(props.getPropAsBoolean(HIVE_SPEC_SCHEMA_FROM_WRITER, DEFAULT_HIVE_SPEC_SCHEMA_FROM_WRITER)) {
+    if(!Strings.isNullOrEmpty(props.getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()))) {
       try {
-        Preconditions.checkArgument(props.contains(WRITER_LATEST_SCHEMA));
-        Schema avroSchema = new Schema.Parser().parse(props.getProp(WRITER_LATEST_SCHEMA));
+        Schema avroSchema = new Schema.Parser().parse(props.getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()));
         schema = TypeInfoUtils.getTypeInfoFromObjectInspector(new AvroObjectInspectorGenerator(avroSchema).getObjectInspector());
       } catch (SerDeException e) {
         throw new IOException(e);


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1485


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
1. enable feature to get schema from writer schema instead of listing directory to get latest schema. 
2. When determine whether there is schema change, use schema version to compare to avoid special character issue. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Run test on parallel pipeline

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

