### PR TITLE
[GOBBLIN-1513] fixed the construction of regex filters

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
@@ -33,6 +33,7 @@ import org.apache.gobblin.dataset.IterableDatasetFinderImpl;
 import org.apache.gobblin.data.management.copy.CopyableFile;
 import org.apache.gobblin.data.management.copy.CopyableFileFilter;
 import org.apache.gobblin.dataset.DatasetsFinder;
+import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
 
@@ -114,7 +115,8 @@ public class DatasetUtils {
 
     try {
       Class<?> pathFilterClass = Class.forName(props.getProperty(PATH_FILTER_KEY));
-      return (PathFilter) GobblinConstructorUtils.invokeLongestConstructor(pathFilterClass, props);
+      return (PathFilter) GobblinConstructorUtils.invokeLongestConstructor(pathFilterClass,
+          PropertiesUtils.extractPropertiesWithPrefixAfterRemovingPrefix(props, CONFIGURATION_KEY_PREFIX));
     } catch (ReflectiveOperationException exception) {
       throw new RuntimeException(exception);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
@@ -43,7 +43,7 @@ public class DatasetUtils {
 
   public static final String CONFIGURATION_KEY_PREFIX = "gobblin.dataset.";
   public static final String DATASET_PROFILE_CLASS_KEY = CONFIGURATION_KEY_PREFIX + "profile.class";
-  private static final String PATH_FILTER_KEY = CONFIGURATION_KEY_PREFIX + "path.filter.class";
+  public static final String PATH_FILTER_KEY = CONFIGURATION_KEY_PREFIX + "path.filter.class";
   private static final String COPYABLE_FILE_FILTER_KEY = CONFIGURATION_KEY_PREFIX + "copyable.file.filter.class";
 
   private static final PathFilter ACCEPT_ALL_PATH_FILTER = new PathFilter() {
@@ -114,12 +114,8 @@ public class DatasetUtils {
 
     try {
       Class<?> pathFilterClass = Class.forName(props.getProperty(PATH_FILTER_KEY));
-      return (PathFilter) pathFilterClass.newInstance();
-    } catch (ClassNotFoundException exception) {
-      throw new RuntimeException(exception);
-    } catch (InstantiationException exception) {
-      throw new RuntimeException(exception);
-    } catch (IllegalAccessException exception) {
+      return (PathFilter) GobblinConstructorUtils.invokeLongestConstructor(pathFilterClass, props);
+    } catch (ReflectiveOperationException exception) {
       throw new RuntimeException(exception);
     }
   }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/PathFilterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/PathFilterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.dataset;
+
+import java.util.Properties;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.util.filters.RegexPathFilter;
+
+
+public class PathFilterTest {
+
+  @Test
+  public void testRegexFilter() {
+    Path unmatchedPath = new Path(".abc");
+    Path matchedPath1 = new Path("abc");
+    Path matchedPath2 = new Path("a.bc");
+    Properties props = new Properties();
+    props.setProperty(DatasetUtils.PATH_FILTER_KEY, RegexPathFilter.class.getName());
+    props.setProperty(RegexPathFilter.REGEX, "^[^.].*"); // match everything that does not start with a dot
+
+    PathFilter includeFilter = DatasetUtils.instantiatePathFilter(props);
+
+    Assert.assertFalse(includeFilter.accept(unmatchedPath));
+    Assert.assertTrue(includeFilter.accept(matchedPath1));
+    Assert.assertTrue(includeFilter.accept(matchedPath2));
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/PathFilterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/PathFilterTest.java
@@ -36,7 +36,7 @@ public class PathFilterTest {
     Path matchedPath2 = new Path("a.bc");
     Properties props = new Properties();
     props.setProperty(DatasetUtils.PATH_FILTER_KEY, RegexPathFilter.class.getName());
-    props.setProperty(RegexPathFilter.REGEX, "^[^.].*"); // match everything that does not start with a dot
+    props.setProperty(DatasetUtils.CONFIGURATION_KEY_PREFIX + RegexPathFilter.REGEX, "^[^.].*"); // match everything that does not start with a dot
 
     PathFilter includeFilter = DatasetUtils.instantiatePathFilter(props);
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
@@ -131,6 +131,28 @@ public class PropertiesUtils {
     return extractedProperties;
   }
 
+  /**
+   * Extract all the keys that start with a <code>prefix</code> in {@link Properties} to a new {@link Properties}
+   * instance. It removes the prefix from the properties.
+   *
+   * @param properties the given {@link Properties} instance
+   * @param prefix of keys to be extracted
+   * @return a {@link Properties} instance
+   */
+  public static Properties extractPropertiesWithPrefixAfterRemovingPrefix(Properties properties, String prefix) {
+    Preconditions.checkNotNull(properties);
+    Preconditions.checkNotNull(prefix);
+
+    Properties extractedProperties = new Properties();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      if (StringUtils.startsWith(entry.getKey().toString(), prefix)) {
+        extractedProperties.put(entry.getKey().toString().substring(prefix.length()), entry.getValue());
+      }
+    }
+
+    return extractedProperties;
+  }
+
   public static String serialize(Properties properties) throws IOException {
     StringWriter outputWriter = new StringWriter();
     properties.store(outputWriter, "");

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filters/RegexPathFilter.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filters/RegexPathFilter.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.util.filters;
 
+import java.util.Properties;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.fs.Path;
@@ -34,6 +35,11 @@ public class RegexPathFilter implements PathFilter {
 
   private final Pattern regex;
   private final boolean include;
+  public static final String REGEX = "path.filter.regex";
+
+  public RegexPathFilter(Properties props) {
+    this(props.getProperty(REGEX));
+  }
 
   public RegexPathFilter(String regex) {
     this(regex, true);

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PropertiesUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PropertiesUtilsTest.java
@@ -55,6 +55,33 @@ public class PropertiesUtilsTest {
   }
 
   @Test
+  public void testExtractPropertiesWithPrefixAfterRemovingPrefix() {
+
+    Properties properties = new Properties();
+    properties.setProperty("k1.kk1", "v1");
+    properties.setProperty("k1.kk2", "v2");
+    properties.setProperty("k2.kk", "v3");
+
+    // First prefix
+    Properties extractedPropertiesK1 = PropertiesUtils.extractPropertiesWithPrefixAfterRemovingPrefix(properties, "k1.");
+    Assert.assertEquals(extractedPropertiesK1.getProperty("kk1"), "v1");
+    Assert.assertEquals(extractedPropertiesK1.getProperty("kk2"), "v2");
+    Assert.assertTrue(!extractedPropertiesK1.containsKey("k2.kk"));
+
+    // Second prefix
+    Properties extractedPropertiesK2 = PropertiesUtils.extractPropertiesWithPrefixAfterRemovingPrefix(properties, "k2");
+    Assert.assertTrue(!extractedPropertiesK2.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK2.containsKey("k1.kk2"));
+    Assert.assertEquals(extractedPropertiesK2.getProperty(".kk"), "v3");
+
+    // Missing prefix
+    Properties extractedPropertiesK3 = PropertiesUtils.extractPropertiesWithPrefixAfterRemovingPrefix(properties, "k3");
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k2.kk"));
+  }
+
+  @Test
   public void testGetStringList() {
     Properties properties = new Properties();
     properties.put("key", "1,2, 3");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@aplex  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1513


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Path filters are supposed to be provided by key "gobblin.dataset.path.filter.class", but `instantiatePathFilter` only calls the empty constructors for the path filter classes. Right now only HiddenFilter can be created with empty constructor.
This PR will make a constructor for RegexPathFilter so that it can be used with config "gobblin.dataset.path.filter.class"

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test to test initialization and basic working of RegexPathFilter

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

