### PR TITLE
[GOBBLIN-1585]GaaS (DagManager) keep retrying a failed job beyond max attempt number

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -156,6 +156,7 @@ public class ConfigurationKeys {
   public static final String JOB_GROUP_KEY = "job.group";
   public static final String JOB_TAG_KEY = "job.tag";
   public static final String JOB_DESCRIPTION_KEY = "job.description";
+  public static final String JOB_CURRENT_ATTEMPTS = "job.currentAttempts";
   // Job launcher type
   public static final String JOB_LAUNCHER_TYPE_KEY = "launcher.type";
   public static final String JOB_SCHEDULE_KEY = "job.schedule";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -157,6 +157,7 @@ public class ConfigurationKeys {
   public static final String JOB_TAG_KEY = "job.tag";
   public static final String JOB_DESCRIPTION_KEY = "job.description";
   public static final String JOB_CURRENT_ATTEMPTS = "job.currentAttempts";
+  public static final String JOB_CURRENT_GENERATION = "job.currentGeneration";
   // Job launcher type
   public static final String JOB_LAUNCHER_TYPE_KEY = "launcher.type";
   public static final String JOB_SCHEDULE_KEY = "job.schedule";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.cluster;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
@@ -17,13 +17,13 @@
 
 package org.apache.gobblin.cluster;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.gobblin.annotation.Alias;
 import org.apache.gobblin.metrics.event.EventName;
+import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.EventMetadataUtils;
 import org.apache.gobblin.runtime.JobContext;
 import org.apache.gobblin.runtime.TaskState;
@@ -43,17 +43,21 @@ public class ClusterEventMetadataGenerator implements EventMetadataGenerator{
     List<TaskState> taskStates = jobContext.getJobState().getTaskStates();
     String taskException = EventMetadataUtils.getTaskFailureExceptions(taskStates);
     String jobException = EventMetadataUtils.getJobFailureExceptions(jobContext.getJobState());
-
+    Map<String,String> jobMetadata = new HashMap<>();
+    jobMetadata.put(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, ""));
+    jobMetadata.put(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, ""));
     switch (eventName) {
       case JOB_COMPLETE:
-        return ImmutableMap.of(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates)));
+        jobMetadata.put(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates)));
+        break;
       case JOB_FAILED:
-        return ImmutableMap.of(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException);
+        jobMetadata.put(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException);
+        break;
       default:
         break;
     }
 
-    return ImmutableMap.of();
+    return jobMetadata;
   }
 }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.cluster;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,21 +44,19 @@ public class ClusterEventMetadataGenerator implements EventMetadataGenerator{
     List<TaskState> taskStates = jobContext.getJobState().getTaskStates();
     String taskException = EventMetadataUtils.getTaskFailureExceptions(taskStates);
     String jobException = EventMetadataUtils.getJobFailureExceptions(jobContext.getJobState());
-    Map<String,String> jobMetadata = new HashMap<>();
-    jobMetadata.put(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, ""));
-    jobMetadata.put(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, ""));
+    ImmutableMap.Builder<String, String> metadataBuilder = ImmutableMap.builder();
+    metadataBuilder.put(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, ""));
+    metadataBuilder.put(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, ""));
     switch (eventName) {
       case JOB_COMPLETE:
-        jobMetadata.put(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates)));
-        break;
+        return metadataBuilder.put(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates))).build();
       case JOB_FAILED:
-        jobMetadata.put(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException);
-        break;
+        return metadataBuilder.put(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException).build();
       default:
         break;
     }
 
-    return jobMetadata;
+    return metadataBuilder.build();
   }
 }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ClusterEventMetadataGenerator.java
@@ -17,13 +17,13 @@
 
 package org.apache.gobblin.cluster;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.gobblin.annotation.Alias;
 import org.apache.gobblin.metrics.event.EventName;
-import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.EventMetadataUtils;
 import org.apache.gobblin.runtime.JobContext;
 import org.apache.gobblin.runtime.TaskState;
@@ -43,19 +43,17 @@ public class ClusterEventMetadataGenerator implements EventMetadataGenerator{
     List<TaskState> taskStates = jobContext.getJobState().getTaskStates();
     String taskException = EventMetadataUtils.getTaskFailureExceptions(taskStates);
     String jobException = EventMetadataUtils.getJobFailureExceptions(jobContext.getJobState());
-    ImmutableMap.Builder<String, String> metadataBuilder = ImmutableMap.builder();
-    metadataBuilder.put(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.HIGH_WATERMARK_FIELD, ""));
-    metadataBuilder.put(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, jobContext.getJobState().getProp(TimingEvent.FlowEventConstants.LOW_WATERMARK_FIELD, ""));
+
     switch (eventName) {
       case JOB_COMPLETE:
-        return metadataBuilder.put(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates))).build();
+        return ImmutableMap.of(PROCESSED_COUNT_KEY, Long.toString(EventMetadataUtils.getProcessedCount(taskStates)));
       case JOB_FAILED:
-        return metadataBuilder.put(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException).build();
+        return ImmutableMap.of(MESSAGE_KEY, taskException.length() != 0 ? taskException : jobException);
       default:
         break;
     }
 
-    return metadataBuilder.build();
+    return ImmutableMap.of();
   }
 }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -611,6 +611,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
           jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "")));
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD,
+          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_GENERATION, "")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,
           "false"));
     }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -608,6 +608,13 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
           jobProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, jobExecutionId)));
     }
 
+    if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
+          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "")));
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,
+          "false"));
+    }
+
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD,
         jobProps.getProperty(ConfigurationKeys.JOB_GROUP_KEY, "")));
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.JOB_NAME_FIELD,

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -89,7 +89,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String PROCESSED_COUNT_FIELD = "processedCount";
     public static final String MAX_ATTEMPTS_FIELD = "maxAttempts";
     public static final String CURRENT_ATTEMPTS_FIELD = "currentAttempts";
-    //This state should always move forward
+    //This state should always move forward, more details can be found in method {@link KafkaJobStatusMonitor.addJobStatusToStateStore}
     public static final String CURRENT_GENERATION_FIELD = "currentGeneration";
     public static final String SHOULD_RETRY_FIELD = "shouldRetry";
   }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -89,6 +89,8 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String PROCESSED_COUNT_FIELD = "processedCount";
     public static final String MAX_ATTEMPTS_FIELD = "maxAttempts";
     public static final String CURRENT_ATTEMPTS_FIELD = "currentAttempts";
+    //This state should always move forward
+    public static final String CURRENT_GENERATION_FIELD = "currentGeneration";
     public static final String SHOULD_RETRY_FIELD = "shouldRetry";
   }
 

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -391,6 +391,8 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
           jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "")));
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD,
+          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_GENERATION, "")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,
           "false"));
     }

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -388,6 +388,13 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD,
         jobProps.getProperty(ConfigurationKeys.FLOW_NAME_KEY)));
 
+    if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
+          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "")));
+      metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,
+          "false"));
+    }
+
     // use job execution id if flow execution id is not present
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD,
         jobProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, jobExecutionId)));

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -55,6 +55,7 @@ public class JobStatus {
   private final String highWatermark;
   private final int maxAttempts;
   private final int currentAttempts;
+  private final int currentGeneration;
   private final boolean shouldRetry;
   private final Supplier<List<Issue>> issues;
   private final int progressPercentage;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -126,6 +126,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     long processedCount = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.PROCESSED_COUNT_FIELD, "0"));
     int maxAttempts = Integer.parseInt(jobState.getProp(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, "1"));
     int currentAttempts = Integer.parseInt(jobState.getProp(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "1"));
+    int currentGeneration = Integer.parseInt(jobState.getProp(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, "1"));
     boolean shouldRetry = Boolean.parseBoolean(jobState.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false"));
     int progressPercentage = jobState.getPropAsInt(TimingEvent.JOB_COMPLETION_PERCENTAGE, 0);
     long lastProgressEventTime = jobState.getPropAsLong(TimingEvent.JOB_LAST_PROGRESS_EVENT_TIME, 0);
@@ -146,7 +147,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     return JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
         jobName(jobName).jobGroup(jobGroup).jobTag(jobTag).jobExecutionId(jobExecutionId).eventName(eventName).
         lowWatermark(lowWatermark).highWatermark(highWatermark).orchestratedTime(orchestratedTime).startTime(startTime).endTime(endTime).
-        message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts).
+        message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts).currentGeneration(currentGeneration).
         shouldRetry(shouldRetry).progressPercentage(progressPercentage).lastProgressEventTime(lastProgressEventTime).
         issues(jobIssues).build();
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -913,6 +913,8 @@ public class DagManager extends AbstractIdleService {
       JobExecutionPlan jobExecutionPlan = DagManagerUtils.getJobExecutionPlan(dagNode);
       jobExecutionPlan.setExecutionStatus(RUNNING);
       JobSpec jobSpec = DagManagerUtils.getJobSpec(dagNode);
+      Map<String, Integer> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, dagNode.getValue().getCurrentAttempts());
+      jobSpec.setConfig(ConfigFactory.parseMap(configWithCurrentAttempts).withFallback(jobSpec.getConfig()));
       Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), jobExecutionPlan);
 
       String specExecutorUri = DagManagerUtils.getSpecExecutorUri(dagNode);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -547,6 +547,7 @@ public class DagManager extends AbstractIdleService {
           node.getValue().setExecutionStatus(PENDING_RESUME);
           // reset currentAttempts because we do not want to count previous execution's attempts in deciding whether to retry a job
           node.getValue().setCurrentAttempts(0);
+          DagManagerUtils.incrementJobGeneration(node);
           Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), node.getValue());
           this.eventSubmitter.get().getTimingEvent(TimingEvent.LauncherTimings.JOB_PENDING_RESUME).stop(jobMetadata);
         }
@@ -913,8 +914,6 @@ public class DagManager extends AbstractIdleService {
       JobExecutionPlan jobExecutionPlan = DagManagerUtils.getJobExecutionPlan(dagNode);
       jobExecutionPlan.setExecutionStatus(RUNNING);
       JobSpec jobSpec = DagManagerUtils.getJobSpec(dagNode);
-      Map<String, Integer> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, dagNode.getValue().getCurrentAttempts());
-      jobSpec.setConfig(ConfigFactory.parseMap(configWithCurrentAttempts).withFallback(jobSpec.getConfig()));
       Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), jobExecutionPlan);
 
       String specExecutorUri = DagManagerUtils.getSpecExecutorUri(dagNode);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.gobblin.service.modules.orchestration;
 
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -148,7 +150,12 @@ public class DagManagerUtils {
   }
 
   public static JobSpec getJobSpec(DagNode<JobExecutionPlan> dagNode) {
-    return dagNode.getValue().getJobSpec();
+    JobSpec jobSpec = dagNode.getValue().getJobSpec();
+    Map<String, Integer> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, dagNode.getValue().getCurrentAttempts(),
+        ConfigurationKeys.JOB_CURRENT_GENERATION, dagNode.getValue().getCurrentGeneration());
+    //Return new spec with new config to avoid change the reference to dagNode
+    return new JobSpec(jobSpec.getUri(), jobSpec.getVersion(), jobSpec.getDescription(), ConfigFactory.parseMap(configWithCurrentAttempts).withFallback(jobSpec.getConfig()),
+        jobSpec.getConfigAsProperties(), jobSpec.getTemplateURI(), jobSpec.getJobTemplate(), jobSpec.getMetadata());
   }
 
   static Config getJobConfig(DagNode<JobExecutionPlan> dagNode) {
@@ -234,6 +241,13 @@ public class DagManagerUtils {
    */
   static void incrementJobAttempt(DagNode<JobExecutionPlan> dagNode) {
     dagNode.getValue().setCurrentAttempts(dagNode.getValue().getCurrentAttempts() + 1);
+  }
+
+  /**
+   * Increment the value of {@link JobExecutionPlan#currentGeneration}
+   */
+  static void incrementJobGeneration(DagNode<JobExecutionPlan> dagNode) {
+    dagNode.getValue().setCurrentGeneration(dagNode.getValue().getCurrentGeneration() + 1);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -245,6 +245,8 @@ public class DagManagerUtils {
 
   /**
    * Increment the value of {@link JobExecutionPlan#currentGeneration}
+   * This method is not thread safe, we achieve correctness by making sure
+   * one dag will only be handled in the same DagManagerThread
    */
   static void incrementJobGeneration(DagNode<JobExecutionPlan> dagNode) {
     dagNode.getValue().setCurrentGeneration(dagNode.getValue().getCurrentGeneration() + 1);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
@@ -62,6 +62,7 @@ class TimingEventUtils {
     jobMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, specExecutor.getClass().getCanonicalName());
     jobMetadata.put(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getMaxAttempts()));
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getCurrentAttempts()));
+    jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, Integer.toString(jobExecutionPlan.getCurrentGeneration()));
     jobMetadata.put(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, Boolean.toString(false));
 
     return jobMetadata;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -65,6 +65,7 @@ public class JobExecutionPlan {
   private final SpecExecutor specExecutor;
   private ExecutionStatus executionStatus = ExecutionStatus.PENDING;
   private final int maxAttempts;
+  private int currentGeneration = 1;
   private int currentAttempts = 0;
   private Optional<Future> jobFuture = Optional.absent();
   private long flowStartTime = 0L;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -296,6 +296,14 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
 
     mergedState.putAll(fallbackState.getProperties());
     mergedState.putAll(state.getProperties());
+    // Set CURRENT_ATTEMPTS_FIELD to right value to avoid continually retrying
+    if (fallbackState.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,0) > state.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,0)) {
+      mergedState.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
+          fallbackState.getProp(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,"0"));
+      if (fallbackState.contains(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD)) {
+        mergedState.setProperty(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, fallbackState.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD));
+      }
+    }
 
     return new org.apache.gobblin.configuration.State(mergedState);
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -258,7 +258,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       String currentStatus = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
       int previousGeneration = previousJobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, 1);
       // This is to make the change backward compatible as we may not have this info in cluster events
-      // If we does not have those info, we think the event are coming from the same attempts as previous one
+      // If we does not have those info, we treat the event as coming from the same attempts as previous one
       int currentGeneration = jobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, previousGeneration);
       int previousAttempts = previousJobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, 1);
       int currentAttempts = jobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, previousAttempts);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -253,14 +253,22 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
 
     List<org.apache.gobblin.configuration.State> states = stateStore.getAll(storeName, tableName);
     if (states.size() > 0) {
-      String previousStatus = states.get(states.size() - 1).getProp(JobStatusRetriever.EVENT_NAME_FIELD);
+      org.apache.gobblin.configuration.State previousJobStatus = states.get(states.size() - 1);
+      String previousStatus = previousJobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
       String currentStatus = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
-
-      // PENDING_RESUME is allowed to override, because it happens when a flow is being resumed from previously being failed
-      if (previousStatus != null && currentStatus != null && !currentStatus.equals(ExecutionStatus.PENDING_RESUME.name())
-        && ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(currentStatus)) < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus))) {
-        log.warn(String.format("Received status %s when status is already %s for flow (%s, %s, %s), job (%s, %s)",
-            currentStatus, previousStatus, flowGroup, flowName, flowExecutionId, jobGroup, jobName));
+      int previousGeneration = previousJobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, 1);
+      int currentGeneration = jobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, 1);
+      int previousAttempts = previousJobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, 1);
+      int currentAttempts = jobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, 1);
+      // We use three things to determine the order, generation means how many times job has been resumed, attempts means during this generation, how many times job has been retried
+      // And job status reflect the execution status in one attempt
+      if (previousStatus != null && currentStatus != null &&
+          (previousGeneration > currentGeneration
+              || (previousGeneration == currentGeneration && previousAttempts > currentAttempts)
+              || (previousGeneration == currentGeneration && previousAttempts == currentAttempts
+              && ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(currentStatus)) < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus))))){
+        log.warn(String.format("Received status %s generation %s attempts %s when status is already %s generation %s attempts %s for flow (%s, %s, %s), job (%s, %s)",
+            currentStatus, currentGeneration, currentAttempts, previousStatus, previousGeneration, previousAttempts, flowGroup, flowName, flowExecutionId, jobGroup, jobName));
         jobStatus = mergeState(states.get(states.size() - 1), jobStatus);
       } else {
         jobStatus = mergeState(jobStatus, states.get(states.size() - 1));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
@@ -182,39 +182,6 @@ public abstract class JobStatusRetrieverTest {
     Assert.assertEquals(jobStatus.getEndTime(), JOB_END_TIME);
     Assert.assertEquals(jobStatus.getOrchestratedTime(), JOB_ORCHESTRATED_TIME);
   }
-
-  @Test (dependsOnMethods = "testGetLatestExecutionIdsForFlow")
-  public void testOutOfOrderJobTimingEventsForRetryingJob() throws IOException {
-    long flowExecutionId = 1240L;
-    Properties properties = new Properties();
-    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "0");
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.RUNNING.name(), JOB_START_TIME, JOB_START_TIME);
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.ORCHESTRATED.name(), JOB_ORCHESTRATED_TIME, JOB_ORCHESTRATED_TIME);
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.FAILED.name(), 0, 0, properties);
-    Iterator<JobStatus>
-        jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
-    JobStatus jobStatus = jobStatusIterator.next();
-    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
-      jobStatus = jobStatusIterator.next();
-    }
-    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.PENDING_RETRY.name());
-    Assert.assertEquals(jobStatus.isShouldRetry(), true);
-    properties = new Properties();
-    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "1");
-    properties.setProperty(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false");
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.RUNNING.name(), JOB_START_TIME, JOB_START_TIME);
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.ORCHESTRATED.name(), JOB_ORCHESTRATED_TIME, JOB_ORCHESTRATED_TIME, properties);
-    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
-    jobStatus = jobStatusIterator.next();
-    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
-      jobStatus = jobStatusIterator.next();
-    }
-    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.RUNNING.name());
-    Assert.assertEquals(jobStatus.isShouldRetry(), false);
-    Assert.assertEquals(jobStatus.getCurrentAttempts(), 1);
-    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.COMPLETE.name(), JOB_END_TIME, JOB_END_TIME);
-  }
-
   @Test (dependsOnMethods = "testJobTiming")
   public void testGetJobStatusesForFlowExecution1() {
     long flowExecutionId = 1234L;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
@@ -99,6 +99,58 @@ public abstract class JobStatusRetrieverTest {
 
     KafkaJobStatusMonitor.addJobStatusToStateStore(jobStatus, this.jobStatusRetriever.getStateStore());
   }
+  @Test (dependsOnMethods = "testGetLatestExecutionIdsForFlow")
+  public void testOutOfOrderJobTimingEventsForRetryingJob() throws IOException {
+    long flowExecutionId = 1240L;
+    Properties properties = new Properties();
+    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "0");
+    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, "1");
+    properties.setProperty(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false");
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.RUNNING.name(), JOB_START_TIME, JOB_START_TIME, properties);
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.ORCHESTRATED.name(), JOB_ORCHESTRATED_TIME, JOB_ORCHESTRATED_TIME, properties);
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.FAILED.name(), 0, 0, properties);
+    Iterator<JobStatus>
+        jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
+    JobStatus jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
+    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.PENDING_RETRY.name());
+    Assert.assertEquals(jobStatus.isShouldRetry(), true);
+    properties = new Properties();
+    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, "1");
+    properties.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "1");
+    properties.setProperty(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false");
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.RUNNING.name(), JOB_START_TIME, JOB_START_TIME, properties);
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.ORCHESTRATED.name(), JOB_ORCHESTRATED_TIME, JOB_ORCHESTRATED_TIME, properties);
+    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
+    jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
+    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.RUNNING.name());
+    Assert.assertEquals(jobStatus.isShouldRetry(), false);
+    Assert.assertEquals(jobStatus.getCurrentAttempts(), 1);
+    Properties properties_new = new Properties();
+    properties_new.setProperty(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, "2");
+    properties_new.setProperty(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, "0");
+    properties_new.setProperty(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false");
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.PENDING_RESUME.name(), JOB_START_TIME, JOB_START_TIME, properties_new);
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.COMPLETE.name(), JOB_END_TIME, JOB_END_TIME, properties);
+    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
+    jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
+    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.PENDING_RESUME.name());
+    addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.COMPLETE.name(), JOB_END_TIME, JOB_END_TIME, properties_new);
+    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
+    jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
+    Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.COMPLETE.name());
+  }
 
   @Test
   public void testGetJobStatusesForFlowExecution() throws IOException {


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1585


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
The issue is that for the same flow execution, we don't receive the event in order. if the job fail and we retry, we may receive running event first, and then the Orchestrate event which update the current attempts and should retry value will be ignored and cause to job to continually try to retrying util the running job finished.

Add low/high water info in cluster event metadata generator since jobStateEvent will not been processed for job status

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

