### PR TITLE
[GOBBLIN-1457] Fix service DB initialization when DB is not empty

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseManager.java
@@ -49,7 +49,13 @@ public class ServiceDatabaseManager extends AbstractIdleService {
 
     Flyway flyway =
         Flyway.configure().locations("classpath:org/apache/gobblin/service/db/migration").failOnMissingLocations(true)
-            .dataSource(databaseProvider.getDatasource()).load();
+            .dataSource(databaseProvider.getDatasource())
+            // Existing GaaS DBs have state store tables.
+            // Flyway will refuse to use such non-empty DBs by default. With baselineOnMigrate(true), it should
+            // create new tables, while keeping old ones intact.
+            .baselineOnMigrate(true)
+            .baselineVersion("0")
+            .load();
 
     log.info("Ensuring service database is migrated to latest schema");
     // Start the migration


### PR DESCRIPTION
By default, Flyway will throw an exception if the database is not
empty and Flyway's own table is missing. Production Gobblin service
DBs already have state tables in them, so migration didn't work.

With this change, we ask Flyway to ignore existing tables when
initializing new db.

https://issues.apache.org/jira/browse/GOBBLIN-1457

