### PR TITLE
[GOBBLIN-1491] Add option to mark up/down D2 servers for gobblin service on leadership change

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -35,6 +35,8 @@ public class ServiceConfigKeys {
   public static final String GOBBLIN_SERVICE_GIT_CONFIG_MONITOR_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "gitConfigMonitor.enabled";
   public static final String GOBBLIN_SERVICE_DAG_MANAGER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "dagManager.enabled";
   public static final String GOBBLIN_SERVICE_JOB_STATUS_MONITOR_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "jobStatusMonitor.enabled";
+  // If true, will mark up/down d2 servers on leadership so that all requests will be routed to the leader node
+  public static final String GOBBLIN_SERVICE_D2_ONLY_ANNOUNCE_LEADER = GOBBLIN_SERVICE_PREFIX + "d2.onlyAnnounceLeader";
 
   // Helix / ServiceScheduler Keys
   public static final String HELIX_CLUSTER_NAME_KEY = GOBBLIN_SERVICE_PREFIX + "helix.cluster.name";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/D2Announcer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/D2Announcer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.core;
+
+
+/**
+ * Interface for marking up/down D2 servers on gobblin service startup. This is only required if using delayed announcement.
+ */
+public interface D2Announcer {
+  /**
+   * Mark up this host's D2 server
+   */
+  void markUpServer();
+
+  /**
+   * Mark down this host's D2 server
+   */
+  void markDownServer();
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceConfiguration.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceConfiguration.java
@@ -71,6 +71,9 @@ public class GobblinServiceConfiguration {
   private final boolean flowCatalogLocalCommit;
 
   @Getter
+  private final boolean onlyAnnounceLeader;
+
+  @Getter
   private final Config innerConfig;
 
   @Getter
@@ -111,5 +114,6 @@ public class GobblinServiceConfiguration {
         ConfigUtils.getBoolean(config, ServiceConfigKeys.GOBBLIN_SERVICE_RESTLI_SERVER_ENABLED_KEY, true);
     this.isTopologySpecFactoryEnabled =
         ConfigUtils.getBoolean(config, ServiceConfigKeys.GOBBLIN_SERVICE_TOPOLOGY_SPEC_FACTORY_ENABLED_KEY, true);
+    this.onlyAnnounceLeader = ConfigUtils.getBoolean(config, ServiceConfigKeys.GOBBLIN_SERVICE_D2_ONLY_ANNOUNCE_LEADER, false);
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -214,6 +214,8 @@ public class GobblinServiceGuiceModule implements Module {
 
     binder.bind(JobIssueEventHandler.class);
 
+    binder.bind(D2Announcer.class).to(NoopD2Announcer.class);
+
     LOGGER.info("Bindings configured");
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -191,6 +191,8 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
   protected Optional<HelixLeaderState> helixLeaderGauges;
 
+  @Inject(optional = true)
+  protected D2Announcer d2Announcer;
 
   private final MetricContext metricContext;
   private final Metrics metrics;
@@ -272,7 +274,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
    * Handle leadership change.
    * @param changeContext notification context
    */
-  private void  handleLeadershipChange(NotificationContext changeContext) {
+  private void handleLeadershipChange(NotificationContext changeContext) {
     if (this.helixManager.isPresent() && this.helixManager.get().isLeader()) {
       LOGGER.info("Leader notification for {} HM.isLeader {}", this.helixManager.get().getInstanceName(),
           this.helixManager.get().isLeader());
@@ -297,6 +299,10 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
           this.eventBus.register(this.dagManager);
         }
       }
+
+      if (configuration.isOnlyAnnounceLeader()) {
+        this.d2Announcer.markUpServer();
+      }
     } else if (this.helixManager.isPresent()) {
       LOGGER.info("Leader lost notification for {} HM.isLeader {}", this.helixManager.get().getInstanceName(),
           this.helixManager.get().isLeader());
@@ -317,6 +323,10 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
       if (configuration.isDagManagerEnabled()) {
         this.dagManager.setActive(false);
         this.eventBus.unregister(this.dagManager);
+      }
+
+      if (configuration.isOnlyAnnounceLeader()) {
+        this.d2Announcer.markDownServer();
       }
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/NoopD2Announcer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/NoopD2Announcer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.core;
+
+
+public class NoopD2Announcer implements D2Announcer {
+  public void markUpServer() {}
+
+  public void markDownServer() {}
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1491


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently, D2 servers are started on all hosts at the time of service start. This change will allow using D2 delayed start, then marking up/down the servers when a host becomes the master/slave respectively. This means only the master will be announced to D2, so all requests will be routed to it.

The logic for markup is linkedin specific so must be implemented in internal code.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

