### PR TITLE
[GOBBLIN-1623] Fix NPE when try to close RestApiConnector

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -32,6 +31,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 
 import com.google.common.base.Charsets;
@@ -86,9 +86,6 @@ public abstract class RestApiConnector implements Closeable {
   public void close() throws IOException {
     // This is to close any idle connections opening by the httpClient
     this.closer.close();
-    if (this.httpClient != null) {
-      this.httpClient.getConnectionManager().closeIdleConnections(0, TimeUnit.MICROSECONDS);
-    }
   }
 
   /**
@@ -147,6 +144,9 @@ public abstract class RestApiConnector implements Closeable {
           .setStatePropertiesPrefix(ConfigurationKeys.SOURCE_CONN_PREFIX)
           .configure(this.state)
           .createClient();
+    }
+    if (httpClient instanceof CloseableHttpClient) {
+      this.closer.register((CloseableHttpClient)httpClient);
     }
     return this.httpClient;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -144,9 +144,9 @@ public abstract class RestApiConnector implements Closeable {
           .setStatePropertiesPrefix(ConfigurationKeys.SOURCE_CONN_PREFIX)
           .configure(this.state)
           .createClient();
-    }
-    if (httpClient instanceof CloseableHttpClient) {
-      this.closer.register((CloseableHttpClient)httpClient);
+      if (httpClient instanceof CloseableHttpClient) {
+        this.closer.register((CloseableHttpClient)httpClient);
+      }
     }
     return this.httpClient;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1623


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Now when we try to call httpClient.getClientManager, it's possible that the implementation of httpClient will throw an NPE in this case. To make it more safer, we close the client when it's a CloseableHttpClient and other than that, we rely on the implementation of httpClient to handle the open connection

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] mint build


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

