### PR TITLE
[GOBBLIN-1584] Add replace record logic for Mysql writer

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -219,7 +219,7 @@ public class ConfigurationKeys {
   /**
    * Optional property to specify whether existing data in databases can be overwritten during ingestion jobs
    */
-  public static final String ALLOW_DATA_OVERWRITE = "allow.data.overwrite";
+  public static final String ALLOW_JDBC_RECORD_OVERWRITE = "allow.jdbc.record.overwrite";
 
   /**
    * Optional property to specify a default Authenticator class for a job

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -217,6 +217,11 @@ public class ConfigurationKeys {
   public static final long DEFAULT_QUEUED_TASK_TIME_MAX_AGE = TimeUnit.HOURS.toMillis(1);
 
   /**
+   * Optional property to specify whether existing data in databases can be overwritten during ingestion jobs
+   */
+  public static final String ALLOW_DATA_OVERWRITE = "allow.data.overwrite";
+
+  /**
    * Optional property to specify a default Authenticator class for a job
    */
   public static final String DEFAULT_AUTHENTICATOR_CLASS = "job.default.authenticator.class";

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
@@ -183,7 +183,6 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
     return String.format(INSERT_STATEMENT_PREFIX_FORMAT, databaseName, table, JOINER_ON_COMMA.join(this.columnNames));
   }
 
-
   @Override
   public void flush() throws SQLException {
     if (this.pendingInserts == null || this.pendingInserts.isEmpty()) {

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
@@ -34,10 +34,12 @@ import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
+import lombok.ToString;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.converter.jdbc.JdbcEntryData;
 import org.apache.gobblin.converter.jdbc.JdbcEntryDatum;
-import lombok.ToString;
 
 
 /**
@@ -65,6 +67,9 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
   protected PreparedStatement insertPstmtForFixedBatch;
   private final Retryer<Boolean> retryer;
 
+  // If this config is true, the inserter can insert duplicate primary records according to the specific language
+  protected final boolean replaceExistingValues;
+
   public BaseJdbcBufferedInserter(State state, Connection conn) {
     this.conn = conn;
     this.batchSize = state.getPropAsInt(WRITER_JDBC_INSERT_BATCH_SIZE, DEFAULT_WRITER_JDBC_INSERT_BATCH_SIZE);
@@ -80,6 +85,8 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
     this.retryer = RetryerBuilder.<Boolean> newBuilder().retryIfException()
         .withWaitStrategy(WaitStrategies.exponentialWait(1000, maxWait, TimeUnit.SECONDS))
         .withStopStrategy(StopStrategies.stopAfterAttempt(maxAttempts)).build();
+
+    this.replaceExistingValues = state.getPropAsBoolean(ConfigurationKeys.ALLOW_DATA_OVERWRITE);
   }
 
   /**
@@ -175,6 +182,7 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
   protected String createInsertStatementStr(String databaseName, String table) {
     return String.format(INSERT_STATEMENT_PREFIX_FORMAT, databaseName, table, JOINER_ON_COMMA.join(this.columnNames));
   }
+
 
   @Override
   public void flush() throws SQLException {

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/BaseJdbcBufferedInserter.java
@@ -36,7 +36,6 @@ import com.google.common.collect.Lists;
 
 import lombok.ToString;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.converter.jdbc.JdbcEntryData;
 import org.apache.gobblin.converter.jdbc.JdbcEntryDatum;
@@ -67,9 +66,6 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
   protected PreparedStatement insertPstmtForFixedBatch;
   private final Retryer<Boolean> retryer;
 
-  // If this config is true, the inserter can insert duplicate primary records according to the specific language
-  protected final boolean replaceExistingValues;
-
   public BaseJdbcBufferedInserter(State state, Connection conn) {
     this.conn = conn;
     this.batchSize = state.getPropAsInt(WRITER_JDBC_INSERT_BATCH_SIZE, DEFAULT_WRITER_JDBC_INSERT_BATCH_SIZE);
@@ -85,8 +81,6 @@ public abstract class BaseJdbcBufferedInserter implements JdbcBufferedInserter {
     this.retryer = RetryerBuilder.<Boolean> newBuilder().retryIfException()
         .withWaitStrategy(WaitStrategies.exponentialWait(1000, maxWait, TimeUnit.SECONDS))
         .withStopStrategy(StopStrategies.stopAfterAttempt(maxAttempts)).build();
-
-    this.replaceExistingValues = state.getPropAsBoolean(ConfigurationKeys.ALLOW_DATA_OVERWRITE);
   }
 
   /**

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/JdbcWriterCommandsFactory.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/JdbcWriterCommandsFactory.java
@@ -38,13 +38,16 @@ public class JdbcWriterCommandsFactory {
    * @return Provides JdbcWriterCommands bases on destination.
    */
   public JdbcWriterCommands newInstance(Destination destination, Connection conn) {
+
+    boolean overwriteRecords = destination.getProperties().getPropAsBoolean(ConfigurationKeys.ALLOW_JDBC_RECORD_OVERWRITE);
+
     switch (destination.getType()) {
       case MYSQL:
-        return new MySqlWriterCommands(destination.getProperties(), conn);
+        return new MySqlWriterCommands(destination.getProperties(), conn, overwriteRecords);
       case TERADATA:
-        return new TeradataWriterCommands(destination.getProperties(), conn);
+        return new TeradataWriterCommands(destination.getProperties(), conn, overwriteRecords);
       case POSTGRES:
-        return new PostgresWriterCommands(destination.getProperties(), conn);
+        return new PostgresWriterCommands(destination.getProperties(), conn, overwriteRecords);
       default:
         throw new IllegalArgumentException(destination.getType() + " is not supported");
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/MySqlBufferedInserter.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/MySqlBufferedInserter.java
@@ -96,12 +96,13 @@ public class MySqlBufferedInserter extends BaseJdbcBufferedInserter {
           + " due to # of params limitation " + this.maxParamSize + " , # of columns: " + this.columnNames.size());
     }
     this.batchSize = actualBatchSize;
-
-    // Use separate insertion statement if replacements are allowed
     super.initializeBatch(databaseName, table);
   }
 
   @Override
+  /**
+   * Use separate insertion statement if data overwrites are allowed
+   */
   protected String createInsertStatementStr(String databaseName, String table) {
     return String.format(this.overwriteRecords ? REPLACE_STATEMENT_PREFIX_FORMAT : INSERT_STATEMENT_PREFIX_FORMAT, databaseName, table, JOINER_ON_COMMA.join(this.columnNames));
   }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/PostgresWriterCommands.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/PostgresWriterCommands.java
@@ -51,7 +51,11 @@ public class PostgresWriterCommands implements JdbcWriterCommands {
   private final JdbcBufferedInserter jdbcBufferedWriter;
   private final Connection conn;
 
-  public PostgresWriterCommands(State state, Connection conn) {
+  public PostgresWriterCommands(State state, Connection conn, boolean overwriteRecords) throws IllegalArgumentException {
+    if (overwriteRecords) {
+      throw new IllegalArgumentException("Replace existing records is not supported in PostgresWriterCommands");
+    }
+
     this.conn = conn;
     this.jdbcBufferedWriter = new PostgresBufferedInserter(state, conn);
   }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/PostgresWriterCommands.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/PostgresWriterCommands.java
@@ -24,13 +24,13 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.converter.jdbc.JdbcEntryData;
-import org.apache.gobblin.converter.jdbc.JdbcType;
-
 import com.google.common.collect.ImmutableMap;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.converter.jdbc.JdbcEntryData;
+import org.apache.gobblin.converter.jdbc.JdbcType;
 
 
 /**
@@ -51,7 +51,7 @@ public class PostgresWriterCommands implements JdbcWriterCommands {
   private final JdbcBufferedInserter jdbcBufferedWriter;
   private final Connection conn;
 
-  public PostgresWriterCommands(State state, Connection conn, boolean overwriteRecords) throws IllegalArgumentException {
+  public PostgresWriterCommands(State state, Connection conn, boolean overwriteRecords) throws UnsupportedOperationException {
     if (overwriteRecords) {
       throw new IllegalArgumentException("Replace existing records is not supported in PostgresWriterCommands");
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/TeradataWriterCommands.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/TeradataWriterCommands.java
@@ -17,12 +17,6 @@
 
 package org.apache.gobblin.writer.commands;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.converter.jdbc.JdbcType;
-import org.apache.gobblin.source.extractor.JobCommitPolicy;
-import org.apache.gobblin.converter.jdbc.JdbcEntryData;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,6 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.converter.jdbc.JdbcEntryData;
+import org.apache.gobblin.converter.jdbc.JdbcType;
+import org.apache.gobblin.source.extractor.JobCommitPolicy;
 
 
 /**
@@ -62,7 +62,7 @@ public class TeradataWriterCommands implements JdbcWriterCommands {
   private final JdbcBufferedInserter jdbcBufferedWriter;
   private final Connection conn;
 
-  public TeradataWriterCommands(State state, Connection conn, boolean overwriteRecords) throws IllegalArgumentException {
+  public TeradataWriterCommands(State state, Connection conn, boolean overwriteRecords) throws UnsupportedOperationException {
     if (overwriteRecords) {
       throw new IllegalArgumentException("Replace existing records is not supported in TeradataWriterCommands");
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/TeradataWriterCommands.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/commands/TeradataWriterCommands.java
@@ -62,7 +62,11 @@ public class TeradataWriterCommands implements JdbcWriterCommands {
   private final JdbcBufferedInserter jdbcBufferedWriter;
   private final Connection conn;
 
-  public TeradataWriterCommands(State state, Connection conn) {
+  public TeradataWriterCommands(State state, Connection conn, boolean overwriteRecords) throws IllegalArgumentException {
+    if (overwriteRecords) {
+      throw new IllegalArgumentException("Replace existing records is not supported in TeradataWriterCommands");
+    }
+
     this.conn = conn;
     this.jdbcBufferedWriter = new TeradataBufferedInserter(state, conn);
   }

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterCommandsTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterCommandsTest.java
@@ -50,7 +50,7 @@ public class JdbcWriterCommandsTest {
     ResultSet rs = createMockResultSet();
     when(pstmt.executeQuery()).thenReturn(rs);
 
-    MySqlWriterCommands writerCommands = new MySqlWriterCommands(new State(), conn);
+    MySqlWriterCommands writerCommands = new MySqlWriterCommands(new State(), conn, false);
     Map<String, JdbcType> actual = writerCommands.retrieveDateColumns("db", "users");
 
     ImmutableMap.Builder<String, JdbcType> builder = ImmutableMap.builder();

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
@@ -17,18 +17,6 @@
 
 package org.apache.gobblin.writer;
 
-import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
-import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_MAX_PARAM_SIZE;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.matches;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -36,11 +24,18 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.converter.jdbc.JdbcEntryData;
 import org.apache.gobblin.writer.commands.JdbcBufferedInserter;
 import org.apache.gobblin.writer.commands.MySqlBufferedInserter;
+
+import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
+import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_MAX_PARAM_SIZE;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.*;
 
 @Test(groups = {"gobblin.writer"}, singleThreaded=true)
 public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
@@ -54,7 +49,7 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
     State state = new State();
     state.setProp(WRITER_JDBC_INSERT_BATCH_SIZE, Integer.toString(batchSize));
 
-    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn);
+    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn, false);
 
     PreparedStatement pstmt = mock(PreparedStatement.class);
     when(conn.prepareStatement(anyString())).thenReturn(pstmt);
@@ -80,9 +75,8 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
 
     State state = new State();
     state.setProp(WRITER_JDBC_INSERT_BATCH_SIZE, Integer.toString(batchSize));
-    state.setProp(ConfigurationKeys.ALLOW_DATA_OVERWRITE, Boolean.toString(true));
 
-    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn);
+    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn, true);
 
     PreparedStatement pstmt = mock(PreparedStatement.class);
     when(conn.prepareStatement(anyString())).thenReturn(pstmt);
@@ -111,7 +105,7 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
     state.setProp(WRITER_JDBC_INSERT_BATCH_SIZE, Integer.toString(batchSize));
     state.setProp(WRITER_JDBC_MAX_PARAM_SIZE, maxParamSize);
 
-    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn);
+    MySqlBufferedInserter inserter = new MySqlBufferedInserter(state, conn, false);
 
     PreparedStatement pstmt = mock(PreparedStatement.class);
     when(conn.prepareStatement(anyString())).thenReturn(pstmt);
@@ -133,6 +127,6 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
 
   @Override
   protected JdbcBufferedInserter getJdbcBufferedInserter(State state, Connection conn) {
-    return new MySqlBufferedInserter(state, conn);
+    return new MySqlBufferedInserter(state, conn, false);
   }
 }

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/PostgresWriterCommandsTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/PostgresWriterCommandsTest.java
@@ -54,7 +54,7 @@ public class PostgresWriterCommandsTest {
     ResultSet rs = createMockResultSet();
     when(pstmt.executeQuery()).thenReturn(rs);
 
-    PostgresWriterCommands writerCommands = new PostgresWriterCommands(new State(), conn);
+    PostgresWriterCommands writerCommands = new PostgresWriterCommands(new State(), conn, false);
     Map<String, JdbcType> actual = writerCommands.retrieveDateColumns("db", "users");
 
     ImmutableMap.Builder<String, JdbcType> builder = ImmutableMap.builder();


### PR DESCRIPTION
* Allows user to configure a mysql ingestion job to allow replacement of the record's value for an existing record in the table.
* Also replaces a backward iteration of ResultSet() with forward iteration in MySqlWriterCommands

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1584 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We only support insertion of new values into tables, not update/upsert. If you run an ingestion job with a record containing a record with the same primary key the whole job will fail because of the duplicate entry. We don't expect ingestion jobs to always contain only new records, so we should handle duplicate entries, ingestion of data already in the table or updates to old values. The insert vs. replace logic should be configurable to the user as well.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It adds a unit test that utilizes replace logic in the JdbcPublisherTest.
I have also tested manually by copying duplicate data and repeated primary keys into a Mysql table and verified the values were updated.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

