### PR TITLE
[GOBBLIN-1571] Tag metrics with proxy url if available

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -105,6 +105,7 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
 
   private static final String HADOOP_FS_DEFAULT_NAME = "fs.default.name";
   private static final String AZKABAN_LINK_JOBEXEC_URL = "azkaban.link.jobexec.url";
+  private static final String AZKABAN_LINK_JOBEXEC_PROXY_URL = "azkaban.link.jobexec.proxyUrl";
   private static final String AZKABAN_FLOW_EXEC_ID = "azkaban.flow.execid";
   private static final String MAPREDUCE_JOB_CREDENTIALS_BINARY = "mapreduce.job.credentials.binary";
 
@@ -379,7 +380,8 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
   private static List<? extends Tag<?>> addAdditionalMetadataTags(Properties jobProps) {
     List<Tag<?>> metadataTags = Lists.newArrayList();
     String jobExecutionId = jobProps.getProperty(AZKABAN_FLOW_EXEC_ID, "");
-    String jobExecutionUrl = jobProps.getProperty(AZKABAN_LINK_JOBEXEC_URL, "");
+    // Display the proxy URL in the metadata tag if it exists
+    String jobExecutionUrl = jobProps.getProperty(AZKABAN_LINK_JOBEXEC_PROXY_URL, jobProps.getProperty(AZKABAN_LINK_JOBEXEC_URL, ""));
 
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD,
         jobProps.getProperty(ConfigurationKeys.FLOW_GROUP_KEY, "")));

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanMultiCallables.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanMultiCallables.java
@@ -491,7 +491,7 @@ class AzkabanMultiCallables {
         this.invalidSession = true;
         throw e;
       } catch (Exception e) {
-        throw new AzkabanClientException("Azkaban client failed to get proxy users", e);
+        throw new AzkabanClientException(String.format("Azkaban client failed to get proxy users for %s", client.url), e);
       }
     }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1571


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
From Azkaban, depending on the setup some URLs are not accessible for users.
In gobblin-as-a-service, it is possible to declare the property `azkaban.link.jobexec.proxyUrl` using the additional configs key tied to the executor. This passes the property to the JobLauncher that is unique per executor

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

