### PR TITLE
[GOBBLIN-1613] Add metadata writers field to GMCE schema

### DIFF
--- a/gobblin-iceberg/build.gradle
+++ b/gobblin-iceberg/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     testCompile project(path: ':gobblin-modules:gobblin-kafka-common', configuration: 'tests')
     testCompile externalDependency.testng
     testCompile externalDependency.mockito
+    // Added to mock static methods for GobblinMCEWriterTest
+    testCompile externalDependency.powermock
 }
 
 configurations {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +29,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -35,6 +37,8 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
+import org.apache.commons.collections.CollectionUtils;
+import com.google.common.annotations.VisibleForTesting;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -288,18 +292,37 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
             ((LongWatermark)watermark.getWatermark()).getValue()-1, ((LongWatermark)watermark.getWatermark()).getValue()));
       }
       tableOperationTypeMap.get(tableString).gmceHighWatermark = ((LongWatermark)watermark.getWatermark()).getValue();
-      write(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
+
+      List<MetadataWriter> allowedWriters = getAllowedMetadataWriters(gmce, metadataWriters);
+      writeToMetadataWriters(recordEnvelope, allowedWriters, newSpecsMap, oldSpecsMap, spec);
     }
     this.recordCount.incrementAndGet();
   }
 
-  // Add fault tolerant ability and make sure we can emit GTE as desired
-  private void write(RecordEnvelope recordEnvelope, ConcurrentHashMap newSpecsMap, ConcurrentHashMap oldSpecsMap, HiveSpec spec) throws IOException {
+  /**
+   * Entry point for calling the allowed metadata writers specified in the GMCE
+   * Adds fault tolerant ability and make sure we can emit GTE as desired
+   * Visible for testing because the WriteEnvelope method has complicated hive logic
+   * @param recordEnvelope
+   * @param allowedWriters metadata writers that will be written to
+   * @param newSpecsMap
+   * @param oldSpecsMap
+   * @param spec
+   * @throws IOException when max number of dataset errors is exceeded
+   */
+  @VisibleForTesting
+  void writeToMetadataWriters(
+      RecordEnvelope<GenericRecord> recordEnvelope,
+      List<MetadataWriter> allowedWriters,
+      ConcurrentHashMap newSpecsMap,
+      ConcurrentHashMap oldSpecsMap,
+      HiveSpec spec
+  ) throws IOException {
     boolean meetException = false;
     String dbName = spec.getTable().getDbName();
     String tableName = spec.getTable().getTableName();
     String tableString = Joiner.on(TABLE_NAME_DELIMITER).join(dbName, tableName);
-    for (MetadataWriter writer : metadataWriters) {
+    for (MetadataWriter writer : allowedWriters) {
       if (meetException) {
         writer.reset(dbName, tableName);
       } else {
@@ -312,6 +335,24 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         }
       }
     }
+  }
+
+  /**
+   *   All metadata writers will be returned if no metadata writers are specified in gmce
+   * @param gmce
+   * @param metadataWriters
+   * @return The metadata writers allowed as specified by GMCE. Relative order of {@code metadataWriters} is maintained
+   */
+  @VisibleForTesting
+  static List<MetadataWriter> getAllowedMetadataWriters(GobblinMetadataChangeEvent gmce, List<MetadataWriter> metadataWriters) {
+    if (CollectionUtils.isEmpty(gmce.getAllowedMetadataWriters())) {
+      return metadataWriters;
+    }
+
+    Set<String> allowSet = new HashSet<>(gmce.getAllowedMetadataWriters());
+    return metadataWriters.stream()
+        .filter(writer -> allowSet.contains(writer.getClass().getName()))
+        .collect(Collectors.toList());
   }
 
   private void addOrThrowException(Exception e, String tableString, String dbName, String tableName) throws IOException{
@@ -379,7 +420,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
    */
   @Override
   public void flush() throws IOException {
-    log.info(String.format("start to flushing %s records", String.valueOf(recordCount.get())));
+    log.info(String.format("begin flushing %s records", String.valueOf(recordCount.get())));
     for (String tableString : tableOperationTypeMap.keySet()) {
       List<String> tid = Splitter.on(TABLE_NAME_DELIMITER).splitToList(tableString);
       flush(tid.get(0), tid.get(1));

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -294,7 +294,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       tableOperationTypeMap.get(tableString).gmceHighWatermark = ((LongWatermark)watermark.getWatermark()).getValue();
 
       List<MetadataWriter> allowedWriters = getAllowedMetadataWriters(gmce, metadataWriters);
-      writeToMetadataWriters(recordEnvelope, allowedWriters, newSpecsMap, oldSpecsMap, spec);
+      writeWithMetadataWriters(recordEnvelope, allowedWriters, newSpecsMap, oldSpecsMap, spec);
     }
     this.recordCount.incrementAndGet();
   }
@@ -311,7 +311,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
    * @throws IOException when max number of dataset errors is exceeded
    */
   @VisibleForTesting
-  void writeToMetadataWriters(
+  void writeWithMetadataWriters(
       RecordEnvelope<GenericRecord> recordEnvelope,
       List<MetadataWriter> allowedWriters,
       ConcurrentHashMap newSpecsMap,

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
@@ -101,7 +101,7 @@ public class GobblinMCEPublisherTest {
     InputStream dataInputStream = clazz.getClassLoader().getResourceAsStream(schemaPath);
     Decoder decoder = DecoderFactory.get().jsonDecoder(schema, dataInputStream);
     GenericRecord recordContainer = reader.read(null, decoder);
-    ;
+
     try {
       while (recordContainer != null) {
         records.add(recordContainer);

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.iceberg.writer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import lombok.SneakyThrows;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.hive.HiveTable;
+import org.apache.gobblin.hive.spec.HiveSpec;
+import org.apache.gobblin.hive.writer.MetadataWriter;
+import org.apache.gobblin.metadata.DatasetIdentifier;
+import org.apache.gobblin.metadata.GobblinMetadataChangeEvent;
+import org.apache.gobblin.metadata.OperationType;
+import org.apache.gobblin.metadata.SchemaSource;
+import org.apache.gobblin.source.extractor.extract.LongWatermark;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaPartition;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaStreamingExtractor;
+import org.apache.gobblin.stream.RecordEnvelope;
+import org.apache.gobblin.util.ClustersNames;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockObjectFactory;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test class uses PowerMockito and Testng
+ * References:
+ * https://github.com/powermock/powermock/issues/434
+ * https://jivimberg.io/blog/2016/04/03/using-powermock-plus-testng-to-mock-a-static-class/
+ * https://www.igorkromin.net/index.php/2018/10/04/how-to-fix-powermock-exception-linkageerror-loader-constraint-violation/
+ */
+@PrepareForTest({GobblinConstructorUtils.class, FileSystem.class})
+@PowerMockIgnore("javax.management.*")
+public class GobblinMCEWriterTest extends PowerMockTestCase {
+
+  private String dbName = "hivedb";
+  private String tableName = "testTable";
+  private GobblinMCEWriter gobblinMCEWriter;
+  private KafkaStreamingExtractor.KafkaWatermark watermark;
+
+  private GobblinMetadataChangeEvent.Builder gmceBuilder;
+
+  // Not using field injection because they must be different classes
+  private MetadataWriter mockWriter;
+  private MetadataWriter exceptionWriter;
+
+  @Mock
+  private FileSystem fs;
+
+  @Mock
+  private HiveSpec mockHiveSpec;
+
+  @Mock
+  private HiveTable mockTable;
+
+  @AfterMethod
+  public void clean() throws Exception {
+    gobblinMCEWriter.close();
+  }
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    initMocks();
+    gmceBuilder = GobblinMetadataChangeEvent.newBuilder()
+        .setDatasetIdentifier(DatasetIdentifier.newBuilder()
+            .setDataPlatformUrn("urn:namespace:dataPlatform:hdfs")
+            .setNativeName("testDB/testTable")
+            .build())
+        .setFlowId("testFlow")
+        .setSchemaSource(SchemaSource.EVENT)
+        .setOperationType(OperationType.add_files)
+        .setCluster(ClustersNames.getInstance().getClusterName());
+    watermark = new KafkaStreamingExtractor.KafkaWatermark(
+        new KafkaPartition.Builder().withTopicName("GobblinMetadataChangeEvent_test").withId(1).build(),
+        new LongWatermark(10L));
+
+    State state = new State();
+    String metadataWriters = String.join(",",
+        Arrays.asList(mockWriter.getClass().getName(), exceptionWriter.getClass().getName()));
+    state.setProp("gmce.metadata.writer.classes", metadataWriters);
+
+    Mockito.doNothing().when(mockWriter)
+        .writeEnvelope(
+            Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+    Mockito.doThrow(new IOException("Test Exception")).when(exceptionWriter)
+        .writeEnvelope(
+            Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+
+    PowerMockito.mockStatic(GobblinConstructorUtils.class);
+    when(GobblinConstructorUtils.invokeConstructor(
+            eq(MetadataWriter.class), eq(mockWriter.getClass().getName()), any(State.class)))
+        .thenReturn(mockWriter);
+    when(GobblinConstructorUtils.invokeConstructor(
+        eq(MetadataWriter.class), eq(exceptionWriter.getClass().getName()), any(State.class)))
+        .thenReturn(exceptionWriter);
+
+    PowerMockito.mockStatic(FileSystem.class);
+    when(FileSystem.get(any()))
+        .thenReturn(fs);
+
+    when(mockTable.getDbName()).thenReturn(dbName);
+    when(mockTable.getTableName()).thenReturn(tableName);
+    when(mockHiveSpec.getTable()).thenReturn(mockTable);
+
+    gobblinMCEWriter = new GobblinMCEWriter(new GobblinMCEWriterBuilder(), state);
+  }
+
+  @Test
+  public void testWriteWhenWriterSpecified() throws IOException {
+    gmceBuilder.setAllowedMetadataWriters(Arrays.asList(mockWriter.getClass().getName()));
+    writeToMetadataWriters(gmceBuilder.build());
+
+    Mockito.verify(mockWriter, Mockito.times(1)).writeEnvelope(
+        Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+    Mockito.verify(exceptionWriter, never()).writeEnvelope(
+        Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+  }
+
+  @Test
+  public void testFaultTolerance() throws IOException {
+
+    gobblinMCEWriter.setMaxErrorDataset(1);
+    gobblinMCEWriter.metadataWriters = Arrays.asList(mockWriter, exceptionWriter, mockWriter);
+    gobblinMCEWriter.tableOperationTypeMap = new HashMap<>();
+
+    String dbName2 = dbName + "2";
+    String otherDb = "someOtherDB";
+    addTableStatus(dbName, "datasetPath");
+    addTableStatus(dbName2, "datasetPath");
+    addTableStatus(otherDb, "otherDatasetPath");
+
+    BiConsumer<String, String> verifyMocksCalled = new BiConsumer<String, String>(){
+      private int timesCalled = 0;
+      @Override
+      @SneakyThrows
+      public void accept(String dbName, String tableName) {
+        timesCalled++;
+
+        // also validates that order is maintained since all writers after an exception should reset instead of write
+        Mockito.verify(mockWriter, Mockito.times(timesCalled)).writeEnvelope(
+            Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+        Mockito.verify(exceptionWriter, Mockito.times(timesCalled)).writeEnvelope(
+            Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
+        Mockito.verify(exceptionWriter, Mockito.times(1)).reset(dbName, tableName);
+        Mockito.verify(mockWriter, Mockito.times(1)).reset(dbName, tableName);
+      }
+    };
+
+    writeToMetadataWriters(gmceBuilder.build());
+    verifyMocksCalled.accept(dbName, tableName);
+
+    // Another exception for same dataset but different db
+    when(mockTable.getDbName()).thenReturn(dbName2);
+    writeToMetadataWriters(gmceBuilder.build());
+    verifyMocksCalled.accept(dbName2, tableName);
+
+    // exception thrown because exceeds max number of datasets with errors
+    when(mockTable.getDbName()).thenReturn(otherDb);
+    Assert.expectThrows(IOException.class, () -> writeToMetadataWriters(gmceBuilder.setDatasetIdentifier(DatasetIdentifier.newBuilder()
+        .setDataPlatformUrn("urn:namespace:dataPlatform:hdfs")
+        .setNativeName("someOtherDB/testTable")
+        .build()).build()));
+  }
+
+  @Test(dataProvider = "AllowMockMetadataWriter")
+  public void testGetAllowedMetadataWriters(List<String> metadataWriters) {
+    Assert.assertNotEquals(mockWriter.getClass().getName(), exceptionWriter.getClass().getName());
+    gmceBuilder.setAllowedMetadataWriters(metadataWriters);
+    List<MetadataWriter> allowedWriters = GobblinMCEWriter.getAllowedMetadataWriters(
+        gmceBuilder.build(),
+        Arrays.asList(mockWriter, exceptionWriter));
+
+    Assert.assertEquals(allowedWriters.size(), 2);
+    Assert.assertEquals(allowedWriters.get(0).getClass().getName(), mockWriter.getClass().getName());
+    Assert.assertEquals(allowedWriters.get(1).getClass().getName(), exceptionWriter.getClass().getName());
+  }
+
+  @DataProvider(name="AllowMockMetadataWriter")
+  public Object[][] allowMockMetadataWriterParams() {
+    initMocks();
+    return new Object[][] {
+        {Arrays.asList(mockWriter.getClass().getName(), exceptionWriter.getClass().getName())},
+        {Collections.emptyList()}
+    };
+  }
+
+  private void initMocks() {
+    MockitoAnnotations.initMocks(this);
+    // Hacky way to have 2 mock MetadataWriter "classes" with different underlying names
+    mockWriter = Mockito.mock(MetadataWriter.class);
+    exceptionWriter = Mockito.mock(TestExceptionMetadataWriter.class);
+  }
+
+  private static abstract class TestExceptionMetadataWriter implements MetadataWriter { }
+
+  private void writeToMetadataWriters(GobblinMetadataChangeEvent gmce) throws IOException {
+    List<MetadataWriter> allowedMetadataWriters = GobblinMCEWriter.getAllowedMetadataWriters(
+        gmce, gobblinMCEWriter.getMetadataWriters());
+
+    gobblinMCEWriter.writeToMetadataWriters(new RecordEnvelope<>(gmce, watermark), allowedMetadataWriters,
+        new ConcurrentHashMap(), new ConcurrentHashMap(), mockHiveSpec);
+  }
+
+  private void addTableStatus(String dbName, String datasetPath) {
+    gobblinMCEWriter.tableOperationTypeMap.put(dbName + "." + tableName, new GobblinMCEWriter.TableStatus(
+        OperationType.add_files, datasetPath, "GobblinMetadataChangeEvent_test-1", 0, 50));
+  }
+
+  @ObjectFactory
+  public IObjectFactory getObjectFactory() {
+    return new PowerMockObjectFactory();
+  }
+}
+

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -145,7 +145,7 @@ public class GobblinMCEWriterTest extends PowerMockTestCase {
   @Test
   public void testWriteWhenWriterSpecified() throws IOException {
     gmceBuilder.setAllowedMetadataWriters(Arrays.asList(mockWriter.getClass().getName()));
-    writeToMetadataWriters(gmceBuilder.build());
+    writeWithMetadataWriters(gmceBuilder.build());
 
     Mockito.verify(mockWriter, Mockito.times(1)).writeEnvelope(
         Mockito.any(RecordEnvelope.class), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(HiveSpec.class));
@@ -183,17 +183,17 @@ public class GobblinMCEWriterTest extends PowerMockTestCase {
       }
     };
 
-    writeToMetadataWriters(gmceBuilder.build());
+    writeWithMetadataWriters(gmceBuilder.build());
     verifyMocksCalled.accept(dbName, tableName);
 
     // Another exception for same dataset but different db
     when(mockTable.getDbName()).thenReturn(dbName2);
-    writeToMetadataWriters(gmceBuilder.build());
+    writeWithMetadataWriters(gmceBuilder.build());
     verifyMocksCalled.accept(dbName2, tableName);
 
     // exception thrown because exceeds max number of datasets with errors
     when(mockTable.getDbName()).thenReturn(otherDb);
-    Assert.expectThrows(IOException.class, () -> writeToMetadataWriters(gmceBuilder.setDatasetIdentifier(DatasetIdentifier.newBuilder()
+    Assert.expectThrows(IOException.class, () -> writeWithMetadataWriters(gmceBuilder.setDatasetIdentifier(DatasetIdentifier.newBuilder()
         .setDataPlatformUrn("urn:namespace:dataPlatform:hdfs")
         .setNativeName("someOtherDB/testTable")
         .build()).build()));
@@ -230,11 +230,11 @@ public class GobblinMCEWriterTest extends PowerMockTestCase {
 
   private static abstract class TestExceptionMetadataWriter implements MetadataWriter { }
 
-  private void writeToMetadataWriters(GobblinMetadataChangeEvent gmce) throws IOException {
+  private void writeWithMetadataWriters(GobblinMetadataChangeEvent gmce) throws IOException {
     List<MetadataWriter> allowedMetadataWriters = GobblinMCEWriter.getAllowedMetadataWriters(
         gmce, gobblinMCEWriter.getMetadataWriters());
 
-    gobblinMCEWriter.writeToMetadataWriters(new RecordEnvelope<>(gmce, watermark), allowedMetadataWriters,
+    gobblinMCEWriter.writeWithMetadataWriters(new RecordEnvelope<>(gmce, watermark), allowedMetadataWriters,
         new ConcurrentHashMap(), new ConcurrentHashMap(), mockHiveSpec);
   }
 

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -61,6 +61,7 @@ import org.apache.gobblin.hive.HiveRegister;
 import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveTable;
 import org.apache.gobblin.hive.policy.HiveRegistrationPolicyBase;
+import org.apache.gobblin.hive.writer.HiveMetadataWriter;
 import org.apache.gobblin.metadata.DataFile;
 import org.apache.gobblin.metadata.DataMetrics;
 import org.apache.gobblin.metadata.DataOrigin;
@@ -136,11 +137,11 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
       client.createDatabase(
           new Database(dedupedDbName, "dedupeddatabase", tmpDir.getAbsolutePath() + "/metastore_deduped", Collections.emptyMap()));
     }
-    hourlyDataFile_1 = new File(tmpDir, "data/tracking/testTable/hourly/2020/03/17/08/data.avro");
+    hourlyDataFile_1 = new File(tmpDir, "testDB/testTable/hourly/2020/03/17/08/data.avro");
     Files.createParentDirs(hourlyDataFile_1);
-    hourlyDataFile_2 = new File(tmpDir, "data/tracking/testTable/hourly/2020/03/17/09/data.avro");
+    hourlyDataFile_2 = new File(tmpDir, "testDB/testTable/hourly/2020/03/17/09/data.avro");
     Files.createParentDirs(hourlyDataFile_2);
-    dailyDataFile = new File(tmpDir, "data/tracking/testTable/daily/2020/03/17/data.avro");
+    dailyDataFile = new File(tmpDir, "testDB/testTable/daily/2020/03/17/data.avro");
     Files.createParentDirs(dailyDataFile);
     dataDir = new File(hourlyDataFile_1.getParent());
     Assert.assertTrue(dataDir.exists());
@@ -152,8 +153,8 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
     gmce = GobblinMetadataChangeEvent.newBuilder()
         .setDatasetIdentifier(DatasetIdentifier.newBuilder()
             .setDataOrigin(DataOrigin.EI)
-            .setDataPlatformUrn("urn:li:dataPlatform:hdfs")
-            .setNativeName("/data/tracking/testTable")
+            .setDataPlatformUrn("urn:namespace:dataPlatform:hdfs")
+            .setNativeName("/testDB/testTable")
             .build())
         .setTopicPartitionOffsetsRange(ImmutableMap.<String, String>builder().put("testTopic-1", "0-1000").build())
         .setFlowId("testFlow")
@@ -169,6 +170,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
         .setPartitionColumns(Lists.newArrayList("testpartition"))
         .setRegistrationPolicy(TestHiveRegistrationPolicy.class.getName())
         .setRegistrationProperties(registrationState)
+        .setAllowedMetadataWriters(Collections.singletonList(HiveMetadataWriter.class.getName()))
         .build();
     state.setProp(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS,
         KafkaStreamTestUtils.MockSchemaRegistry.class.getName());

--- a/gobblin-iceberg/src/test/resources/publisherTest/data.json
+++ b/gobblin-iceberg/src/test/resources/publisherTest/data.json
@@ -1,8 +1,10 @@
-{
-  "id": 1,
-  "name": "Alyssa"
-}
-{
-  "id": 2,
-  "name": "Bob"
-}
+[
+  {
+    "id": 1,
+    "name": "Alyssa"
+  },
+  {
+    "id": 2,
+    "name": "Bob"
+  }
+]

--- a/gobblin-iceberg/src/test/resources/publisherTest/data.json
+++ b/gobblin-iceberg/src/test/resources/publisherTest/data.json
@@ -1,10 +1,8 @@
-[
-  {
-    "id": 1,
-    "name": "Alyssa"
-  },
-  {
-    "id": 2,
-    "name": "Bob"
-  }
-]
+{
+  "id": 1,
+  "name": "Alyssa"
+}
+{
+  "id": 2,
+  "name": "Bob"
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
@@ -276,6 +276,16 @@
         "doc": "The avro schema with iceberg schema id for the data, this is used to match the field id in the file metrics to the field name",
         "default": null,
         "optional": true
+      },
+      {
+        "name": "allowedMetadataWriters",
+        "type": ["null",{
+          "type": "array",
+          "items" : "string"
+        } ],
+        "default": null,
+        "doc": "Array of the metadata writers that are allowed to consume this GMCE. If this field is missing, all metadata writers are allowed.",
+        "optional": true
       }
     ]
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1613] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1613


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

Add optional field to GMCE schema for specifying metadata writers that should write. I've added corresponding code to filter base on this metadata writer field the GobblinMCEWriter

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests added and tested on holdem using iceberg metadata repair job

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

