### PR TITLE
[GOBBLIN-1534] Allow kafka metrics/events reporting to be disabled individually

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -752,6 +752,10 @@ public class ConfigurationKeys {
   public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_ENABLED = Boolean.toString(false);
+  public static final String METRICS_REPORTING_KAFKA_METRICS_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.metrics.enabled";
+  public static final String METRICS_REPORTING_KAFKA_EVENTS_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.events.enabled";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_REPORTER_CLASS =
       "org.apache.gobblin.metrics.kafka.KafkaMetricReporterFactory";
   public static final String DEFAULT_EVENTS_REPORTING_KAFKA_REPORTER_CLASS =

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
@@ -612,20 +612,26 @@ public class GobblinMetrics {
   private void buildKafkaMetricReporter(Properties properties)
       throws MultiReporterException {
     List<MetricReporterException> reporterExceptions = Lists.newArrayList();
-    if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY,
+    if (!Boolean.parseBoolean(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_ENABLED))) {
       return;
     }
 
-    try {
-      buildScheduledReporter(properties, ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_REPORTER_CLASS);
-    } catch (MetricReporterException e) {
-      reporterExceptions.add(e);
+    if (Boolean.parseBoolean(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_METRICS_ENABLED_KEY,
+        Boolean.toString(true)))) {
+      try {
+        buildScheduledReporter(properties, ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_REPORTER_CLASS);
+      } catch (MetricReporterException e) {
+        reporterExceptions.add(e);
+      }
     }
-    try {
-      buildScheduledReporter(properties, ConfigurationKeys.DEFAULT_EVENTS_REPORTING_KAFKA_REPORTER_CLASS);
-    } catch (MetricReporterException e) {
-      reporterExceptions.add(e);
+    if (Boolean.parseBoolean(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_EVENTS_ENABLED_KEY,
+        Boolean.toString(true)))) {
+      try {
+        buildScheduledReporter(properties, ConfigurationKeys.DEFAULT_EVENTS_REPORTING_KAFKA_REPORTER_CLASS);
+      } catch (MetricReporterException e) {
+        reporterExceptions.add(e);
+      }
     }
     if (!reporterExceptions.isEmpty()) {
       throw new MultiReporterException("Failed to start one or more Kafka reporters", reporterExceptions);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1534


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently in both gaas and jobs launched by gaas, we use kafka event reporting, but not kafka metrics reporting. In #3035, there were some changes which includes splitting the kafka reporter factory. As a side effect, the two reporters (metrics/events) became all or nothing, where previously if just one was missing config it would be skipped. This causes gaas and jobs launched by gaas to always contain an error stacktrace about failing to instantiate the kafka metric reporter.

This PR adds config keys to enable/disable the reporters individually. For backwards compatibility, if `metrics.reporting.kafka.enabled` is true, they will both be enabled.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in local gaas

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

