### PR TITLE
[GOBBLIN-1607] Rollback pr3464

### DIFF
--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/RetryWriterTest.java
@@ -34,8 +34,10 @@ public class RetryWriterTest {
   public void retryTest() throws IOException {
     DataWriter<Void> writer = mock(DataWriter.class);
     doThrow(new RuntimeException()).when(writer).writeEnvelope(any(RecordEnvelope.class));
+    State state = new State();
+    state.setProp(RetryWriter.RETRY_MAX_ATTEMPTS, "5");
 
-    DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, new State());
+    DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, state);
     DataWriter<Void> retryWriter = builder.build();
     try {
       retryWriter.writeEnvelope(new RecordEnvelope<>(null));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -85,7 +85,9 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
 
   public static final String GOBBLIN_COPY_BYTES_COPIED_METER = "gobblin.copy.bytesCopiedMeter";
   public static final String GOBBLIN_COPY_CHECK_FILESIZE = "gobblin.copy.checkFileSize";
-  public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = true;
+  // setting GOBBLIN_COPY_CHECK_FILESIZE to true may result in failures because the calculation of
+  // expected bytes to be copied and actual bytes copied may have bugs
+  public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1607


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Rollback pr3464 because it resulted in job failures. there seems to be a possibility that input and output file sizes are not calculated correctly.
from logs
java.io.IOException: Incomplete write: expected 283839, wrote 283935 bytes.

These exceptions sky rocketed after PR 3464 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
not required because rolling back to previous state

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

