### PR TITLE
[GOBBLIN-1619] WriterUtils.mkdirsWithRecursivePermission contains race condition and puts unnecessary load on filesystem

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -19,8 +19,12 @@ package org.apache.gobblin.util;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import java.util.function.BiConsumer;
+import lombok.SneakyThrows;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +40,6 @@ import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import java.util.HashSet;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -286,38 +288,45 @@ public class WriterUtils {
       return;
     }
 
-    gobblinMkDirs(fs, path, perm);
-
-    if (retrierConfig != NO_RETRY_CONFIG) {
-      //Wait until file is not there as it can happen the file fail to exist right away on eventual consistent fs like Amazon S3
-      Retryer<Void> retryer = RetryerFactory.newInstance(retrierConfig);
-
-      try {
-        retryer.call(() -> {
-          if (!fs.exists(path)) {
-            throw new IOException("Path " + path + " does not exist however it should. Will wait more.");
-          }
-          return null;
-        });
-      } catch (Exception e) {
-        throw new IOException("Path " + path + "does not exist however it should. Giving up..."+ e);
-      }
-    }
-  }
-
-  private static void gobblinMkDirs(final FileSystem fs, final Path path, FsPermission perm) throws IOException {
-    Set<Path> parentsThatDidntExistBefore = new HashSet<>();
-    for (Path p = path.getParent(); p != null && !fs.exists(p); p = p.getParent()) {
-      parentsThatDidntExistBefore.add(p);
+    Set<Path> pathsThatDidntExistBefore = new HashSet<>();
+    for (Path p = path; p != null && !fs.exists(p); p = p.getParent()) {
+      pathsThatDidntExistBefore.add(p);
     }
 
-    if (!FileSystem.mkdirs(fs, path, perm)) {
+    if (!fs.mkdirs(path, perm)) {
       throw new IOException(String.format("Unable to mkdir %s with permission %s", path, perm));
     }
 
-    for (Path p : parentsThatDidntExistBefore) {
+    BiConsumer<FileSystem, Path> waitPolicy = getWaitPolicy(retrierConfig);
+    for (Path p : pathsThatDidntExistBefore) {
+      waitPolicy.accept(fs, path);
       fs.setPermission(p, perm);
     }
+  }
+
+  // define behavior for waiting until the file exists before proceeding
+  private static BiConsumer<FileSystem, Path> getWaitPolicy(Config retrierConfig) {
+    return new BiConsumer<FileSystem, Path>() {
+      @SneakyThrows
+      @Override
+      public void accept(FileSystem fs, Path path) {
+        if (retrierConfig != NO_RETRY_CONFIG) {
+          //Wait until file is not there as it can happen the file fail to exist right away on eventual consistent fs like Amazon S3
+          Retryer<Void> retryer = RetryerFactory.newInstance(retrierConfig);
+
+          try {
+            retryer.call(() -> {
+              if (!fs.exists(path)) {
+                throw new IOException("Path " + path + " does not exist however it should. Will wait more.");
+              }
+              return null;
+            });
+          } catch (Exception e) {
+            throw new IOException("Path " + path + "does not exist however it should. Giving up..."+ e);
+          }
+        }
+      }
+    };
   }
 
   public static URI getWriterFsUri(State state, int numBranches, int branchId) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -36,6 +36,8 @@ import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import java.util.HashSet;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -284,13 +286,7 @@ public class WriterUtils {
       return;
     }
 
-    if (path.getParent() != null && !fs.exists(path.getParent())) {
-      mkdirsWithRecursivePermissionWithRetry(fs, path.getParent(), perm, retrierConfig);
-    }
-
-    if (!fs.mkdirs(path, perm)) {
-      throw new IOException(String.format("Unable to mkdir %s with permission %s", path, perm));
-    }
+    gobblinMkDirs(fs, path, perm);
 
     if (retrierConfig != NO_RETRY_CONFIG) {
       //Wait until file is not there as it can happen the file fail to exist right away on eventual consistent fs like Amazon S3
@@ -307,10 +303,20 @@ public class WriterUtils {
         throw new IOException("Path " + path + "does not exist however it should. Giving up..."+ e);
       }
     }
+  }
 
-    // Double check permission, since fs.mkdirs() may not guarantee to set the permission correctly
-    if (!fs.getFileStatus(path).getPermission().equals(perm)) {
-      fs.setPermission(path, perm);
+  private static void gobblinMkDirs(final FileSystem fs, final Path path, FsPermission perm) throws IOException {
+    Set<Path> parentsThatDidntExistBefore = new HashSet<>();
+    for (Path p = path.getParent(); p != null && !fs.exists(p); p = p.getParent()) {
+      parentsThatDidntExistBefore.add(p);
+    }
+
+    if (!FileSystem.mkdirs(fs, path, perm)) {
+      throw new IOException(String.format("Unable to mkdir %s with permission %s", path, perm));
+    }
+
+    for (Path p : parentsThatDidntExistBefore) {
+      fs.setPermission(p, perm);
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1619] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1619


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
#### The current implementation recursively calls fs.mkdirs has the following issues:
- Race condition for creating parent directories, causing FileNotFound exception even when the file exists on file system
- HDFS fs.mkdirs atomically creates missing parent directories. Thus, the recursive approach is making unnecessary calls.

In HDFS, which the current [FileSystem](https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/fs/FileSystem.html) interface is built upon, guarantees the parents will be created. So, all FileSystem class implementations should also follow this behavior. 

 

See the [FileSystem](https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/fs/FileSystem.html) abstract class documentation:

> The behaviour of the filesystem is [specified in the Hadoop documentation. ](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/filesystem/filesystem.html)However, the normative specification of the behavior of this class is actually HDFS: if HDFS does not behave the way these Javadocs or the specification in the Hadoop documentations define, assume that the documentation is incorrect

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests added and change tested internally at LinkedIn on parallel fastingest test pipeline. The parallel test pipeline compared the permissions created with previous implementation and with new implementation. There were not any differences in the way permissions are set, so the change is completely transparent and non-breaking. 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

