### PR TITLE
[GOBBLIN-1530] Add error reporting for missing source nodes that may not exist

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -190,6 +190,11 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
     String destination = ConfigUtils.getString(flowSpec.getConfig(), ServiceConfigKeys.FLOW_DESTINATION_IDENTIFIER_KEY, "");
 
     DataNode sourceNode = this.flowGraph.getNode(source);
+    if (sourceNode == null) {
+      flowSpec.getCompilationErrors()
+          .add(String.format("Flowgraph does not have a node with id %s", source));
+      return null;
+    }
     List<String> destNodeIds = ConfigUtils.getStringList(flowSpec.getConfig(), ServiceConfigKeys.FLOW_DESTINATION_IDENTIFIER_KEY);
     List<DataNode> destNodes = destNodeIds.stream().map(this.flowGraph::getNode).collect(Collectors.toList());
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -197,7 +197,11 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
     }
     List<String> destNodeIds = ConfigUtils.getStringList(flowSpec.getConfig(), ServiceConfigKeys.FLOW_DESTINATION_IDENTIFIER_KEY);
     List<DataNode> destNodes = destNodeIds.stream().map(this.flowGraph::getNode).collect(Collectors.toList());
-
+    if (destNodes.contains(null)) {
+      flowSpec.getCompilationErrors()
+          .add(String.format("Flowgraph does not have a node with id %s", destNodeIds.get(destNodes.indexOf(null))));
+      return null;
+    }
     log.info(String.format("Compiling flow for source: %s and destination: %s", source, destination));
 
     List<FlowSpec> flowSpecs = splitFlowSpec(flowSpec);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -681,6 +681,17 @@ public class MultiHopFlowCompilerTest {
     spec.getCompilationErrors().stream().anyMatch(s -> s.contains("Flowgraph does not have a node with id"));
   }
 
+  @Test (dependsOnMethods = "testMissingSourceNodeError")
+  public void testMissingDestinationNodeError() throws Exception {
+    FlowSpec spec = createFlowSpec("flow/flow5.conf", "HDFS-1", "HDFS-NULL", false, false);
+
+    Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
+
+    Assert.assertEquals(dag, null);
+    Assert.assertEquals(spec.getCompilationErrors().size(), 1);
+    spec.getCompilationErrors().stream().anyMatch(s -> s.contains("Flowgraph does not have a node with id"));
+  }
+
   @Test (dependsOnMethods = "testUnresolvedFlow")
   public void testGitFlowGraphMonitorService()
       throws IOException, GitAPIException, URISyntaxException, InterruptedException {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -671,6 +671,17 @@ public class MultiHopFlowCompilerTest {
   }
 
   @Test (dependsOnMethods = "testUnresolvedFlow")
+  public void testMissingSourceNodeError() throws Exception {
+    FlowSpec spec = createFlowSpec("flow/flow5.conf", "HDFS-NULL", "HDFS-3", false, false);
+
+    Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
+
+    Assert.assertEquals(dag, null);
+    Assert.assertEquals(spec.getCompilationErrors().size(), 1);
+    spec.getCompilationErrors().stream().anyMatch(s -> s.contains("Flowgraph does not have a node with id"));
+  }
+
+  @Test (dependsOnMethods = "testUnresolvedFlow")
   public void testGitFlowGraphMonitorService()
       throws IOException, GitAPIException, URISyntaxException, InterruptedException {
     File remoteDir = new File(TESTDIR + "/remote");

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -665,7 +665,7 @@ public class MultiHopFlowCompilerTest {
 
     Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
 
-    Assert.assertEquals(dag, null);
+    Assert.assertNull(dag);
     Assert.assertEquals(spec.getCompilationErrors().size(), 2);
     spec.getCompilationErrors().stream().anyMatch(s -> s.contains(AzkabanProjectConfig.USER_TO_PROXY));
   }
@@ -687,12 +687,12 @@ public class MultiHopFlowCompilerTest {
 
     Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
 
-    Assert.assertEquals(dag, null);
+    Assert.assertNull(dag);
     Assert.assertEquals(spec.getCompilationErrors().size(), 1);
     spec.getCompilationErrors().stream().anyMatch(s -> s.contains("Flowgraph does not have a node with id"));
   }
 
-  @Test (dependsOnMethods = "testUnresolvedFlow")
+  @Test (dependsOnMethods = "testMissingDestinationNodeError")
   public void testGitFlowGraphMonitorService()
       throws IOException, GitAPIException, URISyntaxException, InterruptedException {
     File remoteDir = new File(TESTDIR + "/remote");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1530


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

When copying data from a source node that does not exist/fails to be added to GaaS FlowGraph, a very cryptic error message pops up where DmasAuthorizer shows a NullPointerException.

This PR guards against source nodes that do not exist so that the error is much easier for developers and users to understand.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

