### PR TITLE
[GOBBLIN-1628] Add/fix some fields of MetadataWriterFailureEvent

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -34,6 +34,8 @@ public class IcebergMCEMetadataKeys {
   public static final String DATASET_HDFS_PATH = "datasetHdfsPath";
   public static final String FAILURE_EVENT_DB_NAME = "databaseName";
   public static final String FAILURE_EVENT_TABLE_NAME = "tableName";
+  public static final String CLUSTER_IDENTIFIER_KEY_NAME = "clusterIdentifier";
+  public static final String EXCEPTION_MESSAGE_KEY_NAME = "exceptionMessage";
 
   private IcebergMCEMetadataKeys() {
   }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -144,7 +144,6 @@ public class IcebergMetadataWriter implements MetadataWriter {
   private static final String ICEBERG_REGISTRATION_BLACKLIST = "iceberg.registration.blacklist";
   private static final String ICEBERG_REGISTRATION_WHITELIST = "iceberg.registration.whitelist";
   private static final String ICEBERG_METADATA_FILE_PERMISSION = "iceberg.metadata.file.permission";
-  private static final String CLUSTER_IDENTIFIER_KEY_NAME = "clusterIdentifier";
   private static final String CREATE_TABLE_TIME = "iceberg.create.table.time";
   private static final String SCHEMA_CREATION_TIME_KEY = "schema.creation.time";
   private static final String ADDED_FILES_CACHE_EXPIRING_TIME = "added.files.cache.expiring.time";
@@ -200,7 +199,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
     tableCurrentWatermarkMap = new HashMap<>();
     List<Tag<?>> tags = Lists.newArrayList();
     String clusterIdentifier = ClustersNames.getInstance().getClusterName();
-    tags.add(new Tag<>(CLUSTER_IDENTIFIER_KEY_NAME, clusterIdentifier));
+    tags.add(new Tag<>(IcebergMCEMetadataKeys.CLUSTER_IDENTIFIER_KEY_NAME, clusterIdentifier));
     metricContext = closer.register(
         GobblinMetricsRegistry.getInstance().getMetricContext(state, IcebergMetadataWriter.class, tags));
     this.eventSubmitter =


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1628


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Add a few fields similar to the format of fields in `IcebergMetadataCommitEvent`
- Add `clusterIdentifier`
- Split topic name/partition to separate fields
- Add exception message as a field (`exception.getCause().getMessage()` because otherwise the message will just be non-descriptive wrapper message like "failed to flush table").

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran in test pipeline and observed failure events

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

