### PR TITLE
[GOBBLIN-1634] Add retries on flow sla kills

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -72,8 +72,8 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_FAILED = "FlowFailed";
     public static final String FLOW_RUNNING = "FlowRunning";
     public static final String FLOW_CANCELLED = "FlowCancelled";
-    public static final String FLOW_SLA_KILLED = "FlowSLAKilled";
-    public static final String FLOW_START_SLA_KILLED = "FlowStartSLAKilled";
+    public static final String FLOW_RUN_DEADLINE_EXCEEDED = "FlowRunDeadlineExceeded";
+    public static final String FLOW_START_DEADLINE_EXCEEDED = "FlowStartDeadlineExceeded";
     public static final String FLOW_PENDING_RESUME = "FlowPendingResume";
   }
 
@@ -94,7 +94,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     //This state should always move forward, more details can be found in method {@link KafkaJobStatusMonitor.addJobStatusToStateStore}
     public static final String CURRENT_GENERATION_FIELD = "currentGeneration";
     public static final String SHOULD_RETRY_FIELD = "shouldRetry";
-    public static final String IS_FLOW_SLA_KILLED = "isFlowSlaKilled";
+    public static final String DOES_CANCELED_FLOW_MERIT_RETRY = "doesCancelledFlowMeritRetry";
   }
 
   public static final String METADATA_START_TIME = "startTime";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -72,6 +72,8 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_FAILED = "FlowFailed";
     public static final String FLOW_RUNNING = "FlowRunning";
     public static final String FLOW_CANCELLED = "FlowCancelled";
+    public static final String FLOW_SLA_KILLED = "FlowSLAKilled";
+    public static final String FLOW_START_SLA_KILLED = "FlowStartSLAKilled";
     public static final String FLOW_PENDING_RESUME = "FlowPendingResume";
   }
 
@@ -92,6 +94,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     //This state should always move forward, more details can be found in method {@link KafkaJobStatusMonitor.addJobStatusToStateStore}
     public static final String CURRENT_GENERATION_FIELD = "currentGeneration";
     public static final String SHOULD_RETRY_FIELD = "shouldRetry";
+    public static final String IS_FLOW_SLA_KILLED = "isFlowSlaKilled";
   }
 
   public static final String METADATA_START_TIME = "startTime";

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -130,7 +130,7 @@ public class KafkaAvroJobStatusMonitorTest {
     } catch(InterruptedException ex) {
       Thread.currentThread().interrupt();
     }
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
@@ -188,7 +188,7 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     ConsumerIterator<byte[], byte[]> iterator = this.kafkaTestHelper.getIteratorForTopic(TOPIC);
@@ -265,7 +265,7 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     ConsumerIterator<byte[], byte[]> iterator = this.kafkaTestHelper.getIteratorForTopic(TOPIC);
@@ -324,7 +324,7 @@ public class KafkaAvroJobStatusMonitorTest {
     AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle = new AtomicBoolean(false);
     Config conf = ConfigFactory.empty().withValue(
         KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX + "." + RETRY_MULTIPLIER, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.toMillis(1L)));
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(shouldThrowFakeExceptionInParseJobStatusToggle, conf);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(shouldThrowFakeExceptionInParseJobStatusToggle, conf);
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
@@ -382,7 +382,7 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
       this.kafkaTestHelper.getIteratorForTopic(TOPIC),
@@ -441,6 +441,7 @@ public class KafkaAvroJobStatusMonitorTest {
   /**
    * Create a Job Orchestrated Event with a configurable currentAttempt
    * @param currentAttempt specify the number of attempts for the JobOrchestration event
+   * @param maxAttempt the maximum number of retries for the event
    * @return the {@link GobblinTrackingEvent}
    */
   private GobblinTrackingEvent createJobOrchestratedEvent(int currentAttempt, int maxAttempt) {
@@ -496,7 +497,7 @@ public class KafkaAvroJobStatusMonitorTest {
     return new GobblinTrackingEvent(timestamp, namespace, eventName, metadata);
   }
 
-  MockKafkaAvroJobStatusMonitor createMockKAJSM(AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle, Config additionalConfig) throws IOException, ReflectiveOperationException {
+  MockKafkaAvroJobStatusMonitor createMockKafkaAvroJobStatusMonitor(AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle, Config additionalConfig) throws IOException, ReflectiveOperationException {
     Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
         .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
         .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -115,7 +115,7 @@ public class KafkaAvroJobStatusMonitorTest {
     //Submit GobblinTrackingEvents to Kafka
     ImmutableList.of(
         createFlowCompiledEvent(),
-        createJobOrchestratedEvent(1),
+        createJobOrchestratedEvent(1, 2),
         createJobStartEvent(),
         createJobSucceededEvent(),
         createDummyEvent(), // note position
@@ -130,48 +130,23 @@ public class KafkaAvroJobStatusMonitorTest {
     } catch(InterruptedException ex) {
       Thread.currentThread().interrupt();
     }
-
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
-        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
-        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
-        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"));
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor =  new MockKafkaAvroJobStatusMonitor("test",config, 1);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
         this.kafkaTestHelper.getIteratorForTopic(TOPIC),
         this::convertMessageAndMetadataToDecodableKafkaRecord);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    StateStore stateStore = jobStatusMonitor.getStateStore();
-    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-    String tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, "NA", "NA");
-    List<State> stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    State state = stateList.get(0);
+    State state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPILED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, this.jobGroup, this.jobName);
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.RUNNING.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
 
     // (per above, is a 'dummy' event)
@@ -179,11 +154,7 @@ public class KafkaAvroJobStatusMonitorTest {
         jobStatusMonitor.deserializeEvent(recordIterator.next())));
 
     // Check that state didn't get set to running since it was already complete
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
 
     jobStatusMonitor.shutDown();
@@ -196,12 +167,12 @@ public class KafkaAvroJobStatusMonitorTest {
     //Submit GobblinTrackingEvents to Kafka
     ImmutableList.of(
         createFlowCompiledEvent(),
-        createJobOrchestratedEvent(1),
+        createJobOrchestratedEvent(1, 2),
         createJobStartEvent(),
         createJobFailedEvent(),
         // Mimic retrying - job orchestration
         // set maximum attempt to 2, and current attempt to 2
-        createJobOrchestratedEvent(2),
+        createJobOrchestratedEvent(2, 2),
         // Mimic retrying - job start (current attempt = 2)
         createJobStartEvent(),
         // Mimic retrying - job failed again (current attempt = 2)
@@ -217,11 +188,7 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
-        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
-        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
-        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"));
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = new MockKafkaAvroJobStatusMonitor("test",config, 1);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     ConsumerIterator<byte[], byte[]> iterator = this.kafkaTestHelper.getIteratorForTopic(TOPIC);
@@ -250,51 +217,27 @@ public class KafkaAvroJobStatusMonitorTest {
         iterator,
         this::convertMessageAndMetadataToDecodableKafkaRecord);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, this.jobGroup, this.jobName);
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.RUNNING.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
 
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
     //Because the maximum attempt is set to 2, so the state is set to PENDING_RETRY after the first failure
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.PENDING_RETRY.name());
     Assert.assertEquals(state.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD), Boolean.toString(true));
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     //Job orchestrated for retrying
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     //Because the maximum attempt is set to 2, so the state is set to PENDING_RETRY after the first failure
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.RUNNING.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     //Because the maximum attempt is set to 2, so the state is set to Failed after trying twice
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.FAILED.name());
     Assert.assertEquals(state.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD), Boolean.toString(false));
@@ -309,7 +252,7 @@ public class KafkaAvroJobStatusMonitorTest {
     //Submit GobblinTrackingEvents to Kafka
     ImmutableList.of(
         createFlowCompiledEvent(),
-        createJobOrchestratedEvent(1),
+        createJobOrchestratedEvent(1, 2),
         createJobSkippedEvent()
         ).forEach(event -> {
       context.submitEvent(event);
@@ -322,11 +265,7 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
-        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
-        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
-        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"));
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = new MockKafkaAvroJobStatusMonitor("test",config, 1);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     ConsumerIterator<byte[], byte[]> iterator = this.kafkaTestHelper.getIteratorForTopic(TOPIC);
@@ -355,19 +294,10 @@ public class KafkaAvroJobStatusMonitorTest {
         iterator,
         this::convertMessageAndMetadataToDecodableKafkaRecord);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, this.jobGroup, this.jobName);
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.CANCELLED.name());
     jobStatusMonitor.shutDown();
   }
@@ -379,7 +309,7 @@ public class KafkaAvroJobStatusMonitorTest {
     //Submit GobblinTrackingEvents to Kafka
     ImmutableList.of(
         createFlowCompiledEvent(),
-        createJobOrchestratedEvent(1)
+        createJobOrchestratedEvent(1, 2)
     ).forEach(event -> {
       context.submitEvent(event);
       kafkaReporter.report();
@@ -390,31 +320,18 @@ public class KafkaAvroJobStatusMonitorTest {
     } catch(InterruptedException ex) {
       Thread.currentThread().interrupt();
     }
-
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
-        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
-        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
-        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"))
-        .withValue(KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX + "." + RETRY_MULTIPLIER, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.toMillis(1L)));
-
-    AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle = new AtomicBoolean(false);
     int minNumFakeExceptionsExpected = 10;
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor = new MockKafkaAvroJobStatusMonitor(
-        "test", config, 1, shouldThrowFakeExceptionInParseJobStatusToggle);
+    AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle = new AtomicBoolean(false);
+    Config conf = ConfigFactory.empty().withValue(
+        KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX + "." + RETRY_MULTIPLIER, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.toMillis(1L)));
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(shouldThrowFakeExceptionInParseJobStatusToggle, conf);
     jobStatusMonitor.buildMetricsContextAndMetrics();
 
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
         this.kafkaTestHelper.getIteratorForTopic(TOPIC),
         this::convertMessageAndMetadataToDecodableKafkaRecord);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    StateStore stateStore = jobStatusMonitor.getStateStore();
-    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-    String tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, "NA", "NA");
-    List<State> stateList = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    State state = stateList.get(0);
+    State state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");;
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPILED.name());
 
     shouldThrowFakeExceptionInParseJobStatusToggle.set(true);
@@ -429,18 +346,13 @@ public class KafkaAvroJobStatusMonitorTest {
     // guardrail against excessive retries (befitting this unit test):
     toggleManagementExecutor.scheduleAtFixedRate(mainThread::interrupt, 20, 5, TimeUnit.SECONDS);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
 
     Assert.assertTrue(jobStatusMonitor.getNumFakeExceptionsFromParseJobStatus() > minNumFakeExceptionsExpected,
         String.format("processMessage returned with only %d (faked) exceptions",
             jobStatusMonitor.getNumFakeExceptionsFromParseJobStatus()));
 
-    tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, this.jobGroup, this.jobName);
-    stateList = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
-
     toggleManagementExecutor.shutdownNow();
     jobStatusMonitor.shutDown();
   }
@@ -452,12 +364,12 @@ public class KafkaAvroJobStatusMonitorTest {
     //Submit GobblinTrackingEvents to Kafka
     ImmutableList.of(
         createFlowCompiledEvent(),
-        createJobOrchestratedEvent(1),
+        createJobOrchestratedEvent(1, 4),
         createJobSLAKilledEvent(),
-        createJobOrchestratedEvent(1),
+        createJobOrchestratedEvent(2, 4),
         createJobStartSLAKilledEvent(),
-        // simulate retry again as maximum attempt is 2, but verify that kill event will not retry
-        createJobOrchestratedEvent(1),
+        // Verify that kill event will not retry
+        createJobOrchestratedEvent(3, 4),
         createJobCancelledEvent()
     ).forEach(event -> {
       context.submitEvent(event);
@@ -470,71 +382,34 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
 
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
-        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
-        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
-        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"));
-    MockKafkaAvroJobStatusMonitor jobStatusMonitor =  new MockKafkaAvroJobStatusMonitor("test",config, 1);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKAJSM(new AtomicBoolean(false), ConfigFactory.empty());
     jobStatusMonitor.buildMetricsContextAndMetrics();
     Iterator<DecodeableKafkaRecord> recordIterator = Iterators.transform(
       this.kafkaTestHelper.getIteratorForTopic(TOPIC),
       this::convertMessageAndMetadataToDecodableKafkaRecord);
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    StateStore stateStore = jobStatusMonitor.getStateStore();
-    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-    String tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, "NA", "NA");
-    List<State> stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    State state = stateList.get(0);
+    State state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPILED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, this.jobGroup, this.jobName);
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
-    jobStatusMonitor.processMessage(recordIterator.next());
 
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
-    //Because the maximum attempt is set to 2, so the state is set to PENDING_RETRY after the first failure
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.PENDING_RETRY.name());
     Assert.assertEquals(state.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD), Boolean.toString(true));
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     //Job orchestrated for retrying
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
-    //Job orchestrated for retrying
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.PENDING_RETRY.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     //Job orchestrated for retrying
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.ORCHESTRATED.name());
 
-    jobStatusMonitor.processMessage(recordIterator.next());
-
-    stateList  = stateStore.getAll(storeName, tableName);
-    Assert.assertEquals(stateList.size(), 1);
-    state = stateList.get(0);
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
     // Received kill flow event, should not retry the flow even though there is 1 pending attempt left
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.CANCELLED.name());
     Assert.assertEquals(state.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD), Boolean.toString(false));
@@ -542,17 +417,24 @@ public class KafkaAvroJobStatusMonitorTest {
     jobStatusMonitor.shutDown();
   }
 
+  private State getNextJobStatusState(MockKafkaAvroJobStatusMonitor jobStatusMonitor, Iterator<DecodeableKafkaRecord> recordIterator,
+      String jobGroup, String jobName) throws IOException {
+    jobStatusMonitor.processMessage(recordIterator.next());
+    StateStore stateStore = jobStatusMonitor.getStateStore();
+    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
+    String tableName = KafkaJobStatusMonitor.jobStatusTableName(this.flowExecutionId, jobGroup, jobName);
+    List<State> stateList  = stateStore.getAll(storeName, tableName);
+    Assert.assertEquals(stateList.size(), 1);
+    return stateList.get(0);
+  }
+
   private GobblinTrackingEvent createFlowCompiledEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.FlowTimings.FLOW_COMPILED;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.METADATA_START_TIME, "1");
-    metadata.put(TimingEvent.METADATA_END_TIME, "2");
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
+    // Shouldn't have job properties in the GTE for FLOW_COMPILED events so that it gets marked as "NA"
+    GobblinTrackingEvent event = createGTE(TimingEvent.FlowTimings.FLOW_COMPILED, Maps.newHashMap());
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD);
+    event.getMetadata().remove(TimingEvent.METADATA_MESSAGE);
     return event;
   }
 
@@ -561,144 +443,45 @@ public class KafkaAvroJobStatusMonitorTest {
    * @param currentAttempt specify the number of attempts for the JobOrchestration event
    * @return the {@link GobblinTrackingEvent}
    */
-  private GobblinTrackingEvent createJobOrchestratedEvent(int currentAttempt) {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.LauncherTimings.JOB_ORCHESTRATED;
+  private GobblinTrackingEvent createJobOrchestratedEvent(int currentAttempt, int maxAttempt) {
     Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, "2");
+    metadata.put(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, String.valueOf(maxAttempt));
     metadata.put(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, String.valueOf(currentAttempt));
     metadata.put(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, Boolean.toString(false));
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.METADATA_START_TIME, "3");
-    metadata.put(TimingEvent.METADATA_END_TIME, "4");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.LauncherTimings.JOB_ORCHESTRATED, metadata);
   }
 
   private GobblinTrackingEvent createJobStartEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.LauncherTimings.JOB_START;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "5");
-    metadata.put(TimingEvent.METADATA_END_TIME, "6");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.LauncherTimings.JOB_START, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobSkippedEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.JOB_SKIPPED_TIME;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "5");
-    metadata.put(TimingEvent.METADATA_END_TIME, "6");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.JOB_SKIPPED_TIME, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobSucceededEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.LauncherTimings.JOB_SUCCEEDED;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "7");
-    metadata.put(TimingEvent.METADATA_END_TIME, "8");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.LauncherTimings.JOB_SUCCEEDED, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobFailedEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.LauncherTimings.JOB_FAILED;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "7");
-    metadata.put(TimingEvent.METADATA_END_TIME, "8");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.LauncherTimings.JOB_FAILED, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobCancelledEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.FlowTimings.FLOW_CANCELLED;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "7");
-    metadata.put(TimingEvent.METADATA_END_TIME, "8");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.FlowTimings.FLOW_CANCELLED, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobSLAKilledEvent() {
-    String namespace = "org.apache.gobblin.metrics";
-    Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.FlowTimings.FLOW_SLA_KILLED;
-    Map<String, String> metadata = Maps.newHashMap();
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
-    metadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, this.flowExecutionId);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, this.jobName);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, this.jobGroup);
-    metadata.put(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, this.jobExecutionId);
-    metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
-    metadata.put(TimingEvent.METADATA_START_TIME, "7");
-    metadata.put(TimingEvent.METADATA_END_TIME, "8");
-
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+    return createGTE(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED, Maps.newHashMap());
   }
 
   private GobblinTrackingEvent createJobStartSLAKilledEvent() {
+    return createGTE(TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED, Maps.newHashMap());
+  }
+
+  private GobblinTrackingEvent createGTE(String eventName, Map<String, String> customMetadata) {
     String namespace = "org.apache.gobblin.metrics";
     Long timestamp = System.currentTimeMillis();
-    String name = TimingEvent.FlowTimings.FLOW_START_SLA_KILLED;
     Map<String, String> metadata = Maps.newHashMap();
     metadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, this.flowGroup);
     metadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, this.flowName);
@@ -709,9 +492,17 @@ public class KafkaAvroJobStatusMonitorTest {
     metadata.put(TimingEvent.METADATA_MESSAGE, this.message);
     metadata.put(TimingEvent.METADATA_START_TIME, "7");
     metadata.put(TimingEvent.METADATA_END_TIME, "8");
+    metadata.putAll(customMetadata);
+    return new GobblinTrackingEvent(timestamp, namespace, eventName, metadata);
+  }
 
-    GobblinTrackingEvent event = new GobblinTrackingEvent(timestamp, namespace, name, metadata);
-    return event;
+  MockKafkaAvroJobStatusMonitor createMockKAJSM(AtomicBoolean shouldThrowFakeExceptionInParseJobStatusToggle, Config additionalConfig) throws IOException, ReflectiveOperationException {
+    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("localhost:0000"))
+        .withValue(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, ConfigValueFactory.fromAnyRef("org.apache.kafka.common.serialization.ByteArrayDeserializer"))
+        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir))
+        .withValue("zookeeper.connect", ConfigValueFactory.fromAnyRef("localhost:2121"))
+        .withFallback(additionalConfig);
+    return new MockKafkaAvroJobStatusMonitor("test",config, 1, shouldThrowFakeExceptionInParseJobStatusToggle);
   }
   /**
    *   Create a dummy event to test if it is filtered out by the consumer.
@@ -762,11 +553,6 @@ public class KafkaAvroJobStatusMonitorTest {
     private final AtomicBoolean shouldThrowFakeExceptionInParseJobStatus;
     @Getter
     private volatile int numFakeExceptionsFromParseJobStatus = 0;
-
-    public MockKafkaAvroJobStatusMonitor(String topic, Config config, int numThreads)
-        throws IOException, ReflectiveOperationException {
-      this(topic, config, numThreads, new AtomicBoolean(false));
-    }
 
     /**
      * @param shouldThrowFakeExceptionInParseJobStatusToggle - pass (and retain) to dial whether `parseJobStatus` throws

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -803,7 +803,7 @@ public class DagManager extends AbstractIdleService {
         cancelDagNode(node);
 
         String dagId = DagManagerUtils.generateDagId(node);
-        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_CANCELLED);
+        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_START_SLA_KILLED);
         this.dags.get(dagId).setMessage("Flow killed because no update received for " + timeOutForJobStart + " ms after orchestration");
 
         return true;
@@ -860,7 +860,7 @@ public class DagManager extends AbstractIdleService {
             node.getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY));
         cancelDagNode(node);
 
-        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_CANCELLED);
+        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_SLA_KILLED);
         this.dags.get(dagId).setMessage("Flow killed due to exceeding SLA of " + flowSla + " ms");
 
         return true;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -803,7 +803,7 @@ public class DagManager extends AbstractIdleService {
         cancelDagNode(node);
 
         String dagId = DagManagerUtils.generateDagId(node);
-        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_START_SLA_KILLED);
+        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED);
         this.dags.get(dagId).setMessage("Flow killed because no update received for " + timeOutForJobStart + " ms after orchestration");
 
         return true;
@@ -860,7 +860,7 @@ public class DagManager extends AbstractIdleService {
             node.getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY));
         cancelDagNode(node);
 
-        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_SLA_KILLED);
+        this.dags.get(dagId).setFlowEvent(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED);
         this.dags.get(dagId).setMessage("Flow killed due to exceeding SLA of " + flowSla + " ms");
 
         return true;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -164,6 +164,12 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
         properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
+      case TimingEvent.FlowTimings.FLOW_START_SLA_KILLED:
+      case TimingEvent.FlowTimings.FLOW_SLA_KILLED:
+        properties.put(TimingEvent.FlowEventConstants.IS_FLOW_SLA_KILLED, true);
+        properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
+        properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
+        break;
       case TimingEvent.JOB_COMPLETION_PERCENTAGE:
         properties.put(TimingEvent.JOB_LAST_PROGRESS_EVENT_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -164,9 +164,9 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
         properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
-      case TimingEvent.FlowTimings.FLOW_START_SLA_KILLED:
-      case TimingEvent.FlowTimings.FLOW_SLA_KILLED:
-        properties.put(TimingEvent.FlowEventConstants.IS_FLOW_SLA_KILLED, true);
+      case TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED:
+      case TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED:
+        properties.put(TimingEvent.FlowEventConstants.DOES_CANCELED_FLOW_MERIT_RETRY, true);
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
         properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -278,8 +278,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     }
 
     modifyStateIfRetryRequired(jobStatus);
-    // Remove data not needed to be stored in state store
-    jobStatus.removeProp(TimingEvent.FlowEventConstants.IS_FLOW_SLA_KILLED);
     stateStore.put(storeName, tableName, jobStatus);
   }
 
@@ -289,12 +287,13 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     // SHOULD_RETRY_FIELD maybe reset by JOB_COMPLETION_PERCENTAGE event
     if ((state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.FAILED.name())
         || state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.PENDING_RETRY.name())
-        || (state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.CANCELLED.name()) && state.contains(TimingEvent.FlowEventConstants.IS_FLOW_SLA_KILLED))
+        || (state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.CANCELLED.name()) && state.contains(TimingEvent.FlowEventConstants.DOES_CANCELED_FLOW_MERIT_RETRY))
     ) && currentAttempts < maxAttempts) {
       state.setProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, true);
       state.setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.PENDING_RETRY.name());
       state.removeProp(TimingEvent.JOB_END_TIME);
     }
+    state.removeProp(TimingEvent.FlowEventConstants.DOES_CANCELED_FLOW_MERIT_RETRY);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1634


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
On Gobblin as a Service flows can fail SLAs if they do not receive a Kafka event in some designated amount of time.

Since GaaS supports retrys on failures, these failures due to SLAs should also be retryable.

However, if the flow is cancelled from a user specified event through the API we do not want to retry.
Additionally, we also do not want to retry if a flow is skipped due to concurrent jobs running at the same time, as it is unlikely without a more sophisticated waiting algorithm that the job will be finished by the time the job is retried again, wasting resources.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

