### PR TITLE
[GOBBLIN-1457] Lazy-load issues to improve performance

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
@@ -22,7 +22,6 @@
       "name" : "latestFlowExecution",
       "parameters" : [ {
         "name" : "flowId",
-        "doc" : "Retrieve the most recent matching FlowExecution(s) of the identified FlowId",
         "type" : "org.apache.gobblin.service.FlowId"
       }, {
         "name" : "count",
@@ -36,22 +35,28 @@
         "name" : "executionStatus",
         "type" : "string",
         "optional" : true
+      }, {
+        "name" : "includeIssues",
+        "type" : "boolean",
+        "default" : "false"
       } ]
     }, {
       "name" : "latestFlowGroupExecutions",
-      "doc" : "Retrieve the most recent matching FlowExecution(s) for each flow in the identified flowGroup",
       "parameters" : [ {
         "name" : "flowGroup",
         "type" : "string"
       }, {
         "name" : "countPerFlow",
-        "doc" : "(maximum) number of FlowExecutions for each flow in flowGroup",
         "type" : "int",
         "optional" : true
       }, {
         "name" : "tag",
         "type" : "string",
         "optional" : true
+      }, {
+        "name" : "includeIssues",
+        "type" : "boolean",
+        "default" : "false"
       } ]
     } ],
     "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
@@ -20,6 +20,7 @@
     } ],
     "finders" : [ {
       "name" : "latestFlowExecution",
+      "doc" : "Retrieve the most recent matching FlowExecution(s) of the identified FlowId",
       "parameters" : [ {
         "name" : "flowId",
         "type" : "org.apache.gobblin.service.FlowId"
@@ -38,17 +39,20 @@
       }, {
         "name" : "includeIssues",
         "type" : "boolean",
-        "default" : "false"
+        "default" : "false",
+        "doc" : "include job issues in the response. Otherwise empty array of issues will be returned."
       } ]
     }, {
       "name" : "latestFlowGroupExecutions",
+      "doc" : "Retrieve the most recent matching FlowExecution(s) for each flow in the identified flowGroup",
       "parameters" : [ {
         "name" : "flowGroup",
         "type" : "string"
       }, {
         "name" : "countPerFlow",
         "type" : "int",
-        "optional" : true
+        "optional" : true,
+        "doc" : "(maximum) number of FlowExecutions for each flow in flowGroup   *"
       }, {
         "name" : "tag",
         "type" : "string",
@@ -56,7 +60,8 @@
       }, {
         "name" : "includeIssues",
         "type" : "boolean",
-        "default" : "false"
+        "default" : "false",
+        "doc" : "include job issues in the response. Otherwise empty array of issues will be returned."
       } ]
     } ],
     "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
@@ -282,7 +282,6 @@
       } ],
       "finders" : [ {
         "name" : "latestFlowExecution",
-        "doc" : "Retrieve the most recent matching FlowExecution(s) of the identified FlowId",
         "parameters" : [ {
           "name" : "flowId",
           "type" : "org.apache.gobblin.service.FlowId"
@@ -298,22 +297,28 @@
           "name" : "executionStatus",
           "type" : "string",
           "optional" : true
+        }, {
+          "name" : "includeIssues",
+          "type" : "boolean",
+          "default" : "false"
         } ]
       }, {
         "name" : "latestFlowGroupExecutions",
-        "doc" : "Retrieve the most recent matching FlowExecution(s) for each flow in the identified flowGroup",
         "parameters" : [ {
           "name" : "flowGroup",
           "type" : "string"
         }, {
           "name" : "countPerFlow",
           "type" : "int",
-          "doc" : "(maximum) number of FlowExecutions for each flow in flowGroup",
           "optional" : true
         }, {
           "name" : "tag",
           "type" : "string",
           "optional" : true
+        }, {
+          "name" : "includeIssues",
+          "type" : "boolean",
+          "default" : "false"
         } ]
       } ],
       "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
@@ -282,6 +282,7 @@
       } ],
       "finders" : [ {
         "name" : "latestFlowExecution",
+        "doc" : "Retrieve the most recent matching FlowExecution(s) of the identified FlowId",
         "parameters" : [ {
           "name" : "flowId",
           "type" : "org.apache.gobblin.service.FlowId"
@@ -300,17 +301,20 @@
         }, {
           "name" : "includeIssues",
           "type" : "boolean",
-          "default" : "false"
+          "default" : "false",
+          "doc" : "include job issues in the response. Otherwise empty array of issues will be returned."
         } ]
       }, {
         "name" : "latestFlowGroupExecutions",
+        "doc" : "Retrieve the most recent matching FlowExecution(s) for each flow in the identified flowGroup",
         "parameters" : [ {
           "name" : "flowGroup",
           "type" : "string"
         }, {
           "name" : "countPerFlow",
           "type" : "int",
-          "optional" : true
+          "optional" : true,
+          "doc" : "(maximum) number of FlowExecutions for each flow in flowGroup   *"
         }, {
           "name" : "tag",
           "type" : "string",
@@ -318,7 +322,8 @@
         }, {
           "name" : "includeIssues",
           "type" : "boolean",
-          "default" : "false"
+          "default" : "false",
+          "doc" : "include job issues in the response. Otherwise empty array of issues will be returned."
         } ]
       } ],
       "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowStatusTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowStatusTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
@@ -127,29 +128,32 @@ public class FlowStatusTest {
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job1").startTime(1000L).endTime(5000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Test message 1").processedCount(100)
-            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2").issues(Collections.emptyList())
-            .build();
+            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2")
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(5000L)
-            .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).issues(Collections.emptyList()).build();
+            .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0)
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     org.apache.gobblin.service.monitoring.JobStatus js2 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job1").jobTag("dataset1").startTime(2000L).endTime(6000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(1).message("Test message 2").processedCount(200)
-            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").issues(Collections.emptyList())
+            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus js3 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job2").jobTag("dataset2").startTime(2000L).endTime(6000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(1).message("Test message 3").processedCount(200)
-            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").issues(Collections.emptyList())
+            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus fs2 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(1).message("Flow message")
-            .issues(Collections.emptyList()).build();
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList1 = Lists.newArrayList(js1, fs1);
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList2 = Lists.newArrayList(js2, js3, fs2);
     _listOfJobStatusLists = Lists.newArrayList();
@@ -198,19 +202,21 @@ public class FlowStatusTest {
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job1").startTime(1000L).endTime(5000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Test message 1").processedCount(100)
-            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2").issues(Collections.emptyList())
+            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus js2 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job2").startTime(2000L).endTime(6000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Test message 2").processedCount(200)
-            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").issues(Collections.emptyList())
+            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Flow message")
-            .issues(Collections.emptyList()).build();
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);
@@ -247,19 +253,21 @@ public class FlowStatusTest {
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job1").startTime(1000L).endTime(5000L)
             .eventName(ExecutionStatus.RUNNING.name()).flowExecutionId(0).message("Test message 1").processedCount(100)
-            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2").issues(Collections.emptyList())
+            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus js2 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job2").startTime(2000L).endTime(6000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Test message 2").processedCount(200)
-            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").issues(Collections.emptyList())
+            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY)
             .eventName(ExecutionStatus.RUNNING.name()).flowExecutionId(0).message("Flow message")
-            .issues(Collections.emptyList()).build();
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);
@@ -296,19 +304,21 @@ public class FlowStatusTest {
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job1").startTime(1000L).endTime(5000L)
             .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Test message 1").processedCount(100)
-            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2").issues(Collections.emptyList())
+            .jobExecutionId(1).lowWatermark("watermark:1").highWatermark("watermark:2")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus js2 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup("jgroup1").jobName("job2").startTime(2000L).endTime(6000L)
             .eventName(ExecutionStatus.FAILED.name()).flowExecutionId(0).message("Test message 2").processedCount(200)
-            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").issues(Collections.emptyList())
+            .jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3")
+            .issues(Suppliers.ofInstance(Collections.emptyList()))
             .build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 =
         org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1").flowName("flow1")
             .jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
             .eventName(ExecutionStatus.FAILED.name()).flowExecutionId(0).message("Flow message")
-            .issues(Collections.emptyList()).build();
+            .issues(Suppliers.ofInstance(Collections.emptyList())).build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
@@ -59,14 +59,16 @@ public class FlowExecutionResource extends ComplexKeyResourceTemplate<FlowStatus
 
   @Finder("latestFlowExecution")
   public List<FlowExecution> getLatestFlowExecution(@Context PagingContext context, @QueryParam("flowId") FlowId flowId,
-      @Optional @QueryParam("count") Integer count, @Optional @QueryParam("tag") String tag, @Optional @QueryParam("executionStatus") String executionStatus) {
-    return this.flowExecutionResourceHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus);
+      @Optional @QueryParam("count") Integer count, @Optional @QueryParam("tag") String tag, @Optional @QueryParam("executionStatus") String executionStatus,
+      @Optional("false") @QueryParam("includeIssues") Boolean includeIssues) {
+    return this.flowExecutionResourceHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus,includeIssues);
   }
 
   @Finder("latestFlowGroupExecutions")
   public List<FlowExecution> getLatestFlowGroupExecutions(@Context PagingContext context, @QueryParam("flowGroup") String flowGroup,
-      @Optional @QueryParam("countPerFlow") Integer countPerFlow, @Optional @QueryParam("tag") String tag) {
-    return this.flowExecutionResourceHandler.getLatestFlowGroupExecutions(context, flowGroup, countPerFlow, tag);
+      @Optional @QueryParam("countPerFlow") Integer countPerFlow, @Optional @QueryParam("tag") String tag,
+      @Optional("false") @QueryParam("includeIssues") Boolean includeIssues) {
+    return this.flowExecutionResourceHandler.getLatestFlowGroupExecutions(context, flowGroup, countPerFlow, tag, includeIssues);
   }
 
   /**

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
@@ -57,13 +57,23 @@ public class FlowExecutionResource extends ComplexKeyResourceTemplate<FlowStatus
     return this.flowExecutionResourceHandler.get(key);
   }
 
+  /**
+   * Retrieve the most recent matching FlowExecution(s) of the identified FlowId
+   * @param includeIssues include job issues in the response. Otherwise empty array of issues will be returned.
+   */
   @Finder("latestFlowExecution")
   public List<FlowExecution> getLatestFlowExecution(@Context PagingContext context, @QueryParam("flowId") FlowId flowId,
       @Optional @QueryParam("count") Integer count, @Optional @QueryParam("tag") String tag, @Optional @QueryParam("executionStatus") String executionStatus,
       @Optional("false") @QueryParam("includeIssues") Boolean includeIssues) {
-    return this.flowExecutionResourceHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus,includeIssues);
+    return this.flowExecutionResourceHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus, includeIssues);
   }
 
+  /**
+   * Retrieve the most recent matching FlowExecution(s) for each flow in the identified flowGroup
+   * @param countPerFlow (maximum) number of FlowExecutions for each flow in flowGroup   *
+   * @param includeIssues include job issues in the response. Otherwise empty array of issues will be returned.
+   * @return
+   */
   @Finder("latestFlowGroupExecutions")
   public List<FlowExecution> getLatestFlowGroupExecutions(@Context PagingContext context, @QueryParam("flowGroup") String flowGroup,
       @Optional @QueryParam("countPerFlow") Integer countPerFlow, @Optional @QueryParam("tag") String tag,

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
@@ -34,7 +34,8 @@ public interface FlowExecutionResourceHandler {
   /**
    * Get latest {@link FlowExecution}
    */
-  public List<FlowExecution> getLatestFlowExecution(PagingContext context, FlowId flowId, Integer count, String tag, String executionStatus);
+  public List<FlowExecution> getLatestFlowExecution(PagingContext context, FlowId flowId, Integer count, String tag,
+      String executionStatus, Boolean includeIssues);
 
   /**
    * Get latest {@link FlowExecution} for every flow in `flowGroup`
@@ -42,7 +43,8 @@ public interface FlowExecutionResourceHandler {
    * NOTE: `executionStatus` param not provided yet, without justifying use case, due to complexity of interaction with `countPerFlow`
    * and resulting efficiency concern of performing across many flows sharing the single named group.
    */
-  public List<FlowExecution> getLatestFlowGroupExecutions(PagingContext context, String flowGroup, Integer countPerFLow, String tag);
+  public List<FlowExecution> getLatestFlowGroupExecutions(PagingContext context, String flowGroup, Integer countPerFLow,
+      String tag, Boolean includeIssues);
 
   /**
    * Resume a failed {@link FlowExecution} from the point before failure

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
@@ -82,7 +82,7 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
     if (monitoringFlowStatus == null) {
       return null;
     }
-    FlowExecution flowExecution = FlowExecutionResourceLocalHandler.convertFlowStatus(monitoringFlowStatus);
+    FlowExecution flowExecution = FlowExecutionResourceLocalHandler.convertFlowStatus(monitoringFlowStatus, false);
     return new FlowStatus()
         .setId(flowExecution.getId())
         .setExecutionStatistics(flowExecution.getExecutionStatistics())

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -19,6 +19,8 @@ package org.apache.gobblin.service.monitoring;
 
 import java.util.List;
 
+import com.google.common.base.Supplier;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -54,7 +56,7 @@ public class JobStatus {
   private final int maxAttempts;
   private final int currentAttempts;
   private final boolean shouldRetry;
-  private final List<Issue> issues;
+  private final Supplier<List<Issue>> issues;
   private final int progressPercentage;
   private final long lastProgressEventTime;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
@@ -73,13 +73,15 @@ public class GobblinServiceFlowExecutionResourceHandler implements FlowExecution
   }
 
   @Override
-  public List<FlowExecution> getLatestFlowExecution(PagingContext context, FlowId flowId, Integer count, String tag, String executionStatus) {
-    return this.localHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus);
+  public List<FlowExecution> getLatestFlowExecution(PagingContext context, FlowId flowId, Integer count, String tag,
+      String executionStatus, Boolean includeIssues) {
+    return this.localHandler.getLatestFlowExecution(context, flowId, count, tag, executionStatus, includeIssues);
   }
 
   @Override
-  public List<FlowExecution> getLatestFlowGroupExecutions(PagingContext context, String flowGroup, Integer countPerFlow, String tag) {
-    return this.localHandler.getLatestFlowGroupExecutions(context, flowGroup, countPerFlow, tag);
+  public List<FlowExecution> getLatestFlowGroupExecutions(PagingContext context, String flowGroup, Integer countPerFlow,
+      String tag, Boolean includeIssues) {
+    return this.localHandler.getLatestFlowGroupExecutions(context, flowGroup, countPerFlow, tag, includeIssues);
   }
 
   @Override


### PR DESCRIPTION
Previously, we loaded issues from the db on batch execution requests.
This can result in long response times when large number of flows
are queried.

Now the users can specify if they want to retrieve them, or omit
and speed up the query.

https://issues.apache.org/jira/browse/GOBBLIN-1457

