### PR TITLE
[GOBBLIN-1512] add a path filter to filter  out only files starting with a dot

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import org.apache.gobblin.util.PathUtils;
+import org.apache.gobblin.util.filters.DotFileFilter;
 import org.apache.gobblin.util.filters.HiddenFilter;
 
 
@@ -87,6 +88,25 @@ public class TimeAwareRecursiveCopyableDatasetTest {
     fs.mkdirs(baseDir3);
     PeriodFormatter formatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").toFormatter();
     Period period = formatter.parsePeriod(NUM_LOOKBACK_DAYS_HOURS_STR);
+  }
+
+  @Test
+  public void testDotFileFilter() throws IOException {
+    Path subDirPath = new Path(baseDir1, new Path("testDotFileFilter"));
+    Path path1 = new Path(subDirPath, "_file1");
+    Path path2 = new Path(subDirPath, ".file2");
+    Path path3 = new Path(subDirPath, "file3");
+
+    fs.mkdirs(subDirPath);
+    fs.create(path1);
+    fs.create(path2);
+    fs.create(path3);
+
+    DotFileFilter filter = new DotFileFilter();
+
+    Assert.assertTrue(filter.accept(path1));
+    Assert.assertFalse(filter.accept(path2));
+    Assert.assertTrue(filter.accept(path3));
   }
 
   @Test

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filters/DotFileFilter.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filters/DotFileFilter.java
@@ -17,29 +17,15 @@
 
 package org.apache.gobblin.util.filters;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
-
 /**
- * A {@link PathFilter} that filters out hidden files (those starting with '_' or '.').
+ * A {@link PathFilter} similar to {@link HiddenFilter}, but does not filter files starting with '_'.
  */
-public class HiddenFilter implements PathFilter {
-
-  private static final String[] HIDDEN_FILE_PREFIX = { "_", "." };
+public class DotFileFilter extends HiddenFilter {
 
   @Override
-  public boolean accept(Path path) {
-    String name = path.getName();
-    for (String prefix : getHiddenFilePrefix()) {
-      if (name.startsWith(prefix)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   protected String[] getHiddenFilePrefix() {
-    return HIDDEN_FILE_PREFIX;
+    return new String[] { "." };
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1512


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
used HiddenFilter to filters out files starting with .

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

