### PR TITLE
[GOBBLIN-1614] Fix bug where partitioned tables would always return the wrong equali…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -748,10 +748,11 @@ public class HiveCopyEntityHelper {
     return builder.build();
   }
 
-  private void checkPartitionedTableCompatibility(Table desiredTargetTable, Table existingTargetTable)
+  @VisibleForTesting
+  protected void checkPartitionedTableCompatibility(Table desiredTargetTable, Table existingTargetTable)
       throws IOException {
 
-    if (HiveUtils.areTablePathsEquivalent(this.targetFs, desiredTargetTable.getDataLocation(), existingTargetTable.getDataLocation())) {
+    if (!HiveUtils.areTablePathsEquivalent(getTargetFs(), desiredTargetTable.getDataLocation(), existingTargetTable.getDataLocation())) {
       throw new HiveTableLocationNotMatchException(desiredTargetTable.getDataLocation(), existingTargetTable.getDataLocation());
     }
 


### PR DESCRIPTION
…ty in paths

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1614


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
For Partitioned Hive Tables, Gobblin with attempt to resolve the URI using the FS when performing table equality checks to ensure that the user is not trying to register their table under a new path.

This is to fix a bug where snapshot tables could perform this check, but partitioned tables would fail when their paths are equivalent.

Boolean check for hive table equality was reversed

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested on a partitioned table, added unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

