### PR TITLE
[GOBBLIN-1589] add FileContextFactory to cache FileContext instances

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -17,14 +17,25 @@
 
 package org.apache.gobblin.writer;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.List;
+
 import org.apache.gobblin.codec.StreamCodec;
 import org.apache.gobblin.commit.SpeculativeAttemptAwareConstruct;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -38,15 +49,8 @@ import org.apache.gobblin.util.ForkOperatorUtils;
 import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.JobConfigurationUtils;
 import org.apache.gobblin.util.WriterUtils;
+import org.apache.gobblin.util.filesystem.FileContextFactory;
 import org.apache.gobblin.util.recordcount.IngestionRecordCountProvider;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileContext;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -100,7 +104,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     // Add all job configuration properties so they are picked up by Hadoop
     JobConfigurationUtils.putStateIntoConfiguration(properties, conf);
     this.fs = WriterUtils.getWriterFS(properties, this.numBranches, this.branchId);
-    this.fileContext = FileContext.getFileContext(
+    this.fileContext = FileContextFactory.getInstance(
         WriterUtils.getWriterFsUri(properties, this.numBranches, this.branchId),
         conf);
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -17,11 +17,6 @@
 
 package org.apache.gobblin.data.management.copy.writer;
 
-import com.codahale.metrics.Meter;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,7 +26,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterators;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.iface.NotConfiguredException;
@@ -58,19 +71,11 @@ import org.apache.gobblin.util.FinalState;
 import org.apache.gobblin.util.ForkOperatorUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.WriterUtils;
+import org.apache.gobblin.util.filesystem.FileContextFactory;
 import org.apache.gobblin.util.io.StreamCopier;
 import org.apache.gobblin.util.io.StreamThrottler;
 import org.apache.gobblin.util.io.ThrottledInputStream;
 import org.apache.gobblin.writer.DataWriter;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileContext;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Options;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.fs.permission.FsPermission;
 
 
 /**
@@ -143,7 +148,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     } else {
       this.fs = FileSystem.get(uri, conf);
     }
-    this.fileContext = FileContext.getFileContext(uri, conf);
+    this.fileContext = FileContextFactory.getInstance(uri, conf);
     if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
       this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
     } else {

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FileContextBasedFsStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FileContextBasedFsStateStore.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.metastore;
 import java.io.IOException;
 import java.net.URI;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -27,6 +28,7 @@ import org.apache.hadoop.fs.UnsupportedFileSystemException;
 
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.util.HadoopUtils;
+import org.apache.gobblin.util.filesystem.FileContextFactory;
 
 
 /**
@@ -51,19 +53,19 @@ public class FileContextBasedFsStateStore<T extends State> extends FsStateStore<
   public FileContextBasedFsStateStore(String fsUri, String storeRootDir, Class stateClass)
       throws IOException {
     super(fsUri, storeRootDir, stateClass);
-    this.fc = FileContext.getFileContext(URI.create(fsUri));
+    this.fc = FileContextFactory.getInstance((URI.create(fsUri)), new Configuration());
   }
 
   public FileContextBasedFsStateStore(FileSystem fs, String storeRootDir, Class<T> stateClass)
       throws UnsupportedFileSystemException {
     super(fs, storeRootDir, stateClass);
-    this.fc = FileContext.getFileContext(this.fs.getUri());
+    this.fc = FileContextFactory.getInstance(this.fs.getUri(), new Configuration());
   }
 
   public FileContextBasedFsStateStore(String storeUrl, Class<T> stateClass)
       throws IOException {
     super(storeUrl, stateClass);
-    this.fc = FileContext.getFileContext(this.fs.getUri());
+    this.fc = FileContextFactory.getInstance(this.fs.getUri(), new Configuration());
   }
 
   /**

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileContextFactory.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileContextFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.filesystem;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.UnsupportedFileSystemException;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A Factory to create {@link FileContext}. It caches {@link FileContext} for the same {@link URI}.
+ * This code is influenced by {@see org.apache.hadoop.fs.FileSystem.Cache}
+ */
+@Slf4j
+public class FileContextFactory {
+
+  static final Cache CACHE = new Cache();
+
+  private FileContextFactory() {
+  }
+
+  public static FileContext getInstance(URI uri, Configuration conf) throws UnsupportedFileSystemException {
+    String scheme = uri.getScheme();
+    String disableCacheName = String.format("fs.%s.impl.disable.cache", scheme);
+    if (conf.getBoolean(disableCacheName, false)) {
+      log.debug("Bypassing cache to create FileContext {}", uri);
+      return FileContext.getFileContext(uri, conf);
+    } else {
+      return CACHE.get(uri, conf);
+    }
+  }
+
+  static class Cache {
+    private final Map<Cache.Key, FileContext> map = new HashMap<>();
+
+    Cache() {
+    }
+
+    FileContext get(URI uri, Configuration conf) throws UnsupportedFileSystemException {
+      Cache.Key key = new Cache.Key(uri, conf);
+      return getInternal(uri, conf, key);
+    }
+
+    private FileContext getInternal(URI uri, Configuration conf, Key key) throws UnsupportedFileSystemException {
+      FileContext fc;
+
+      synchronized (this) {
+        fc = this.map.get(key);
+      }
+
+      if (fc != null) {
+        return fc;
+      } else {
+        fc = FileContext.getFileContext(uri, conf);
+        synchronized (this) {
+          this.map.putIfAbsent(key, fc);
+          return fc;
+        }
+      }
+    }
+
+    @AllArgsConstructor
+    @EqualsAndHashCode(exclude = "conf")
+    static class Key {
+      URI uri;
+      Configuration conf;
+    }
+  }
+}

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/FileContextFactoryTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/FileContextFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FileContextFactoryTest {
+
+  @Test
+  public void test() throws IOException {
+    Configuration con1 = new Configuration();
+    Configuration con2 = new Configuration();
+    con2.set("mykey", "myval");
+
+    FileContext fc1 = FileContextFactory.getInstance((URI.create("file:///")), con1);
+    FileContext fc2 = FileContextFactory.getInstance((URI.create("file:///")), con1);
+    FileContext fc3 = FileContextFactory.getInstance((URI.create("file:///")), con2);
+    FileContext fc4 = FileContextFactory.getInstance((URI.create("hdfs://localhost")), con1);
+
+    Assert.assertEquals(fc1, fc2);
+    Assert.assertEquals(fc1, fc3);  // configuration is not checked while caching the object
+    Assert.assertNotEquals(fc1, fc4);
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@sv2000 @phet please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1589


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
provide a way to cache FileContext. This is needed because unlike FileSystem, FileContext is not cached and thus every file being copied in distcp creates a new object of FileContext. This often causes OOM errors.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test in FileContextFactoryTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

