### PR TITLE
[GOBBLIN-1637] Add writer, operation, and partition info to failed metadata writer events

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriterWithPartitionInfoException.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriterWithPartitionInfoException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive.writer;
+
+import java.io.IOException;
+import java.util.Set;
+
+
+public class HiveMetadataWriterWithPartitionInfoException extends IOException {
+  public Set<String> addedPartitionValues;
+  public Set<String> droppedPartitionValues;
+
+  HiveMetadataWriterWithPartitionInfoException(Set<String> addedPartitionValues, Set<String> droppedPartitionValues, Exception exception) {
+    super(exception);
+    this.addedPartitionValues = addedPartitionValues;
+    this.droppedPartitionValues = droppedPartitionValues;
+  }
+}

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
@@ -33,14 +33,14 @@ public class GobblinMetadataException extends IOException {
   public String GMCETopicPartition;
   public long highWatermark;
   public long lowWatermark;
-  public String failedWriter;
+  public List<String> failedWriters;
   public OperationType operationType;
   public Set<String> addedPartitionValues;
   public Set<String> droppedPartitionValues;
   public List<HiveRegistrationUnit.Column> partitionKeys;
 
   GobblinMetadataException(String datasetPath, String dbName, String tableName, String GMCETopicPartition, long lowWatermark, long highWatermark,
-      String failedWriter, OperationType operationType, List<HiveRegistrationUnit.Column> partitionKeys, Exception exception) {
+      List<String> failedWriters, OperationType operationType, List<HiveRegistrationUnit.Column> partitionKeys, Exception exception) {
     super(String.format("failed to flush table %s, %s", dbName, tableName), exception);
     this.datasetPath = datasetPath;
     this.dbName = dbName;
@@ -48,7 +48,7 @@ public class GobblinMetadataException extends IOException {
     this.GMCETopicPartition = GMCETopicPartition;
     this.highWatermark = highWatermark;
     this.lowWatermark = lowWatermark;
-    this.failedWriter = failedWriter;
+    this.failedWriters = failedWriters;
     this.operationType = operationType;
     this.addedPartitionValues = new HashSet<>();
     this.droppedPartitionValues = new HashSet<>();

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
@@ -18,6 +18,10 @@
 package org.apache.gobblin.iceberg.writer;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.gobblin.metadata.OperationType;
 
 
 public class GobblinMetadataException extends IOException {
@@ -27,8 +31,12 @@ public class GobblinMetadataException extends IOException {
   public String GMCETopicPartition;
   public long highWatermark;
   public long lowWatermark;
-  public Exception exception;
-  GobblinMetadataException(String datasetPath, String dbName, String tableName, String GMCETopicPartition, long lowWatermark, long highWatermark, Exception exception) {
+  public String failedWriter;
+  public OperationType operationType;
+  public Set<String> addedPartitionValues;
+  public Set<String> droppedPartitionValues;
+  GobblinMetadataException(String datasetPath, String dbName, String tableName, String GMCETopicPartition, long lowWatermark, long highWatermark,
+      String failedWriter, OperationType operationType, Exception exception) {
     super(String.format("failed to flush table %s, %s", dbName, tableName), exception);
     this.datasetPath = datasetPath;
     this.dbName = dbName;
@@ -36,5 +44,9 @@ public class GobblinMetadataException extends IOException {
     this.GMCETopicPartition = GMCETopicPartition;
     this.highWatermark = highWatermark;
     this.lowWatermark = lowWatermark;
+    this.failedWriter = failedWriter;
+    this.operationType = operationType;
+    this.addedPartitionValues = new HashSet<>();
+    this.droppedPartitionValues = new HashSet<>();
   }
 }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMetadataException.java
@@ -19,8 +19,10 @@ package org.apache.gobblin.iceberg.writer;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.metadata.OperationType;
 
 
@@ -35,8 +37,10 @@ public class GobblinMetadataException extends IOException {
   public OperationType operationType;
   public Set<String> addedPartitionValues;
   public Set<String> droppedPartitionValues;
+  public List<HiveRegistrationUnit.Column> partitionKeys;
+
   GobblinMetadataException(String datasetPath, String dbName, String tableName, String GMCETopicPartition, long lowWatermark, long highWatermark,
-      String failedWriter, OperationType operationType, Exception exception) {
+      String failedWriter, OperationType operationType, List<HiveRegistrationUnit.Column> partitionKeys, Exception exception) {
     super(String.format("failed to flush table %s, %s", dbName, tableName), exception);
     this.datasetPath = datasetPath;
     this.dbName = dbName;
@@ -48,5 +52,6 @@ public class GobblinMetadataException extends IOException {
     this.operationType = operationType;
     this.addedPartitionValues = new HashSet<>();
     this.droppedPartitionValues = new HashSet<>();
+    this.partitionKeys = partitionKeys;
   }
 }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -40,6 +40,7 @@ public class IcebergMCEMetadataKeys {
   public static final String OPERATION_TYPE_KEY = "operationType";
   public static final String ADDED_PARTITION_VALUES_KEY = "failedToAddPartitionValues";
   public static final String DROPPED_PARTITION_VALUES_KEY = "failedToDropPartitionValues";
+  public static final String PARTITION_KEYS = "partitionKeys";
 
   private IcebergMCEMetadataKeys() {
   }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -36,7 +36,7 @@ public class IcebergMCEMetadataKeys {
   public static final String FAILURE_EVENT_TABLE_NAME = "tableName";
   public static final String CLUSTER_IDENTIFIER_KEY_NAME = "clusterIdentifier";
   public static final String EXCEPTION_MESSAGE_KEY_NAME = "exceptionMessage";
-  public static final String FAILED_WRITER_KEY = "failedWriter";
+  public static final String FAILED_WRITERS_KEY = "failedWriters";
   public static final String OPERATION_TYPE_KEY = "operationType";
   public static final String ADDED_PARTITION_VALUES_KEY = "failedToAddPartitionValues";
   public static final String DROPPED_PARTITION_VALUES_KEY = "failedToDropPartitionValues";

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMCEMetadataKeys.java
@@ -36,6 +36,10 @@ public class IcebergMCEMetadataKeys {
   public static final String FAILURE_EVENT_TABLE_NAME = "tableName";
   public static final String CLUSTER_IDENTIFIER_KEY_NAME = "clusterIdentifier";
   public static final String EXCEPTION_MESSAGE_KEY_NAME = "exceptionMessage";
+  public static final String FAILED_WRITER_KEY = "failedWriter";
+  public static final String OPERATION_TYPE_KEY = "operationType";
+  public static final String ADDED_PARTITION_VALUES_KEY = "failedToAddPartitionValues";
+  public static final String DROPPED_PARTITION_VALUES_KEY = "failedToDropPartitionValues";
 
   private IcebergMCEMetadataKeys() {
   }

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -365,10 +365,10 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap().values().iterator().next().size(), 1);
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap()
         .get(new File(tmpDir, "testDB/testIcebergTable").getAbsolutePath())
-        .get("hivedb.testIcebergTable").lowWatermark, 50L);
+        .get("hivedb.testIcebergTable").get(0).lowWatermark, 50L);
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap()
         .get(new File(tmpDir, "testDB/testIcebergTable").getAbsolutePath())
-        .get("hivedb.testIcebergTable").highWatermark, 52L);
+        .get("hivedb.testIcebergTable").get(0).highWatermark, 52L);
 
     // No events sent yet since the topic has not been flushed
     Assert.assertEquals(eventsSent.size(), 0);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1637


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

- Add info of which metadata writer failed in the failure events
- Add which operation type failed. To do this, split up the events so that there's a separate event if opType changes, otherwise the event offset ranges could contain multiple different offsets
- Add which partition values were intended to be added/dropped as part of these GMCE. To do this added a `HiveMetadataWriterWithPartitionInfoException.java` only thrown from hive writer in order to pass partition info back to MCE Writer
- Fix bug in hive metadata writer where failure in flush would throw RuntimeException, but catch block only catches IOException so fault tolerant behaviour would never work for flush failures

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in test pipeline

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

