### PR TITLE
[GOBBLIN-1520] Standardize FsSpec's protocol in file name

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -44,8 +44,10 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
+import org.apache.gobblin.util.AvroUtils;
 import org.apache.gobblin.util.CompletedFuture;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.filters.AndPathFilter;
 import org.apache.gobblin.util.filters.HiddenFilter;
 
 
@@ -82,7 +84,8 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
     List<Pair<SpecExecutor.Verb, Spec>> specList = new ArrayList<>();
     FileStatus[] fileStatuses;
     try {
-      fileStatuses = this.fs.listStatus(this.specDirPath, new HiddenFilter());
+      fileStatuses = this.fs.listStatus(this.specDirPath,
+          new AndPathFilter(new HiddenFilter(), new AvroUtils.AvroPathFilter()));
     } catch (IOException e) {
       log.error("Error when listing files at path: {}", this.specDirPath.toString(), e);
       return null;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -168,8 +168,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
     fs.delete(tmpJobSpecPath.getParent(), true);
   }
 
-  @VisibleForTesting
-  String annotateSpecFileName(String rawName) {
+  private String annotateSpecFileName(String rawName) {
     return rawName + AvroUtils.AVRO_SUFFIX;
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -41,6 +42,7 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
+import org.apache.gobblin.util.AvroUtils;
 import org.apache.gobblin.util.CompletedFuture;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.HadoopUtils;
@@ -49,6 +51,12 @@ import org.apache.gobblin.util.HadoopUtils;
 /**
  * An implementation of {@link SpecProducer} that produces {@link JobSpec}s to the {@value FsSpecConsumer#SPEC_PATH_KEY}
  * for consumption by the {@link FsSpecConsumer}.
+ *
+ * The pair {@link FsSpecProducer} and {@link FsSpecConsumer} assumes serialization format as Avro. More specifically,
+ * {@link JobSpec}s will be serialized as ".avro" file by {@link FsSpecProducer} and {@link FsSpecConsumer} filtered
+ * all files without proper postfix to avoid loading corrupted {@link JobSpec}s that could possibly existed due to
+ * ungraceful exits of the application or weak file system semantics.
+ *
  */
 @Slf4j
 public class FsSpecProducer implements SpecProducer<Spec> {
@@ -136,7 +144,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
     DatumWriter<AvroJobSpec> datumWriter = new SpecificDatumWriter<>(AvroJobSpec.SCHEMA$);
     DataFileWriter<AvroJobSpec> dataFileWriter = new DataFileWriter<>(datumWriter);
 
-    Path jobSpecPath = new Path(this.specConsumerPath, jobSpec.getUri());
+    Path jobSpecPath = new Path(this.specConsumerPath, annotateSpecFileName(jobSpec.getUri()));
 
     //Write the new JobSpec to a temporary path first.
     Path tmpDir = new Path(this.specConsumerPath, UUID.randomUUID().toString());
@@ -160,4 +168,8 @@ public class FsSpecProducer implements SpecProducer<Spec> {
     fs.delete(tmpJobSpecPath.getParent(), true);
   }
 
+  @VisibleForTesting
+  String annotateSpecFileName(String rawName) {
+    return rawName + AvroUtils.AVRO_SUFFIX;
+  }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -93,7 +93,7 @@ public class AvroUtils {
 
   public static final String FIELD_LOCATION_DELIMITER = ".";
 
-  private static final String AVRO_SUFFIX = ".avro";
+  public static final String AVRO_SUFFIX = ".avro";
 
   private static final String SCHEMA_CREATION_TIME_KEY = "CreatedOn";
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
 https://issues.apache.org/jira/browse/GOBBLIN-1520


### Description
This PR standardize the file format used in `FsSpecProducer` and `FsSpecConsumer`, by persisting all `Specs` in a file with ".avro" as extension file and only load files with the same extension in consumer side. 
Also added related unit tests. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

