### PR TITLE
[GOBBLIN-1521] Create local mode of streaming kafka job to help user quickly onboard

### DIFF
--- a/gobblin-docker/gobblin-recipes/kafka-hdfs/docker-compose.yml
+++ b/gobblin-docker/gobblin-recipes/kafka-hdfs/docker-compose.yml
@@ -17,11 +17,6 @@
 
 version: '3'
 services:
-  gobblin-standalone:
-    image: apache/gobblin:latest
-    command: --mode "standalone"
-    volumes:
-      - "${LOCAL_JOB_DIR}:/etc/gobblin-standalone/jobs"
   zookeeper:
     image: wurstmeister/zookeeper
     ports:

--- a/gobblin-docker/gobblin-recipes/kafka-hdfs/docker-compose.yml
+++ b/gobblin-docker/gobblin-recipes/kafka-hdfs/docker-compose.yml
@@ -17,6 +17,11 @@
 
 version: '3'
 services:
+  gobblin-standalone:
+    image: apache/gobblin:latest
+    command: --mode "standalone"
+    volumes:
+      - "${LOCAL_JOB_DIR}:/etc/gobblin-standalone/jobs"
   zookeeper:
     image: wurstmeister/zookeeper
     ports:

--- a/gobblin-docs/user-guide/Run-Gobblin-Streaming-kafka-hdfs-Locally.md
+++ b/gobblin-docs/user-guide/Run-Gobblin-Streaming-kafka-hdfs-Locally.md
@@ -1,0 +1,30 @@
+# Table of Contents
+
+[TOC]
+
+# Introduction
+
+Gobblin streaming enable user to ingest data from Kafka to HDFS in streaming manner. Normally it's running on yarn, to get the full function, 
+you need have helix cluster, yarn cluster, kafka server and schema registry set up. But we also have one local mode of streaming task using EmbeddedGobblin
+for user to easily start and test out the job. Here is the steps:
+
+# Setup local kafka cluster 
+
+Just follow [kafka quick start](https://kafka.apache.org/quickstart) to set up your kafka cluster, and create test topic "testEvents"
+
+# Run EmbeddedGobblin to start the job
+
+We are using configuration: /gobblin-modules/gobblin-kafka-09/src/test/resources/kafkaHDFSStreaming.conf to execute the job.
+
+To run the job, in your intellij, you can run the test in /gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/KafkaStreamingLocalTest
+by remove the line '(enabled=false)'. In order to run the test in IDE, you may need to manually delete log4j-over-slf4j jar in IDE 
+
+Under your kafka dir, you can run following command to produce data into your kafka topic
+
+`bin/kafka-console-producer.sh --topic testEvents --bootstrap-server localhost:9092`
+
+The job will continually consume from testEvents and write out data as txt file onto your local fileSystem (/tmp/gobblin/kafka/publish). It will write put data every 60 seconds, and will never end until
+you manually kill it.
+
+If you want the job ingest data as avro/orc, you will need to have schema registry as schema source and change the job configuration to control the behavior
+

--- a/gobblin-docs/user-guide/Run-Gobblin-Streaming-kafka-hdfs-Locally.md
+++ b/gobblin-docs/user-guide/Run-Gobblin-Streaming-kafka-hdfs-Locally.md
@@ -26,5 +26,5 @@ Under your kafka dir, you can run following command to produce data into your ka
 The job will continually consume from testEvents and write out data as txt file onto your local fileSystem (/tmp/gobblin/kafka/publish). It will write put data every 60 seconds, and will never end until
 you manually kill it.
 
-If you want the job ingest data as avro/orc, you will need to have schema registry as schema source and change the job configuration to control the behavior
+If you want the job ingest data as avro/orc, you will need to have schema registry as schema source and change the job configuration to control the behavior, a sample configuration can be found [here](https://github.com/apache/gobblin/blob/master/gobblin-modules/gobblin-azkaban/src/main/resources/conf/gobblin_jobs/kafka-hdfs-streaming-avro.conf)
 

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
@@ -217,7 +217,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
   }
 
   protected void renamePath(Path tmpTablePath, Path tablePath) throws IOException {
-    HadoopUtils.renamePath(this.fs, tmpTablePath, tablePath);
+    HadoopUtils.renamePath(this.fs, tmpTablePath, tablePath, true);
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/KafkaStreamingLocalTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/KafkaStreamingLocalTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.kafka;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.apache.gobblin.runtime.api.JobExecutionResult;
+import org.apache.gobblin.runtime.embedded.EmbeddedGobblin;
+import org.apache.gobblin.writer.test.GobblinTestEventBusWriter;
+import org.apache.gobblin.writer.test.TestingEventBusAsserter;
+import org.testng.annotations.Test;
+
+
+public class KafkaStreamingLocalTest {
+  //disable the test as streaming task will never end unless manually kill it
+  @Test(enabled=false)
+  public void testStreamingLocally() {
+    String eventBusId = this.getClass().getName() + ".jobFileTest";
+
+    TestingEventBusAsserter asserter = new TestingEventBusAsserter(eventBusId);
+
+    EmbeddedGobblin embeddedGobblin =
+        new EmbeddedGobblin("TestJob").jobFile(this.getClass().getClassLoader().getResource("kafkaHdfsStreaming.conf").getPath());
+    embeddedGobblin.setConfiguration(GobblinTestEventBusWriter.FULL_EVENTBUSID_KEY, eventBusId);
+
+    try {
+      JobExecutionResult result = embeddedGobblin.run();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/gobblin-modules/gobblin-kafka-09/src/test/resources/kafkaHdfsStreaming.conf
+++ b/gobblin-modules/gobblin-kafka-09/src/test/resources/kafkaHdfsStreaming.conf
@@ -27,18 +27,19 @@ streaming.watermark.commitIntervalMillis=2000
 
 # Converter configs
 # Default Generic Record based pipeline
-recordStreamProcessor.classes="org.apache.gobblin.converter.GenericRecordBasedKafkaSchemaChangeInjector"
-
+# only use this config when kafka schemaRegistry is enabled
+#recordStreamProcessor.classes="org.apache.gobblin.converter.GenericRecordBasedKafkaSchemaChangeInjector"
+recordStreamProcessor.classes="org.apache.gobblin.converter.string.KafkaRecordToStringConverter, org.apache.gobblin.converter.string.StringToBytesConverter"
 # Record-metadata decoration into main record
 # This is not supported in OSS yet since we found decorate will require re-build generic record which is expansive
 gobblin.kafka.converter.recordMetadata.enable=true
 
 # Writer configs
-writer.builder.class=org.apache.gobblin.writer.AvroDataWriterBuilder
-writer.partitioner.class=org.apache.gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner
-writer.output.format=AVRO
-writer.partition.columns=header.time
-writer.partition.pattern=yyyy/MM/dd
+writer.builder.class=org.apache.gobblin.writer.SimpleDataWriterBuilder
+#writer.partitioner.class=org.apache.gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner
+writer.output.format=txt
+#writer.partition.columns=header.time
+#writer.partition.pattern=yyyy/MM/dd
 writer.destination.type=HDFS
 writer.staging.dir=/tmp/gobblin/streaming/writer-staging
 writer.output.dir=/tmp/gobblin/streaming/writer-output
@@ -49,39 +50,43 @@ state.store.enabled=false
 # Publisher config
 data.publisher.type=org.apache.gobblin.publisher.NoopPublisher
 data.publisher.final.dir=/tmp/gobblin/kafka/publish
-flush.data.publisher.class=org.apache.gobblin.prototype.kafka.TimePartitionedStreamingDataPublisher
+flush.data.publisher.class=org.apache.gobblin.publisher.TimePartitionedStreamingDataPublisher
 ###Config that controls intervals between flushes (and consequently, data publish)
 stream.flush.interval.secs=60
 
 ### Following are Kafka Upstream related configurations
 # Kafka source configurations
-topic.whitelist=
+topic.whitelist=testEvents
 bootstrap.with.offset=EARLIEST
 source.kafka.fetchTimeoutMillis=3000
 kafka.consumer.maxPollRecords=100
 
 #Kafka broker/schema registry configs
-kafka.schema.registry.url=
-kafka.schema.registry.class=
-kafka.schemaRegistry.class=
-kafka.schemaRegistry.url=
-kafka.brokers=
+#kafka.schema.registry.url=
+#kafka.schema.registry.class=org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistry
+#kafka.schemaRegistry.class=org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistry
+#kafka.schemaRegistry.url=
+kafka.brokers="localhost:9092"
 
 #Kafka SSL configs
-security.protocol = SSL
-ssl.protocol = TLS
-ssl.trustmanager.algorithm =
-ssl.keymanager.algorithm =
-ssl.truststore.type =
-ssl.truststore.location =
-ssl.truststore.password =
-ssl.keystore.type =
-ssl.keystore.password =
-ssl.key.password =
-ssl.secure.random.implementation =
-ssl.keystore.location=<path to your kafka certs>
+#security.protocol = SSL
+#ssl.protocol = TLS
+#ssl.trustmanager.algorithm =
+#ssl.keymanager.algorithm =
+#ssl.truststore.type =
+#ssl.truststore.location =
+#ssl.truststore.password =
+#ssl.keystore.type =
+#ssl.keystore.password =
+#ssl.key.password =
+#ssl.secure.random.implementation =
+#ssl.keystore.location=<path to your kafka certs>
 
 metrics.enabled=false
+
+# consumer client config
+gobblin.kafka.consumerClient.class="org.apache.gobblin.kafka.client.Kafka09ConsumerClient$Factory"
+source.kafka.value.deserializer="org.apache.gobblin.source.extractor.extract.kafka.Kafka09JsonSource$KafkaGsonDeserializer"
 
 # Only Required for Local-testing
 kafka.consumer.runtimeIngestionPropsEnabled=false

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -323,8 +323,10 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
   @Override
   public S getSchema() {
     try {
-      Schema schema = (Schema) this._schemaRegistry.get().getLatestSchemaByTopic(this.topicPartitions.get(0).getTopicName());
-      return (S) schema;
+      if(this._schemaRegistry.isPresent()) {
+        return (S)(Schema) this._schemaRegistry.get().getLatestSchemaByTopic(this.topicPartitions.get(0).getTopicName());
+      }
+      return (S) this.topicPartitions.iterator().next().getTopicName();
     } catch (SchemaRegistryException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1521


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Using embedded gobblin to run streaming job, and create a guid to help user quickly onboard
* Change kafka09ConsumerClient to make get earliest and latest offset won't change the current position of the consumer, and support assignAndSeek() method
* Change FsStateStore rename method to enable overwrite so that we can write to existing state store
* Change reference in kafka-hdfs-streaming-avro.job to OSS class to give user better idea about how the config looks like if they want to ingest as avro, although we don't use that config in this local job since we don't have schema registry setup.  
* change KafkaStreamingExtractor to support the scenario where schemaRegistry is not setup

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test we can run the job locally

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

