### PR TITLE
[GOBBLIN-1617] pass configurations to some HadoopUtils APIs

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -64,6 +64,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   public static final String FS_WRITER_METRICS_KEY = "fs_writer_metrics";
 
   protected final State properties;
+  protected final Configuration conf;
   protected final String id;
   protected final int numBranches;
   protected final int branchId;
@@ -96,7 +97,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     this.writerAttemptIdOptional = Optional.fromNullable(builder.getWriterAttemptId());
     this.encoders = builder.getEncoders();
 
-    Configuration conf = new Configuration();
+    this.conf = new Configuration();
     // Add all job configuration properties so they are picked up by Hadoop
     JobConfigurationUtils.putStateIntoConfiguration(properties, conf);
     this.fs = WriterUtils.getWriterFS(properties, this.numBranches, this.branchId);
@@ -266,7 +267,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     LOG.info(String.format("Moving data from %s to %s", this.stagingFile, this.outputFile));
     // For the same reason as deleting the staging file if it already exists, overwrite
     // the output file if it already exists to prevent task retry from being blocked.
-    HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile, true);
+    HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile, true, this.conf);
     this.properties.appendToSetProp(this.allOutputFilesPropName, this.outputFile.toString());
 
     FsWriterMetrics metrics = new FsWriterMetrics(

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
@@ -203,6 +203,12 @@ public class HadoopUtils {
     }
   }
 
+  /**
+   * Moves the object to the filesystem trash according to the file system policy.
+   * @param fs FileSystem object
+   * @param path Path to the object to be moved to trash.
+   * @throws IOException
+   */
   public static void moveToTrash(FileSystem fs, Path path) throws IOException {
     moveToTrash(fs, path, new Configuration());
   }
@@ -268,6 +274,14 @@ public class HadoopUtils {
     renamePath(fs, oldName, newName, false);
   }
 
+  /**
+   * A wrapper around {@link FileSystem#rename(Path, Path)} which throws {@link IOException} if
+   * {@link FileSystem#rename(Path, Path)} returns False.
+   * @param fs FileSystem object
+   * @param oldName old name of the path
+   * @param new name of the path
+   * @throws IOException
+   */
   public static void renamePath(FileSystem fs, Path oldName, Path newName, boolean overwrite) throws IOException {
     renamePath(fs, oldName, newName, overwrite, new Configuration());
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
@@ -203,16 +203,22 @@ public class HadoopUtils {
     }
   }
 
+  public static void moveToTrash(FileSystem fs, Path path) throws IOException {
+    moveToTrash(fs, path, new Configuration());
+  }
+
   /**
    * Moves the object to the filesystem trash according to the file system policy.
    * @param fs FileSystem object
    * @param path Path to the object to be moved to trash.
+   * @param conf Configurations
    * @throws IOException
    */
-  public static void moveToTrash(FileSystem fs, Path path) throws IOException {
-    Trash trash = new Trash(fs, new Configuration());
+  public static void moveToTrash(FileSystem fs, Path path, Configuration conf) throws IOException {
+    Trash trash = new Trash(fs, conf);
     trash.moveToTrash(path);
   }
+
   /**
    * Renames a src {@link Path} on fs {@link FileSystem} to a dst {@link Path}. If fs is a {@link LocalFileSystem} and
    * src is a directory then {@link File#renameTo} is called directly to avoid a directory rename race condition where
@@ -262,11 +268,15 @@ public class HadoopUtils {
     renamePath(fs, oldName, newName, false);
   }
 
+  public static void renamePath(FileSystem fs, Path oldName, Path newName, boolean overwrite) throws IOException {
+    renamePath(fs, oldName, newName, overwrite, new Configuration());
+  }
+
   /**
    * A wrapper around {@link FileSystem#rename(Path, Path)} which throws {@link IOException} if
    * {@link FileSystem#rename(Path, Path)} returns False.
    */
-  public static void renamePath(FileSystem fs, Path oldName, Path newName, boolean overwrite) throws IOException {
+  public static void renamePath(FileSystem fs, Path oldName, Path newName, boolean overwrite, Configuration conf) throws IOException {
     //In default implementation of rename with rewrite option in FileSystem, if the parent dir of dst does not exist, it will throw exception,
     //Which will fail some of our job unintentionally. So we only call that method when fs is an instance of DistributedFileSystem to avoid inconsistency problem
     if(fs instanceof DistributedFileSystem) {
@@ -278,7 +288,7 @@ public class HadoopUtils {
       }
       if (fs.exists(newName)) {
         if (overwrite) {
-          HadoopUtils.moveToTrash(fs, newName);
+          HadoopUtils.moveToTrash(fs, newName, conf);
         } else {
           throw new FileAlreadyExistsException(String.format("Failed to rename %s to %s: dst already exists", oldName, newName));
         }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@ZihanLi58  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
In this PR, I am adding an option to pass configuration to some HadoopUtils APIs. This will provide more control to the user.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

