### PR TITLE
[GOBBLIN-1457] Bump commons-dbcp2 version

### DIFF
--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -36,7 +36,7 @@ ext.externalDependency = [
     "commonsCli": "commons-cli:commons-cli:1.3.1",
     "commonsCodec": "commons-codec:commons-codec:1.10",
     "commonsDbcp": "commons-dbcp:commons-dbcp:1.4",
-    "commonsDbcp2": "org.apache.commons:commons-dbcp2:2.8.0",
+    "commonsDbcp2": "org.apache.commons:commons-dbcp2:2.9.0",
     "commonsEmail": "org.apache.commons:commons-email:1.4",
     "commonsLang": "commons-lang:commons-lang:2.6",
     "commonsLang3": "org.apache.commons:commons-lang3:3.4",


### PR DESCRIPTION
Previous version was blocked by security scanner due to unpatched
vulnerabilities.

https://issues.apache.org/jira/browse/GOBBLIN-1457
