### PR TITLE
[GOBBLIN-1611] Fix a wrong value for writer.codec.type in the document

### DIFF
--- a/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
+++ b/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
@@ -396,7 +396,7 @@ Properties for Gobblin's fork operator.
 | Name | Description | Required | Default Value |
 | --- | --- | --- | --- |
 | `writer.destination.type` | Writer destination type. Can be HDFS, KAFKA, MYSQL or TERADATA | No | HDFS | 
-| `writer.output.format` | Writer output format; currently only Avro is supported. | No | AVRO | 
+| `writer.output.format` | Writer output format; currently Avro and Parquet are supported. | No | AVRO |
 | `writer.fs.uri` | File system URI for writer output. | No | file:/// | 
 | `writer.staging.dir` | Staging directory of writer output. All staging data that the writer produces will be placed in this directory, but all the data will be eventually moved to the writer.output.dir. | Yes | None |
 | `writer.output.dir` | Output directory of writer output. All output data that the writer produces will be placed in this directory, but all the data will be eventually moved to the final directory by the publisher. | Yes | None |
@@ -406,7 +406,7 @@ Properties for Gobblin's fork operator.
 | `writer.partitioner.class` | Partitioner used for distributing records into multiple output files. `writer.builder.class` must be a subclass of `PartitionAwareDataWriterBuilder`, otherwise Gobblin will throw an error.  | No | None (will not use partitioner) |
 | `writer.buffer.size` |  Writer buffer size in bytes. This parameter is only applicable for the AvroHdfsDataWriter. | No | 4096 | 
 | `writer.deflate.level` |  Writer deflate level. Deflate is a type of compression for Avro data. | No | 9 | 
-| `writer.codec.type` |  This is used to specify the type of compression used when writing data out. Possible values are NOCOMPRESSION, DEFLATE, SNAPPY. | No | DEFLATE | 
+| `writer.codec.type` |  This is used to specify the type of compression used when writing data out. Possible values are NULL, DEFLATE, SNAPPY, BZIP2, XZ (for AvroHdfsDataWriter), or UNCOMPRESSED, GZIP, SNAPPY, LZO (for ParquetHdfsDataWriter). | No | DEFLATE (for AvroHdfsDataWriter), UNCOMPRESSED (for ParquetHdfsDataWriter) |
 | `writer.eager.initialization` | This is used to control the writer creation. If the value is set to true, writer is created before records are read. This means an empty file will be created even if no records were read. | No | False | 
 | `writer.parquet.page.size` | The page size threshold | No | 1048576 |
 | `writer.parquet.dictionary.page.size` | The block size threshold. | No | 134217728 |


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1611


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

The description about  the writer.codec.type property in the document has a little mistake. This PR corrects it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a documentation fix.
I ran `mkdocs serve` locally and confirmed the document was modified as expected.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

