### PR TITLE
[GOBBLIN-1546] Don't contact schema registry for every record read by job status monitor

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/FixedSchemaVersionWriter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/FixedSchemaVersionWriter.java
@@ -44,4 +44,9 @@ public class FixedSchemaVersionWriter implements SchemaVersionWriter<Integer> {
       throws IOException {
     return inputStream.readInt();
   }
+
+  @Override
+  public void advanceInputStreamToRecord(DataInputStream inputStream) throws IOException {
+    inputStream.readInt();
+  }
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/NoopSchemaVersionWriter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/NoopSchemaVersionWriter.java
@@ -42,4 +42,8 @@ public class NoopSchemaVersionWriter implements SchemaVersionWriter<Void> {
       throws IOException {
     return null;
   }
+
+  @Override
+  public void advanceInputStreamToRecord(DataInputStream inputStream) throws IOException {
+  }
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/SchemaVersionWriter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/util/SchemaVersionWriter.java
@@ -54,4 +54,10 @@ public interface SchemaVersionWriter<S> {
    */
   public S readSchemaVersioningInformation(DataInputStream inputStream) throws IOException;
 
+  /**
+   * Advance inputStream to the location where actual record starts, but ignore the schema information.
+   * @param inputStream {@link java.io.DataInputStream} containing schema information and serialized record.
+   * @throws IOException
+   */
+  public void advanceInputStreamToRecord(DataInputStream inputStream) throws IOException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -94,7 +94,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
   public GobblinTrackingEvent deserializeEvent(DecodeableKafkaRecord<byte[],byte[]> message) {
     try {
       InputStream is = new ByteArrayInputStream(message.getValue());
-      schemaVersionWriter.readSchemaVersioningInformation(new DataInputStream(is));
+      schemaVersionWriter.advanceInputStreamToRecord(new DataInputStream(is));
       Decoder decoder = DecoderFactory.get().binaryDecoder(is, this.decoder.get());
 
       return this.reader.get().read(null, decoder);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1546

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

The kafka job status monitor is currently calling `readSchemaVersioningInformation` to advance the input stream of the kafka messages it reads to the record portion, which calls the schema registry every time, but the result of it is ignored. This PR adds another API that just advances the input stream without contacting the schema registry, to remove a point of failure.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tested in local gaas deployment

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

