### PR TITLE
Fix bug in `JobSpecSerializer` of inadequately preventing access errors (within `MysqlJobCatalog`)

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_serde/JobSpecSerializer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_serde/JobSpecSerializer.java
@@ -39,8 +39,9 @@ public class JobSpecSerializer implements JsonSerializer<JobSpec> {
     jobSpecJson.add(JOB_SPEC_URI_KEY, context.serialize(src.getUri()));
     jobSpecJson.add(JOB_SPEC_VERSION_KEY, context.serialize(src.getVersion()));
     jobSpecJson.add(JOB_SPEC_DESCRIPTION_KEY, context.serialize(src.getDescription()));
-    jobSpecJson.add(JOB_SPEC_TEMPLATE_URI_KEY, src.getTemplateURI().isPresent() ? context.serialize(src.getJobTemplate().get()): null);
+    jobSpecJson.add(JOB_SPEC_TEMPLATE_URI_KEY, src.getTemplateURI().isPresent() ? context.serialize(src.getTemplateURI().get()) : null);
     jobSpecJson.add(JOB_SPEC_CONFIG_AS_PROPERTIES_KEY, context.serialize(src.getConfigAsProperties()));
+    // NOTE: do not serialize `JobSpec.jobTemplate`, since `transient`
 
     return jobSpecJson;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
   (fix issue blocking rollout of:)
    - https://issues.apache.org/jira/browse/GOBBLIN-1569


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Correct small error from mixing up two `Optional`s contained by the same class.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Previously added unit test passes; see: https://github.com/apache/gobblin/pull/3421

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

