### PR TITLE
[GOBBLIN-1565]Make GMCEWriter fault tolerant so that one topic failure will not affect other topics in the same container

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -123,6 +123,15 @@ public class HiveMetadataWriter implements MetadataWriter {
     }
   }
 
+  @Override
+  public void reset(String dbName, String tableName) throws IOException {
+    String tableKey = tableNameJoiner.join(dbName, tableName);
+    this.currentExecutionMap.remove(tableKey);
+    this.schemaCreationTimeMap.remove(tableKey);
+    this.latestSchemaMap.remove(tableKey);
+    this.specMaps.remove(tableKey);
+  }
+
   public void write(GobblinMetadataChangeEvent gmce, Map<String, Collection<HiveSpec>> newSpecsMap,
       Map<String, Collection<HiveSpec>> oldSpecsMap, HiveSpec tableSpec) throws IOException {
     String dbName = tableSpec.getTable().getDbName();

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriter.java
@@ -48,6 +48,16 @@ public interface MetadataWriter extends Closeable {
   void flush(String dbName, String tableName) throws IOException;
 
   /**
+   * If something wrong happens, we want to reset the table inside the writer so that we can continual
+   * registration for this table
+   *
+   * @param dbName The db name of metadata-registration target.
+   * @param tableName The table name of metadata-registration target.
+   * @throws IOException
+   */
+  void reset(String dbName, String tableName) throws IOException;
+
+  /**
    * Compute and cache the metadata from the GMCE
    * @param recordEnvelope Containing {@link GobblinMetadataChangeEvent}
    * @param newSpecsMap The container (as a map) for new specs.

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriter.java
@@ -48,8 +48,8 @@ public interface MetadataWriter extends Closeable {
   void flush(String dbName, String tableName) throws IOException;
 
   /**
-   * If something wrong happens, we want to reset the table inside the writer so that we can continual
-   * registration for this table
+   * If something wrong happens, we want to clean up in-memory state for the table inside the writer so that we can continue
+   * registration for this table without affect correctness
    *
    * @param dbName The db name of metadata-registration target.
    * @param tableName The table name of metadata-registration target.

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
@@ -20,22 +20,19 @@ package org.apache.gobblin.iceberg.writer;
 import java.io.IOException;
 
 
-public class MetadataFlushException extends IOException {
-  public String datasetName;
+public class GobblinMetadataException extends IOException {
+  public String datasetPath;
   public String dbName;
   public String tableName;
-  public String GMCETopicName;
-  public int GMCETopicPartition;
+  public String GMCETopicPartition;
   public long highWatermark;
   public long lowWatermark;
   public Exception exception;
-  MetadataFlushException(String datasetName, String dbName, String tableName, String GMCETopicName,
-      int GMCETopicPartition, long lowWatermark, long highWatermark, Exception exception) {
+  GobblinMetadataException(String datasetPath, String dbName, String tableName, String GMCETopicPartition, long lowWatermark, long highWatermark, Exception exception) {
     super(String.format("failed to flush table %s, %s", dbName, tableName), exception);
-    this.datasetName = datasetName;
+    this.datasetPath = datasetPath;
     this.dbName = dbName;
     this.tableName = tableName;
-    this.GMCETopicName = GMCETopicName;
     this.GMCETopicPartition = GMCETopicPartition;
     this.highWatermark = highWatermark;
     this.lowWatermark = lowWatermark;

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificData;
+import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -114,7 +115,6 @@ import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
 import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
-import org.apache.gobblin.source.extractor.extract.kafka.KafkaStreamingExtractor.KafkaWatermark;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.time.TimeIterator;
 import org.apache.gobblin.util.AvroUtils;
@@ -1018,9 +1018,9 @@ public class IcebergMetadataWriter implements MetadataWriter {
       if (whitelistBlacklist.acceptTable(tableSpec.getTable().getDbName(), tableSpec.getTable().getTableName())) {
         TableIdentifier tid = TableIdentifier.of(tableSpec.getTable().getDbName(), tableSpec.getTable().getTableName());
         String topicPartition = tableTopicPartitionMap.computeIfAbsent(tid,
-            t -> ((KafkaWatermark) recordEnvelope.getWatermark()).getTopicPartition().toString());
+            t -> recordEnvelope.getWatermark().getSource());
         Long currentWatermark = getAndPersistCurrentWatermark(tid, topicPartition);
-        Long currentOffset = ((KafkaWatermark) recordEnvelope.getWatermark()).getLwm().getValue();
+        Long currentOffset = ((LongWatermark)recordEnvelope.getWatermark().getWatermark()).getValue();
 
         if (currentOffset > currentWatermark) {
           if (currentWatermark == DEFAULT_WATERMARK) {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -861,6 +861,11 @@ public class IcebergMetadataWriter implements MetadataWriter {
     }
   }
 
+  @Override
+  public void reset(String dbName, String tableName) throws IOException {
+      this.tableMetadataMap.remove(TableIdentifier.of(dbName, tableName));
+  }
+
   /**
    * NOTE: completion watermark for a window [t1, t2] is marked as t2 if audit counts match
    * for that window (aka its is set to the beginning of next window)

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/MetadataFlushException.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/MetadataFlushException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.iceberg.writer;
+
+import java.io.IOException;
+
+
+public class MetadataFlushException extends IOException {
+  public String datasetName;
+  public String dbName;
+  public String tableName;
+  public String GMCETopicName;
+  public int GMCETopicPartition;
+  public long highWatermark;
+  public long lowWatermark;
+  public Exception exception;
+  MetadataFlushException(String datasetName, String dbName, String tableName, String GMCETopicName,
+      int GMCETopicPartition, long lowWatermark, long highWatermark, Exception exception) {
+    super(String.format("failed to flush table %s, %s", dbName, tableName), exception);
+    this.datasetName = datasetName;
+    this.dbName = dbName;
+    this.tableName = tableName;
+    this.GMCETopicName = GMCETopicName;
+    this.GMCETopicPartition = GMCETopicPartition;
+    this.highWatermark = highWatermark;
+    this.lowWatermark = lowWatermark;
+  }
+}

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -177,8 +177,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
     state.setProp("gmce.metadata.writer.classes", "org.apache.gobblin.hive.writer.HiveMetadataWriter");
     gobblinMCEWriter = new GobblinMCEWriter(new GobblinMCEWriterBuilder(), state);
   }
-
-  @Test(dependsOnGroups={"icebergMetadataWriterTest"})
+  @Test
   public void testHiveWriteAddFileGMCE() throws IOException {
     gobblinMCEWriter.writeEnvelope(new RecordEnvelope<>(gmce,
         new KafkaStreamingExtractor.KafkaWatermark(
@@ -215,7 +214,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
 
   }
 
-  @Test(dependsOnMethods = {"testHiveWriteAddFileGMCE"})
+  @Test(dependsOnMethods = {"testHiveWriteAddFileGMCE"}, groups={"hiveMetadataWriterTest"})
   public void testHiveWriteRewriteFileGMCE() throws IOException {
     gmce.setTopicPartitionOffsetsRange(null);
     Map<String, String> registrationState = gmce.getRegistrationProperties();

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -343,10 +343,10 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap().size(), 1);
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap()
         .get(new File(tmpDir, "data/tracking/testIcebergTable").getAbsolutePath())
-        .get("hivedb.testIcebergTable").peek().lowWatermark, 50L);
+        .get("hivedb.testIcebergTable").lowWatermark, 50L);
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap()
         .get(new File(tmpDir, "data/tracking/testIcebergTable").getAbsolutePath())
-        .get("hivedb.testIcebergTable").peek().highWatermark, 52L);
+        .get("hivedb.testIcebergTable").highWatermark, 52L);
     //We should not see exception as we have fault tolerant
     gobblinMCEWriter.flush();
     gmce.getDatasetIdentifier().setNativeName("data/tracking/testFaultTolerant");


### PR DESCRIPTION
…e will not affect other topics in the same container

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1565


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
GMIP should be fault tolerant, so that one topic failure should not affect other topics in the same container. One potential solution is that we can catch the error and document the error dataset, if we have more than one datasets have issue, that normally something wrong happening on the whole job, we should fail the task, but if there is only one problematic topic, we can handle the exception and let the pipeline move on and process other topics.
Left some todo for emitting GTE so that we can rely on those event to detect failure and do backfill as needed

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Add new unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

