### PR TITLE
[GOBBLIN-1516] Only schedule TaskMetricsUpdateder when metric-reporting is enabled by config

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
@@ -61,7 +61,9 @@ public class GobblinHelixTaskStateTracker extends AbstractTaskStateTracker {
   @Override
   public void registerNewTask(Task task) {
     try {
-      this.scheduledReporters.put(task.getTaskId(), scheduleTaskMetricsUpdater(new TaskMetricsUpdater(task), task));
+      if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
+        this.scheduledReporters.put(task.getTaskId(), scheduleTaskMetricsUpdater(new TaskMetricsUpdater(task), task));
+      }
     } catch (RejectedExecutionException ree) {
       // Propagate the exception to caller that has full control of the life-cycle of a helix task.
       log.error(String.format("Scheduling of task state reporter for task %s was rejected", task.getTaskId()));

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/local/LocalTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/local/LocalTaskStateTracker.java
@@ -51,6 +51,7 @@ public class LocalTaskStateTracker extends AbstractTaskStateTracker {
   private final JobState jobState;
 
   // This is used to retry failed tasks
+  // Life cycle of this object is managed by the same ServiceManager managing the life cycle of LocalStateTracker
   private final TaskExecutor taskExecutor;
 
   // Mapping between tasks and the task state reporters associated with them
@@ -75,7 +76,9 @@ public class LocalTaskStateTracker extends AbstractTaskStateTracker {
   @Override
   public void registerNewTask(Task task) {
     try {
-      this.scheduledReporters.put(task.getTaskId(), scheduleTaskMetricsUpdater(new TaskMetricsUpdater(task), task));
+      if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
+        this.scheduledReporters.put(task.getTaskId(), scheduleTaskMetricsUpdater(new TaskMetricsUpdater(task), task));
+      }
     } catch (RejectedExecutionException ree) {
       LOG.error(String.format("Scheduling of task state reporter for task %s was rejected", task.getTaskId()));
     }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTaskStateTracker.java
@@ -60,7 +60,9 @@ public class MRTaskStateTracker extends AbstractTaskStateTracker {
   @Override
   public void registerNewTask(Task task) {
     try {
-      scheduleTaskMetricsUpdater(new MRTaskMetricsUpdater(task, this.context), task);
+      if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
+        scheduleTaskMetricsUpdater(new MRTaskMetricsUpdater(task, this.context), task);
+      }
     } catch (RejectedExecutionException ree) {
       LOG.error(String.format("Scheduling of task state reporter for task %s was rejected", task.getTaskId()));
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1516


### Description
This PR contains two parts: 
- Rename `Optional<ScheduledThreadPoolExecutor> writerMetricsUpdater` to be `writerMetricsUpdateExecutor` which is more accurate. The original name collide with `WriterMetricsUpdater` class which is the actual Runnable to be scheduled. 
- Within `registerNewTask`, only schedule the `TaskMetricsUpdater` if `metrics.enabled` is true. The `TaskMetricsUpdater` holds a reference to `Task` object and `TaskMetricsUpdater` is only terminated/removed after commit. As a result, when there are a large number of tasks being executed, all of them will only be GC'ed after commit phase. This is particularly not friendly to `AsyncDataWriter` when there are data being buffer until commit. For such application, we might consider disable the writer metric reporting to exchange for more efficient heap usage.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

