### PR TITLE
[GOBBLIN-1625] Add coverage for edge cases when table paths do not exist, check parents

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.data.management.copy.hive;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -455,6 +456,93 @@ public class HiveCopyEntityHelperTest {
     FileSystem mockFS = Mockito.mock(FileSystem.class);
     Mockito.when(helper.getTargetFs()).thenReturn(mockFS);
     Mockito.when(mockFS.resolvePath(Mockito.any())).thenReturn(new Path("hdfs://testPath/db/table"));
+
+    Mockito.doCallRealMethod().when(helper).checkPartitionedTableCompatibility(table, existingTargetTable);
+    helper.checkPartitionedTableCompatibility(table, existingTargetTable);
+  }
+
+  @Test
+  public void testPartitionedTableEqualityPathNotExist() throws Exception {
+    // If the paths are not equal, test if the parents are equivalent
+    FieldSchema partitionSchema = new FieldSchema("part", "string", "some comment");
+    List partitions = new ArrayList();
+    Path testPath = new Path("/testPath/db/table");
+    Path existingTablePath = new Path("/existing/testPath/db/table");
+    org.apache.hadoop.hive.ql.metadata.Table table = new org.apache.hadoop.hive.ql.metadata.Table("testDb","table1");
+    table.setDataLocation(testPath);
+    partitions.add(partitionSchema);
+    table.setPartCols(partitions);
+    org.apache.hadoop.hive.ql.metadata.Table existingTargetTable = new Table("testDb","table1");
+    existingTargetTable.setDataLocation(existingTablePath);
+    existingTargetTable.setPartCols(partitions);
+    HiveDataset hiveDataset = Mockito.mock(HiveDataset.class);
+    HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
+    Mockito.when(helper.getDataset()).thenReturn(hiveDataset);
+    Mockito.when(helper.getExistingTargetTable()).thenReturn(Optional.of(existingTargetTable));
+    Mockito.when(helper.getTargetTable()).thenReturn(table);
+    // Mock filesystem resolver
+    FileSystem mockFS = Mockito.mock(FileSystem.class);
+    Mockito.when(helper.getTargetFs()).thenReturn(mockFS);
+    Mockito.when(mockFS.resolvePath(existingTablePath)).thenThrow(FileNotFoundException.class);
+    Mockito.when(mockFS.resolvePath(existingTablePath.getParent())).thenReturn(new Path("hdfs://testPath/db/"));
+    Mockito.when(mockFS.resolvePath(testPath.getParent())).thenReturn(new Path("hdfs://testPath/db/"));
+
+    Mockito.doCallRealMethod().when(helper).checkPartitionedTableCompatibility(table, existingTargetTable);
+    helper.checkPartitionedTableCompatibility(table, existingTargetTable);
+  }
+
+  @Test
+  public void testTablePathInequality() throws Exception {
+    // If the child directory of the user specified path and the existing table path differs, there will never be a match
+    FieldSchema partitionSchema = new FieldSchema("part", "string", "some comment");
+    List partitions = new ArrayList();
+    Path testPath = new Path("/existing/testPath/db/newTable");
+    Path existingTablePath = new Path("/existing/testPath/db/table");
+    org.apache.hadoop.hive.ql.metadata.Table table = new org.apache.hadoop.hive.ql.metadata.Table("testDb","table1");
+    table.setDataLocation(testPath);
+    partitions.add(partitionSchema);
+    table.setPartCols(partitions);
+    org.apache.hadoop.hive.ql.metadata.Table existingTargetTable = new Table("testDb","table1");
+    existingTargetTable.setDataLocation(existingTablePath);
+    existingTargetTable.setPartCols(partitions);
+    HiveDataset hiveDataset = Mockito.mock(HiveDataset.class);
+    HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
+    Mockito.when(helper.getDataset()).thenReturn(hiveDataset);
+    Mockito.when(helper.getExistingTargetTable()).thenReturn(Optional.of(existingTargetTable));
+    Mockito.when(helper.getTargetTable()).thenReturn(table);
+    // Mock filesystem resolver
+    FileSystem mockFS = Mockito.mock(FileSystem.class);
+    Mockito.when(helper.getTargetFs()).thenReturn(mockFS);
+    Mockito.when(mockFS.resolvePath(existingTablePath)).thenThrow(FileNotFoundException.class);
+
+    Mockito.doCallRealMethod().when(helper).checkPartitionedTableCompatibility(table, existingTargetTable);
+    Assert.assertThrows(IOException.class, () -> helper.checkPartitionedTableCompatibility(table, existingTargetTable));
+  }
+
+  @Test
+  public void testTablePathEqualityExactPathMatch() throws Exception {
+    // If the user does not specify a difference in the paths, there shouldn't be any error thrown
+    FieldSchema partitionSchema = new FieldSchema("part", "string", "some comment");
+    List partitions = new ArrayList();
+    Path testPath = new Path("/existing/testPath/db/table");
+    Path existingTablePath = new Path("/existing/testPath/db/table");
+    org.apache.hadoop.hive.ql.metadata.Table table = new org.apache.hadoop.hive.ql.metadata.Table("testDb","table1");
+    table.setDataLocation(testPath);
+    partitions.add(partitionSchema);
+    table.setPartCols(partitions);
+    org.apache.hadoop.hive.ql.metadata.Table existingTargetTable = new Table("testDb","table1");
+    existingTargetTable.setDataLocation(existingTablePath);
+    existingTargetTable.setPartCols(partitions);
+    HiveDataset hiveDataset = Mockito.mock(HiveDataset.class);
+    HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
+    Mockito.when(helper.getDataset()).thenReturn(hiveDataset);
+    Mockito.when(helper.getExistingTargetTable()).thenReturn(Optional.of(existingTargetTable));
+    Mockito.when(helper.getTargetTable()).thenReturn(table);
+    // Mock filesystem resolver
+    FileSystem mockFS = Mockito.mock(FileSystem.class);
+    Mockito.when(helper.getTargetFs()).thenReturn(mockFS);
+    // Shouldn't matter since the strings are exact matches
+    Mockito.when(mockFS.resolvePath(existingTablePath)).thenThrow(FileNotFoundException.class);
 
     Mockito.doCallRealMethod().when(helper).checkPartitionedTableCompatibility(table, existingTargetTable);
     helper.checkPartitionedTableCompatibility(table, existingTargetTable);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1625


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
There are edge cases where hive tables are rejected due to the mismatch check not being robust enough. For example:
1. If the user specified path and the existing hive table path are exact matches, we should always return that they are equivalent

2. If the existing hive table path does not exist on the filesystem, we need to recursively check the parents to see if the fs.uri and folder directories are equivalent

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test cases for each observed scenario

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

