### PR TITLE
[GOBBLIN-1601] implement ChangePermissionCommitStep

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -27,11 +27,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import javax.annotation.Nullable;
-
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
@@ -45,6 +40,10 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
+
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alias;
 import org.apache.gobblin.configuration.ConfigurationKeys;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -361,6 +362,7 @@ public class CopyableFile extends CopyEntity implements File {
 
   public static Map<String, OwnerAndPermission> resolveReplicatedAncestorOwnerAndPermissionsRecursively(FileSystem sourceFs, Path fromPath,
       Path toPath, CopyConfiguration copyConfiguration) throws IOException {
+    Preconditions.checkArgument(sourceFs.getFileStatus(fromPath).isDirectory(), "Source path must be a directory.");
 
     Map<String, OwnerAndPermission> ownerAndPermissions = Maps.newHashMap();
 
@@ -376,7 +378,6 @@ public class CopyableFile extends CopyEntity implements File {
       ownerAndPermissions.put(PathUtils.getPathWithoutSchemeAndAuthority(currentOriginPath).toString(), resolveReplicatedOwnerAndPermission(sourceFs, currentOriginPath, copyConfiguration));
       currentOriginPath = currentOriginPath.getParent();
     }
-    // Now currentTargetPath and currentOriginPath are the same path.
 
     // Walk through the parents and preserve the permissions from Origin -> Target as we go in lockstep.
     while (currentOriginPath != null && currentTargetPath != null

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -17,16 +17,26 @@
 
 package org.apache.gobblin.data.management.copy;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.apache.gobblin.data.management.copy.PreserveAttributes.Option;
 import org.apache.gobblin.data.management.partition.File;
 import org.apache.gobblin.dataset.DatasetConstants;
@@ -35,11 +45,6 @@ import org.apache.gobblin.dataset.Descriptor;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.guid.Guid;
-import org.apache.hadoop.fs.FileChecksum;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
 
 
 /**
@@ -349,6 +354,36 @@ public class CopyableFile extends CopyEntity implements File {
     while (PathUtils.isAncestor(toPath, currentPath.getParent())) {
       ownerAndPermissions.add(resolveReplicatedOwnerAndPermission(sourceFs, currentPath, copyConfiguration));
       currentPath = currentPath.getParent();
+    }
+
+    return ownerAndPermissions;
+  }
+
+  public static Map<String, OwnerAndPermission> resolveReplicatedAncestorOwnerAndPermissionsRecursively(FileSystem sourceFs, Path fromPath,
+      Path toPath, CopyConfiguration copyConfiguration) throws IOException {
+
+    Map<String, OwnerAndPermission> ownerAndPermissions = Maps.newHashMap();
+
+    // We only pass directories to this method anyways. Those directories themselves need permissions set.
+    Path currentOriginPath = fromPath;
+    Path currentTargetPath = toPath;
+
+    if (!PathUtils.isAncestor(currentTargetPath, currentOriginPath)) {
+      throw new IOException(String.format("currentTargetPath %s must be an ancestor of currentOriginPath %s.", currentTargetPath, currentOriginPath));
+    }
+
+    while (PathUtils.isAncestor(currentTargetPath, currentOriginPath.getParent())) {
+      ownerAndPermissions.put(PathUtils.getPathWithoutSchemeAndAuthority(currentOriginPath).toString(), resolveReplicatedOwnerAndPermission(sourceFs, currentOriginPath, copyConfiguration));
+      currentOriginPath = currentOriginPath.getParent();
+    }
+    // Now currentTargetPath and currentOriginPath are the same path.
+
+    // Walk through the parents and preserve the permissions from Origin -> Target as we go in lockstep.
+    while (currentOriginPath != null && currentTargetPath != null
+        && currentOriginPath.getName().equals(currentTargetPath.getName())) {
+      ownerAndPermissions.put(PathUtils.getPathWithoutSchemeAndAuthority(currentOriginPath).toString(), resolveReplicatedOwnerAndPermission(sourceFs, currentOriginPath, copyConfiguration));
+      currentOriginPath = currentOriginPath.getParent();
+      currentTargetPath = currentTargetPath.getParent();
     }
 
     return ownerAndPermissions;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -486,14 +486,14 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       }
 
       if (ownerAndPermission.getFsPermission() != null) {
-        log.debug("Applying permissions %s to path %s.", ownerAndPermission.getFsPermission(), path);
+        log.debug("Applying permissions {} to path {}.", ownerAndPermission.getFsPermission(), path);
         fs.setPermission(path, addExecutePermissionToOwner(ownerAndPermission.getFsPermission()));
       }
 
       String group = ownerAndPermission.getGroup();
       String owner = ownerAndPermission.getOwner();
       if (group != null || owner != null) {
-        log.debug("Applying owner %s and group %s to path %s.", owner, group, path);
+        log.debug("Applying owner {} and group {} to path {}.", owner, group, path);
         fs.setOwner(path, owner, group);
       }
     } else {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/SetPermissionCommitStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/SetPermissionCommitStep.java
@@ -66,6 +66,7 @@ public class SetPermissionCommitStep implements CommitStep {
       try {
         log.info("Setting permission {} on path {}", entry.getValue().getFsPermission(), path);
         fs.setPermission(path, entry.getValue().getFsPermission());
+        // TODO : we can also set owner and group here.
       } catch (AccessControlException e) {
         log.warn("Error while setting permission on " + path, e);
         if (this.stopOnError) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/SetPermissionCommitStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/SetPermissionCommitStep.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.commit;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.AccessControlException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.commit.CommitStep;
+import org.apache.gobblin.data.management.copy.OwnerAndPermission;
+
+/**
+ * An implementation of {@link CommitStep} for setting any file permissions.
+ * Current implementation only sets permissions, but it is capable of setting owner and group as well.
+ */
+@Slf4j
+public class SetPermissionCommitStep implements CommitStep {
+  Map<String, OwnerAndPermission> pathAndPermissions;
+  private final URI fsUri;
+  public final boolean stopOnError;
+  public static final String STOP_ON_ERROR_KEY = "stop.on.error";
+  public static final String DEFAULT_STOP_ON_ERROR = "false";
+  private boolean isCompleted = false;
+
+  public SetPermissionCommitStep(FileSystem targetFs, Map<String, OwnerAndPermission> pathAndPermissions,
+      Properties props) {
+    this.pathAndPermissions = pathAndPermissions;
+    this.fsUri = targetFs.getUri();
+    this.stopOnError = Boolean.parseBoolean(props.getProperty(STOP_ON_ERROR_KEY, DEFAULT_STOP_ON_ERROR));
+  }
+
+  @Override
+  public boolean isCompleted() throws IOException {
+    return isCompleted;
+  }
+
+  @Override
+  public void execute() throws IOException {
+    FileSystem fs = FileSystem.get(this.fsUri, new Configuration());
+
+    for (Map.Entry<String, OwnerAndPermission> entry : pathAndPermissions.entrySet()) {
+      Path path = new Path(entry.getKey());
+      try {
+        log.info("Setting permission {} on path {}", entry.getValue().getFsPermission(), path);
+        fs.setPermission(path, entry.getValue().getFsPermission());
+      } catch (AccessControlException e) {
+        log.warn("Error while setting permission on " + path, e);
+        if (this.stopOnError) {
+          log.info("Skip setting rest of the permissions because stopOnError is true.");
+          break;
+        }
+      }
+    }
+
+    isCompleted = true;
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/util/commit/SetPermissionCommitStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/util/commit/SetPermissionCommitStepTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.commit;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.data.management.copy.OwnerAndPermission;
+
+
+/**
+ * Test for {@link SetPermissionCommitStep}.
+ */
+@Test(groups = { "gobblin.commit" })
+public class SetPermissionCommitStepTest {
+  private static final String ROOT_DIR = "set-permission-commit-step-test";
+
+  private FileSystem fs;
+  private SetPermissionCommitStep step;
+  Path dir1;
+  FsPermission permission = new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL);
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fs = FileSystem.getLocal(new Configuration());
+    this.fs.delete(new Path(ROOT_DIR), true);
+
+    dir1 = new Path(ROOT_DIR, "dir1");
+    this.fs.mkdirs(dir1);
+
+    OwnerAndPermission ownerAndPermission = new OwnerAndPermission("owner", "group", permission);
+    Map<String, OwnerAndPermission> pathAndPermissions = new HashMap<>();
+    pathAndPermissions.put(dir1.toString(), ownerAndPermission);
+
+    this.step = new SetPermissionCommitStep(this.fs, pathAndPermissions, new Properties());
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.fs.delete(new Path(ROOT_DIR), true);
+  }
+
+  @Test
+  public void testExecute() throws IOException {
+    Assert.assertNotEquals(this.fs.getFileStatus(dir1).getPermission(), permission);
+    this.step.execute();
+    Assert.assertEquals(this.fs.getFileStatus(dir1).getPermission(), permission);
+  }
+}


### PR DESCRIPTION
add a configuration to match permission of ancestor directories permissions in source and destination

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@Will-Lo @ZihanLi58 please review

### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1601


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Provide a configuration to replicate permissions of ancestor directories of the directory to be copied on the destination side directories. We save the permissions of ancestor directories in a PostPublishStep which is executed after the publish.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
created SetPermissionCommitStepTest to test SetPermissionCommitStep

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

