### PR TITLE
[GOBBLIN-1606] change DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE value

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -85,7 +85,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
 
   public static final String GOBBLIN_COPY_BYTES_COPIED_METER = "gobblin.copy.bytesCopiedMeter";
   public static final String GOBBLIN_COPY_CHECK_FILESIZE = "gobblin.copy.checkFileSize";
-  public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
+  public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = true;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
 
@@ -161,6 +161,9 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     this.recoveryHelper = new RecoveryHelper(this.fs, state);
     this.actualProcessedCopyableFile = Optional.absent();
 
+    if (getMetricContext().getInnerMetricContext().getContextAwareMetrics().containsKey(GOBBLIN_COPY_BYTES_COPIED_METER)) {
+      getMetricContext().remove(GOBBLIN_COPY_BYTES_COPIED_METER);
+    }
     this.copySpeedMeter = getMetricContext().meter(GOBBLIN_COPY_BYTES_COPIED_METER);
 
     this.bufferSize = state.getPropAsInt(CopyConfiguration.BUFFER_SIZE, StreamCopier.DEFAULT_BUFFER_SIZE);
@@ -295,6 +298,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
         log.warn("Broker error. Some features of stream copier may not be available.", nce);
       } finally {
         os.close();
+        log.info("OutputStream for file {} is closed.", writeAt);
         inputStream.close();
       }
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -161,9 +161,11 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     this.recoveryHelper = new RecoveryHelper(this.fs, state);
     this.actualProcessedCopyableFile = Optional.absent();
 
-    if (getMetricContext().getInnerMetricContext().getContextAwareMetrics().containsKey(GOBBLIN_COPY_BYTES_COPIED_METER)) {
+    // remove the old metric which counts how many bytes are copied, because in case of retries, this can give incorrect value
+    if (getMetricContext().getMetrics().containsKey(GOBBLIN_COPY_BYTES_COPIED_METER)) {
       getMetricContext().remove(GOBBLIN_COPY_BYTES_COPIED_METER);
     }
+
     this.copySpeedMeter = getMetricContext().meter(GOBBLIN_COPY_BYTES_COPIED_METER);
 
     this.bufferSize = state.getPropAsInt(CopyConfiguration.BUFFER_SIZE, StreamCopier.DEFAULT_BUFFER_SIZE);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileUtils.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileUtils.java
@@ -43,37 +43,41 @@ public class CopyableFileUtils {
   }
 
   public static CopyableFile getTestCopyableFile() {
-    return getTestCopyableFile(null, null);
+    return getTestCopyableFile(0L, null);
   }
 
   public static CopyableFile getTestCopyableFile(String resourcePath) {
     return getTestCopyableFile(resourcePath, null);
   }
 
+  public static CopyableFile getTestCopyableFile(Long size, OwnerAndPermission ownerAndPermission) {
+    return getTestCopyableFile(null, null, size, ownerAndPermission);
+  }
+
   public static CopyableFile getTestCopyableFile(OwnerAndPermission ownerAndPermission) {
-    return getTestCopyableFile(null, null, ownerAndPermission);
+    return getTestCopyableFile(null, null, 0L, ownerAndPermission);
   }
 
   public static CopyableFile getTestCopyableFile(String resourcePath, OwnerAndPermission ownerAndPermission) {
-    return getTestCopyableFile(resourcePath, null, ownerAndPermission);
+    return getTestCopyableFile(resourcePath, null, 0L, ownerAndPermission);
   }
 
-  public static CopyableFile getTestCopyableFile(String resourcePath, String relativePath,
+  public static CopyableFile getTestCopyableFile(String resourcePath, String relativePath, Long size,
       OwnerAndPermission ownerAndPermission) {
-    return getTestCopyableFile(resourcePath, getRandomPath(), relativePath, ownerAndPermission);
+    return getTestCopyableFile(resourcePath, getRandomPath(), relativePath, size, ownerAndPermission);
   }
 
   public static CopyableFile getTestCopyableFile(String resourcePath, String destinationPath, String relativePath,
-      OwnerAndPermission ownerAndPermission) {
+      Long size, OwnerAndPermission ownerAndPermission) {
 
     FileStatus status = null;
 
     if (resourcePath == null) {
       resourcePath = getRandomPath();
-      status = new FileStatus(0l, false, 0, 0l, 0l, new Path(resourcePath));
+      status = new FileStatus(size, false, 0, 0l, 0l, new Path(resourcePath));
     } else {
       String filePath = CopyableFileUtils.class.getClassLoader().getResource(resourcePath).getFile();
-      status = new FileStatus(0l, false, 0, 0l, 0l, new Path(filePath));
+      status = new FileStatus(size, false, 0, 0l, 0l, new Path(filePath));
     }
 
     if (relativePath == null) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/UnGzipConverterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/UnGzipConverterTest.java
@@ -81,7 +81,7 @@ public class UnGzipConverterTest {
       String fullPath = getClass().getClassLoader().getResource(filePath).getFile();
 
       FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder()
-          .file(CopyableFileUtils.getTestCopyableFile(filePath, "/tmp/" + fileName, null, null))
+          .file(CopyableFileUtils.getTestCopyableFile(filePath, "/tmp/" + fileName, null, 0L, null))
           .inputStream(fs.open(new Path(fullPath))).build();
 
       Iterable<FileAwareInputStream> iterable = converter.convertRecord("outputSchema", fileAwareInputStream, new WorkUnitState());

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.gobblin.data.management.copy.writer;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,9 +25,26 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Properties;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.crypto.EncryptionConfigParser;
@@ -50,17 +64,6 @@ import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
 import org.apache.gobblin.util.TestUtils;
 import org.apache.gobblin.util.WriterUtils;
 import org.apache.gobblin.util.io.StreamUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -85,7 +88,7 @@ public class FileAwareInputStreamDataWriterTest {
     FileStatus status = fs.getFileStatus(testTempPath);
     OwnerAndPermission ownerAndPermission =
         new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile((long) streamString1.length(), ownerAndPermission);
     CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
     WorkUnitState state = TestUtils.createTestWorkUnitState();
     state.setProp(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false);
@@ -174,7 +177,7 @@ public class FileAwareInputStreamDataWriterTest {
     FileStatus status = fs.getFileStatus(testTempPath);
     OwnerAndPermission ownerAndPermission =
         new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile((long) streamString.length, ownerAndPermission);
 
     CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
 
@@ -208,7 +211,7 @@ public class FileAwareInputStreamDataWriterTest {
     FileStatus status = fs.getFileStatus(testTempPath);
     OwnerAndPermission ownerAndPermission =
         new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile((long) streamString.length, ownerAndPermission);
 
     CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
 
@@ -254,7 +257,7 @@ public class FileAwareInputStreamDataWriterTest {
     FileStatus status = fs.getFileStatus(testTempPath);
     OwnerAndPermission ownerAndPermission =
         new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile((long) streamString.length, ownerAndPermission);
 
     CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
 
@@ -429,7 +432,7 @@ public class FileAwareInputStreamDataWriterTest {
     FileStatus status = fs.getFileStatus(testTempPath);
     OwnerAndPermission ownerAndPermission = new OwnerAndPermission(status.getOwner(), status.getGroup(),
         new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile((long) streamString1.length(), ownerAndPermission);
     CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
     WorkUnitState state = TestUtils.createTestWorkUnitState();
     state.setProp(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG, false);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
@@ -16,19 +16,6 @@
  */
 package org.apache.gobblin.data.management.copy.writer;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.WorkUnitState;
-import org.apache.gobblin.data.management.copy.CopySource;
-import org.apache.gobblin.data.management.copy.CopyableDatasetMetadata;
-import org.apache.gobblin.data.management.copy.CopyableFile;
-import org.apache.gobblin.data.management.copy.CopyableFileUtils;
-import org.apache.gobblin.data.management.copy.FileAwareInputStream;
-import org.apache.gobblin.data.management.copy.OwnerAndPermission;
-import org.apache.gobblin.data.management.copy.TestCopyableDataset;
-import org.apache.gobblin.data.management.copy.converter.UnGzipConverter;
-import org.apache.gobblin.util.PathUtils;
-import org.apache.gobblin.util.TestUtils;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 
@@ -48,6 +35,19 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.data.management.copy.CopySource;
+import org.apache.gobblin.data.management.copy.CopyableDatasetMetadata;
+import org.apache.gobblin.data.management.copy.CopyableFile;
+import org.apache.gobblin.data.management.copy.CopyableFileUtils;
+import org.apache.gobblin.data.management.copy.FileAwareInputStream;
+import org.apache.gobblin.data.management.copy.OwnerAndPermission;
+import org.apache.gobblin.data.management.copy.TestCopyableDataset;
+import org.apache.gobblin.data.management.copy.converter.UnGzipConverter;
+import org.apache.gobblin.util.PathUtils;
+import org.apache.gobblin.util.TestUtils;
 
 
 public class TarArchiveInputStreamDataWriterTest {
@@ -118,7 +118,7 @@ public class TarArchiveInputStreamDataWriterTest {
         new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL,
             FsAction.ALL));
     CopyableFile cf =
-        CopyableFileUtils.getTestCopyableFile(filePath, new Path(testTempPath, newFileName).toString(), newFileName,
+        CopyableFileUtils.getTestCopyableFile(filePath, new Path(testTempPath, newFileName).toString(), newFileName, 0L,
             ownerAndPermission);
 
     FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
@@ -71,6 +71,7 @@ public class InnerMetricContext extends MetricRegistry implements ReportableCont
 
   // A map from simple names to context-aware metrics. All metrics registered with this context (using
   // their simple names) are also registered with the MetricRegistry using their fully-qualified names.
+  @Getter
   private final ConcurrentMap<String, InnerMetric> contextAwareMetrics = Maps.newConcurrentMap();
 
   // This is used to work on tags associated with this context

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
@@ -71,7 +71,6 @@ public class InnerMetricContext extends MetricRegistry implements ReportableCont
 
   // A map from simple names to context-aware metrics. All metrics registered with this context (using
   // their simple names) are also registered with the MetricRegistry using their fully-qualified names.
-  @Getter
   private final ConcurrentMap<String, InnerMetric> contextAwareMetrics = Maps.newConcurrentMap();
 
   // This is used to work on tags associated with this context


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@jack-moseley  @ZihanLi58  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1606


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
a) change default value of gobblin_copy_check_filesize to true because it makes more sense to abort the copy if the copied file size does not match the source file size
b) remove the old metric which counts how many bytes are copied, because in case of retries, this can give incorrect value

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated existing unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

