### PR TITLE
[GOBBLIN-1567] do not set a custom maxConnLifetime for sql connection

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
@@ -70,6 +70,7 @@ public class ServiceDatabaseProviderImpl implements ServiceDatabaseProvider {
     // To improve performance, we only check connections on creation, and set a maximum connection lifetime
     // If database goes to read-only mode, then connection would not work correctly for up to configured lifetime
     dataSource.setTestOnCreate(true);
+    dataSource.setMaxConnLifetimeMillis(configuration.getMaxConnectionLifetime().toMillis());
     dataSource.setTimeBetweenEvictionRunsMillis(Duration.ofSeconds(10).toMillis());
     dataSource.setMinIdle(2);
     dataSource.setMaxTotal(configuration.getMaxConnections());
@@ -86,7 +87,7 @@ public class ServiceDatabaseProviderImpl implements ServiceDatabaseProvider {
     private String password;
 
     @Builder.Default
-    private Duration maxConnectionLifetime = Duration.ofMinutes(1);
+    private Duration maxConnectionLifetime = Duration.ofMillis(-1);
 
     @Builder.Default
     private int maxConnections = 100;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1567


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
do not set a custom maxConnLifetime for sql connection. the default -1 is good.
setting it to 60 seconds, often gives errors like this
```
An internal object pool swallowed an Exception.
org.apache.commons.dbcp2.LifetimeExceededException: The lifetime of the connection [60,002] milliseconds exceeds the maximum permitted value of [60,000] milliseconds
```

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

