### PR TITLE
[GOBBLIN-1596] Ignore already exists exception if the table has already been created…

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -276,14 +276,16 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
       Table table) throws TException, IOException{
     try (AutoCloseableHiveLock lock = this.locks.getTableLock(dbName, tableName)) {
       try {
-        if(!existsTable(dbName, tableName, client)) {
+        if (!existsTable(dbName, tableName, client)) {
           try (Timer.Context context = this.metricContext.timer(CREATE_HIVE_TABLE).time()) {
             client.createTable(getTableWithCreateTimeNow(table));
             log.info(String.format("Created Hive table %s in db %s", tableName, dbName));
             return true;
           }
         }
-      }catch (TException e) {
+      } catch (AlreadyExistsException ignore) {
+        // Table already exists, continue
+      } catch (TException e) {
         log.error(
             String.format("Unable to create Hive table %s in db %s: " + e.getMessage(), tableName, dbName), e);
         throw e;

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -479,7 +479,8 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   }
 
   public boolean existsTable(String dbName, String tableName, IMetaStoreClient client) throws IOException {
-    if (this.optimizedChecks && this.tableAndDbExistenceCache.getIfPresent(dbName + ":" + tableName ) != null ) {
+    Boolean tableExits = this.tableAndDbExistenceCache.getIfPresent(dbName + ":" + tableName );
+    if (this.optimizedChecks && tableExits != null && tableExits) {
       return true;
     }
     try {


### PR DESCRIPTION
… by another thread or job entirely

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1596


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Hive Registration throws an error when creating a table to add partitions to, if the table already exists. Although we should have locks to prevent this, we can't guard against other jobs that could also cause a race condition too. We can ignore the exception in the error handling for `ensureHiveTableExistenceBeforeAlternation`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

