### PR TITLE
[GOBBLIN-1588] Send failure events for write failures when watermark is advanced in MCE writer

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -439,9 +439,9 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
    * Submit event indicating that a specific set of GMCEs have been skipped, so there is a gap in the registration
    */
   private void submitFailureEvent(GobblinMetadataException exception) {
-    log.warn(String.format("Sending GTE to indicate table flush failure for %s", exception.tableName));
+    log.warn(String.format("Sending GTE to indicate table flush failure for %s.%s", exception.dbName, exception.tableName));
 
-    GobblinEventBuilder gobblinTrackingEvent = new GobblinEventBuilder(IcebergMCEMetadataKeys.ICEBERG_COMMIT_EVENT_NAME);
+    GobblinEventBuilder gobblinTrackingEvent = new GobblinEventBuilder(IcebergMCEMetadataKeys.METADATA_WRITER_FAILURE_EVENT);
 
     gobblinTrackingEvent.addMetadata(IcebergMCEMetadataKeys.DATASET_HDFS_PATH, exception.datasetPath);
     gobblinTrackingEvent.addMetadata(IcebergMCEMetadataKeys.FAILURE_EVENT_DB_NAME, exception.dbName);

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -31,6 +31,8 @@ public class IcebergMCEMetadataKeys {
   public static final String GMCE_HIGH_WATERMARK = "gmceHighWatermark";
   public static final String GMCE_LOW_WATERMARK = "gmceLowWatermark";
   public static final String DATASET_HDFS_PATH = "datasetHdfsPath";
+  public static final String FAILURE_EVENT_DB_NAME = "databaseName";
+  public static final String FAILURE_EVENT_TABLE_NAME = "tableName";
 
   private IcebergMCEMetadataKeys() {
   }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.iceberg.writer;
 public class IcebergMCEMetadataKeys {
   public static final String METRICS_NAMESPACE_ICEBERG_WRITER = "IcebergWriter";
   public static final String ICEBERG_COMMIT_EVENT_NAME = "IcebergMetadataCommitEvent";
+  public static final String METADATA_WRITER_FAILURE_EVENT = "MetadataWriterFailureEvent";
   public static final String LAG_KEY_NAME = "endToEndLag";
   public static final String SNAPSHOT_KEY_NAME = "currentSnapshotId";
   public static final String MANIFEST_LOCATION = "currentManifestLocation";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1588


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Sent failure events in both cases where a watermark could be advanced
1. After a flush due to operation change, if a previous write failed
2. After a periodic flush where GMCE watermark will be advanced

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated unit test to check that events are sent

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

