### PR TITLE
[GOBBLIN-1608] Fix case where error GTE is incorrectly sent from MCE writer

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -319,12 +319,12 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       tableErrorMap.put(tableString, gobblinMetadataException);
     }
     this.datasetErrorMap.put(tableStatus.datasetPath, tableErrorMap);
+    tableOperationTypeMap.remove(tableString);
     log.error(String.format("Meet exception when flush table %s", tableString), e);
     if (datasetErrorMap.size() > maxErrorDataset) {
       //Fail the job if the error size exceeds some number
       throw new IOException(String.format("Container fails to flush for more than %s dataset, last exception we met is: ", maxErrorDataset), e);
     }
-    tableOperationTypeMap.remove(tableString);
   }
 
   // Add fault tolerant ability and make sure we can emit GTE as desired
@@ -358,6 +358,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       this.datasetErrorMap.get(datasetPath).remove(tableString);
     }
   }
+
   /**
    * Call the metadata writers to do flush each table metadata.
    * Flush of metadata writer is the place that do real metadata
@@ -390,7 +391,6 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
 
   @Override
   public void close() throws IOException {
-    this.flush();
     this.closer.close();
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1608


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

When `max.error.dateset` is reached and the container is failed, gobblin will cause close() on the writer, which will call flush(). This causes a couple issues with events due to assumptions on where flush() is called.

- Move `tableOperationTypeMap.remove(tableString)` to before the container is failed, otherwise an extra flush() will be called on the table. This flush() shouldn't actually do anything since writer.reset has been called for the dataset already.
- Don't send error GTEs for all tables if flush() is called from close(). This event emission is here because GMCE watermark is advanced when flush() is called periodically, but when flush() is called from close the watermark is not advanced so events should not be sent.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tested with one dataset in e2e pipeline.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

