### PR TITLE
[GOBBLIN-1616] Make RestApiConnector be able to close the connection finally

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -17,15 +17,19 @@
 
 package org.apache.gobblin.source.extractor.extract.restapi;
 
+import com.google.common.io.Closer;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.util.EntityUtils;
@@ -53,7 +57,7 @@ import lombok.extern.slf4j.Slf4j;
  * A class for connecting to Rest APIs, construct queries and getting responses.
  */
 @Slf4j
-public abstract class RestApiConnector {
+public abstract class RestApiConnector implements Closeable {
 
   public static final String REST_API_CONNECTOR_CLASS = "rest.api.connector.class";
 
@@ -68,6 +72,7 @@ public abstract class RestApiConnector {
   protected long createdAt;
   protected String instanceUrl;
   protected String updatedQuery;
+  protected Closer closer = Closer.create();
 
   protected final State state;
 
@@ -75,6 +80,15 @@ public abstract class RestApiConnector {
     this.state = state;
     this.authTokenTimeout =
         state.getPropAsInt(ConfigurationKeys.SOURCE_CONN_TIMEOUT, ConfigurationKeys.DEFAULT_CONN_TIMEOUT);
+  }
+
+  @Override
+  public void close() throws IOException {
+    // This is to close any idle connections opening by the httpClient
+    this.closer.close();
+    if (this.httpClient != null) {
+      this.httpClient.getConnectionManager().closeIdleConnections(0, TimeUnit.MICROSECONDS);
+    }
   }
 
   /**
@@ -178,7 +192,9 @@ public abstract class RestApiConnector {
         if (httpEntity != null) {
           EntityUtils.consume(httpEntity);
         }
-        // httpResponse.close();
+        if(httpResponse instanceof CloseableHttpResponse) {
+          this.closer.register((CloseableHttpResponse)httpResponse);
+        }
       } catch (Exception e) {
         throw new RestApiProcessingException("Failed to consume httpEntity; error - " + e.getMessage(), e);
       }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
@@ -247,4 +247,8 @@ public abstract class RestApiExtractor extends QueryBasedExtractor<JsonArray, Js
     this.connector.setAuthTokenTimeout(timeOut);
   }
 
+  @Override
+  public void closeConnection() throws Exception {
+    this.connector.close();
+  }
 }

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConnector.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConnector.java
@@ -21,8 +21,10 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.message.BasicNameValuePair;
@@ -95,7 +97,11 @@ public class SalesforceConnector extends RestApiConnector {
     try {
       HttpPost post = new HttpPost(host + DEFAULT_AUTH_TOKEN_PATH);
       post.setEntity(new UrlEncodedFormEntity(formParams));
-      return getHttpClient().execute(post).getEntity();
+      HttpResponse httpResponse= getHttpClient().execute(post);
+      if (httpResponse instanceof CloseableHttpResponse) {
+        this.closer.register((CloseableHttpResponse) httpResponse);
+      }
+      return httpResponse.getEntity();
     } catch (Exception e) {
       throw new RestApiConnectionException("Failed to authenticate salesforce host:"
           + host + "; error-" + e.getMessage(), e);

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
@@ -894,6 +894,7 @@ public class SalesforceExtractor extends RestApiExtractor {
       log.info("Closing salesforce bulk job connection");
       this.bulkConnection.closeJob(this.getBulkJobId());
     }
+    this.sfConnector.close();
   }
 
   private static List<Command> constructGetCommand(String restQuery) {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1616


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In RestApiConnector, we only consume the HttpEntity but not close the response, which potentially leave the socket as CLOSE_WAIT status and eat up the resources. 



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
local build

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

