### PR TITLE
[GOBBLIn-1595]Fix the dead lock during hive registration

### DIFF
--- a/gobblin-aws/build.gradle
+++ b/gobblin-aws/build.gradle
@@ -58,7 +58,9 @@ dependencies {
   compile externalDependency.hadoopYarnClient
   compile externalDependency.avroMapredH2
   compile externalDependency.findBugsAnnotations
-  compile externalDependency.helix
+  compile (externalDependency.helix) {
+    exclude group: 'io.dropwizard.metrics', module: 'metrics-core'
+  }
 
   testCompile project(path: ':gobblin-cluster', configuration: 'tests')
   testCompile project(":gobblin-example")

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -276,7 +276,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
       Table table) throws TException, IOException{
     try (AutoCloseableHiveLock lock = this.locks.getTableLock(dbName, tableName)) {
       try {
-        if(!existsTable(dbName, tableName)) {
+        if(!existsTable(dbName, tableName, client)) {
           try (Timer.Context context = this.metricContext.timer(CREATE_HIVE_TABLE).time()) {
             client.createTable(getTableWithCreateTimeNow(table));
             log.info(String.format("Created Hive table %s in db %s", tableName, dbName));
@@ -472,35 +472,30 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   private void createOrAlterTable(IMetaStoreClient client, Table table, HiveSpec spec) throws TException, IOException {
     String dbName = table.getDbName();
     String tableName = table.getTableName();
-    boolean tableExistenceInCache;
-    if (this.optimizedChecks) {
-      try {
-        this.tableAndDbExistenceCache.get(dbName + ":" + tableName, new Callable<Boolean>() {
-          @Override
-          public Boolean call() throws Exception {
-            return ensureHiveTableExistenceBeforeAlternation(tableName, dbName, client, table);
-          }
-        });
-      } catch (ExecutionException ee) {
-        throw new IOException("Table existence checking throwing execution exception.", ee);
-      }
-    } else {
-      this.ensureHiveTableExistenceBeforeAlternation(tableName, dbName, client, table);
-    }
+    this.ensureHiveTableExistenceBeforeAlternation(tableName, dbName, client, table);
     alterTableIfNeeded(tableName, dbName, client, table, spec);
+  }
+
+  public boolean existsTable(String dbName, String tableName, IMetaStoreClient client) throws IOException {
+    if (this.optimizedChecks && this.tableAndDbExistenceCache.getIfPresent(dbName + ":" + tableName ) != null ) {
+      return true;
+    }
+    try {
+      boolean exists;
+      try (Timer.Context context = this.metricContext.timer(TABLE_EXISTS).time()) {
+        exists =  client.tableExists(dbName, tableName);
+      }
+      this.tableAndDbExistenceCache.put(dbName + ":" + tableName, exists);
+      return exists;
+    } catch (TException e) {
+      throw new IOException(String.format("Unable to check existence of table %s in db %s", tableName, dbName), e);
+    }
   }
 
   @Override
   public boolean existsTable(String dbName, String tableName) throws IOException {
-    if (this.optimizedChecks && this.tableAndDbExistenceCache.getIfPresent(dbName + ":" + tableName ) != null ) {
-      return true;
-    }
     try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient()) {
-      try (Timer.Context context = this.metricContext.timer(TABLE_EXISTS).time()) {
-        return client.get().tableExists(dbName, tableName);
-      }
-    } catch (TException e) {
-      throw new IOException(String.format("Unable to check existence of table %s in db %s", tableName, dbName), e);
+      return existsTable(dbName, tableName, client.get());
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1595


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In hive registration, we get one client and call ensureHiveTableExistenceBeforeAlternation to check table existence, and inside the method, we call tableExist method which again will try to get one client and cause dead lock. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

