### PR TITLE
[GOBBLIN-1640] add an API in AbstractBaseKafkaConsumerClient to list selected topics

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -162,4 +162,13 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
    * Get a list of all kafka topics
    */
   public abstract List<KafkaTopic> getTopics();
+
+  /**
+   * Get a list of {@link KafkaTopic} with the provided topic names.
+   * The default implementation lists all the topics.
+   * Implementations of this class can improve this method.
+   */
+  public Collection<KafkaTopic> getTopics(Collection<String> topics) {
+    return getTopics();
+  }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
I think we should provide an API to fetch only one kafka topic's partitions. Right now, there is only getTopics() API which fetches all the topics metadata which is very unnecessary.

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1640


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

