### PR TITLE
[GOBBLIN-1620]Make yarn container allocation group by helix tag

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -84,6 +84,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_JOB_TAG_KEY = GOBBLIN_CLUSTER_PREFIX + "helixJobTag";
   public static final String HELIX_PLANNING_JOB_TAG_KEY = GOBBLIN_CLUSTER_PREFIX + "helixPlanningJobTag";
   public static final String HELIX_INSTANCE_TAGS_KEY = GOBBLIN_CLUSTER_PREFIX + "helixInstanceTags";
+  public static final String HELIX_DEFAULT_TAG = "GobblinHelixDefaultTag";
 
   // Helix job quota
   public static final String HELIX_JOB_TYPE_KEY = GOBBLIN_CLUSTER_PREFIX + "helixJobType";
@@ -183,6 +184,13 @@ public class GobblinClusterConfigurationKeys {
   // container can be replaced with another container e.g. Gobblin-on-Yarn mode.
   public static final String CONTAINER_EXIT_ON_HEALTH_CHECK_FAILURE_ENABLED = GOBBLIN_CLUSTER_PREFIX + "container.exitOnHealthCheckFailure";
   public static final boolean DEFAULT_CONTAINER_EXIT_ON_HEALTH_CHECK_FAILURE_ENABLED = false;
+
+  // Config to specify the resource requirement for each Gobblin job run, so that helix tasks within this job will
+  // be assigned to containers with desired resource. This config need to cooperate with helix job tag, so that helix
+  // cluster knows how to distribute tasks to correct containers.
+  public static final String HELIX_JOB_CONTAINER_MEMORY_MBS = GOBBLIN_CLUSTER_PREFIX + "job.container.memory.mbs";
+  public static final String HELIX_JOB_CONTAINER_CORES = GOBBLIN_CLUSTER_PREFIX + "job.container.cores";
+
 
 
   //Config to enable/disable reuse of existing Helix Cluster

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -413,6 +413,20 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
         gobblinJobState.getPropAsLong(GobblinClusterConfigurationKeys.HELIX_WORKFLOW_EXPIRY_TIME_SECONDS,
             GobblinClusterConfigurationKeys.DEFAULT_HELIX_WORKFLOW_EXPIRY_TIME_SECONDS));
 
+    Map<String, String> jobConfigMap = new HashMap<>();
+    if (this.jobConfig.hasPath(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_MEMORY_MBS)) {
+      jobConfigMap.put(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_MEMORY_MBS,
+          jobConfig.getString(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_MEMORY_MBS));
+      log.info("Job {} has specific memory requirement:{}, add this config to command config map",
+          this.jobContext.getJobId(), jobConfig.getString(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_MEMORY_MBS));
+    }
+    if (this.jobConfig.hasPath(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_CORES)) {
+      jobConfigMap.put(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_CORES,
+          jobConfig.getString(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_CORES));
+      log.info("Job {} has specific Vcore requirement:{}, add this config to command config map",
+          this.jobContext.getJobId(), jobConfig.getString(GobblinClusterConfigurationKeys.HELIX_JOB_CONTAINER_CORES));
+    }
+    jobConfigBuilder.setJobCommandConfigMap(jobConfigMap);
     return jobConfigBuilder;
   }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnContainerRequestBundle.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnContainerRequestBundle.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.yarn;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.yarn.api.records.Resource;
+
+/**
+ * The class that represents current Yarn container request that will be used by {link @YarnService}.
+ * Yarn container allocation should associate with helix tag, as workflows can have specific helix tag setup
+ * and specific resource requirement.
+ */
+@Slf4j
+@Getter
+public class YarnContainerRequestBundle {
+  int totalContainers;
+  private final Map<String, Integer> helixTagContainerCountMap;
+  private final Map<String, Resource> helixTagResourceMap;
+  private final Map<String, Set<String>> resourceHelixTagMap;
+
+  public YarnContainerRequestBundle() {
+    this.totalContainers = 0;
+    this.helixTagContainerCountMap = new HashMap<>();
+    this.helixTagResourceMap = new HashMap<>();
+    this.resourceHelixTagMap = new HashMap<>();
+  }
+
+  public void add(String helixTag, int containerCount, Resource resource) {
+    helixTagContainerCountMap.put(helixTag, helixTagContainerCountMap.getOrDefault(helixTag, 0) + containerCount);
+    if(!helixTagResourceMap.containsKey(helixTag)) {
+      helixTagResourceMap.put(helixTag, resource);
+    }
+    Set<String> tagSet = resourceHelixTagMap.getOrDefault(resource.toString(), new HashSet<>());
+    tagSet.add(helixTag);
+    resourceHelixTagMap.put(resource.toString(), tagSet);
+    totalContainers += containerCount;
+  }
+
+  // This method assumes the resource requirement for the helix tag is already stored in the map
+  public void add(String helixTag, int containerCount) {
+    if (!helixTagContainerCountMap.containsKey(helixTag) && !helixTagResourceMap.containsKey(helixTag)) {
+      log.error("Helix tag {} is not present in the request bundle yet, can't process the request to add {} "
+          + "container for it without specifying the resource requirement", helixTag, containerCount);
+    }
+    helixTagContainerCountMap.put(helixTag, helixTagContainerCountMap.get(helixTag) + containerCount);
+    this.totalContainers += containerCount;
+  }
+
+  public void set(String helixTag, int containerCount) {
+    if (!helixTagContainerCountMap.containsKey(helixTag) && !helixTagResourceMap.containsKey(helixTag)) {
+      log.error("Helix tag {} is not present in the request bundle yet, can't process the request to set {} "
+          + "container for it without specifying the resource requirement", helixTag, containerCount);
+    }
+    this.totalContainers += containerCount - helixTagContainerCountMap.get(helixTag);
+    helixTagContainerCountMap.put(helixTag, helixTagContainerCountMap.get(helixTag) + containerCount);
+  }
+}

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -20,7 +20,6 @@ package org.apache.gobblin.yarn;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import lombok.AllArgsConstructor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -70,7 +70,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -127,6 +126,7 @@ public class YarnService extends AbstractIdleService {
   private final String applicationName;
   private final String applicationId;
   private final String appViewAcl;
+  //Default helix instance tag derived from cluster level config
   private final String helixInstanceTags;
 
   private final Config config;
@@ -158,6 +158,7 @@ public class YarnService extends AbstractIdleService {
   private final String containerTimezone;
   private final HelixManager helixManager;
 
+  @Getter(AccessLevel.PROTECTED)
   private volatile Optional<Resource> maxResourceCapacity = Optional.absent();
 
   // Security tokens for accessing HDFS
@@ -167,10 +168,10 @@ public class YarnService extends AbstractIdleService {
 
   private final Object allContainersStopped = new Object();
 
-  // A map from container IDs to pairs of Container instances and Helix participant IDs of the containers
+  // A map from container IDs to Container instances, Helix participant IDs of the containers and Helix Tag
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
-  private final ConcurrentMap<ContainerId, Map.Entry<Container, String>> containerMap = Maps.newConcurrentMap();
+  private final ConcurrentMap<ContainerId, ContainerInfo> containerMap = Maps.newConcurrentMap();
 
   // A cache of the containers with an outstanding container release request.
   // This is a cache instead of a set to get the automatic cleanup in case a container completes before the requested
@@ -189,6 +190,12 @@ public class YarnService extends AbstractIdleService {
   // into the set if the container running the instance completes. Unused Helix
   // instance names get picked up when replacement containers get allocated.
   private final Set<String> unusedHelixInstanceNames = ConcurrentHashMap.newKeySet();
+
+  private final Map<String, Integer> helixTagRequestedContainerCount = Maps.newConcurrentMap();
+  private final Map<String, Integer> helixTagAllocatedContainerCount = Maps.newConcurrentMap();
+  private volatile YarnContainerRequestBundle yarnContainerRequest;
+  private final AtomicInteger priorityNumGenerator = new AtomicInteger(0);
+  private final Map<String, Integer> resourcePriorityMap = new HashMap<>();
 
   private volatile boolean shutdownInProgress = false;
 
@@ -236,7 +243,8 @@ public class YarnService extends AbstractIdleService {
     this.containerHostAffinityEnabled = config.getBoolean(GobblinYarnConfigurationKeys.CONTAINER_HOST_AFFINITY_ENABLED);
 
     this.helixInstanceMaxRetries = config.getInt(GobblinYarnConfigurationKeys.HELIX_INSTANCE_MAX_RETRIES);
-    this.helixInstanceTags = ConfigUtils.getString(config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY, null);
+    this.helixInstanceTags = ConfigUtils.getString(config,
+        GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY, GobblinClusterConfigurationKeys.HELIX_DEFAULT_TAG);
 
     this.containerJvmArgs = config.hasPath(GobblinYarnConfigurationKeys.CONTAINER_JVM_ARGS_KEY) ?
         Optional.of(config.getString(GobblinYarnConfigurationKeys.CONTAINER_JVM_ARGS_KEY)) :
@@ -286,14 +294,8 @@ public class YarnService extends AbstractIdleService {
           this.requestedContainerCores));
       return;
     }
-
-    requestContainer(newContainerRequest.getReplacedContainer().transform(new Function<Container, String>() {
-
-      @Override
-      public String apply(Container container) {
-        return container.getNodeId().getHost();
-      }
-    }));
+    requestContainer(newContainerRequest.getReplacedContainer().transform(container -> container.getNodeId().getHost()),
+        newContainerRequest.getResource());
   }
 
   protected NMClientCallbackHandler getNMClientCallbackHandler() {
@@ -359,10 +361,10 @@ public class YarnService extends AbstractIdleService {
       ExecutorsUtils.shutdownExecutorService(this.containerLaunchExecutor, Optional.of(LOGGER));
 
       // Stop the running containers
-      for (Map.Entry<Container, String> entry : this.containerMap.values()) {
-        LOGGER.info(String.format("Stopping container %s running participant %s", entry.getKey().getId(),
-            entry.getValue()));
-        this.nmClientAsync.stopContainerAsync(entry.getKey().getId(), entry.getKey().getNodeId());
+      for (ContainerInfo containerInfo : this.containerMap.values()) {
+        LOGGER.info("Stopping container {} running participant {}", containerInfo.getContainer().getId(),
+            containerInfo.getHelixParticipantId());
+        this.nmClientAsync.stopContainerAsync(containerInfo.getContainer().getId(), containerInfo.getContainer().getNodeId());
       }
 
       if (!this.containerMap.isEmpty()) {
@@ -431,13 +433,13 @@ public class YarnService extends AbstractIdleService {
    * number of containers. The intended usage is for the caller of this method to make periodic calls to attempt to
    * adjust the cluster towards the desired number of containers.
    *
-   * @param numTargetContainers the desired number of containers
+   * @param yarnContainerRequestBundle the desired containers information, including numbers, resource and helix tag
    * @param inUseInstances  a set of in use instances
    */
-  public synchronized void requestTargetNumberOfContainers(int numTargetContainers, Set<String> inUseInstances) {
-    LOGGER.debug("Requesting numTargetContainers {} current numRequestedContainers {} in use instances {} map size {}",
-        numTargetContainers, this.numRequestedContainers, inUseInstances, this.containerMap.size());
-
+  public synchronized void requestTargetNumberOfContainers(YarnContainerRequestBundle yarnContainerRequestBundle, Set<String> inUseInstances) {
+    LOGGER.debug("Requesting numTargetContainers {}, current numRequestedContainers {} in use, instances {} map size is {}",
+        yarnContainerRequestBundle.getTotalContainers(), this.numRequestedContainers, inUseInstances, this.containerMap.size());
+    int numTargetContainers = yarnContainerRequestBundle.getTotalContainers();
     // YARN can allocate more than the requested number of containers, compute additional allocations and deallocations
     // based on the max of the requested and actual allocated counts
     int numAllocatedContainers = this.containerMap.size();
@@ -450,8 +452,14 @@ public class YarnService extends AbstractIdleService {
     // Request additional containers if the desired count is higher than the max of the current allocation or previously
     // requested amount. Note that there may be in-flight or additional allocations after numContainers has been computed
     // so overshooting can occur, but periodic calls to this method will make adjustments towards the target.
-    for (int i = numContainers; i < numTargetContainers; i++) {
-      requestContainer(Optional.<String>absent());
+    for (Map.Entry<String, Integer> entry : yarnContainerRequestBundle.getHelixTagContainerCountMap().entrySet()) {
+      String currentHelixTag = entry.getKey();
+      int desiredContainer = entry.getValue();
+      int requestedContainerCount = helixTagRequestedContainerCount.getOrDefault(currentHelixTag, 0);
+      for(; requestedContainerCount < desiredContainer; requestedContainerCount++) {
+        requestContainer(Optional.absent(), yarnContainerRequestBundle.getHelixTagResourceMap().get(currentHelixTag));
+      }
+      helixTagRequestedContainerCount.put(currentHelixTag, requestedContainerCount);
     }
 
     // If the total desired is lower than the currently allocated amount then release free containers.
@@ -465,9 +473,14 @@ public class YarnService extends AbstractIdleService {
       int numToShutdown = numContainers - numTargetContainers;
 
       // Look for eligible containers to release. If a container is in use then it is not released.
-      for (Map.Entry<ContainerId, Map.Entry<Container, String>> entry : this.containerMap.entrySet()) {
-        if (!inUseInstances.contains(entry.getValue().getValue())) {
-          containersToRelease.add(entry.getValue().getKey());
+      for (Map.Entry<ContainerId, ContainerInfo> entry : this.containerMap.entrySet()) {
+        ContainerInfo containerInfo = entry.getValue();
+        if (!inUseInstances.contains(containerInfo.getHelixParticipantId())) {
+          containersToRelease.add(containerInfo.getContainer());
+          String helixTag = containerInfo.getHelixTag();
+          if (!Strings.isNullOrEmpty(helixTag)) {
+            helixTagRequestedContainerCount.put(helixTag, helixTagRequestedContainerCount.get(helixTag) - 1);
+          }
         }
 
         if (containersToRelease.size() == numToShutdown) {
@@ -479,32 +492,44 @@ public class YarnService extends AbstractIdleService {
 
       this.eventBus.post(new ContainerReleaseRequest(containersToRelease));
     }
-
+    this.yarnContainerRequest = yarnContainerRequestBundle;
     this.numRequestedContainers = numTargetContainers;
+    LOGGER.info("Current tag-container being requested:{}, tag-container allocated: {}",
+        this.helixTagRequestedContainerCount, this.helixTagAllocatedContainerCount);
   }
 
+    // Request initial containers with default resource and helix tag
   private void requestInitialContainers(int containersRequested) {
-    requestTargetNumberOfContainers(containersRequested, Collections.EMPTY_SET);
+    YarnContainerRequestBundle initialYarnContainerRequest = new YarnContainerRequestBundle();
+    Resource capability = Resource.newInstance(this.requestedContainerMemoryMbs, this.requestedContainerCores);
+    YarnHelixUtils.ensureResourceFitMaxCapacity(this.maxResourceCapacity, capability);
+    initialYarnContainerRequest.add(this.helixInstanceTags, containersRequested, capability);
+    requestTargetNumberOfContainers(initialYarnContainerRequest, Collections.EMPTY_SET);
   }
 
-  private void requestContainer(Optional<String> preferredNode) {
-    Priority priority = Records.newRecord(Priority.class);
-    priority.setPriority(0);
+  private void requestContainer(Optional<String> preferredNode, Optional<Resource> capability) {
+    Resource desiredResource = capability.or(Resource.newInstance(
+        this.requestedContainerMemoryMbs, this.requestedContainerCores));
+    requestContainer(preferredNode, desiredResource);
+  }
 
-    Resource capability = Records.newRecord(Resource.class);
-    int maxMemoryCapacity = this.maxResourceCapacity.get().getMemory();
-    capability.setMemory(this.requestedContainerMemoryMbs <= maxMemoryCapacity ?
-        this.requestedContainerMemoryMbs : maxMemoryCapacity);
-    int maxCoreCapacity = this.maxResourceCapacity.get().getVirtualCores();
-    capability.setVirtualCores(this.requestedContainerCores <= maxCoreCapacity ?
-        this.requestedContainerCores : maxCoreCapacity);
+  private void requestContainer(Optional<String> preferredNode, Resource capability) {
+    YarnHelixUtils.ensureResourceFitMaxCapacity(this.maxResourceCapacity, capability);
+
+    // Due to YARN-314, different resource size needs different priority, otherwise Yarn will not allocate container
+    Priority priority = Records.newRecord(Priority.class);
+    if(!resourcePriorityMap.containsKey(capability.toString())) {
+      resourcePriorityMap.put(capability.toString(), priorityNumGenerator.getAndIncrement());
+    }
+    int priorityNum = resourcePriorityMap.get(capability.toString());
+    priority.setPriority(priorityNum);
 
     String[] preferredNodes = preferredNode.isPresent() ? new String[] {preferredNode.get()} : null;
     this.amrmClientAsync.addContainerRequest(
         new AMRMClient.ContainerRequest(capability, preferredNodes, null, priority));
   }
 
-  protected ContainerLaunchContext newContainerLaunchContext(Container container, String helixInstanceName)
+  protected ContainerLaunchContext newContainerLaunchContext(ContainerInfo containerInfo)
       throws IOException {
     Path appWorkDir = GobblinClusterUtils.getAppWorkDirPathFromConfig(this.config, this.fs, this.applicationName, this.applicationId);
     Path containerWorkDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.CONTAINER_WORK_DIR_NAME);
@@ -527,7 +552,7 @@ public class YarnService extends AbstractIdleService {
     ContainerLaunchContext containerLaunchContext = Records.newRecord(ContainerLaunchContext.class);
     containerLaunchContext.setLocalResources(resourceMap);
     containerLaunchContext.setEnvironment(YarnHelixUtils.getEnvironmentVariables(this.yarnConfiguration));
-    containerLaunchContext.setCommands(Lists.newArrayList(buildContainerCommand(container, helixInstanceName)));
+    containerLaunchContext.setCommands(Lists.newArrayList(buildContainerCommand(containerInfo)));
 
     Map<ApplicationAccessType, String> acls = new HashMap<>(1);
     acls.put(ApplicationAccessType.VIEW_APP, this.appViewAcl);
@@ -580,11 +605,11 @@ public class YarnService extends AbstractIdleService {
   }
 
   @VisibleForTesting
-  protected String buildContainerCommand(Container container, String helixInstanceName) {
+  protected String buildContainerCommand(ContainerInfo containerInfo) {
     String containerProcessName = GobblinYarnTaskRunner.class.getSimpleName();
     StringBuilder containerCommand = new StringBuilder()
         .append(ApplicationConstants.Environment.JAVA_HOME.$()).append("/bin/java")
-        .append(" -Xmx").append((int) (container.getResource().getMemory() * this.jvmMemoryXmxRatio) -
+        .append(" -Xmx").append((int) (containerInfo.getContainer().getResource().getMemory() * this.jvmMemoryXmxRatio) -
             this.jvmMemoryOverheadMbs).append("M")
         .append(" -D").append(GobblinYarnConfigurationKeys.JVM_USER_TIMEZONE_CONFIG).append("=").append(this.containerTimezone)
         .append(" -D").append(GobblinYarnConfigurationKeys.GOBBLIN_YARN_CONTAINER_LOG_DIR_NAME).append("=").append(ApplicationConstants.LOG_DIR_EXPANSION_VAR)
@@ -596,11 +621,11 @@ public class YarnService extends AbstractIdleService {
         .append(" --").append(GobblinClusterConfigurationKeys.APPLICATION_ID_OPTION_NAME)
         .append(" ").append(this.applicationId)
         .append(" --").append(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME)
-        .append(" ").append(helixInstanceName);
+        .append(" ").append(containerInfo.getHelixParticipantId());
 
-    if (!Strings.isNullOrEmpty(this.helixInstanceTags)) {
+    if (!Strings.isNullOrEmpty(containerInfo.getHelixTag())) {
       containerCommand.append(" --").append(GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_OPTION_NAME)
-          .append(" ").append(helixInstanceTags);
+          .append(" ").append(containerInfo.getHelixTag());
     }
     return containerCommand.append(" 1>").append(ApplicationConstants.LOG_DIR_EXPANSION_VAR).append(File.separator).append(
           containerProcessName).append(".").append(ApplicationConstants.STDOUT)
@@ -640,11 +665,13 @@ public class YarnService extends AbstractIdleService {
    * A replacement container is needed in all but the last case.
    */
   protected void handleContainerCompletion(ContainerStatus containerStatus) {
-    Map.Entry<Container, String> completedContainerEntry = this.containerMap.remove(containerStatus.getContainerId());
+    ContainerInfo completedContainerInfo = this.containerMap.remove(containerStatus.getContainerId());
     //Get the Helix instance name for the completed container. Because callbacks are processed asynchronously, we might
     //encounter situations where handleContainerCompletion() is called before onContainersAllocated(), resulting in the
     //containerId missing from the containersMap.
-    String completedInstanceName = completedContainerEntry == null?  UNKNOWN_HELIX_INSTANCE : completedContainerEntry.getValue();
+    String completedInstanceName = completedContainerInfo == null?  UNKNOWN_HELIX_INSTANCE : completedContainerInfo.getHelixParticipantId();
+    String helixTag = completedContainerInfo == null ? helixInstanceTags : completedContainerInfo.getHelixTag();
+    helixTagAllocatedContainerCount.put(helixTag, helixTagAllocatedContainerCount.get(helixTag) - 1);
 
     LOGGER.info(String.format("Container %s running Helix instance %s has completed with exit status %d",
         containerStatus.getContainerId(), completedInstanceName, containerStatus.getExitStatus()));
@@ -657,7 +684,7 @@ public class YarnService extends AbstractIdleService {
     if (containerStatus.getExitStatus() == ContainerExitStatus.ABORTED) {
       if (this.releasedContainerCache.getIfPresent(containerStatus.getContainerId()) != null) {
         LOGGER.info("Container release requested, so not spawning a replacement for containerId {}", containerStatus.getContainerId());
-        if (completedContainerEntry != null) {
+        if (completedContainerInfo != null) {
           LOGGER.info("Adding instance {} to the pool of unused instances", completedInstanceName);
           this.unusedHelixInstanceNames.add(completedInstanceName);
         }
@@ -683,7 +710,7 @@ public class YarnService extends AbstractIdleService {
     if (this.shutdownInProgress) {
       return;
     }
-    if(completedContainerEntry != null) {
+    if(completedContainerInfo != null) {
       this.helixInstanceRetryCount.putIfAbsent(completedInstanceName, new AtomicInteger(0));
       int retryCount = this.helixInstanceRetryCount.get(completedInstanceName).incrementAndGet();
 
@@ -715,10 +742,13 @@ public class YarnService extends AbstractIdleService {
             .submit(GobblinYarnEventConstants.EventNames.HELIX_INSTANCE_COMPLETION, eventMetadataBuilder.get().build());
       }
     }
-    LOGGER.info(String.format("Requesting a new container to replace %s to run Helix instance %s", containerStatus.getContainerId(), completedInstanceName));
+    Optional<Resource> newContainerResource = completedContainerInfo != null ?
+        Optional.of(completedContainerInfo.getContainer().getResource()) : Optional.absent();
+    LOGGER.info("Requesting a new container to replace {} to run Helix instance {} with helix tag {} and resource {}",
+        containerStatus.getContainerId(), completedInstanceName, helixTag, newContainerResource.orNull());
     this.eventBus.post(new NewContainerRequest(
-        shouldStickToTheSameNode(containerStatus.getExitStatus()) && completedContainerEntry != null ?
-            Optional.of(completedContainerEntry.getKey()) : Optional.<Container>absent()));
+        shouldStickToTheSameNode(containerStatus.getExitStatus()) && completedContainerInfo != null ?
+            Optional.of(completedContainerInfo.getContainer()) : Optional.absent(), newContainerResource));
   }
 
   private ImmutableMap.Builder<String, String> buildContainerStatusEventMetadata(ContainerStatus containerStatus) {
@@ -755,12 +785,19 @@ public class YarnService extends AbstractIdleService {
     @Override
     public void onContainersAllocated(List<Container> containers) {
       for (final Container container : containers) {
+        String containerId = container.getId().toString();
+        String containerHelixTag = YarnHelixUtils.findHelixTagForContainer(container,
+            helixTagAllocatedContainerCount, yarnContainerRequest);
+        if (Strings.isNullOrEmpty(containerHelixTag)) {
+          containerHelixTag = helixInstanceTags;
+        }
         if (eventSubmitter.isPresent()) {
           eventSubmitter.get().submit(GobblinYarnEventConstants.EventNames.CONTAINER_ALLOCATION,
-              GobblinYarnMetricTagNames.CONTAINER_ID, container.getId().toString());
+              GobblinYarnMetricTagNames.CONTAINER_ID, containerId);
         }
 
-        LOGGER.info(String.format("Container %s has been allocated", container.getId()));
+        LOGGER.info("Container {} has been allocated with resource {} for helix tag {}",
+            container.getId(), container.getResource(), containerHelixTag);
 
         //Iterate over the (thread-safe) set of unused instances to find the first instance that is not currently live.
         //Once we find a candidate instance, it is removed from the set.
@@ -781,6 +818,8 @@ public class YarnService extends AbstractIdleService {
               instanceName = null;
             }
           }
+          helixTagAllocatedContainerCount.put(containerHelixTag,
+              helixTagAllocatedContainerCount.getOrDefault(containerHelixTag, 0) + 1);
         }
 
         if (Strings.isNullOrEmpty(instanceName)) {
@@ -789,8 +828,8 @@ public class YarnService extends AbstractIdleService {
               .getHelixInstanceName(HELIX_YARN_INSTANCE_NAME_PREFIX, helixInstanceIdGenerator.incrementAndGet());
         }
 
-        final String finalInstanceName = instanceName;
-        containerMap.put(container.getId(), new AbstractMap.SimpleImmutableEntry<>(container, finalInstanceName));
+        ContainerInfo containerInfo = new ContainerInfo(container, instanceName, containerHelixTag);
+        containerMap.put(container.getId(), containerInfo);
 
         // Find matching requests and remove the request to reduce the chance that a subsequent request
         // will request extra containers. YARN does not have a delta request API and the requests are not
@@ -819,11 +858,11 @@ public class YarnService extends AbstractIdleService {
           @Override
           public void run() {
             try {
-              LOGGER.info("Starting container " + container.getId());
+              LOGGER.info("Starting container " + containerId);
 
-              nmClientAsync.startContainerAsync(container, newContainerLaunchContext(container, finalInstanceName));
+              nmClientAsync.startContainerAsync(container, newContainerLaunchContext(containerInfo));
             } catch (IOException ioe) {
-              LOGGER.error("Failed to start container " + container.getId(), ioe);
+              LOGGER.error("Failed to start container " + containerId, ioe);
             }
           }
         });
@@ -938,5 +977,14 @@ public class YarnService extends AbstractIdleService {
 
       LOGGER.error(String.format("Failed to stop container %s due to error %s", containerId, t));
     }
+  }
+
+  //A class encapsulates Container instances, Helix participant IDs of the containers and Helix Tag
+  @AllArgsConstructor
+  @Getter
+  static class ContainerInfo {
+     private final Container container;
+     private final String helixParticipantId;
+     private final String helixTag;
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/NewContainerRequest.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/NewContainerRequest.java
@@ -17,9 +17,11 @@
 
 package org.apache.gobblin.yarn.event;
 
+import lombok.Getter;
 import org.apache.hadoop.yarn.api.records.Container;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.yarn.api.records.Resource;
 
 
 /**
@@ -30,9 +32,17 @@ import com.google.common.base.Optional;
 public class NewContainerRequest {
 
   private final Optional<Container> replacedContainer;
+  @Getter
+  private final Optional<Resource> resource;
 
   public NewContainerRequest(Optional<Container> replacedContainer) {
     this.replacedContainer = replacedContainer;
+    this.resource = Optional.absent();
+  }
+
+  public NewContainerRequest(Optional<Container> replacedContainer, Optional<Resource> resource) {
+    this.replacedContainer = replacedContainer;
+    this.resource = resource;
   }
 
   /**

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnTestUtils.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnTestUtils.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.yarn.api.records.Resource;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -74,5 +75,11 @@ public class GobblinYarnTestUtils {
     Credentials credentials = new Credentials();
     credentials.addToken(token.getService(), token);
     credentials.writeTokenStorageFile(path, new Configuration());
+  }
+
+  public static YarnContainerRequestBundle createYarnContainerRequest(int n, Resource resource) {
+    YarnContainerRequestBundle yarnContainerRequestBundle = new YarnContainerRequestBundle();
+    yarnContainerRequestBundle.add("GobblinKafkaStreaming", n, resource);
+    return yarnContainerRequestBundle;
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
@@ -198,9 +198,11 @@ public class YarnServiceTestWithExpiration {
 
   @Test(groups = {"gobblin.yarn", "disabledOnCI"})
   public void testStartError() throws Exception{
-    this.expiredYarnService.requestTargetNumberOfContainers(10, Collections.EMPTY_SET);
+    Resource resource = Resource.newInstance(16, 1);
+    this.expiredYarnService.requestTargetNumberOfContainers(
+        GobblinYarnTestUtils.createYarnContainerRequest(10, resource), Collections.EMPTY_SET);
 
-    Assert.assertFalse(this.expiredYarnService.getMatchingRequestsList(64, 1).isEmpty());
+    Assert.assertFalse(this.expiredYarnService.getMatchingRequestsList(resource).isEmpty());
     Assert.assertEquals(this.expiredYarnService.getNumRequestedContainers(), 10);
 
     AssertWithBackoff.create().logger(LOG).timeoutMs(60000).maxSleepMs(2000).backoffFactor(1.5)

--- a/gobblin-yarn/src/test/resources/YarnServiceTest.conf
+++ b/gobblin-yarn/src/test/resources/YarnServiceTest.conf
@@ -17,6 +17,7 @@
 
 # Yarn/Helix configuration properties
 gobblin.cluster.helix.cluster.name=YarnServiceTest
+gobblin.cluster.helixInstanceTags=GobblinKafkaStreaming
 gobblin.yarn.app.name=YarnServiceTest
 gobblin.yarn.work.dir=YarnServiceTest
 
@@ -30,7 +31,7 @@ gobblin.yarn.app.master.cores=1
 gobblin.yarn.app.report.interval.minutes=1
 gobblin.yarn.max.get.app.report.failures=4
 gobblin.yarn.email.notification.on.shutdown=false
-gobblin.yarn.initial.containers=1
+gobblin.yarn.initial.containers=0
 gobblin.yarn.container.memory.mbs=64
 gobblin.yarn.container.cores=1
 gobblin.yarn.container.affinity.enabled=true


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/projects/GOBBLIN/issues/GOBBLIN-1620


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- GobblinHelixJobLauncher can pick up helix tag and resource config for each Gobblin job run. These configs will be read by YarnAutoScalingManager and YarnService, thus allocated container can have helix instances with required tag and desired resources. Since helix instances can contain unique tags, tasks within each Gobblin job run will be assigned to containers with specific tag and resource.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test in testing pipeline. 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

