### PR TITLE
[GOBBLIN-1525] Avoid casting v2resourcehandler to resource handler

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/ControllerUserDefinedMessageHandlerFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/ControllerUserDefinedMessageHandlerFactory.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.gobblin.service.FlowConfigsV2ResourceHandler;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandler;
@@ -37,7 +38,6 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.service.FlowConfig;
 import org.apache.gobblin.service.FlowConfigResourceLocalHandler;
-import org.apache.gobblin.service.FlowConfigsResourceHandler;
 import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.restli.FlowConfigUtils;
@@ -51,7 +51,7 @@ import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 class ControllerUserDefinedMessageHandlerFactory implements MessageHandlerFactory {
   private boolean flowCatalogLocalCommit;
   private GobblinServiceJobScheduler jobScheduler;
-  private FlowConfigsResourceHandler resourceHandler;
+  private FlowConfigsV2ResourceHandler resourceHandler;
   private String serviceName;
 
   @Override
@@ -80,12 +80,12 @@ class ControllerUserDefinedMessageHandlerFactory implements MessageHandlerFactor
   private static class ControllerUserDefinedMessageHandler extends MessageHandler {
     private boolean flowCatalogLocalCommit;
     private GobblinServiceJobScheduler jobScheduler;
-    private FlowConfigsResourceHandler resourceHandler;
+    private FlowConfigsV2ResourceHandler resourceHandler;
     private String serviceName;
 
     public ControllerUserDefinedMessageHandler(Message message, NotificationContext context, String serviceName,
         boolean flowCatalogLocalCommit, GobblinServiceJobScheduler scheduler,
-        FlowConfigsResourceHandler resourceHandler) {
+        FlowConfigsV2ResourceHandler resourceHandler) {
       super(message, context);
       this.serviceName = serviceName;
       this.flowCatalogLocalCommit = flowCatalogLocalCommit;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1525

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Continuing from https://github.com/apache/gobblin/pull/3373/files
    
    ControllerUserDefinedMessageHandlerFactory is casting FlowConfigV2ResourceLocalHandler to FlowConfigResourceLocalHandler, causing class cast exceptions when fetching the responses as they are not backwards compatible. 
    
    This PR fixes this issue by explicitly setting the class variable to be the newer and supported version of the resource handler.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

