### PR TITLE
[GOBBLIN-1580] Check table exists instead of call create table directly to make sure table exists

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -205,6 +205,12 @@ public class GobblinMCEPublisher extends DataPublisher {
           //This means the table is not compatible with iceberg, so return a dummy metric
           return DUMMY_METRICS;
         }
+        try {
+          return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), MetricsConfig.getDefault(), mapping);
+        } catch (Exception e) {
+          //This means the table is not compatible with iceberg, so return a dummy metric
+          return new Metrics(100000000L, null, null, null);
+        }
       }
       case AVRO: {
         try {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -205,12 +205,6 @@ public class GobblinMCEPublisher extends DataPublisher {
           //This means the table is not compatible with iceberg, so return a dummy metric
           return DUMMY_METRICS;
         }
-        try {
-          return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), MetricsConfig.getDefault(), mapping);
-        } catch (Exception e) {
-          //This means the table is not compatible with iceberg, so return a dummy metric
-          return new Metrics(100000000L, null, null, null);
-        }
       }
       case AVRO: {
         try {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1580


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Make change to so that cacheDbTableExistence make more sense will not affect alter table even this flag is enabled.
Check table existence before we try to create the table

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

