### PR TITLE
[GOBBLIN-1636] Close DatasetCleaner after clean task

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/runtime/retention/DatasetCleanerCli.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/runtime/retention/DatasetCleanerCli.java
@@ -43,12 +43,21 @@ public class DatasetCleanerCli implements CliApplication {
 
   @Override
   public void run(String[] args) {
+    DatasetCleaner datasetCleaner = null;
     try {
       Properties properties = readProperties(parseConfigLocation(args));
-      DatasetCleaner datasetCleaner = new DatasetCleaner(FileSystem.get(new Configuration()), properties);
+      datasetCleaner = new DatasetCleaner(FileSystem.get(new Configuration()), properties);
       datasetCleaner.clean();
     } catch (IOException e) {
       throw new RuntimeException(e);
+    } finally {
+      if (datasetCleaner != null) {
+        try {
+          datasetCleaner.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/runtime/retention/DatasetCleanerTask.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/runtime/retention/DatasetCleanerTask.java
@@ -47,16 +47,25 @@ public class DatasetCleanerTask extends BaseAbstractTask {
   }
 
   @Override
-  public void run() {
+  public void run(){
+    DatasetCleaner datasetCleaner = null;
     try {
       Configuration conf = new Configuration();
       JobConfigurationUtils.putStateIntoConfiguration(this.taskContext.getTaskState(), conf);
-      DatasetCleaner datasetCleaner = new DatasetCleaner(FileSystem.get(conf), this.taskContext.getTaskState().getProperties());
+      datasetCleaner = new DatasetCleaner(FileSystem.get(conf), this.taskContext.getTaskState().getProperties());
       datasetCleaner.clean();
       this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
     } catch (IOException e) {
       this.workingState = WorkUnitState.WorkingState.FAILED;
       throw new RuntimeException(e);
+    } finally {
+      if (datasetCleaner != null) {
+        try {
+          datasetCleaner.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
     }
   }
 

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -61,7 +61,11 @@ public class DatasetCleanerJob extends AbstractJob implements Tool {
   @Override
   public void run() throws Exception {
     if (this.datasetCleaner != null) {
-      this.datasetCleaner.clean();
+      try {
+        this.datasetCleaner.clean();
+      } finally {
+        this.datasetCleaner.close();
+      }
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1636


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
DatasetCleaner internally launches the clean tasks for each version of the dataset in an ExecutorService and then waits for the tasks to get completed in the close() method but since DatasetCleanerTask never invokes close() soWe observed that the Gobblin tasks and Job finish early and don’t wait for all the dataset versions to get deleted successfully. 



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

