### PR TITLE
[GOBBLIN-1522] use FlowConfigsV2ResourceHandler when forwarding specs to master inst…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -394,7 +394,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
   }
 
   private void ensureInjected() {
-    if (resourceHandler == null) {
+    if (v2ResourceHandler == null) {
       throw new IllegalStateException("GobblinServiceManager should be constructed through Guice dependency injection "
           + "or through a static factory method");
     }
@@ -514,7 +514,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
         this.helixManager.get()
             .getMessagingService()
             .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(),
-                new ControllerUserDefinedMessageHandlerFactory(flowCatalogLocalCommit, scheduler, resourceHandler,
+                new ControllerUserDefinedMessageHandlerFactory(flowCatalogLocalCommit, scheduler, v2ResourceHandler,
                     configuration.getServiceName()));
       }
     } catch (Exception e) {


### PR DESCRIPTION
…ances

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@aplex @phet  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1522


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We should avoid the use of FlowConfigResourceLocalHandler because it is deprecated in favor of FlowConfigV2ResourceLocalHandler.
GobblinServiceManager currently uses FlowConfigResourceLocalHandler to create ControllerUserDefinedMessageHandlerFactory. The result of this is that when a helix message sent by a slave instance of the master instance is received it is handled by a V1 local handler, which we want to avoid.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

