### PR TITLE
[GOBBLIN-1495] Fix NPE when trying to fetch Hadoop tokens for cluster with no remote namenodes

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/hadoop/TokenUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/hadoop/TokenUtils.java
@@ -188,7 +188,11 @@ public class TokenUtils {
         : Optional.fromNullable(state.getProp(USER_TO_PROXY));
     final Configuration conf = new Configuration();
 
-    List<String> remoteFSURIList = state.getPropAsList(OTHER_NAMENODES);
+    List<String> remoteFSURIList = new ArrayList<>();
+    if (state.contains(OTHER_NAMENODES)) {
+      remoteFSURIList = state.getPropAsList(OTHER_NAMENODES);
+    }
+
     String renewer = state.getProp(TOKEN_RENEWER);
     log.info("Getting tokens for {}, using renewer: {}, including remote FS: {}", userToProxy, renewer, remoteFSURIList.toString());
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1495


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When the application tries to fetch Hadoop tokens for a cluster with no remote namenodes, the current implementation of the getHadoopTokens method doesn't check for the property "other_namenodes" while getting remoteFSURIList. This property is not mandatory and won't be present if there are not remote namenodes. In such cases, it throws NPE.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested by releasing snapshot version locally, application succeeded successfully.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

