### PR TITLE
[GOBBLIN-1598]Fix metrics already exist issue in dag manager

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
@@ -36,11 +36,17 @@ public class MetricNameRegexFilterTest {
     MetricNameRegexFilter metricNameRegexFilter1 = new MetricNameRegexFilter(".*");
     Assert.assertTrue(metricNameRegexFilter1.matches("test1", mock(Metric.class)));
     Assert.assertTrue(metricNameRegexFilter1.matches("test2", mock(Metric.class)));
-    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));
+    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));;
 
     MetricNameRegexFilter metricNameRegexFilter2 = new MetricNameRegexFilter("test1");
     Assert.assertTrue(metricNameRegexFilter2.matches("test1", mock(Metric.class)));
     Assert.assertFalse(metricNameRegexFilter2.matches("test2", mock(Metric.class)));
     Assert.assertFalse(metricNameRegexFilter2.matches("test3", mock(Metric.class)));
+    MetricNameRegexFilter metricNameRegexFilter3 = new MetricNameRegexFilter("GobblinService\\..*\\.RunningStatus");
+    Assert.assertTrue(metricNameRegexFilter3.matches("GobblinService.testGroup.testFlow.RunningStatus", mock(Metric.class)));
+    Assert.assertTrue(metricNameRegexFilter3.matches("GobblinService.test..RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexFilter3.matches("test3.RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexFilter3.matches("GobblinService.test4RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexFilter3.matches("GobblinServicetest5.RunningStatus", mock(Metric.class)));
   }
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
@@ -36,7 +36,7 @@ public class MetricNameRegexFilterTest {
     MetricNameRegexFilter metricNameRegexFilter1 = new MetricNameRegexFilter(".*");
     Assert.assertTrue(metricNameRegexFilter1.matches("test1", mock(Metric.class)));
     Assert.assertTrue(metricNameRegexFilter1.matches("test2", mock(Metric.class)));
-    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));;
+    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));
 
     MetricNameRegexFilter metricNameRegexFilter2 = new MetricNameRegexFilter("test1");
     Assert.assertTrue(metricNameRegexFilter2.matches("test1", mock(Metric.class)));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -70,6 +70,7 @@ import org.apache.gobblin.metrics.RootMetricContext;
 import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.metrics.metric.filter.MetricNameRegexFilter;
 import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.Spec;
@@ -399,6 +400,7 @@ public class DagManager extends AbstractIdleService {
       } else { //Mark the DagManager inactive.
         log.info("Inactivating the DagManager. Shutting down all DagManager threads");
         this.scheduledExecutorPool.shutdown();
+        RootMetricContext.get().removeMatching(new MetricNameRegexFilter(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "\\..*\\." + ServiceMetricNames.RUNNING_STATUS));
         try {
           this.scheduledExecutorPool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -400,7 +401,9 @@ public class DagManager extends AbstractIdleService {
       } else { //Mark the DagManager inactive.
         log.info("Inactivating the DagManager. Shutting down all DagManager threads");
         this.scheduledExecutorPool.shutdown();
-        RootMetricContext.get().removeMatching(new MetricNameRegexFilter(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "\\..*\\." + ServiceMetricNames.RUNNING_STATUS));
+        // The DMThread's metrics mappings follow the lifecycle of the DMThread itself and so are lost by DM deactivation-reactivation but the RootMetricContext is a (persistent) singleton.
+        // To avoid IllegalArgumentException by the RMC preventing (re-)add of a metric already known, remove all metrics that a new DMThread thread would attempt to add (in DagManagerThread::initialize) whenever running post-re-enablement
+        RootMetricContext.get().removeMatching(getMetricsFilterForDagManager());
         try {
           this.scheduledExecutorPool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -411,6 +414,11 @@ public class DagManager extends AbstractIdleService {
       log.error("Exception encountered when activating the new DagManager", e);
       throw new RuntimeException(e);
     }
+  }
+
+  @VisibleForTesting
+  protected static MetricNameRegexFilter getMetricsFilterForDagManager() {
+    return new MetricNameRegexFilter(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "\\..*\\." + ServiceMetricNames.RUNNING_STATUS);
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/TestServiceMetrics.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/TestServiceMetrics.java
@@ -15,32 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.metrics.metric.filter;
-
-import static org.mockito.Mockito.mock;
+package org.apache.gobblin.service.modules.orchestration;
 
 import com.codahale.metrics.Metric;
-
+import org.apache.gobblin.metrics.metric.filter.MetricNameRegexFilter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.*;
 
-/**
- * Tests for {@link MetricNameRegexFilter}.
- */
 @Test
-public class MetricNameRegexFilterTest {
-
+public class TestServiceMetrics {
   @Test
   public void matchesTest() {
-    MetricNameRegexFilter metricNameRegexFilter1 = new MetricNameRegexFilter(".*");
-    Assert.assertTrue(metricNameRegexFilter1.matches("test1", mock(Metric.class)));
-    Assert.assertTrue(metricNameRegexFilter1.matches("test2", mock(Metric.class)));
-    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));
 
-    MetricNameRegexFilter metricNameRegexFilter2 = new MetricNameRegexFilter("test1");
-    Assert.assertTrue(metricNameRegexFilter2.matches("test1", mock(Metric.class)));
-    Assert.assertFalse(metricNameRegexFilter2.matches("test2", mock(Metric.class)));
-    Assert.assertFalse(metricNameRegexFilter2.matches("test3", mock(Metric.class)));
+    MetricNameRegexFilter metricNameRegexForDagManager = DagManager.getMetricsFilterForDagManager();
+    Assert.assertTrue(metricNameRegexForDagManager.matches("GobblinService.testGroup.testFlow.RunningStatus", mock(Metric.class)));
+    Assert.assertTrue(metricNameRegexForDagManager.matches("GobblinService.test..RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexForDagManager.matches("test3.RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexForDagManager.matches("GobblinService.test4RunningStatus", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexForDagManager.matches("GobblinServicetest5.RunningStatus", mock(Metric.class)));
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1598


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
2021/06/12 07:11:32.067 ERROR [DagManager] [pool-19-thread-3] [gobblin-service-war] [] Exception encountered in org.apache.gobblin.service.modules.orchestration.DagManager$DagManagerThread
java.lang.IllegalArgumentException: A metric named GobblinService.testFlow.RunningStatus already exists
 at org.apache.gobblin.metrics.InnerMetricContext.register(InnerMetricContext.java:266) 


Likely root cause:

If we activate/deactivate DagManager several times, DagManagerThreads alongside with their flowGauges maps will be recreated, but RootMetricContext will still stay the same. So the newly created threads will incorrectly think that the flow was not registered previously, and try to register it again.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

