### PR TITLE
[GOBBLIN-1492] Optimize flowspec keys on configToProperties

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
@@ -1,0 +1,33 @@
+package org.apache.gobblin.runtime.api;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.gobblin.config.ConfigBuilder;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+
+public class FlowSpecTest {
+
+  @Test
+  public void testDuplicateKeysShareMem() throws URISyntaxException {
+    FlowSpec flowSpec1 = FlowSpec.builder("flowspec1").withVersion("version1").withDescription("description1")
+        .withConfig(ConfigBuilder.create().addPrimitive("key1", "value1").build()).build();
+    FlowSpec flowSpec2 = FlowSpec.builder("flowspec2").withVersion("version2").withDescription("description2")
+        .withConfig(ConfigBuilder.create().addPrimitive("key1", "value2").build()).build();
+
+    List<String> flowSpec1Keys = flowSpec1.getConfigAsProperties().stringPropertyNames().stream().sorted().collect(
+        Collectors.toList());
+    List<String> flowSpec2Keys = flowSpec2.getConfigAsProperties().stringPropertyNames().stream().sorted().collect(
+        Collectors.toList());;
+
+    for (int i = 0; i < flowSpec1Keys.size(); i++) {
+      // Since the keys are interned, they should resolve to the same object
+      Assert.assertTrue(flowSpec1Keys.get(i) == flowSpec2Keys.get(i));
+    }
+
+
+  }
+
+}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.runtime.api;
 
 import java.net.URISyntaxException;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -303,7 +303,11 @@ public class ConfigUtils {
    * values Strings. This implementation will try to recognize booleans and numbers. All keys are
    * treated as strings.*/
   private static Map<String, Object> guessPropertiesTypes(Map<Object, Object> srcProperties) {
+<<<<<<< HEAD
     Map<String, Object> res = Maps.newHashMapWithExpectedSize(srcProperties.size());
+=======
+    Map<String, Object> res = new HashMap<>(srcProperties.size());
+>>>>>>> ff249aa9c (Restore accidentally deleted line)
     for (Map.Entry<Object, Object> prop : srcProperties.entrySet()) {
       Object value = prop.getValue();
       if (null != value && value instanceof String && !Strings.isNullOrEmpty(value.toString())) {
@@ -562,6 +566,7 @@ public class ConfigUtils {
 
     PasswordManager passwordManager = PasswordManager.getInstance(configToProperties(config));
     Map<String, String> tmpMap = Maps.newHashMapWithExpectedSize(encryptedConfig.entrySet().size());
+
     for (Map.Entry<String, ConfigValue> entry : encryptedConfig.entrySet()) {
       String val = entry.getValue().unwrapped().toString();
       val = passwordManager.readPassword(val);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -303,11 +303,7 @@ public class ConfigUtils {
    * values Strings. This implementation will try to recognize booleans and numbers. All keys are
    * treated as strings.*/
   private static Map<String, Object> guessPropertiesTypes(Map<Object, Object> srcProperties) {
-<<<<<<< HEAD
     Map<String, Object> res = Maps.newHashMapWithExpectedSize(srcProperties.size());
-=======
-    Map<String, Object> res = new HashMap<>(srcProperties.size());
->>>>>>> ff249aa9c (Restore accidentally deleted line)
     for (Map.Entry<Object, Object> prop : srcProperties.entrySet()) {
       Object value = prop.getValue();
       if (null != value && value instanceof String && !Strings.isNullOrEmpty(value.toString())) {
@@ -566,7 +562,6 @@ public class ConfigUtils {
 
     PasswordManager passwordManager = PasswordManager.getInstance(configToProperties(config));
     Map<String, String> tmpMap = Maps.newHashMapWithExpectedSize(encryptedConfig.entrySet().size());
-
     for (Map.Entry<String, ConfigValue> entry : encryptedConfig.entrySet()) {
       String val = entry.getValue().unwrapped().toString();
       val = passwordManager.readPassword(val);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -115,7 +115,8 @@ public class ConfigUtils {
       Config resolvedConfig = config.resolve();
       for (Map.Entry<String, ConfigValue> entry : resolvedConfig.entrySet()) {
         if (!prefix.isPresent() || entry.getKey().startsWith(prefix.get())) {
-          String propKey = desanitizeKey(entry.getKey());
+          // Intern the string so that constant keys are not duplicated to save memory
+          String propKey = desanitizeKey(entry.getKey()).intern();
           String propVal;
           try {
             propVal = resolvedConfig.getString(entry.getKey());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1492


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Use String.intern() on FlowSpec keys so that duplicate strings are not created. Duplicate keys in configToProperties can lead about to high heap usage (5% of Gobblin as a Service)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

