### PR TITLE
[GOBBLIN-1545] wrap RestLiServiceException inside a CreateKVResponse so that service…

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
@@ -70,8 +70,8 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
     // Return conflict and take no action if flowSpec has already been created
     if (this.flowCatalog.exists(flowSpec.getUri())) {
       log.warn("FlowSpec with URI {} already exists, no action will be taken", flowSpec.getUri());
-      throw new RestLiServiceException(HttpStatus.S_409_CONFLICT,
-          "FlowSpec with URI " + flowSpec.getUri() + " already exists, no action will be taken");
+      return new CreateKVResponse<>(new RestLiServiceException(HttpStatus.S_409_CONFLICT,
+          "FlowSpec with URI " + flowSpec.getUri() + " already exists, no action will be taken"));
     }
 
     Map<String, AddSpecResponse> responseMap = this.flowCatalog.put(flowSpec, triggerListener);
@@ -93,10 +93,10 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
       if (!flowSpec.getCompilationErrors().isEmpty()) {
         message = message + " Compilation errors encountered: " + flowSpec.getCompilationErrors();
       }
-      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, message);
+      return new CreateKVResponse<>(new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, message));
     }
 
-    return new CreateKVResponse(new ComplexResourceKey<>(flowConfig.getId(), flowStatusId), flowConfig, httpStatus);
+    return new CreateKVResponse<>(new ComplexResourceKey<>(flowConfig.getId(), flowStatusId), flowConfig, httpStatus);
   }
 
   /**


### PR DESCRIPTION
… logs do not log exceptions

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1545


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Throwing exception in the service logs may confuse users (or log parsing scripts) that there is some issue with the service that requires attention. So we should not throw exception when it is a bad request and no issue from the service side. In these cases, we should wrap the exception in a Restli response that the caller can open.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

