### PR TITLE
[GOBBLIN-1532] Additional logging for memory-manager and partition-writer to help with writer-memory understanding

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/GobblinOrcMapreduceRecordWriter.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/GobblinOrcMapreduceRecordWriter.java
@@ -25,8 +25,6 @@ import org.apache.orc.StripeInformation;
 import org.apache.orc.Writer;
 import org.apache.orc.mapreduce.OrcMapreduceRecordWriter;
 
-import com.google.common.base.Joiner;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.util.reflection.RestrictedFieldAccessingUtils;

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/GobblinOrcMapreduceRecordWriter.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/GobblinOrcMapreduceRecordWriter.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.gobblin.compaction.mapreduce.orc;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.Writer;
+import org.apache.orc.mapreduce.OrcMapreduceRecordWriter;
+
+import com.google.common.base.Joiner;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.util.reflection.RestrictedFieldAccessingUtils;
+
+
+/**
+ * A thin extension to {@link OrcMapreduceRecordWriter} for obtaining a vector of stripe information.
+ */
+@Slf4j
+public class GobblinOrcMapreduceRecordWriter extends OrcMapreduceRecordWriter {
+  public GobblinOrcMapreduceRecordWriter(Writer writer) {
+    super(writer);
+  }
+
+  public GobblinOrcMapreduceRecordWriter(Writer writer, int rowBatchSize) {
+    super(writer, rowBatchSize);
+  }
+
+  @Override
+  public void close(TaskAttemptContext taskAttemptContext)
+      throws IOException {
+    super.close(taskAttemptContext);
+
+    // TODO: Emit this information as kafka events for ease for populating dashboard.
+    try {
+      String stripeSizeVec = ((Writer) RestrictedFieldAccessingUtils.getRestrictedFieldByReflection(
+        this, "writer", this.getClass())).getStripes()
+          .stream()
+          .mapToLong(StripeInformation::getDataLength).mapToObj(String::valueOf)
+          .reduce((x,y) -> x.concat(",").concat(y)).get();
+      log.info("The vector of Stripe-Size in enclosing writer is:" + stripeSizeVec);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      log.error("Failed to access writer object from super class to obtain stripe information");
+    }
+  }
+}

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyCompactorOutputFormat.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyCompactorOutputFormat.java
@@ -34,6 +34,7 @@ import org.apache.orc.mapreduce.OrcOutputFormat;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter;
+import org.apache.gobblin.writer.GobblinOrcMemoryManager;
 import org.apache.gobblin.writer.GobblinOrcWriter;
 
 import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.COMPACTION_OUTPUT_EXTENSION;
@@ -68,7 +69,7 @@ public class OrcKeyCompactorOutputFormat extends OrcOutputFormat {
 
     Path filename = getDefaultWorkFile(taskAttemptContext, extension);
     Writer writer = OrcFile.createWriter(filename,
-        org.apache.orc.mapred.OrcOutputFormat.buildOptions(conf));
+        org.apache.orc.mapred.OrcOutputFormat.buildOptions(conf).memory(new GobblinOrcMemoryManager(conf)));
     int rowBatchSize = conf.getInt(GobblinOrcWriter.ORC_WRITER_BATCH_SIZE, GobblinOrcWriter.DEFAULT_ORC_WRITER_BATCH_SIZE);
     log.info("Creating OrcMapreduceRecordWriter with row batch size = {}", rowBatchSize);
     return new OrcMapreduceRecordWriter(writer, rowBatchSize);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -168,6 +168,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
                   @Override
                   public DataWriter<D> get() {
                     try {
+                      log.info(String.format("Adding one more writer to loading cache of existing writer "
+                          + "with size = %d", partitionWriters.size()));
                       return createPartitionWriter(key);
                     } catch (IOException e) {
                       throw new RuntimeException("Error creating writer", e);

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcMemoryManager.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcMemoryManager.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.impl.MemoryManagerImpl;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A thin layer extending {@link MemoryManagerImpl} for logging and instrumentation purpose.
+ */
+@Slf4j
+public class GobblinOrcMemoryManager extends MemoryManagerImpl {
+  public GobblinOrcMemoryManager(Configuration conf) {
+    super(conf);
+    log.info("The pool reserved for memory manager is :{}", getTotalMemoryPool());
+  }
+
+  @Override
+  public synchronized void addWriter(Path path, long requestedAllocation, Callback callback)
+      throws IOException {
+    super.addWriter(path, requestedAllocation, callback);
+    log.info("Adding writer for Path {}, Current allocation: {}", path.toString(), getAllocationScale());
+  }
+
+  @Override
+  public synchronized void removeWriter(Path path)
+      throws IOException {
+    super.removeWriter(path);
+    log.info("Closing writer for Path {}, Current allocation: {}", path.toString(), getAllocationScale());
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1532


### Description
- The default memory manager in ORC writer didn't show enough logging in terms of the estimates it made and the pool allocation status. The added extension for that is to provide those information through logging so that we could have better idea on the allocation scale, the total pool size, etc. 
- Also adds a log line in the partition writer to show how much partitions were being used in concurrent. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

