### PR TITLE
[GOBBLIN-1497] Reduce the number of calls on FlowSpec initialization where possible,…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/FlowConfigUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/FlowConfigUtils.java
@@ -22,12 +22,10 @@ import java.util.Properties;
 
 import com.google.common.collect.Maps;
 import com.linkedin.data.template.StringMap;
-import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.service.FlowConfig;
 import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.Schedule;
-import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PropertiesUtils;
 
 
@@ -60,7 +58,7 @@ public class FlowConfigUtils {
   }
 
   public static String serializeFlowConfig(FlowConfig flowConfig) throws IOException {
-    Properties properties = ConfigUtils.configToProperties(ConfigFactory.parseMap(flowConfig.getProperties()));
+    Properties properties = PropertiesUtils.stringMapToProperties(flowConfig.getProperties());
     properties.setProperty(FLOWCONFIG_ID_NAME, flowConfig.getId().getFlowName());
     properties.setProperty(FLOWCONFIG_ID_GROUP, flowConfig.getId().getFlowGroup());
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/FlowConfigUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/FlowConfigUtils.java
@@ -58,7 +58,8 @@ public class FlowConfigUtils {
   }
 
   public static String serializeFlowConfig(FlowConfig flowConfig) throws IOException {
-    Properties properties = PropertiesUtils.stringMapToProperties(flowConfig.getProperties());
+    Properties properties = new Properties();
+    properties.putAll(flowConfig.getProperties());
     properties.setProperty(FLOWCONFIG_ID_NAME, flowConfig.getId().getFlowName());
     properties.setProperty(FLOWCONFIG_ID_GROUP, flowConfig.getId().getFlowGroup());
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -203,8 +203,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       Spec spec = this.flowCatalog.get().getSpecWrapper(specUris.next());
       try {
         // Disable FLOW_RUN_IMMEDIATELY on service startup or leadership change if the property is set to true
-        if (spec instanceof FlowSpec && ((FlowSpec) spec).getConfigAsProperties()
-            .getProperty(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false").equals("true")) {
+        if (spec instanceof FlowSpec && PropertiesUtils.getPropAsBoolean((
+            (FlowSpec) spec).getConfigAsProperties(), ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false")) {
           Spec modifiedSpec = disableFlowRunImmediatelyOnStart((FlowSpec) spec);
           onAddSpec(modifiedSpec);
         } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -202,8 +202,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
     while (specUris.hasNext()) {
       Spec spec = this.flowCatalog.get().getSpecWrapper(specUris.next());
       try {
-        // Disable FLOW_RUN_IMMEDIATELY on service startup or leadership change
-        if (spec instanceof FlowSpec) {
+        // Disable FLOW_RUN_IMMEDIATELY on service startup or leadership change if the property is set to true
+        if (spec instanceof FlowSpec && ((FlowSpec) spec).getConfigAsProperties()
+            .getProperty(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false").equals("true")) {
           Spec modifiedSpec = disableFlowRunImmediatelyOnStart((FlowSpec) spec);
           onAddSpec(modifiedSpec);
         } else {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
@@ -152,4 +152,12 @@ public class PropertiesUtils {
         .map(entry -> "\"" + entry.getKey() + "\"" + " : " + "\"" + entry.getValue() + "\"")
         .collect(Collectors.joining(",\n"));
   }
+
+  public static Properties stringMapToProperties(Map<String, String> values) {
+    Properties properties = new Properties();
+    for (Map.Entry<String, String> entry : values.entrySet()) {
+      properties.setProperty(entry.getKey(), entry.getValue());
+    }
+    return properties;
+  }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
@@ -152,12 +152,4 @@ public class PropertiesUtils {
         .map(entry -> "\"" + entry.getKey() + "\"" + " : " + "\"" + entry.getValue() + "\"")
         .collect(Collectors.joining(",\n"));
   }
-
-  public static Properties stringMapToProperties(Map<String, String> values) {
-    Properties properties = new Properties();
-    for (Map.Entry<String, String> entry : values.entrySet()) {
-      properties.setProperty(entry.getKey(), entry.getValue());
-    }
-    return properties;
-  }
 }


### PR DESCRIPTION
… and configToProperties/vice versa

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1497


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

FlowSpecs contain both configs and property fields that duplicate the same key/value information, however there are slight differences with properties being mutable, configs being type-safe, and legacy code being compatible with properties but not configs.

As such, FlowSpec creation and configToProperties are memory expensive operations at scale, and we should aim to minimize them as much as possible.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

