### PR TITLE
[GOBBLIN-1610] Exclude Jackson from elasticsearch-deps for avoiding version conflict

### DIFF
--- a/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
+++ b/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 configurations {
  compile {
     exclude group: "org.apache.hadoop"
+    exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.sun.jersey.contribs"
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1610


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently, following the "Getting Started" guide fails due to Jackson's version conflict.
It comes from the gobblin-elasticsearch-deps module, so this PR excludes Jackson from its dependencies.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a fix for a configuration file.
I ran `./gradlew :gobblin-modules:gobblin-elasticsearch:test` locally and confirmed it succeeded.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

