### PR TITLE
[GOBBLIN-1630] Remove flow level metrics for adhoc flows

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1014,7 +1014,7 @@ public class ConfigurationKeys {
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
   public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
   public static final String WHITELISTED_EDGE_IDS = "gobblin.flow.whitelistedEdgeIds";
-  public static final String GOBBLIN_FLOW_ISADHOC = "gobblin.flow.isAdhoc";
+  public static final String GOBBLIN_FLOW_ISADHOC = "gobblin.internal.flow.isAdhoc";
   /***
    * Configuration properties related to TopologySpec Store
    */

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1014,7 +1014,7 @@ public class ConfigurationKeys {
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
   public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
   public static final String WHITELISTED_EDGE_IDS = "gobblin.flow.whitelistedEdgeIds";
-
+  public static final String GOBBLIN_FLOW_ISADHOC = "gobblin.flow.isAdhoc";
   /***
    * Configuration properties related to TopologySpec Store
    */

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -669,7 +669,8 @@ public class DagManager extends AbstractIdleService {
       }
 
       FlowId flowId = DagManagerUtils.getFlowId(dag);
-      if (!flowGauges.containsKey(flowId.toString())) {
+      // Do not register flow-specific metrics for a flow
+      if (!flowGauges.containsKey(flowId.toString()) && !DagManagerUtils.isDagFromAdhocFlow(dag)) {
         String flowStateGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, flowId.getFlowGroup(),
             flowId.getFlowName(), ServiceMetricNames.RUNNING_STATUS);
         flowGauges.put(flowId.toString(), FlowState.RUNNING);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -1194,7 +1194,7 @@ public class DagManager extends AbstractIdleService {
     }
   }
 
-  private enum FlowState {
+  public enum FlowState {
     FAILED(-1),
     RUNNING(0),
     SUCCESSFUL(1);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -309,7 +309,8 @@ public class DagManagerUtils {
 
   static boolean isDagFromAdhocFlow(Dag<JobExecutionPlan> dag) {
     // Every dag should have at least one node, and every dag will clone the job configurations which include the schedule
-    return dag.getStartNodes().get(0).getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC);
+    // defaults to false (so metrics are still tracked) if the dag property is not configured due to old dags
+    return ConfigUtils.getBoolean(dag.getStartNodes().get(0).getValue().getJobSpec().getConfig(), ConfigurationKeys.GOBBLIN_FLOW_ISADHOC,false);
   }
 
   static void emitFlowEvent(Optional<EventSubmitter> eventSubmitter, Dag<JobExecutionPlan> dag, String flowEvent) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -307,16 +307,20 @@ public class DagManagerUtils {
     return (int) (flowExecutionId % numThreads);
   }
 
+  static Config getDagJobConfig(Dag<JobExecutionPlan> dag) {
+    // Every dag should have at least one node, and the job configurations are cloned among each node
+    return dag.getStartNodes().get(0).getValue().getJobSpec().getConfig();
+  }
+
   static boolean isDagFromAdhocFlow(Dag<JobExecutionPlan> dag) {
-    // Every dag should have at least one node, and every dag will clone the job configurations which include the schedule
     // defaults to false (so metrics are still tracked) if the dag property is not configured due to old dags
-    return ConfigUtils.getBoolean(dag.getStartNodes().get(0).getValue().getJobSpec().getConfig(), ConfigurationKeys.GOBBLIN_FLOW_ISADHOC,false);
+    return ConfigUtils.getBoolean(getDagJobConfig(dag), ConfigurationKeys.GOBBLIN_FLOW_ISADHOC,false);
   }
 
   static void emitFlowEvent(Optional<EventSubmitter> eventSubmitter, Dag<JobExecutionPlan> dag, String flowEvent) {
     if (eventSubmitter.isPresent() && !dag.isEmpty()) {
       // Every dag node will contain the same flow metadata
-      Config config = dag.getNodes().get(0).getValue().getJobSpec().getConfig();
+      Config config = getDagJobConfig(dag);
       Map<String, String> flowMetadata = TimingEventUtils.getFlowMetadata(config);
 
       if (dag.getFlowEvent() != null) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -307,6 +307,11 @@ public class DagManagerUtils {
     return (int) (flowExecutionId % numThreads);
   }
 
+  static boolean isDagFromAdhocFlow(Dag<JobExecutionPlan> dag) {
+    // Every dag should have at least one node, and every dag will clone the job configurations which include the schedule
+    return dag.getStartNodes().get(0).getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC);
+  }
+
   static void emitFlowEvent(Optional<EventSubmitter> eventSubmitter, Dag<JobExecutionPlan> dag, String flowEvent) {
     if (eventSubmitter.isPresent() && !dag.isEmpty()) {
       // Every dag node will contain the same flow metadata

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -222,7 +222,8 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       String flowGroup = flowConfig.getString(ConfigurationKeys.FLOW_GROUP_KEY);
       String flowName = flowConfig.getString(ConfigurationKeys.FLOW_NAME_KEY);
 
-      if (!flowGauges.containsKey(spec.getUri().toString())) {
+      // Only register the metric of flows that are scheduled, run once flows should not be tracked indefinitely
+      if (!flowGauges.containsKey(spec.getUri().toString()) && flowConfig.hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)) {
         String flowCompiledGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, flowGroup, flowName, ServiceMetricNames.COMPILED);
         flowGauges.put(spec.getUri().toString(), new FlowCompiledState());
         ContextAwareGauge<Integer> gauge = RootMetricContext.get().newContextAwareGauge(flowCompiledGaugeName, () -> flowGauges.get(spec.getUri().toString()).state.value);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -117,31 +117,26 @@ public class JobExecutionPlan {
       URI jobTemplateUri = new URI(jobConfig.getString(ConfigurationKeys.JOB_TEMPLATE_PATH));
       JobSpec jobSpec = jobSpecBuilder.withTemplate(jobTemplateUri).build();
 
-      //Add flowGroup to job spec
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup)));
-
-      //Add flowName to job spec
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName)));
-
-      //Add job name
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef(jobName)));
-
-      //Add flow execution id
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
-
-      // Remove schedule
-      jobSpec.setConfig(jobSpec.getConfig().withoutPath(ConfigurationKeys.JOB_SCHEDULE_KEY));
-
-      //Remove template uri
-      jobSpec.setConfig(jobSpec.getConfig().withoutPath(GOBBLIN_JOB_TEMPLATE_KEY));
-
-      // Add job.name and job.group
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef(jobName)));
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup)));
-
-      //Add flow failure option
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_FAILURE_OPTION,
-          ConfigValueFactory.fromAnyRef(flowFailureOption)));
+      jobSpec.setConfig(jobSpec.getConfig()
+          //Add flowGroup to job spec
+          .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+          //Add flowName to job spec
+          .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+          //Add job name
+          .withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef(jobName))
+          //Add flow execution id
+          .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId))
+          // Remove schedule due to namespace conflict with azkaban schedule key, but still keep track if flow is scheduled or not
+          .withValue(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC, ConfigValueFactory.fromAnyRef(!jobSpec.getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)))
+          .withoutPath(ConfigurationKeys.JOB_SCHEDULE_KEY)
+          //Remove template uri
+          .withoutPath(GOBBLIN_JOB_TEMPLATE_KEY)
+          // Add job.name and job.group
+          .withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef(jobName))
+          .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+          //Add flow failure option
+          .withValue(ConfigurationKeys.FLOW_FAILURE_OPTION, ConfigValueFactory.fromAnyRef(flowFailureOption))
+      );
 
       //Add tracking config to JobSpec.
       addTrackingEventConfig(jobSpec, sysConfig);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -306,7 +306,7 @@ public class OrchestratorTest {
         + "Spec after deletion");
   }
 
-  @Test
+  @Test (dependsOnMethods = "deleteFlowSpec")
   public void doNotRegisterMetricsAdhocFlows() throws Exception {
     MetricContext metricContext = this.orchestrator.getMetricContext();
     this.topologyCatalog.getInitComplete().countDown(); // unblock orchestration

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/UserQuotaManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/UserQuotaManagerTest.java
@@ -43,7 +43,7 @@ public class UserQuotaManagerTest {
   // Tests that if exceeding the quota on startup, do not throw an exception and do not decrement the counter
   @Test
   public void testExceedsQuotaOnStartup() throws Exception {
-    List<Dag<JobExecutionPlan>> dags = DagManagerTest.buildDagList(2, "user");
+    List<Dag<JobExecutionPlan>> dags = DagManagerTest.buildDagList(2, "user", ConfigFactory.empty());
     // Ensure that the current attempt is 1, normally done by DagManager
     dags.get(0).getNodes().get(0).getValue().setCurrentAttempts(1);
     dags.get(1).getNodes().get(0).getValue().setCurrentAttempts(1);
@@ -57,7 +57,7 @@ public class UserQuotaManagerTest {
 
   @Test
   public void testExceedsQuotaThrowsException() throws Exception {
-    List<Dag<JobExecutionPlan>> dags = DagManagerTest.buildDagList(2, "user2");
+    List<Dag<JobExecutionPlan>> dags = DagManagerTest.buildDagList(2, "user2", ConfigFactory.empty());
 
     // Ensure that the current attempt is 1, normally done by DagManager
     dags.get(0).getNodes().get(0).getValue().setCurrentAttempts(1);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1630


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Gobblin-as-a-Service emits flow level events for users to keep track of their flow compilation status, job status, number of workunits etc. However, users rarely if ever track adhoc-flows, where they are generally used in a fire-and-forget manner. Furthermore, keeping track of metrics continuously adds strains to the metric libraries which leads to wasted resources.

We should only be emitting flow level events for flows that are scheduled and saved.

This PR adds a flag for adhoc flows such that downstream executions can also differentiate scheduled and adhoc flows, so that downstream workloads can also prevent the emission of metrics for these flows that are not tracked.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

