### PR TITLE
[GOBBLIN-1577] change the multiplier used in ExponentialWaitStrategy to a reasonable…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -888,8 +888,6 @@ public class ConfigurationKeys {
   public static final String KAFKA_SOURCE_AVG_FETCH_TIME_CAP = "kakfa.source.avgFetchTimeCap";
   public static final int DEFAULT_KAFKA_SOURCE_AVG_FETCH_TIME_CAP = 100;
   public static final String SHARED_KAFKA_CONFIG_PREFIX = "gobblin.kafka.sharedConfig";
-  public static final String KAFKA_JOB_STATUS_MONITOR_RETRY_TIME_OUT_MINUTES =
-      "gobblin.kafka.jobStatusMonitor.retry.timeOut.minutes";
 
   /**
    * Kafka schema registry HTTP client configuration

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.compaction.mapreduce;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
@@ -55,6 +54,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -186,7 +186,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
         ImmutableMap.<String, Object>builder()
             .put(RETRY_TIME_OUT_MS, TimeUnit.MINUTES.toMillis(2L))   //Overall retry for 2 minutes
             .put(RETRY_INTERVAL_MS, TimeUnit.SECONDS.toMillis(5L)) //Try to retry 5 seconds
-            .put(RETRY_MULTIPLIER, 2L) // Muliply by 2 every attempt
+            .put(RETRY_MULTIPLIER, 2L) // Multiply by 2 every attempt
             .put(RETRY_TYPE, RetryType.EXPONENTIAL.name())
             .build();
     COMPACTION_RETRY_DEFAULTS = ConfigFactory.parseMap(configMap);

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -60,7 +60,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
       Path outputPath = new Path(publisherOutput, pathSuffix);
 
       WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
-            this.permissions.get(branchId), this.retrierConfig);
+            this.permissions.get(branchId), this.retryerConfig);
 
       movePath(parallelRunner, workUnitState, status.getPath(), outputPath, branchId);
     }

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedStreamingDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedStreamingDataPublisher.java
@@ -78,7 +78,7 @@ public class TimePartitionedStreamingDataPublisher extends TimePartitionedDataPu
       // This is used to force the publisher save recordPublisherOutputDirs as the granularity to be parent of new file paths
       // which will be used to do hive registration
       WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
-          publisherOutputDir, this.permissions.get(branchId), retrierConfig);
+          publisherOutputDir, this.permissions.get(branchId), retryerConfig);
     }
     super.publishData(state, branchId, publishSingleTaskData, writerOutputPathsMoved);
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimestampDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimestampDataPublisher.java
@@ -53,7 +53,7 @@ public class TimestampDataPublisher extends BaseDataPublisher {
     Path publisherOutputDir = getPublisherOutputDir(state, branchId);
     if (!this.publisherFileSystemByBranches.get(branchId).exists(publisherOutputDir)) {
       WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
-          publisherOutputDir, this.permissions.get(branchId), this.retrierConfig);
+          publisherOutputDir, this.permissions.get(branchId), this.retryerConfig);
     }
     super.publishData(state, branchId, publishSingleTaskData, writerOutputPathsMoved);
   }
@@ -75,7 +75,7 @@ public class TimestampDataPublisher extends BaseDataPublisher {
 
     if (!this.publisherFileSystemByBranches.get(branchId).exists(newDst)) {
       WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
-          newDst.getParent(), this.permissions.get(branchId), this.retrierConfig);
+          newDst.getParent(), this.permissions.get(branchId), this.retryerConfig);
     }
 
     super.movePath(parallelRunner, state, src, newDst, branchId);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -80,7 +80,7 @@ import static org.apache.gobblin.util.retry.RetryerFactory.*;
  */
 @Slf4j
 public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], byte[]> {
-  static final String JOB_STATUS_MONITOR_PREFIX = "jobStatusMonitor";
+  public static final String JOB_STATUS_MONITOR_PREFIX = "jobStatusMonitor";
   //We use table suffix that is different from the Gobblin job state store suffix of jst to avoid confusion.
   //gst refers to the state store suffix for GaaS-orchestrated Gobblin jobs.
   public static final String GET_AND_SET_JOB_STATUS = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
@@ -131,10 +131,8 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
 
     this.flowNameGroupToWorkUnitCount = new ConcurrentHashMap<>();
 
-    Config retryerOverridesConfig = config.hasPath(ConfigurationKeys.KAFKA_JOB_STATUS_MONITOR_RETRY_TIME_OUT_MINUTES)
-        ? ConfigFactory.parseMap(ImmutableMap.of(
-                RETRY_TIME_OUT_MS,
-                config.getDuration(ConfigurationKeys.KAFKA_JOB_STATUS_MONITOR_RETRY_TIME_OUT_MINUTES, TimeUnit.MINUTES)))
+    Config retryerOverridesConfig = config.hasPath(KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX)
+        ? config.getConfig(KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX)
         : ConfigFactory.empty();
     // log exceptions to expose errors we suffer under and/or guide intervention when resolution not readily forthcoming
     this.persistJobStatusRetryer =

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
@@ -56,17 +56,12 @@ public class RetryerFactory<T> {
   private static final Predicate<Throwable> RETRY_EXCEPTION_PREDICATE;
   private static final Config DEFAULTS;
   static {
-    RETRY_EXCEPTION_PREDICATE = new Predicate<Throwable>() {
-      @Override
-      public boolean apply(Throwable t) {
-        return !(t instanceof NonTransientException);
-      }
-    };
+    RETRY_EXCEPTION_PREDICATE = t -> !(t instanceof NonTransientException);
 
     Map<String, Object> configMap = ImmutableMap.<String, Object>builder()
                                                 .put(RETRY_TIME_OUT_MS, TimeUnit.MINUTES.toMillis(5L))
                                                 .put(RETRY_INTERVAL_MS, TimeUnit.SECONDS.toMillis(30L))
-                                                .put(RETRY_MULTIPLIER, 2L)
+                                                .put(RETRY_MULTIPLIER, TimeUnit.SECONDS.toMillis(1L))
                                                 .put(RETRY_TYPE, RetryType.EXPONENTIAL.name())
                                                 .put(RETRY_TIMES, 2)
                                                 .build();


### PR DESCRIPTION
… number 2 seconds

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1577


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The retryer multiplier for exponential wait strategy was 2ms which makes some of our jobs retries too fast. It works essentially same as instant retry when we do not want it. changing it to 1s

Also changed a part in JobStatusMonitor where it can accept retryer configs via config object that was passed to it.

also did some codestyle fixes which I came across while navigating the code


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

