### PR TITLE
[GOBBLIN-1502] dont add a partition if it already exists but the getPartition fails …

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -586,7 +586,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
         }
         log.info(String.format("Added partition %s to table %s with location %s", stringifyPartition(nativePartition),
             table.getTableName(), nativePartition.getSd().getLocation()));
-      } catch (TException e) {
+      } catch (AlreadyExistsException e) {
         try {
           if (this.skipDiffComputation) {
             onPartitionExistWithoutComputingDiff(table, nativePartition, e);
@@ -632,7 +632,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
             onPartitionExist(client, table, partition, nativePartition, existedPartition);
           }
         }
-      } catch (TException e) {
+      } catch (NoSuchObjectException e) {
         try (Timer.Context context = this.metricContext.timer(ADD_PARTITION_TIMER).time()) {
           client.add_partition(getPartitionWithCreateTimeNow(nativePartition));
         }


### PR DESCRIPTION
…with TException, dont alter a partition if a partition does not exist but the add_partition fails with TException

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1502


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
During hive registration , we should not add a partition if it already exists and the getPartition fails
with any TException other than NoSuchObjectException
Also, we should not alter a partition if a partition does not exist but the add_partition fails with any TException other than AlreadyExistsException

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

