### PR TITLE
[GOBBLIN-1575] use reference count in helix manager, so that connect/disconnect are called once and at the right time

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -110,12 +110,9 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
   @Getter
   private DistributeJobMonitor jobMonitor;
 
-  public GobblinHelixDistributeJobExecutionLauncher(Builder builder) throws Exception {
-    if (builder.taskDriverHelixManager.isPresent()) {
-      this.planningJobHelixManager = builder.taskDriverHelixManager.get();
-    } else {
-      this.planningJobHelixManager = builder.jobHelixManager;
-    }
+  public GobblinHelixDistributeJobExecutionLauncher(Builder builder) {
+    this.planningJobHelixManager = builder.taskDriverHelixManager.orElseGet(() -> builder.jobHelixManager);
+
     this.helixTaskDriver = new TaskDriver(this.planningJobHelixManager);
     this.sysProps = builder.sysProps;
     this.jobPlanningProps = builder.jobPlanningProps;
@@ -151,7 +148,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
           // work flow should never be deleted explicitly because it has a expiry time
           // If cancellation is requested, we should set the job state to CANCELLED/ABORT
           this.helixTaskDriver.waitToStop(planningJobId, this.helixJobStopTimeoutSeconds * 1000);
-          log.info("Stopped the workflow ", planningJobId);
+          log.info("Stopped the workflow {}", planningJobId);
         }
       } catch (HelixException e) {
         // Cancellation may throw an exception, but Helix set the job state to STOP and it should eventually stop

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -137,7 +137,6 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
 
   @Override
   public void close()  throws IOException {
-    this.planningJobHelixManager.disconnect();
   }
 
   private void executeCancellation() {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -111,7 +111,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
   private DistributeJobMonitor jobMonitor;
 
   public GobblinHelixDistributeJobExecutionLauncher(Builder builder) {
-    this.planningJobHelixManager = builder.taskDriverHelixManager.orElseGet(() -> builder.jobHelixManager);
+    this.planningJobHelixManager = builder.planningJobHelixManager;
 
     this.helixTaskDriver = new TaskDriver(this.planningJobHelixManager);
     this.sysProps = builder.sysProps;
@@ -137,6 +137,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
 
   @Override
   public void close()  throws IOException {
+    this.planningJobHelixManager.disconnect();
   }
 
   private void executeCancellation() {
@@ -165,8 +166,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
   public static class Builder {
     Properties sysProps;
     Properties jobPlanningProps;
-    HelixManager jobHelixManager;
-    Optional<HelixManager> taskDriverHelixManager;
+    HelixManager planningJobHelixManager;
     Path appWorkDir;
     GobblinHelixPlanningJobLauncherMetrics planningJobLauncherMetrics;
     GobblinHelixMetrics helixMetrics;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -17,10 +17,6 @@
 
 package org.apache.gobblin.cluster;
 
-import com.github.rholder.retry.RetryException;
-import com.github.rholder.retry.Retryer;
-import com.github.rholder.retry.RetryerBuilder;
-import com.github.rholder.retry.StopStrategies;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
@@ -44,6 +40,10 @@ import org.apache.helix.task.TaskDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -143,13 +144,14 @@ class GobblinHelixJobTask implements Task {
   /**
    * Launch the actual {@link GobblinHelixJobLauncher}.
    */
+  @SneakyThrows
   @Override
   public TaskResult run() {
     log.info("Running planning job {} [{} {}]", this.planningJobId, this.applicationName, this.instanceName);
     this.jobTaskMetrics.updateTimeBetweenJobSubmissionAndExecution(this.jobPlusSysConfig);
+    this.jobHelixManager.connect();
 
     try (Closer closer = Closer.create()) {
-      this.jobHelixManager.connect();
       Optional<String> planningIdFromStateStore = this.jobsMapping.getPlanningJobId(jobUri);
 
       long timeOut = PropertiesUtils.getPropAsLong(jobPlusSysConfig,

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
@@ -88,7 +88,6 @@ class GobblinHelixJobTask implements Task {
 
     // make a copy of helix manager, so that each job can keep using it without worrying about disconnect from the GobblinTaskRunner where they are created
     this.jobHelixManager =  GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(jobPlusSysConfig),
-        jobPlusSysConfig.getProperty(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY),
         GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY, builder.getJobHelixManager().getInstanceType());
 
     this.jobLauncherListener = new GobblinHelixJobLauncherListener(launcherMetrics);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
@@ -84,12 +84,8 @@ class GobblinHelixJobTask implements Task {
     this.helixMetrics = helixMetrics;
     this.taskConfig = context.getTaskConfig();
     this.sysConfig = builder.getConfig();
+    this.jobHelixManager = builder.getJobHelixManager();
     this.jobPlusSysConfig = ConfigUtils.configToProperties(sysConfig);
-
-    // make a copy of helix manager, so that each job can keep using it without worrying about disconnect from the GobblinTaskRunner where they are created
-    this.jobHelixManager =  GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(jobPlusSysConfig),
-        GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY, builder.getJobHelixManager().getInstanceType());
-
     this.jobLauncherListener = new GobblinHelixJobLauncherListener(launcherMetrics);
 
     Map<String, String> configMap = this.taskConfig.getConfigMap();

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixManagerFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixManagerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
+
+
+public class GobblinHelixManagerFactory {
+
+  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
+      InstanceType type, String zkAddr) {
+    return new GobblinZkHelixManager(clusterName, instanceName, type, zkAddr);
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixManagerFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixManagerFactory.java
@@ -17,14 +17,13 @@
 
 package org.apache.gobblin.cluster;
 
-import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 
 
 public class GobblinHelixManagerFactory {
 
-  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
+  public static GobblinReferenceCountingZkHelixManager getZKHelixManager(String clusterName, String instanceName,
       InstanceType type, String zkAddr) {
-    return new GobblinZkHelixManager(clusterName, instanceName, type, zkAddr);
+    return new GobblinReferenceCountingZkHelixManager(clusterName, instanceName, type, zkAddr);
   }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -160,7 +160,11 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
   /**
    * Build the {@link HelixManager} for the Application Master.
    */
-  protected static HelixManager buildHelixManager(Config config, String zkConnectionString, String clusterName, InstanceType type) {
+  protected static HelixManager buildHelixManager(Config config, String clusterName, InstanceType type) {
+    Preconditions.checkArgument(config.hasPath(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY));
+    String zkConnectionString = config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);
+    log.info("Using ZooKeeper connection string: " + zkConnectionString);
+
     String helixInstanceName = ConfigUtils.getString(config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_KEY,
         GobblinClusterManager.class.getSimpleName());
     return HelixManagerFactory.getZKHelixManager(
@@ -168,22 +172,16 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
   }
 
   public void initialize() {
-    Preconditions.checkArgument(this.config.hasPath(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY));
-    String zkConnectionString = this.config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);
-    log.info("Using ZooKeeper connection string: " + zkConnectionString);
-
     if (this.dedicatedManagerCluster) {
       Preconditions.checkArgument(this.config.hasPath(GobblinClusterConfigurationKeys.MANAGER_CLUSTER_NAME_KEY));
       log.info("We will use separate clusters to manage GobblinClusterManager and job distribution.");
       // This will create and register a Helix controller in ZooKeeper
       this.managerClusterHelixManager = buildHelixManager(this.config,
-          zkConnectionString,
           GobblinClusterConfigurationKeys.MANAGER_CLUSTER_NAME_KEY,
           InstanceType.CONTROLLER);
 
       // This will create a Helix administrator to dispatch jobs to ZooKeeper
       this.jobClusterHelixManager = buildHelixManager(this.config,
-          zkConnectionString,
           GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY,
           InstanceType.ADMINISTRATOR);
 
@@ -195,14 +193,13 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
 
       if (this.dedicatedJobClusterController) {
         this.jobClusterController = Optional.of(GobblinHelixMultiManager
-            .buildHelixManager(this.config, zkConnectionString, GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY,
+            .buildHelixManager(this.config, GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY,
                 InstanceType.CONTROLLER));
       }
 
       if (this.dedicatedTaskDriverCluster) {
         // This will create a Helix administrator to dispatch jobs to ZooKeeper
         this.taskDriverHelixManager = Optional.of(buildHelixManager(this.config,
-            zkConnectionString,
             GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY,
             InstanceType.ADMINISTRATOR));
 
@@ -216,7 +213,7 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
         // This will create a dedicated controller for planning job distribution
         if (dedicatedTaskDriverClusterController) {
           this.taskDriverClusterController = Optional.of(GobblinHelixMultiManager
-              .buildHelixManager(this.config, zkConnectionString, GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY,
+              .buildHelixManager(this.config, GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY,
                   InstanceType.CONTROLLER));
         }
       }
@@ -226,7 +223,6 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
       boolean isHelixClusterManaged = ConfigUtils.getBoolean(this.config, GobblinClusterConfigurationKeys.IS_HELIX_CLUSTER_MANAGED,
           GobblinClusterConfigurationKeys.DEFAULT_IS_HELIX_CLUSTER_MANAGED);
       this.managerClusterHelixManager = buildHelixManager(this.config,
-          zkConnectionString,
           GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY,
           isHelixClusterManaged ? InstanceType.PARTICIPANT : InstanceType.CONTROLLER);
       this.jobClusterHelixManager = this.managerClusterHelixManager;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -30,7 +30,6 @@ import java.util.function.Function;
 
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
-import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
@@ -167,7 +166,7 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
 
     String helixInstanceName = ConfigUtils.getString(config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_KEY,
         GobblinClusterManager.class.getSimpleName());
-    return HelixManagerFactory.getZKHelixManager(
+    return GobblinHelixManagerFactory.getZKHelixManager(
         config.getString(clusterName), helixInstanceName, type, zkConnectionString);
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinReferenceCountingZkHelixManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinReferenceCountingZkHelixManager.java
@@ -31,10 +31,10 @@ import lombok.extern.slf4j.Slf4j;
  * Calls to connect and disconnect to the underlying ZKHelixManager are made only for the first and last usage respectively.
  */
 @Slf4j
-public class GobblinZkHelixManager extends ZKHelixManager {
-  final AtomicInteger usageCount = new AtomicInteger(0);
+public class GobblinReferenceCountingZkHelixManager extends ZKHelixManager {
+  private final AtomicInteger usageCount = new AtomicInteger(0);
 
-  public GobblinZkHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddress) {
+  public GobblinReferenceCountingZkHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddress) {
     super(clusterName, instanceName, instanceType, zkAddress);
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -48,7 +48,6 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
-import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
@@ -285,18 +284,18 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
 
     if (this.isTaskDriver && this.dedicatedTaskDriverCluster) {
       // This will create a Helix manager to receive the planning job
-      this.taskDriverHelixManager = Optional.of(HelixManagerFactory.getZKHelixManager(
+      this.taskDriverHelixManager = Optional.of(GobblinHelixManagerFactory.getZKHelixManager(
           ConfigUtils.getString(this.clusterConfig, GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY, ""),
           this.helixInstanceName,
           InstanceType.PARTICIPANT,
           zkConnectionString));
-      this.jobHelixManager = HelixManagerFactory.getZKHelixManager(
+      this.jobHelixManager = GobblinHelixManagerFactory.getZKHelixManager(
           this.clusterName,
           this.helixInstanceName,
           InstanceType.ADMINISTRATOR,
           zkConnectionString);
     } else {
-      this.jobHelixManager = HelixManagerFactory.getZKHelixManager(
+      this.jobHelixManager = GobblinHelixManagerFactory.getZKHelixManager(
           this.clusterName,
           this.helixInstanceName,
           InstanceType.PARTICIPANT,
@@ -305,8 +304,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   }
 
   private HelixManager getReceiverManager() {
-    return taskDriverHelixManager.isPresent()?taskDriverHelixManager.get()
-        : this.jobHelixManager;
+    return taskDriverHelixManager.isPresent() ? taskDriverHelixManager.get() : this.jobHelixManager;
   }
 
   private TaskStateModelFactory createTaskStateModelFactory(Map<String, TaskFactory> taskFactoryMap) {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinZkHelixManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinZkHelixManager.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.helix.InstanceType;
+import org.apache.helix.manager.zk.ZKHelixManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A {@link ZKHelixManager} which keeps a reference count of users.
+ * Every user should call connect and disconnect to increase and decrease the count.
+ * Calls to connect and disconnect to the underlying ZKHelixManager are made only for the first and last usage respectively.
+ */
+@Slf4j
+public class GobblinZkHelixManager extends ZKHelixManager {
+  final AtomicInteger usageCount = new AtomicInteger(0);
+
+  public GobblinZkHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddress) {
+    super(clusterName, instanceName, instanceType, zkAddress);
+  }
+
+  @Override
+  public void connect() throws Exception {
+    if (usageCount.incrementAndGet() == 1) {
+      super.connect();
+    }
+  }
+
+  @Override
+  public void disconnect() {
+    if (usageCount.decrementAndGet() <= 0) {
+      super.disconnect();
+    }
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -126,15 +126,8 @@ class HelixRetriggeringJobCallable implements Callable {
     this.planningJobLauncherMetrics = planningJobLauncherMetrics;
     this.helixMetrics = helixMetrics;
     this.appWorkDir = appWorkDir;
-
-    // make a copy of helix managers, so that each job can keep using it without worrying about disconnect from the GobblinClusterManager where they are created
-    this.jobHelixManager = GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(sysProps),
-        GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY, jobHelixManager.getInstanceType());
-
-    this.taskDriverHelixManager = taskDriverHelixManager.map(
-        helixManager -> GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(sysProps),
-            GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY, helixManager.getInstanceType()));
-
+    this.jobHelixManager = jobHelixManager;
+    this.taskDriverHelixManager = taskDriverHelixManager;
     this.isDistributeJobEnabled = isDistributeJobEnabled();
     this.jobUri = jobProps.getProperty(GobblinClusterConfigurationKeys.JOB_SPEC_URI);
     this.jobsMapping = jobsMapping;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -129,12 +129,10 @@ class HelixRetriggeringJobCallable implements Callable {
 
     // make a copy of helix managers, so that each job can keep using it without worrying about disconnect from the GobblinClusterManager where they are created
     this.jobHelixManager = GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(sysProps),
-        sysProps.getProperty(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY),
         GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY, jobHelixManager.getInstanceType());
 
     this.taskDriverHelixManager = taskDriverHelixManager.map(
         helixManager -> GobblinHelixMultiManager.buildHelixManager(ConfigUtils.propertiesToConfig(sysProps),
-            sysProps.getProperty(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY),
             GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY, helixManager.getInstanceType()));
 
     this.isDistributeJobEnabled = isDistributeJobEnabled();
@@ -260,8 +258,7 @@ class HelixRetriggeringJobCallable implements Callable {
     String newPlanningId;
     Closer closer = Closer.create();
     try {
-      HelixManager planningJobHelixManager = this.taskDriverHelixManager.isPresent()?
-          this.taskDriverHelixManager.get() : this.jobHelixManager;
+      HelixManager planningJobHelixManager = this.taskDriverHelixManager.orElse(this.jobHelixManager);
       planningJobHelixManager.connect();
 
       String builderStr = jobProps.getProperty(GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_BUILDER,


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1575


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
GobblinTaskRunner creates a HelixManager and passes it to HelixJobTask. When the GobblinTaskRunner is stopped, it disconnects to HelixManager, but because the HelixJobTask is also using the same HelixManager object, it cannot use it do its own shutdown operation. This PR will make a copy of HelixManager to be used by HelixJobTask 's.

Same argument with GobblinClusterManager passing the same HelixManager object to HelixRetriggeringJobCallable

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

