### PR TITLE
[GOBBLIN-1514] Throw more useful error from already cancelled tasks

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -112,6 +112,10 @@ public class SingleTask {
   public void run()
       throws IOException, InterruptedException {
 
+    if (_jobState == null) {
+      throw new RuntimeException("jobState is null. Task may have already been cancelled.");
+    }
+
     // Add dynamic configuration to the job state
     _dynamicConfig.entrySet().forEach(e -> _jobState.setProp(e.getKey(), e.getValue().unwrapped().toString()));
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1514


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently sometimes when a task is attempted to be cancelled but is unsuccessful (due to helix being disconnected for example), the job will continue to run on the worker but the taskdriver will delete the jobState, causing an NPE here. This PR just throws a better error message, since the job is meant to be cancelled anyway.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

