### PR TITLE
[GOBBLIN-1536] Fix issue code generation

### DIFF
--- a/gobblin-modules/gobblin-troubleshooter/src/main/java/org/apache/gobblin/troubleshooter/AutoTroubleshooterLogAppender.java
+++ b/gobblin-modules/gobblin-troubleshooter/src/main/java/org/apache/gobblin/troubleshooter/AutoTroubleshooterLogAppender.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.text.StrBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.log4j.AppenderSkeleton;
@@ -142,7 +143,21 @@ public class AutoTroubleshooterLogAppender extends AppenderSkeleton {
      * multiple application versions.
      * */
 
-    return getHash(throwable.getClass().toString() + ExceptionUtils.getStackTrace(throwable));
+    return getHash(getStackTraceWithoutExceptionMessage(throwable));
+  }
+
+  private String getStackTraceWithoutExceptionMessage(Throwable throwable) {
+    StrBuilder sb = new StrBuilder();
+
+    for (Throwable currentThrowable : ExceptionUtils.getThrowableList(throwable)) {
+      sb.appendln(currentThrowable.getClass().getName());
+      for (StackTraceElement stackTraceElement : currentThrowable.getStackTrace()) {
+        sb.appendln(stackTraceElement);
+      }
+      sb.appendln("---");
+    }
+
+    return sb.toString();
   }
 
   private IssueSeverity convert(Level level) {


### PR DESCRIPTION
Issue code should depend only on exception stack trace and type,
but previously there was a bug when exception message was included
in generation of the code. Since the message can have variable
parts, like paths and dataset names, some issue got multiple
codes assigned to them.

https://issues.apache.org/jira/browse/GOBBLIN-1536
