### PR TITLE
[GOBBLIN-1576] skip appending record count to staging file if present…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -304,6 +304,10 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   private synchronized String addRecordCountToStagingFile()
       throws IOException {
     String filePath = this.stagingFile.toString();
+    if(IngestionRecordCountProvider.containsRecordCount(filePath)) {
+      LOG.info(String.format("Path %s already has record count", filePath));
+      return filePath;
+    }
     String filePathWithRecordCount = IngestionRecordCountProvider.constructFilePath(filePath, recordsWritten());
     LOG.info("Renaming " + filePath + " to " + filePathWithRecordCount);
     HadoopUtils.renamePath(this.fs, new Path(filePath), new Path(filePathWithRecordCount), true);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProvider.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProvider.java
@@ -56,7 +56,7 @@ public class IngestionRecordCountProvider extends RecordCountProvider {
    */
   public static boolean containsRecordCount(String filepath) {
     String[] components = filepath.split(Pattern.quote(SEPARATOR));
-    return components.length >= 2 && StringUtils.isNumeric(components[components.length - 2]);
+    return components.length >= 3 && StringUtils.isNumeric(components[components.length - 2]);
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.util.recordcount;
 
+import java.util.regex.Pattern;
 import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -33,6 +34,8 @@ public class IngestionRecordCountProviderTest {
     IngestionRecordCountProvider filenameRecordCountProvider = new IngestionRecordCountProvider();
     Assert.assertEquals(IngestionRecordCountProvider.constructFilePath("/a/b/c.avro", 123), "/a/b/c.123.avro");
     Assert.assertEquals(filenameRecordCountProvider.getRecordCount(new Path("/a/b/c.123.avro")), 123);
+    Assert.assertEquals(IngestionRecordCountProvider.containsRecordCount("/a/b/c.123.avro"), true);
+    Assert.assertEquals(IngestionRecordCountProvider.containsRecordCount("/a/b/c.xyz.avro"), false);
   }
 
 }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.util.recordcount;
 
-import java.util.regex.Pattern;
 import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
… already

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1576


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Skip renaming of staging files with record counts if it already exists. This case happens when the commit fails and some staging files are present already.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test case

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

