### PR TITLE
[GOBBLIN-1599] Fixes Avro usage on deprecated APIs

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/avro/FieldAttributeBasedDeltaFieldsProvider.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/avro/FieldAttributeBasedDeltaFieldsProvider.java
@@ -79,7 +79,7 @@ public class FieldAttributeBasedDeltaFieldsProvider implements AvroDeltaFieldNam
   private List<String> getDeltaFieldNamesForNewSchema(Schema originalSchema) {
     List<String> deltaFields = new ArrayList<>();
     for (Field field : originalSchema.getFields()) {
-      String deltaAttributeField = field.getJsonProp(this.attributeField).getValueAsText();
+      String deltaAttributeField = field.getProp(this.attributeField);
       ObjectNode objectNode = getDeltaPropValue(deltaAttributeField);
       if (objectNode == null || objectNode.get(this.deltaPropName) == null) {
         continue;

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -198,7 +198,7 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
     for (Field field : record.getFields()) {
       Optional<Schema> newFieldSchema = getKeySchema(field);
       if (newFieldSchema.isPresent()) {
-        fields.add(new Field(field.name(), newFieldSchema.get(), field.doc(), field.defaultValue()));
+        fields.add(new Field(field.name(), newFieldSchema.get(), field.doc(), field.defaultVal()));
       }
     }
     if (!fields.isEmpty()) {

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/converter/filter/AvroSchemaFieldRemover.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/converter/filter/AvroSchemaFieldRemover.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
-import org.codehaus.jackson.JsonNode;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -108,7 +107,7 @@ public class AvroSchemaFieldRemover {
   private Schema removeFieldsFromRecords(Schema schema, Map<String, Schema> schemaMap) {
 
     Schema newRecord = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError());
-    convertFieldToSchemaWithProps(schema.getJsonProps(), newRecord);
+    convertFieldToSchemaWithProps(schema.getObjectProps(), newRecord);
 
     // Put an incomplete schema into schemaMap to avoid re-processing a recursive field.
     // The fields in the incomplete schema will be populated once the current schema is completely processed.
@@ -120,12 +119,12 @@ public class AvroSchemaFieldRemover {
         Field newField;
         if (this.children.containsKey(field.name())) {
           newField = new Field(field.name(), this.children.get(field.name()).removeFields(field.schema(), schemaMap),
-              field.doc(), field.defaultValue());
+              field.doc(), field.defaultVal());
         } else {
           newField = new Field(field.name(), DO_NOTHING_INSTANCE.removeFields(field.schema(), schemaMap), field.doc(),
-              field.defaultValue());
+              field.defaultVal());
         }
-        for (Map.Entry<String, JsonNode> stringJsonNodeEntry : field.getJsonProps().entrySet()) {
+        for (Map.Entry<String, Object> stringJsonNodeEntry : field.getObjectProps().entrySet()) {
           newField.addProp(stringJsonNodeEntry.getKey(), stringJsonNodeEntry.getValue());
         }
         newFields.add(newField);

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/converter/filter/GobblinTrackingEventFlattenFilterConverter.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/converter/filter/GobblinTrackingEventFlattenFilterConverter.java
@@ -86,9 +86,9 @@ public class GobblinTrackingEventFlattenFilterConverter extends AvroToAvroConver
       if (!field.schema().getType().equals(Schema.Type.MAP)) {
         if (fieldsRenameMap.containsKey(curFieldName)) {
           newFields.add(
-              new Schema.Field(fieldsRenameMap.get(curFieldName), field.schema(), field.doc(), field.defaultValue()));
+              new Schema.Field(fieldsRenameMap.get(curFieldName), field.schema(), field.doc(), field.defaultVal()));
         } else {
-          newFields.add(new Schema.Field(curFieldName, field.schema(), field.doc(), field.defaultValue()));
+          newFields.add(new Schema.Field(curFieldName, field.schema(), field.doc(), field.defaultVal()));
         }
         this.nonMapFields.add(curFieldName);
       } else {

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/test/SequentialTestSource.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/test/SequentialTestSource.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import avro.shaded.com.google.common.base.Throwables;
+import com.google.common.base.Throwables;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.SourceState;

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/FlattenNestedKeyConverter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/FlattenNestedKeyConverter.java
@@ -75,7 +75,7 @@ public class FlattenNestedKeyConverter extends Converter<Schema, Schema, Generic
     List<Field> fields = new ArrayList<>();
     // Clone the existing fields
     for (Field field : inputSchema.getFields()) {
-      fields.add(new Field(field.name(), field.schema(), field.doc(), field.defaultValue(), field.order()));
+      fields.add(new Field(field.name(), field.schema(), field.doc(), field.defaultVal(), field.order()));
     }
 
     // Convert each of nested keys into a top level field
@@ -102,7 +102,7 @@ public class FlattenNestedKeyConverter extends Converter<Schema, Schema, Generic
       Field field = optional.get();
 
       // Make a copy under a new name
-      Field copy = new Field(name, field.schema(), field.doc(), field.defaultValue(), field.order());
+      Field copy = new Field(name, field.schema(), field.doc(), field.defaultVal(), field.order());
       fields.add(copy);
     }
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/filter/AvroFieldsPickConverter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/filter/AvroFieldsPickConverter.java
@@ -145,13 +145,13 @@ public class AvroFieldsPickConverter extends AvroToAvroConverterBase {
 
       if (child.children.isEmpty()) { //Leaf
         newFields.add(
-            new Field(innerSrcField.name(), innerSrcField.schema(), innerSrcField.doc(), innerSrcField.defaultValue()));
+            new Field(innerSrcField.name(), innerSrcField.schema(), innerSrcField.doc(), innerSrcField.defaultVal()));
       } else {
         Schema innerSrcSchema = innerSrcField.schema();
 
         Schema innerDestSchema = createSchemaHelper(innerSrcSchema, child); //Recurse of schema
         Field innerDestField =
-            new Field(innerSrcField.name(), innerDestSchema, innerSrcField.doc(), innerSrcField.defaultValue());
+            new Field(innerSrcField.name(), innerDestSchema, innerSrcField.doc(), innerSrcField.defaultVal());
         newFields.add(innerDestField);
       }
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/utils/AvroHiveTypeUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/utils/AvroHiveTypeUtils.java
@@ -205,7 +205,7 @@ public class AvroHiveTypeUtils {
         .equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
       int maxLength = 0;
       try {
-        maxLength = schema.getJsonProp(AvroSerDe.AVRO_PROP_MAX_LENGTH).getValueAsInt();
+        maxLength = (Integer) schema.getObjectProp(AvroSerDe.AVRO_PROP_MAX_LENGTH);
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain maxLength value from file schema: " + schema, ex);
       }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedMultiDatasets.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedMultiDatasets.java
@@ -17,7 +17,7 @@
 
 package org.apache.gobblin.data.management.copy.replication;
 
-import avro.shaded.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.gobblin.dataset.Dataset;
 import java.io.IOException;
 import java.net.URI;

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
@@ -77,7 +77,6 @@ public class KafkaKeyValueProducerPusher<K, V> implements Pusher<Pair<K, V>> {
     props.put(ProducerConfig.RETRIES_CONFIG, 3);
     //To guarantee ordered delivery, the maximum in flight requests must be set to 1.
     props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
-    props.put(ProducerConfig.BLOCK_ON_BUFFER_FULL_CONFIG, true);
 
     // add the kafka scoped config. if any of the above are specified then they are overridden
     if (kafkaConfig.isPresent()) {

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/converter/EnvelopePayloadConverter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/converter/EnvelopePayloadConverter.java
@@ -70,7 +70,7 @@ public class EnvelopePayloadConverter extends BaseEnvelopeSchemaConverter<Generi
       return createLatestPayloadField(field);
     }
     // Make a copy of the field to the output schema
-    return new Field(field.name(), field.schema(), field.doc(), field.defaultValue(), field.order());
+    return new Field(field.name(), field.schema(), field.doc(), field.defaultVal(), field.order());
   }
 
   /**
@@ -83,7 +83,7 @@ public class EnvelopePayloadConverter extends BaseEnvelopeSchemaConverter<Generi
       throws SchemaConversionException {
     try {
       Schema payloadSchema = fetchLatestPayloadSchema();
-      return new Field(field.name(), payloadSchema, DECORATED_PAYLOAD_DOC, field.defaultValue(), field.order());
+      return new Field(field.name(), payloadSchema, DECORATED_PAYLOAD_DOC, field.defaultVal(), field.order());
     } catch (Exception e) {
       throw new SchemaConversionException(e);
     }

--- a/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
+++ b/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
@@ -31,7 +31,7 @@ import com.google.api.services.webmasters.model.ApiDimensionFilter;
 import com.google.common.base.Splitter;
 import com.google.gson.JsonArray;
 
-import avro.shaded.com.google.common.collect.Iterables;
+import com.google.common.collect.Iterables;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;

--- a/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -41,7 +41,7 @@ import com.google.api.services.webmasters.model.ApiDimensionFilter;
 import com.google.api.services.webmasters.model.SearchAnalyticsQueryResponse;
 import com.google.common.base.Optional;
 
-import avro.shaded.com.google.common.base.Joiner;
+import com.google.common.base.Joiner;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.WorkUnitState;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -43,7 +43,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import avro.shaded.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroFlattener.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroFlattener.java
@@ -26,7 +26,6 @@ import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.codehaus.jackson.JsonNode;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -412,12 +411,12 @@ public class AvroFlattener {
             }
           }
         }
-        Schema.Field field = new Schema.Field(flattenName, flattenedFieldSchema, f.doc(), f.defaultValue(), f.order());
+        Schema.Field field = new Schema.Field(flattenName, flattenedFieldSchema, f.doc(), f.defaultVal(), f.order());
 
         if (StringUtils.isNotBlank(flattenSource)) {
           field.addProp(FLATTENED_SOURCE_KEY, flattenSource);
         }
-        for (Map.Entry<String, JsonNode> entry : f.getJsonProps().entrySet()) {
+        for (Map.Entry<String, Object> entry : f.getObjectProps().entrySet()) {
           field.addProp(entry.getKey(), entry.getValue());
         }
         flattenedFields.add(field);
@@ -467,7 +466,7 @@ public class AvroFlattener {
     Preconditions.checkNotNull(oldSchema);
     Preconditions.checkNotNull(newSchema);
 
-    Map<String, JsonNode> props = oldSchema.getJsonProps();
+    Map<String, Object> props = oldSchema.getObjectProps();
     copyProperties(props, newSchema);
   }
 
@@ -476,12 +475,12 @@ public class AvroFlattener {
    * @param props Properties to copy to Avro Schema
    * @param schema Avro Schema to copy properties to
    */
-  private static void copyProperties(Map<String, JsonNode> props, Schema schema) {
+  private static void copyProperties(Map<String, Object> props, Schema schema) {
     Preconditions.checkNotNull(schema);
 
     // (if null, don't copy but do not throw exception)
     if (null != props) {
-      for (Map.Entry<String, JsonNode> prop : props.entrySet()) {
+      for (Map.Entry<String, Object> prop : props.entrySet()) {
         schema.addProp(prop.getKey(), prop.getValue());
       }
     }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/orc/AvroOrcSchemaConverter.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/orc/AvroOrcSchemaConverter.java
@@ -101,8 +101,17 @@ public class AvroOrcSchemaConverter {
    */
   private static TypeDescription getTypeDescriptionForBinarySchema(Schema avroSchema) {
     if ("decimal".equalsIgnoreCase(avroSchema.getProp("logicalType"))) {
-      int scale = avroSchema.getJsonProp("scale").asInt(0);
-      int precision = avroSchema.getJsonProp("precision").asInt();
+      int scale, precision;
+      try {
+        scale = (Integer) avroSchema.getObjectProp("scale");
+      } catch (ClassCastException e) {
+        scale = 0;
+      }
+      try {
+        precision = (Integer) avroSchema.getObjectProp("precision");
+      } catch (ClassCastException e) {
+        precision = 0;
+      }
 
       return TypeDescription.createDecimal().withScale(scale).withPrecision(precision);
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
Gobblin depended on an old deprecated Avro API that worked with Jackson JsonNode objects. In Gobblin's default Avro dependency version (1.8) these APIs were already marked as deprecated. In Avro 1.9 these APIs were replaced by similar APIs that work with `Object` rather than `JsonNode` Java objects.

### Tests
My PR does not need unit tests to validate whether it is working. Simply attempting to compile the project with a flag to inject avro 1.9+ (`-PavroVersion=1.9.1`) validates that this PR fixes the issue.
Functionally the change also worked appropriately as I was able to use newer Avro versions to read events from Kafka using gobblin jobs that depended on these new versions.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

