### PR TITLE
[GOBBLIN-1639] Prevent metrics reporting if configured, clean up workunit count metric

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1131,4 +1131,8 @@ public class ConfigurationKeys {
    * */
   public static final String TROUBLESHOOTER_IN_MEMORY_ISSUE_REPOSITORY_MAX_SIZE = "gobblin.troubleshooter.inMemoryIssueRepository.maxSize";
   public static final int DEFAULT_TROUBLESHOOTER_IN_MEMORY_ISSUE_REPOSITORY_MAX_SIZE = 100;
+
+  public static final String JOB_METRICS_REPORTER_CLASS_KEY = "gobblin.job.metrics.reporter.class";
+  public static final String DEFAULT_JOB_METRICS_REPORTER_CLASS = "org.apache.gobblin.runtime.metrics.DefaultGobblinJobMetricReporter";
+
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1014,7 +1014,7 @@ public class ConfigurationKeys {
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
   public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
   public static final String WHITELISTED_EDGE_IDS = "gobblin.flow.whitelistedEdgeIds";
-  public static final String GOBBLIN_JOB_SHOULD_OUTPUT_METRICS = "gobblin.internal.job.shouldOutputMetrics";
+  public static final String GOBBLIN_OUTPUT_JOB_LEVEL_METRICS = "gobblin.job.outputJobLevelMetrics";
   /***
    * Configuration properties related to TopologySpec Store
    */

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1014,7 +1014,7 @@ public class ConfigurationKeys {
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
   public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
   public static final String WHITELISTED_EDGE_IDS = "gobblin.flow.whitelistedEdgeIds";
-  public static final String GOBBLIN_FLOW_ISADHOC = "gobblin.internal.flow.isAdhoc";
+  public static final String GOBBLIN_JOB_SHOULD_OUTPUT_METRICS = "gobblin.internal.job.shouldOutputMetrics";
   /***
    * Configuration properties related to TopologySpec Store
    */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.gobblin.runtime.metrics.GobblinJobMetricReporter;
@@ -44,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Function;
@@ -73,11 +71,9 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.initializer.ConverterInitializerFactory;
 import org.apache.gobblin.destination.DestinationDatasetHandlerService;
-import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.GobblinMetricsRegistry;
 import org.apache.gobblin.metrics.MetricContext;
-import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.EventName;
 import org.apache.gobblin.metrics.event.EventSubmitter;
@@ -250,9 +246,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           PropertiesUtils.getPropAsList(jobProps, ConfigurationKeys.EVENT_METADATA_GENERATOR_CLASS_KEY,
               ConfigurationKeys.DEFAULT_EVENT_METADATA_GENERATOR_CLASS_KEY));
 
-      String jobMetricsReporterClassName = this.jobProps.contains(ConfigurationKeys.JOB_METRICS_REPORTER_CLASS_KEY) ?
-          this.jobProps.getProperty(ConfigurationKeys.JOB_METRICS_REPORTER_CLASS_KEY) : ConfigurationKeys.DEFAULT_JOB_METRICS_REPORTER_CLASS;
-      this.gobblinJobMetricsReporter =  GobblinConstructorUtils.invokeConstructor(GobblinJobMetricReporter.class, jobMetricsReporterClassName,
+      String jobMetricsReporterClassName = this.jobProps.getProperty(ConfigurationKeys.JOB_METRICS_REPORTER_CLASS_KEY, ConfigurationKeys.DEFAULT_JOB_METRICS_REPORTER_CLASS);
+      this.gobblinJobMetricsReporter =  (GobblinJobMetricReporter) GobblinConstructorUtils.invokeLongestConstructor(Class.forName(jobMetricsReporterClassName),
           this.runtimeMetricContext);
 
     } catch (Exception e) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -674,9 +674,9 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         }
       }
     } finally {
-      // Register metrics then stop metrics reporting, reporting is done when the metricsContext is closed
+      // Register metrics then stop metrics reporting, metrics will flush and emit when the metricsContext is closed
       if (this.jobContext.getJobMetricsOptional().isPresent()) {
-        if (jobState.getPropAsBoolean(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, true)) {
+        if (jobState.getPropAsBoolean(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true)) {
           String workunitCreationGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_JOB_METRICS_PREFIX,
               TimingEvent.LauncherTimings.WORK_UNITS_CREATION, jobState.getJobName());
           long workUnitsCreationTime = workUnitsCreationTimer.getDuration() / TimeUnit.SECONDS.toMillis(1);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -680,7 +680,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         }
       }
     } finally {
-      // Register metrics then stop metrics reporting, metrics will flush and emit when the metricsContext is closed
+      // Stop metrics reporting
       if (this.jobContext.getJobMetricsOptional().isPresent()) {
         JobMetrics.remove(jobState);
       }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
@@ -1,0 +1,41 @@
+package org.apache.gobblin.runtime.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.gobblin.metrics.ContextAwareGauge;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.ServiceMetricNames;
+import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.runtime.JobState;
+
+
+/**
+ * A metrics reporter that reports only workunitsCreationTimer - which is the current default behavior
+ *
+ */
+public class DefaultGobblinJobMetricReporter implements GobblinJobMetricReporter {
+
+  private Optional<MetricContext> metricContext;
+
+  public DefaultGobblinJobMetricReporter(Optional<MetricContext> metricContext) {
+     this.metricContext = metricContext;
+  }
+
+  public void reportWorkUnitCreationTimerMetrics(TimingEvent workUnitsCreationTimer, JobState jobState) {
+    if (!this.metricContext.isPresent()) {
+      return;
+    }
+    String workunitCreationGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_JOB_METRICS_PREFIX,
+        TimingEvent.LauncherTimings.WORK_UNITS_CREATION, jobState.getJobName());
+    long workUnitsCreationTime = workUnitsCreationTimer.getDuration() / TimeUnit.SECONDS.toMillis(1);
+    ContextAwareGauge<Integer> workunitCreationGauge = this.metricContext.get()
+        .newContextAwareGauge(workunitCreationGaugeName, () -> (int) workUnitsCreationTime);
+    this.metricContext.get().register(workunitCreationGaugeName, workunitCreationGauge);
+  }
+
+  public void reportWorkUnitCountMetrics(int workUnitCount, JobState jobstate) {
+    return;
+  }
+
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.runtime.metrics;
 
 import com.codahale.metrics.MetricRegistry;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
@@ -1,7 +1,7 @@
 package org.apache.gobblin.runtime.metrics;
 
 import com.codahale.metrics.MetricRegistry;
-import java.util.Optional;
+import com.google.common.base.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.MetricContext;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/DefaultGobblinJobMetricReporter.java
@@ -28,8 +28,8 @@ import org.apache.gobblin.runtime.JobState;
 
 
 /**
- * A metrics reporter that reports only workunitsCreationTimer - which is the current default behavior
- *
+ * A metrics reporter that reports only workunitsCreationTimer - which is the current default behavior for all Gobblin jobs not emitted by GaaS
+ * Emit metrics with JobMetrics as the prefix
  */
 public class DefaultGobblinJobMetricReporter implements GobblinJobMetricReporter {
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.runtime.metrics;
 
 import org.apache.gobblin.metrics.event.TimingEvent;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
@@ -1,0 +1,13 @@
+package org.apache.gobblin.runtime.metrics;
+
+import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.runtime.JobState;
+
+
+public interface GobblinJobMetricReporter {
+
+  public void reportWorkUnitCreationTimerMetrics(TimingEvent workUnitsCreationTimer, JobState jobState);
+
+  public void reportWorkUnitCountMetrics(int workUnitCount, JobState jobState);
+
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporter.java
@@ -6,8 +6,8 @@ import org.apache.gobblin.runtime.JobState;
 
 public interface GobblinJobMetricReporter {
 
-  public void reportWorkUnitCreationTimerMetrics(TimingEvent workUnitsCreationTimer, JobState jobState);
+   void reportWorkUnitCreationTimerMetrics(TimingEvent workUnitsCreationTimer, JobState jobState);
 
-  public void reportWorkUnitCountMetrics(int workUnitCount, JobState jobState);
+   void reportWorkUnitCountMetrics(int workUnitCount, JobState jobState);
 
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.runtime.metrics;
 
 import com.codahale.metrics.MetricRegistry;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
@@ -1,7 +1,7 @@
 package org.apache.gobblin.runtime.metrics;
 
 import com.codahale.metrics.MetricRegistry;
-import java.util.Optional;
+import com.google.common.base.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.ContextAwareGauge;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/ServiceGobblinJobMetricReporter.java
@@ -1,0 +1,50 @@
+package org.apache.gobblin.runtime.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metrics.ContextAwareGauge;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.ServiceMetricNames;
+import org.apache.gobblin.metrics.event.JobEvent;
+import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.runtime.JobState;
+
+
+/**
+ * A metrics reporter to report job-level metrics to Gobblin-as-a-Service
+ * Metrics should have the name FLOW_GROUP.FLOW_NAME.EDGE_ID.METRIC_NAME
+ * If edge ID does not exist due to a different flowgraph being used, use the jobName as default
+ */
+public class ServiceGobblinJobMetricReporter implements GobblinJobMetricReporter {
+  static String FLOW_EDGE_ID_KEY = "flow.edge.id";
+  private Optional<MetricContext> metricContext;
+
+  public ServiceGobblinJobMetricReporter(Optional<MetricContext> metricContext) {
+    this.metricContext = metricContext;
+  }
+
+  public void reportWorkUnitCreationTimerMetrics(TimingEvent workUnitsCreationTimer, JobState jobState) {
+    if (!this.metricContext.isPresent() || !jobState.getPropAsBoolean(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true)) {
+      return;
+    }
+    String workunitCreationGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, jobState.getProp(ConfigurationKeys.FLOW_GROUP_KEY),
+        jobState.getProp(ConfigurationKeys.FLOW_NAME_KEY), jobState.getProp(FLOW_EDGE_ID_KEY, jobState.getJobName()), TimingEvent.LauncherTimings.WORK_UNITS_CREATION);
+    long workUnitsCreationTime = workUnitsCreationTimer.getDuration() / TimeUnit.SECONDS.toMillis(1);
+    ContextAwareGauge<Integer> workunitCreationGauge =
+        this.metricContext.get().newContextAwareGauge(workunitCreationGaugeName, () -> (int) workUnitsCreationTime);
+    this.metricContext.get().register(workunitCreationGaugeName, workunitCreationGauge);
+  }
+
+  public void reportWorkUnitCountMetrics(int workUnitCount, JobState jobState) {
+    if (!this.metricContext.isPresent() || !jobState.getPropAsBoolean(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true)) {
+      return;
+    }
+    String workunitCountGaugeName =  MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, jobState.getProp(ConfigurationKeys.FLOW_GROUP_KEY),
+        jobState.getProp(ConfigurationKeys.FLOW_NAME_KEY), jobState.getProp(FLOW_EDGE_ID_KEY, jobState.getJobName()), JobEvent.WORK_UNITS_CREATED);
+    ContextAwareGauge<Integer> workunitCountGauge = this.metricContext.get()
+        .newContextAwareGauge(workunitCountGaugeName, () -> Integer.valueOf(workUnitCount));
+    this.metricContext.get().register(workunitCountGaugeName, workunitCountGauge);
+  }
+}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
@@ -30,7 +30,6 @@ import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
 import org.apache.gobblin.runtime.JobContext;
 import org.apache.gobblin.runtime.JobLauncherTestHelper;
 import org.apache.gobblin.runtime.JobState;
-import org.apache.gobblin.runtime.local.LocalJobLauncher;
 import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -39,9 +38,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Unit test for {@link LocalJobLauncher}.
- *
- * @author Yinan Li
+ * Unit test for {@link GobblinJobMetricReporter and its implementation classes}.
  */
 @Test(groups = { "gobblin.runtime.local" })
 public class GobblinJobMetricReporterTest {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
@@ -52,6 +52,7 @@ public class GobblinJobMetricReporterTest {
 
   @BeforeClass
   public void startUp() throws Exception {
+    testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
     this.launcherProps = new Properties();
     this.launcherProps.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/metrics/GobblinJobMetricReporterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.runtime.metrics;
+
+import com.codahale.metrics.Metric;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metastore.FsStateStore;
+import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
+import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.runtime.JobContext;
+import org.apache.gobblin.runtime.JobLauncherTestHelper;
+import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.runtime.local.LocalJobLauncher;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+
+/**
+ * Unit test for {@link LocalJobLauncher}.
+ *
+ * @author Yinan Li
+ */
+@Test(groups = { "gobblin.runtime.local" })
+public class GobblinJobMetricReporterTest {
+
+  private Properties launcherProps;
+  private JobLauncherTestHelper jobLauncherTestHelper;
+  private ITestMetastoreDatabase testMetastoreDatabase;
+
+  @BeforeClass
+  public void startUp() throws Exception {
+    this.launcherProps = new Properties();
+    this.launcherProps.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
+    this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
+    this.launcherProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
+    this.launcherProps.setProperty(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, "false");
+    this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY, testMetastoreDatabase.getJdbcUrl());
+
+    StateStore<JobState.DatasetState> datasetStateStore =
+        new FsStateStore<>(this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
+            this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY), JobState.DatasetState.class);
+
+    this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, datasetStateStore);
+  }
+
+  @Test
+  public void testLaunchJobWithDefaultMetricsReporter() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testDefaultMetricsReporter");
+    try {
+      JobContext jobContext = this.jobLauncherTestHelper.runTest(jobProps);
+      Map<String, Metric> metrics = jobContext.getJobMetricsOptional().get().getMetricContext().getMetrics();
+      Assert.assertTrue(metrics.containsKey("JobMetrics.WorkUnitsCreationTimer.GobblinTest1-testDefaultMetricsReporter"));
+
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+
+  @Test
+  public void testLaunchJobWithServiceMetricsReporter() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, "true");
+    jobProps.setProperty(ConfigurationKeys.JOB_METRICS_REPORTER_CLASS_KEY, ServiceGobblinJobMetricReporter.class.getName());
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, "FlowName_FlowGroup_JobName_EdgeId_Hash");
+    jobProps.setProperty(ConfigurationKeys.FLOW_GROUP_KEY, "FlowGroup");
+    jobProps.setProperty(ConfigurationKeys.FLOW_NAME_KEY, "FlowName");
+    jobProps.setProperty("flow.edge.id", "EdgeId");
+    try {
+      JobContext jobContext = this.jobLauncherTestHelper.runTest(jobProps);
+      Map<String, Metric> metrics = jobContext.getJobMetricsOptional().get().getMetricContext().getMetrics();
+      Assert.assertTrue(metrics.containsKey("GobblinService.FlowGroup.FlowName.EdgeId.WorkUnitsCreated"));
+      Assert.assertTrue(metrics.containsKey("GobblinService.FlowGroup.FlowName.EdgeId.WorkUnitsCreationTimer"));
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() throws IOException {
+    if (testMetastoreDatabase != null) {
+      testMetastoreDatabase.close();
+    }
+  }
+
+  private Properties loadJobProps() throws IOException {
+    Properties jobProps = new Properties();
+    jobProps.load(new FileReader("gobblin-test/resource/job-conf/GobblinTest1.pull"));
+    jobProps.putAll(this.launcherProps);
+    jobProps.setProperty(JobLauncherTestHelper.SOURCE_FILE_LIST_KEY,
+        "gobblin-test/resource/source/test.avro.0," + "gobblin-test/resource/source/test.avro.1,"
+            + "gobblin-test/resource/source/test.avro.2," + "gobblin-test/resource/source/test.avro.3");
+
+    return jobProps;
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -676,7 +676,7 @@ public class DagManager extends AbstractIdleService {
 
       FlowId flowId = DagManagerUtils.getFlowId(dag);
       // Do not register flow-specific metrics for a flow
-      if (!flowGauges.containsKey(flowId.toString()) && !DagManagerUtils.isDagFromAdhocFlow(dag)) {
+      if (!flowGauges.containsKey(flowId.toString()) && DagManagerUtils.shouldFlowOutputMetrics(dag)) {
         String flowStateGaugeName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, flowId.getFlowGroup(),
             flowId.getFlowName(), ServiceMetricNames.RUNNING_STATUS);
         flowGauges.put(flowId.toString(), FlowState.RUNNING);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -314,7 +314,7 @@ public class DagManagerUtils {
 
   static boolean shouldFlowOutputMetrics(Dag<JobExecutionPlan> dag) {
     // defaults to false (so metrics are still tracked) if the dag property is not configured due to old dags
-    return ConfigUtils.getBoolean(getDagJobConfig(dag), ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, true);
+    return ConfigUtils.getBoolean(getDagJobConfig(dag), ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true);
   }
 
   static void emitFlowEvent(Optional<EventSubmitter> eventSubmitter, Dag<JobExecutionPlan> dag, String flowEvent) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -312,9 +312,9 @@ public class DagManagerUtils {
     return dag.getStartNodes().get(0).getValue().getJobSpec().getConfig();
   }
 
-  static boolean isDagFromAdhocFlow(Dag<JobExecutionPlan> dag) {
+  static boolean shouldFlowOutputMetrics(Dag<JobExecutionPlan> dag) {
     // defaults to false (so metrics are still tracked) if the dag property is not configured due to old dags
-    return ConfigUtils.getBoolean(getDagJobConfig(dag), ConfigurationKeys.GOBBLIN_FLOW_ISADHOC,false);
+    return ConfigUtils.getBoolean(getDagJobConfig(dag), ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, true);
   }
 
   static void emitFlowEvent(Optional<EventSubmitter> eventSubmitter, Dag<JobExecutionPlan> dag, String flowEvent) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -127,7 +127,7 @@ public class JobExecutionPlan {
           //Add flow execution id
           .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId))
           // Remove schedule due to namespace conflict with azkaban schedule key, but still keep track if flow is scheduled or not
-          .withValue(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, ConfigValueFactory.fromAnyRef(jobSpec.getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)))
+          .withValue(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, ConfigValueFactory.fromAnyRef(jobSpec.getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)))
           .withoutPath(ConfigurationKeys.JOB_SCHEDULE_KEY)
           //Remove template uri
           .withoutPath(GOBBLIN_JOB_TEMPLATE_KEY)

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -127,7 +127,7 @@ public class JobExecutionPlan {
           //Add flow execution id
           .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId))
           // Remove schedule due to namespace conflict with azkaban schedule key, but still keep track if flow is scheduled or not
-          .withValue(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC, ConfigValueFactory.fromAnyRef(!jobSpec.getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)))
+          .withValue(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, ConfigValueFactory.fromAnyRef(jobSpec.getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY)))
           .withoutPath(ConfigurationKeys.JOB_SCHEDULE_KEY)
           //Remove template uri
           .withoutPath(GOBBLIN_JOB_TEMPLATE_KEY)

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -22,14 +22,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.rholder.retry.Attempt;
@@ -53,11 +51,8 @@ import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.metastore.FileContextBasedFsStateStore;
 import org.apache.gobblin.metastore.FileContextBasedFsStateStoreFactory;
 import org.apache.gobblin.metastore.StateStore;
-import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.ServiceMetricNames;
-import org.apache.gobblin.metrics.event.CountEventBuilder;
-import org.apache.gobblin.metrics.event.JobEvent;
 import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.TaskContext;
 import org.apache.gobblin.runtime.kafka.HighLevelConsumer;
@@ -114,8 +109,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
 
   private final JobIssueEventHandler jobIssueEventHandler;
 
-  private final ConcurrentHashMap<String, Long> flowNameGroupToWorkUnitCount;
-
   private final Retryer<Void> persistJobStatusRetryer;
 
   public KafkaJobStatusMonitor(String topic, Config config, int numThreads, JobIssueEventHandler jobIssueEventHandler)
@@ -128,8 +121,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
 
     this.jobIssueEventHandler = jobIssueEventHandler;
-
-    this.flowNameGroupToWorkUnitCount = new ConcurrentHashMap<>();
 
     Config retryerOverridesConfig = config.hasPath(KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX)
         ? config.getConfig(KafkaJobStatusMonitor.JOB_STATUS_MONITOR_PREFIX)
@@ -189,11 +180,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       try (Timer.Context context = getMetricContext().timer(PROCESS_JOB_ISSUE).time()) {
         jobIssueEventHandler.processEvent(gobblinTrackingEvent);
       }
-    }
-
-    if (gobblinTrackingEvent.getName().equals(JobEvent.WORK_UNITS_CREATED)) {
-      emitWorkUnitCountMetric(gobblinTrackingEvent);
-      return;
     }
 
     try {
@@ -312,29 +298,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     mergedState.putAll(state.getProperties());
 
     return new org.apache.gobblin.configuration.State(mergedState);
-  }
-
-  private void emitWorkUnitCountMetric(GobblinTrackingEvent event) {
-    Properties properties = new Properties();
-    properties.putAll(event.getMetadata());
-
-    Long numWorkUnits = Long.parseLong(properties.getProperty(CountEventBuilder.COUNT_KEY));
-    String workUnitCountName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
-        properties.getProperty(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD),
-        properties.getProperty(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD),
-        JobEvent.WORK_UNITS_CREATED);
-
-    SortedMap<String, Gauge> existingGauges = this.getMetricContext().getGauges(
-        (name, metric) -> name.equals(workUnitCountName));
-
-    // If gauge for this flow name and group exists, then value will be updated by reference. Otherwise create
-    // a new gauge and save a reference to the value in the HashMap
-    this.flowNameGroupToWorkUnitCount.put(workUnitCountName, numWorkUnits);
-    if (existingGauges.isEmpty()) {
-      ContextAwareGauge gauge = this.getMetricContext().newContextAwareGauge(workUnitCountName,
-          () -> this.flowNameGroupToWorkUnitCount.get(workUnitCountName));
-      this.getMetricContext().register(workUnitCountName, gauge);
-    }
   }
 
   public static String jobStatusTableName(String flowExecutionId, String jobGroup, String jobName) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -904,7 +904,7 @@ public class DagManagerTest {
 
     Long flowId = System.currentTimeMillis();
     Dag<JobExecutionPlan> adhocDag = buildDag(String.valueOf(flowId), flowId, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, true).build());    //Add a dag to the queue of dags
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true).build());    //Add a dag to the queue of dags
     this.queue.offer(adhocDag);
 
     Iterator<JobStatus> jobStatusIterator1 =
@@ -927,7 +927,7 @@ public class DagManagerTest {
     Assert.assertNull(metricContext.getParent().get().getGauges().get(flowStateGaugeName0));
 
     Dag<JobExecutionPlan> scheduledDag = buildDag(String.valueOf(flowId+1), flowId+1, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, false).build());
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, false).build());
     this.queue.offer(scheduledDag);
     this._dagManagerThread.run();
     String flowStateGaugeName1 = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, "group"+(flowId+1),

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -904,7 +904,7 @@ public class DagManagerTest {
 
     Long flowId = System.currentTimeMillis();
     Dag<JobExecutionPlan> adhocDag = buildDag(String.valueOf(flowId), flowId, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true).build());    //Add a dag to the queue of dags
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, false).build());    //Add a dag to the queue of dags
     this.queue.offer(adhocDag);
 
     Iterator<JobStatus> jobStatusIterator1 =
@@ -927,7 +927,7 @@ public class DagManagerTest {
     Assert.assertNull(metricContext.getParent().get().getGauges().get(flowStateGaugeName0));
 
     Dag<JobExecutionPlan> scheduledDag = buildDag(String.valueOf(flowId+1), flowId+1, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, false).build());
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS, true).build());
     this.queue.offer(scheduledDag);
     this._dagManagerThread.run();
     String flowStateGaugeName1 = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, "group"+(flowId+1),

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -904,7 +904,7 @@ public class DagManagerTest {
 
     Long flowId = System.currentTimeMillis();
     Dag<JobExecutionPlan> adhocDag = buildDag(String.valueOf(flowId), flowId, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC, true).build());    //Add a dag to the queue of dags
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, true).build());    //Add a dag to the queue of dags
     this.queue.offer(adhocDag);
 
     Iterator<JobStatus> jobStatusIterator1 =
@@ -927,7 +927,7 @@ public class DagManagerTest {
     Assert.assertNull(metricContext.getParent().get().getGauges().get(flowStateGaugeName0));
 
     Dag<JobExecutionPlan> scheduledDag = buildDag(String.valueOf(flowId+1), flowId+1, "FINISH_RUNNING", 1, "proxyUser",
-        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC, false).build());
+        ConfigBuilder.create().addPrimitive(ConfigurationKeys.GOBBLIN_JOB_SHOULD_OUTPUT_METRICS, false).build());
     this.queue.offer(scheduledDag);
     this._dagManagerThread.run();
     String flowStateGaugeName1 = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, "group"+(flowId+1),

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
@@ -199,9 +199,9 @@ public class JobExecutionPlanDagFactoryTest {
     Assert.assertEquals(dag2.getStartNodes().size(), 1);
     Assert.assertEquals(dag2.getEndNodes().size(), 1);
     Assert.assertEquals(dag2.getNodes().size(), 1);
-    // Dag1 is scheduled so should be adhoc, but not dag2
-    Assert.assertFalse(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getBoolean(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC));
-    Assert.assertTrue(dag2.getStartNodes().get(0).getValue().getJobSpec().getConfig().getBoolean(ConfigurationKeys.GOBBLIN_FLOW_ISADHOC));
+    // Dag1 is scheduled so should be adhoc and output metrics, but not dag2
+    Assert.assertTrue(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getBoolean(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS));
+    Assert.assertFalse(dag2.getStartNodes().get(0).getValue().getJobSpec().getConfig().getBoolean(ConfigurationKeys.GOBBLIN_OUTPUT_JOB_LEVEL_METRICS));
   }
 
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1639


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

For Adhoc flows in GaaS, metrics are still being emitted on the Gobblin pipeline. This will use the adhoc configuration to determine whether or not to emit these metrics.

For non-GaaS initiated pipelines (will be controlled by a configuration key) there will be no naming changes
For GaaS pipelines they will use the naming convention `GobblinService.<FlowGroup>.<FlowName>.<EdgeId>.<MetricName>` so that they can be grouped together with the flow compilation status and the running status of these flows

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

