### PR TITLE
[GOBBLIN-1484]Make Gobblin metadata writer be able to support schema source DB

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -287,16 +287,13 @@ public class HiveMetadataWriter implements MetadataWriter {
   }
 
   private String fetchSchemaFromTable(String dbName, String tableName) throws IOException {
-    //note: If the pipeline does not register the source table, if may leave the schema unchange until pipeline restart.
     String tableKey = tableNameJoiner.join(dbName, tableName);
-    if (!lastestSchemaMap.containsKey(tableKey)) {
-      Optional<HiveTable> table = hiveRegister.getTable(dbName, tableName);
-      if (table.isPresent()) {
-        lastestSchemaMap.put(tableKey, table.get().getSerDeProps().getProp(
-            AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()));
-      }
+    if (lastestSchemaMap.containsKey(tableKey)) {
+      return lastestSchemaMap.get(tableKey);
     }
-    return lastestSchemaMap.get(tableKey);
+    Optional<HiveTable> table = hiveRegister.getTable(dbName, tableName);
+    return table.isPresent()? table.get().getSerDeProps().getProp(
+        AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()) : null;
   }
 
   @Override

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -287,9 +287,16 @@ public class HiveMetadataWriter implements MetadataWriter {
   }
 
   private String fetchSchemaFromTable(String dbName, String tableName) throws IOException {
-    Optional<HiveTable> table = hiveRegister.getTable(dbName, tableName);
-    return table.isPresent()? table.get().getSerDeProps().getProp(
-        AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()) : null;
+    //note: If the pipeline does not register the source table, if may leave the schema unchange until pipeline restart.
+    String tableKey = tableNameJoiner.join(dbName, tableName);
+    if (!lastestSchemaMap.containsKey(tableKey)) {
+      Optional<HiveTable> table = hiveRegister.getTable(dbName, tableName);
+      if (table.isPresent()) {
+        lastestSchemaMap.put(tableKey, table.get().getSerDeProps().getProp(
+            AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()));
+      }
+    }
+    return lastestSchemaMap.get(tableKey);
   }
 
   @Override

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister;
 import org.apache.gobblin.hive.policy.HiveRegistrationPolicyBase;
 import org.apache.gobblin.iceberg.Utils.IcebergUtils;
 import org.apache.gobblin.iceberg.publisher.GobblinMCEPublisher;
@@ -146,6 +147,10 @@ public abstract class GobblinMCEProducer implements Closeable {
     if (state.contains(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES)) {
       regProperties.put(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES,
           state.getProp(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES));
+    }
+    if (state.contains(HiveMetaStoreBasedRegister.SCHEMA_SOURCE_DB)) {
+      regProperties.put(HiveMetaStoreBasedRegister.SCHEMA_SOURCE_DB,
+          state.getProp(HiveMetaStoreBasedRegister.SCHEMA_SOURCE_DB));
     }
     if (!regProperties.isEmpty()) {
       gmceBuilder.setRegistrationProperties(regProperties);

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -233,15 +233,12 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       String tableName = spec.getTable().getTableName();
       String tableString = Joiner.on(TABLE_NAME_DELIMITER).join(dbName, tableName);
       if (tableOperationTypeMap.containsKey(tableString)
-          && tableOperationTypeMap.get(tableString) != gmce.getOperationType()
-          && !gmce.getOperationType().equals(OperationType.change_property)) {
+          && tableOperationTypeMap.get(tableString) != gmce.getOperationType()) {
         for (MetadataWriter writer : metadataWriters) {
           writer.flush(dbName, tableName);
         }
       }
-      if(!tableOperationTypeMap.containsKey(tableString) || !gmce.getOperationType().equals(OperationType.change_property)) {
-        tableOperationTypeMap.put(tableString, gmce.getOperationType());
-      }
+      tableOperationTypeMap.put(tableString, gmce.getOperationType());
       for (MetadataWriter writer : metadataWriters) {
         writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
       }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -289,6 +289,10 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         : (gmce.getRegistrationPolicyForOldData() != null ? gmce.getRegistrationPolicyForOldData() : defaultPolicy);
 
     tmpState.setProp(ConfigurationKeys.HIVE_REGISTRATION_POLICY, policyClass);
+    if (!forNew) {
+      //For old data, we don't use the old spec to update table, we set the flag to true to avoid listing operation
+      tmpState.setProp(HiveRegistrationPolicy.MAPREDUCE_JOB_INPUT_PATH_EMPTY_KEY, true);
+    }
     if (gmce.getPartitionColumns() != null && !gmce.getPartitionColumns().isEmpty()) {
       //We only support on partition column for now
       //TODO: Support multi partition columns

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -233,12 +233,15 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       String tableName = spec.getTable().getTableName();
       String tableString = Joiner.on(TABLE_NAME_DELIMITER).join(dbName, tableName);
       if (tableOperationTypeMap.containsKey(tableString)
-          && tableOperationTypeMap.get(tableString) != gmce.getOperationType()) {
+          && tableOperationTypeMap.get(tableString) != gmce.getOperationType()
+          && !gmce.getOperationType().equals(OperationType.change_property)) {
         for (MetadataWriter writer : metadataWriters) {
           writer.flush(dbName, tableName);
         }
       }
-      tableOperationTypeMap.put(tableString, gmce.getOperationType());
+      if(!tableOperationTypeMap.containsKey(tableString) || !gmce.getOperationType().equals(OperationType.change_property)) {
+        tableOperationTypeMap.put(tableString, gmce.getOperationType());
+      }
       for (MetadataWriter writer : metadataWriters) {
         writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
       }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -317,6 +317,10 @@ public class IcebergMetadataWriter implements MetadataWriter {
     for (Map.Entry<String, String> entry : gmce.getTopicPartitionOffsetsRange().entrySet()) {
       List<String> rangePair = Splitter.on(ConfigurationKeys.RANGE_DELIMITER_KEY).splitToList(entry.getValue());
       Range range = Range.openClosed(Long.parseLong(rangePair.get(0)), Long.parseLong(rangePair.get(1)));
+      if (range.lowerEndpoint().equals(range.upperEndpoint())) {
+        //Ignore this case
+        continue;
+      }
       List<Range> existRanges = offsets.getOrDefault(entry.getKey(), new ArrayList<>());
       List<Range> newRanges = new ArrayList<>();
       for (Range r : existRanges) {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -20,8 +20,10 @@ package org.apache.gobblin.iceberg.writer;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
+import java.util.Map;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -30,6 +32,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -90,6 +93,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
       .endRecord();
   org.apache.avro.Schema _avroPartitionSchema;
   private String dbName = "hivedb";
+  private String dedupedDbName = "hivedb_deduped";
   private String tableName = "testTable";
 
   private GobblinMCEWriter gobblinMCEWriter;
@@ -126,6 +130,12 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
       client.createDatabase(
           new Database(dbName, "database", tmpDir.getAbsolutePath() + "/metastore", Collections.emptyMap()));
     }
+    try {
+      client.getDatabase(dedupedDbName);
+    } catch (NoSuchObjectException e) {
+      client.createDatabase(
+          new Database(dedupedDbName, "dedupeddatabase", tmpDir.getAbsolutePath() + "/metastore_deduped", Collections.emptyMap()));
+    }
     hourlyDataFile_1 = new File(tmpDir, "data/tracking/testTable/hourly/2020/03/17/08/data.avro");
     Files.createParentDirs(hourlyDataFile_1);
     hourlyDataFile_2 = new File(tmpDir, "data/tracking/testTable/hourly/2020/03/17/09/data.avro");
@@ -137,6 +147,8 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
     writeRecord(hourlyDataFile_1);
     writeRecord(hourlyDataFile_2);
     writeRecord(dailyDataFile);
+    Map<String, String> registrationState = new HashMap();
+    registrationState.put("hive.database.name", dbName);
     gmce = GobblinMetadataChangeEvent.newBuilder()
         .setDatasetIdentifier(DatasetIdentifier.newBuilder()
             .setDataOrigin(DataOrigin.EI)
@@ -156,7 +168,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
         .setCluster(ClustersNames.getInstance().getClusterName())
         .setPartitionColumns(Lists.newArrayList("testpartition"))
         .setRegistrationPolicy(TestHiveRegistrationPolicy.class.getName())
-        .setRegistrationProperties(ImmutableMap.<String, String>builder().put("hive.database.name", dbName).build())
+        .setRegistrationProperties(registrationState)
         .build();
     state.setProp(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS,
         KafkaStreamTestUtils.MockSchemaRegistry.class.getName());
@@ -206,6 +218,11 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
   @Test(dependsOnMethods = {"testHiveWriteAddFileGMCE"})
   public void testHiveWriteRewriteFileGMCE() throws IOException {
     gmce.setTopicPartitionOffsetsRange(null);
+    Map<String, String> registrationState = gmce.getRegistrationProperties();
+    registrationState.put("additional.hive.database.names", dedupedDbName);
+    registrationState.put(HiveMetaStoreBasedRegister.SCHEMA_SOURCE_DB, dbName);
+    gmce.setRegistrationProperties(registrationState);
+    gmce.setSchemaSource(SchemaSource.NONE);
     FileSystem fs = FileSystem.get(new Configuration());
     String filePath = new Path(hourlyDataFile_1.getParentFile().getAbsolutePath()).toString();
     String filePath_1 = new Path(hourlyDataFile_2.getParentFile().getAbsolutePath()).toString();
@@ -225,7 +242,9 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
 
     //Test hive writer re-write operation can de-register old partitions and register new one
     try {
-       Assert.assertTrue(client.getPartition("hivedb", "testTable",Lists.newArrayList("2020-03-17-00")) != null);
+      Assert.assertTrue(client.getPartition("hivedb", "testTable",Lists.newArrayList("2020-03-17-00")) != null);
+      // Test additional table been registered
+      Assert.assertTrue(client.tableExists(dedupedDbName, "testTable"));
     } catch (TException e) {
       throw new IOException(e);
     }
@@ -264,7 +283,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
         partitionValue = "2020-03-17-00";
       }
       HivePartition partition = new HivePartition.Builder().withPartitionValues(Lists.newArrayList(partitionValue))
-          .withDbName("hivedb").withTableName("testTable").build();
+          .withDbName(table.getDbName()).withTableName(table.getTableName()).build();
       partition.setLocation(path.toString());
       return Optional.of(partition);
     }
@@ -278,9 +297,9 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
       }
       return tables;
     }
-    protected Iterable<String> getDatabaseNames(Path path) {
+    /*protected Iterable<String> getDatabaseNames(Path path) {
       return Lists.newArrayList("hivedb");
-    }
+    }    */
     protected List<String> getTableNames(Optional<String> dbPrefix, Path path) {
       return Lists.newArrayList("testTable");
     }

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -297,9 +297,6 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
       }
       return tables;
     }
-    /*protected Iterable<String> getDatabaseNames(Path path) {
-      return Lists.newArrayList("hivedb");
-    }    */
     protected List<String> getTableNames(Optional<String> dbPrefix, Path path) {
       return Lists.newArrayList("testTable");
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1484


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Sometime we need the avro schema in place even for ORC tables, we have that information in ingestion job but not for compaction job. And it's hard to get the avro schema from orc file itself, so we want to support schema source db, so that we can fetch the schema from source db where ingestion job registers to.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

