### PR TITLE
[GOBBLIN-1581] Iterate over Sql ResultSet in Only the Forward Direction

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/MySqlWriterCommands.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/MySqlWriterCommands.java
@@ -82,7 +82,7 @@ public class MySqlWriterCommands implements JdbcWriterCommands {
   public boolean isEmpty(String database, String table) throws SQLException {
     String sql = String.format(SELECT_SQL_FORMAT, database, table);
     try (PreparedStatement pstmt = this.conn.prepareStatement(sql); ResultSet resultSet = pstmt.executeQuery();) {
-      if (!resultSet.first()) {
+      if (!resultSet.next()) {
         throw new RuntimeException("Should have received at least one row from SQL " + pstmt);
       }
       return 0 == resultSet.getInt(1);


### PR DESCRIPTION
* after sql-connector was bumped, exception results from ResultSet.first() being called because it iterates in backward direction of set

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1581 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
after sql-connector was bumped, exception results from ResultSet.first() being called because it iterates in backward direction of set

can also be addressed by changing the prepare statement of every sql cmd that is executed
_PreparedStatement pstmt = this.conn.prepareStatement(sql) ->
PreparedStatement pstmt = this.conn.prepareStatement(sql, ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)_

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested manually with snapshot and ingestion job

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

