### PR TITLE
[GOBBLIN-1544] Fix edge case when current hour == datepartition hour

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -864,6 +864,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
    * For each timestamp in sorted collection of timestamps in descending order
    * if timestamp is greater than previousWatermark
    * and hour(now) > hour(prevWatermark) + 1
+   * and hour(now) > hour(timestamp)
    *    check audit counts for completeness between
    *    a source and reference tier for [timestamp, timstamp + 1 unit of granularity]
    *    If the audit count matches update the watermark to the timestamp and break
@@ -895,7 +896,8 @@ public class IcebergMetadataWriter implements MetadataWriter {
       while (iterator.hasNext()) {
         ZonedDateTime timestampDT = iterator.next();
         if (timestampDT.isAfter(prevWatermarkDT)
-            && TimeIterator.durationBetween(prevWatermarkDT, now, granularity) > 1) {
+            && TimeIterator.durationBetween(prevWatermarkDT, now, granularity) > 1
+            && TimeIterator.durationBetween(timestampDT, now, granularity) > 0) {
           long timestampMillis = timestampDT.toInstant().toEpochMilli();
           if(auditCountVerifier.get().isComplete(table, timestampMillis, TimeIterator.inc(timestampDT, granularity, 1).toInstant().toEpochMilli())) {
             completionWatermark = timestampMillis;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1544] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1544


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Addresses case where cw=2pm, dp =4pm, current hour=4pm
With current logic, audit call will be made so we need to check hour(dp) < hour(now)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

