### PR TITLE
[GOBBLIN-1553] Catch exception when iceberg does not support get metrics for non-optional union type

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -198,7 +198,12 @@ public class GobblinMCEPublisher extends DataPublisher {
           //This means the table is not compatible with iceberg, so return a dummy metric
           return new Metrics(100000000L, null, null, null);
         }
-        return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), MetricsConfig.getDefault(), mapping);
+        try {
+          return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), MetricsConfig.getDefault(), mapping);
+        } catch (Exception e) {
+          //This means the table is not compatible with iceberg, so return a dummy metric
+          return new Metrics(100000000L, null, null, null);
+        }
       }
       case AVRO: {
         try {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -76,6 +76,7 @@ public class GobblinMCEPublisher extends DataPublisher {
   private final Closer closer = Closer.create();
   private final Configuration conf;
   private static final PathFilter HIDDEN_FILES_FILTER = new HiddenFilter();
+  private static final Metrics DUMMY_METRICS = new Metrics(100000000L, null, null, null, null);
 
   public GobblinMCEPublisher(State state) throws IOException {
 
@@ -196,13 +197,13 @@ public class GobblinMCEPublisher extends DataPublisher {
       case ORC: {
         if (mapping == null) {
           //This means the table is not compatible with iceberg, so return a dummy metric
-          return new Metrics(100000000L, null, null, null);
+          return DUMMY_METRICS;
         }
         try {
           return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), MetricsConfig.getDefault(), mapping);
         } catch (Exception e) {
           //This means the table is not compatible with iceberg, so return a dummy metric
-          return new Metrics(100000000L, null, null, null);
+          return DUMMY_METRICS;
         }
       }
       case AVRO: {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1553
    - this is one hotfix


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
There is one update in upstream that support get iceberg schema for non-optinal union type, but get metrics will throw exception. So we need to catch this kind of exception when get metrics as well

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

