### PR TITLE
GOBBLIN-1579 Fail job on hive existing target table location mismatch

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
@@ -81,12 +81,10 @@ public class UnpartitionedTableFileSet extends HiveFileSet {
             existingTargetTable = Optional.absent();
             break ;
           default:
-            log.error("Source and target table are not compatible. Aborting copy of table " + this.helper.getTargetTable(),
-                new HiveTableLocationNotMatchException(this.helper.getTargetTable().getDataLocation(),
-                    existingTargetTable.get().getDataLocation()));
+            log.error("Source and target table are not compatible. Aborting copy of table " + this.helper.getTargetTable());
             multiTimer.close();
-
-            return Lists.newArrayList();
+            throw new HiveTableLocationNotMatchException(this.helper.getTargetTable().getDataLocation(),
+                    existingTargetTable.get().getDataLocation());
         }
       }
     }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSetTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.hive;
+
+import com.google.common.base.Optional;
+import org.apache.gobblin.data.management.copy.CopyEntity;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class UnpartitionedTableFileSetTest {
+
+    @Test(expectedExceptions = { HiveTableLocationNotMatchException.class })
+    public void testHiveTableLocationNotMatchException() throws Exception {
+        Path testPath = new Path("/testPath/db/table");
+        Path existingTablePath = new Path("/existing/testPath/db/table");
+        Table table = new Table("testDb","table1");
+        table.setDataLocation(testPath);
+        Table existingTargetTable = new Table("testDb","table1");
+        existingTargetTable.setDataLocation(existingTablePath);
+        HiveDataset hiveDataset = Mockito.mock(HiveDataset.class);
+        Mockito.when(hiveDataset.getTable()).thenReturn(table);
+        HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
+        Mockito.when(helper.getDataset()).thenReturn(hiveDataset);
+        Mockito.when(helper.getExistingTargetTable()).thenReturn(Optional.of(existingTargetTable));
+        Mockito.when(helper.getTargetTable()).thenReturn(table);
+        Mockito.when(helper.getExistingEntityPolicy()).thenReturn(HiveCopyEntityHelper.ExistingEntityPolicy.ABORT);
+        MetricContext metricContext = MetricContext.builder("testUnpartitionedTableFileSet").build();
+        EventSubmitter eventSubmitter = new EventSubmitter.Builder(metricContext,"loc.nomatch.exp").build();
+        Mockito.when(helper.getEventSubmitter()).thenReturn(eventSubmitter);
+        UnpartitionedTableFileSet upts = new UnpartitionedTableFileSet("testLocationMatch",hiveDataset,helper);
+        List<CopyEntity> copyEntities = (List<CopyEntity>)upts.generateCopyEntities();
+    }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1579


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
When path of the existing hive table in target does not match with the desired path of the target table to be copied, HiveTableLocationNotMatchException is logged, empty list is returned and job state is set to committed. Propagating the HiveTableLocationNotMatchException so that job state can be set as failed.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
UnpartitionedTableFileSetTest.java

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

