### PR TITLE
[GOBBLIN-1633] Fix compaction actions on job failure not retried if compaction succeeds

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
@@ -32,7 +32,6 @@ import org.apache.gobblin.compaction.mapreduce.MRCompactorJobRunner;
 import org.apache.gobblin.compaction.mapreduce.RecordKeyDedupReducerBase;
 import org.apache.gobblin.compaction.mapreduce.RecordKeyMapperBase;
 import org.apache.gobblin.compaction.parser.CompactionPathParser;
-import org.apache.gobblin.compaction.source.CompactionSource;
 import org.apache.gobblin.compaction.verify.InputRecordCountHelper;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
@@ -183,8 +182,6 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
           this.configurator.getConfiguredJob().getJobID().toString());
       compactionState.setProp(DUPLICATE_COUNT_TOTAL,
           job.getCounters().findCounter(RecordKeyDedupReducerBase.EVENT_COUNTER.DEDUPED).getValue());
-      compactionState.setProp(CompactionSlaEventHelper.LAST_RUN_START_TIME,
-          this.state.getProp(CompactionSource.COMPACTION_INIT_TIME));
       helper.saveState(new Path(result.getDstAbsoluteDir()), compactionState);
       log.info("duplicated records count for " + dstPath + " : " + compactionState.getProp(DUPLICATE_COUNT_TOTAL));
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionTimeRangeVerifier.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionTimeRangeVerifier.java
@@ -99,7 +99,8 @@ public class CompactionTimeRangeVerifier implements CompactionVerifier<FileSyste
         if (compactState.contains(CompactionSlaEventHelper.LAST_RUN_START_TIME)
             && compactState.getPropAsLong(CompactionSlaEventHelper.LAST_RUN_START_TIME)
             > latestEligibleCompactTime.getMillis()) {
-          log.warn("Last compaction for {} is {}, not before {}", dataset.datasetRoot(),
+          log.warn("Last compaction for {} is {}, which is not before latestEligibleCompactTime={}",
+              dataset.datasetRoot(),
               new DateTime(compactState.getPropAsLong(CompactionSlaEventHelper.LAST_RUN_START_TIME), timeZone),
               latestEligibleCompactTime);
           return new Result(false,

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionTimeRangeVerifier.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/verify/CompactionTimeRangeVerifier.java
@@ -39,7 +39,7 @@ import org.joda.time.format.PeriodFormatterBuilder;
 
 
 /**
- * A simple class which verify current dataset belongs to a specific time range. Will skip to do
+ * A simple class which verify current dataset belongs to a specific time range. Will skip doing
  * compaction if dataset is not in a correct time range.
  */
 
@@ -74,7 +74,7 @@ public class CompactionTimeRangeVerifier implements CompactionVerifier<FileSyste
       // get earliest time
       String maxTimeAgoStrList = this.state.getProp(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO,
           TimeBasedSubDirDatasetsFinder.DEFAULT_COMPACTION_TIMEBASED_MAX_TIME_AGO);
-      String maxTimeAgoStr = getMachedLookbackTime(datasetName, maxTimeAgoStrList,
+      String maxTimeAgoStr = getMatchedLookbackTime(datasetName, maxTimeAgoStrList,
           TimeBasedSubDirDatasetsFinder.DEFAULT_COMPACTION_TIMEBASED_MAX_TIME_AGO);
       Period maxTimeAgo = formatter.parsePeriod(maxTimeAgoStr);
       earliest = compactionStartTime.minus(maxTimeAgo);
@@ -82,7 +82,7 @@ public class CompactionTimeRangeVerifier implements CompactionVerifier<FileSyste
       // get latest time
       String minTimeAgoStrList = this.state.getProp(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO,
           TimeBasedSubDirDatasetsFinder.DEFAULT_COMPACTION_TIMEBASED_MIN_TIME_AGO);
-      String minTimeAgoStr = getMachedLookbackTime(datasetName, minTimeAgoStrList,
+      String minTimeAgoStr = getMatchedLookbackTime(datasetName, minTimeAgoStrList,
           TimeBasedSubDirDatasetsFinder.DEFAULT_COMPACTION_TIMEBASED_MIN_TIME_AGO);
       Period minTimeAgo = formatter.parsePeriod(minTimeAgoStr);
       latest = compactionStartTime.minus(minTimeAgo);
@@ -90,7 +90,7 @@ public class CompactionTimeRangeVerifier implements CompactionVerifier<FileSyste
       // get latest last run start time, we want to limit the duration between two compaction for the same dataset
       if (state.contains(TimeBasedSubDirDatasetsFinder.MIN_RECOMPACTION_DURATION)) {
         String minDurationStrList = this.state.getProp(TimeBasedSubDirDatasetsFinder.MIN_RECOMPACTION_DURATION);
-        String minDurationStr = getMachedLookbackTime(datasetName, minDurationStrList,
+        String minDurationStr = getMatchedLookbackTime(datasetName, minDurationStrList,
             TimeBasedSubDirDatasetsFinder.DEFAULT_MIN_RECOMPACTION_DURATION);
         Period minDurationTime = formatter.parsePeriod(minDurationStr);
         DateTime latestEligibleCompactTime = compactionStartTime.minus(minDurationTime);
@@ -144,7 +144,7 @@ public class CompactionTimeRangeVerifier implements CompactionVerifier<FileSyste
    * @param datasetName A description of dataset without time partition information. Example 'Identity/MemberAccount' or 'PageViewEvent'
    * @return The lookback time matched with given dataset.
    */
-  public static String getMachedLookbackTime(String datasetName, String datasetsAndLookBacks,
+  public static String getMatchedLookbackTime(String datasetName, String datasetsAndLookBacks,
       String sysDefaultLookback) {
     String defaultLookback = sysDefaultLookback;
 

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/verify/CompactionTimeVerifierTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/verify/CompactionTimeVerifierTest.java
@@ -27,15 +27,15 @@ public class CompactionTimeVerifierTest {
   public void testOneDatasetTime() {
     String timeString = "Identity.MemberAccount:1d2h";
 
-    String lb1 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb1 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb1, "1d2h");
-    String lb2 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb2 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb2, "2d");
 
     timeString = "2d;Identity.MemberAccount:1d2h";
-    String lb3 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb3 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb3, "1d2h");
-    String lb4 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb4 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb4, "2d");
   }
 
@@ -43,30 +43,30 @@ public class CompactionTimeVerifierTest {
   public void testTwoDatasetTime() {
     String timeString = "Identity.*:1d2h;BizProfile.BizCompany:3d";
 
-    String lb1 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb1 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb1, "1d2h");
-    String lb2 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb2 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb2, "3d");
-    String lb3 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb3 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb3, "2d");
 
     timeString = "2d;Identity.MemberAccount:1d2h;BizProfile.BizCompany:3d";
-    String lb4 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb4 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb4, "1d2h");
-    String lb5 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb5 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb5, "3d");
-    String lb6 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb6 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb6, "2d");
   }
 
   @Test
   public void testDefaultDatasetTime() {
     String timeString = "Identity.*:1d2h;3d2h;BizProfile.BizCompany:3d";
-    String lb1 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb1 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb1, "3d2h");
 
     timeString = "3d2h";
-    String lb2 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb2 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb2, "3d2h");
   }
 
@@ -74,28 +74,28 @@ public class CompactionTimeVerifierTest {
   public void testEmptySpace() {
     String timeString = "Identity.* :   1d2h ; BizProfile.BizCompany : 3d";
 
-    String lb1 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb1 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb1, "1d2h");
-    String lb2 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb2 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb2, "3d");
-    String lb3 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb3 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb3, "2d");
 
     timeString = "2d;Identity.MemberAccount  :1d2h;   BizProfile.BizCompany:3d";
-    String lb4 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb4 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb4, "1d2h");
-    String lb5 = CompactionTimeRangeVerifier.getMachedLookbackTime("BizProfile/BizCompany", timeString, "2d");
+    String lb5 = CompactionTimeRangeVerifier.getMatchedLookbackTime("BizProfile/BizCompany", timeString, "2d");
     Assert.assertEquals(lb5, "3d");
-    String lb6 = CompactionTimeRangeVerifier.getMachedLookbackTime("ABC/Unknown", timeString, "2d");
+    String lb6 = CompactionTimeRangeVerifier.getMatchedLookbackTime("ABC/Unknown", timeString, "2d");
     Assert.assertEquals(lb6, "2d");
   }
 
   @Test
   public void testPartialMatchedNames() {
     String timeString = "Identity.Member$ :   1d2h";
-    String lb1 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/Member", timeString, "2d");
+    String lb1 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/Member", timeString, "2d");
     Assert.assertEquals(lb1, "1d2h");
-    String lb2 = CompactionTimeRangeVerifier.getMachedLookbackTime("Identity/MemberAccount", timeString, "2d");
+    String lb2 = CompactionTimeRangeVerifier.getMatchedLookbackTime("Identity/MemberAccount", timeString, "2d");
     Assert.assertEquals(lb2, "2d");
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -608,7 +608,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         }
       } catch (Throwable t) {
         jobState.setState(JobState.RunningState.FAILED);
-        String errMsg = "Failed to launch and run job " + jobId + " due to" + t.getMessage();
+        String errMsg = "Failed to launch and run job " + jobId + " due to " + t.getMessage();
         LOG.error(errMsg + ": " + t, t);
         this.jobContext.getJobState().setJobFailureException(t);
       } finally {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1633] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1633


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
- The issue is that when [CompactionCompleteFileOperationAction.java](https://github.com/apache/gobblin/pull/3494/files#diff-1cff14b642342f6005b830c658cae9c6030148c9c79cf3a914d9acac57f3c644) succeeds , it persists the init time using the key `CompactionSlaEventHelper.LAST_RUN_START_TIME`. However, if the job fails after this point but before metadata registration, then the files will not be registered until the next re-compaction cycle determined by `compaction.timebased.min.recompaction.duration`. 
- Note: This value for the `CompactionSlaEventHelper.LAST_RUN_START_TIME` is used by the [CompactionTimeRangeVerifier.java](https://github.com/apache/gobblin/pull/3494/files#diff-e35a620545631e579301d1d49744d2465729932480c4f9de8eecc0375962b77b) to determine when the last successful compaction started and whether to proceed with recompaction.
- The solution is to persist the value for the key `CompactionSlaEventHelper.LAST_RUN_START_TIME` after the MR compaction task has completed instead of after the file operation is completed. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


It is extremely difficult to add tests to the MR Compaction Task due to the tight coupling with the job submission. I have regression tested this using a parallel test pipeline and compacting twice.

The first compaction job successfully compacts the hourly partition to a daily partition, and the second compaction job does not create any work units due to the compaction
```
26-04-2022 11:07:37 PDT daily-compaction-orc INFO - WARN Last compaction for /data/tracking/streaming_parallel_test/PageViewEvent/hourly/2022/04/26 is 2022-04-26T10:51:07.084-07:00, which is not before latestEligibleCompactTime=2022-04-26T10:06:23.429-07:00
```

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

