### PR TITLE
[GOBBLIN-1499] fix the bug that compaction job hang when there is no fix the bug that compaction job hang when there is no path match the datasets patten

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/source/CompactionSource.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/source/CompactionSource.java
@@ -119,6 +119,7 @@ public class CompactionSource implements WorkUnitStreamSource<String, String> {
       CompactionWorkUnitIterator workUnitIterator = new CompactionWorkUnitIterator();
 
       if (datasets.size() == 0) {
+        workUnitIterator.done();
         return new BasicWorkUnitStream.Builder(workUnitIterator).build();
       }
 

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -295,7 +295,6 @@ public class HiveMetadataWriter implements MetadataWriter {
     spec.getTable()
         .getSerDeProps()
         .setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchemaMap.get(tableKey));
-
   }
 
   private String fetchSchemaFromTable(String dbName, String tableName) throws IOException {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -292,9 +292,10 @@ public class HiveMetadataWriter implements MetadataWriter {
       return;
     }
     //Force to set the schema even there is no schema literal defined in the spec
-    if(latestSchemaMap.containsKey(tableKey)) {
-      spec.getTable().getSerDeProps().setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchemaMap.get(tableKey));
-    }
+    spec.getTable()
+        .getSerDeProps()
+        .setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchemaMap.get(tableKey));
+
   }
 
   private String fetchSchemaFromTable(String dbName, String tableName) throws IOException {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -292,9 +292,9 @@ public class HiveMetadataWriter implements MetadataWriter {
       return;
     }
     //Force to set the schema even there is no schema literal defined in the spec
-    spec.getTable()
-        .getSerDeProps()
-        .setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchemaMap.get(tableKey));
+    if(latestSchemaMap.containsKey(tableKey)) {
+      spec.getTable().getSerDeProps().setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchemaMap.get(tableKey));
+    }
   }
 
   private String fetchSchemaFromTable(String dbName, String tableName) throws IOException {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1499


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
fix the bug that compaction job hang when there is no path match the datasets patten. When get the compaction workunit, it reach the end only when isDone set to true and workunit size is zero. But if there is no match of pattern, isDone is always false, so job hang.



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

