### PR TITLE
Fix bug when shrinking the container in Yarn service

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -436,7 +436,7 @@ public class YarnService extends AbstractIdleService {
     int numTargetContainers = yarnContainerRequestBundle.getTotalContainers();
     // YARN can allocate more than the requested number of containers, compute additional allocations and deallocations
     // based on the max of the requested and actual allocated counts
-    int numAllocatedContainers = Math.max(this.containerMap.size(), allocatedContainerCountMap.values().stream().mapToInt(Integer::intValue).sum());
+    int numAllocatedContainers = this.containerMap.size();
 
     // Request additional containers if the desired count is higher than the max of the current allocation or previously
     // requested amount. Note that there may be in-flight or additional allocations after numContainers has been computed

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -202,15 +202,6 @@ public class YarnService extends AbstractIdleService {
 
   private volatile boolean shutdownInProgress = false;
 
-  // The number of containers requested based on the desired target number of containers. This is used to determine
-  // how may additional containers to request since the the currently allocated amount may be less than this amount if we
-  // are waiting for containers to be allocated.
-  // The currently allocated amount may also be higher than this amount if YARN returned more than the requested number
-  // of containers.
-  @VisibleForTesting
-  @Getter(AccessLevel.PROTECTED)
-  private int numRequestedContainers = 0;
-
   public YarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
       FileSystem fs, EventBus eventBus, HelixManager helixManager) throws Exception {
     this.applicationName = applicationName;
@@ -440,17 +431,12 @@ public class YarnService extends AbstractIdleService {
    * @param inUseInstances  a set of in use instances
    */
   public synchronized void requestTargetNumberOfContainers(YarnContainerRequestBundle yarnContainerRequestBundle, Set<String> inUseInstances) {
-    LOGGER.debug("Requesting numTargetContainers {}, current numRequestedContainers {} in use, instances {} map size is {}",
-        yarnContainerRequestBundle.getTotalContainers(), this.numRequestedContainers, inUseInstances, this.containerMap.size());
+    LOGGER.debug("Requesting numTargetContainers {}, in use instances count is {}, container map size is {}",
+        yarnContainerRequestBundle.getTotalContainers(), inUseInstances, this.containerMap.size());
     int numTargetContainers = yarnContainerRequestBundle.getTotalContainers();
     // YARN can allocate more than the requested number of containers, compute additional allocations and deallocations
     // based on the max of the requested and actual allocated counts
-    int numAllocatedContainers = this.containerMap.size();
-
-    // The number of allocated containers may be higher than the previously requested amount
-    // and there may be outstanding allocation requests, so the max of both counts is computed here
-    // and used to decide whether to allocate containers.
-    int numContainers = Math.max(numRequestedContainers, numAllocatedContainers);
+    int numAllocatedContainers = Math.max(this.containerMap.size(), allocatedContainerCountMap.values().stream().mapToInt(Integer::intValue).sum());
 
     // Request additional containers if the desired count is higher than the max of the current allocation or previously
     // requested amount. Note that there may be in-flight or additional allocations after numContainers has been computed
@@ -462,7 +448,7 @@ public class YarnService extends AbstractIdleService {
       for(; requestedContainerCount < desiredContainerCount; requestedContainerCount++) {
         requestContainer(Optional.absent(), yarnContainerRequestBundle.getHelixTagResourceMap().get(currentHelixTag));
       }
-      requestedContainerCountMap.put(currentHelixTag, requestedContainerCount);
+      requestedContainerCountMap.put(currentHelixTag, desiredContainerCount);
     }
 
     // If the total desired is lower than the currently allocated amount then release free containers.
@@ -473,17 +459,13 @@ public class YarnService extends AbstractIdleService {
       LOGGER.debug("Shrinking number of containers by {}", (numAllocatedContainers - numTargetContainers));
 
       List<Container> containersToRelease = new ArrayList<>();
-      int numToShutdown = numContainers - numTargetContainers;
+      int numToShutdown = numAllocatedContainers - numTargetContainers;
 
       // Look for eligible containers to release. If a container is in use then it is not released.
       for (Map.Entry<ContainerId, ContainerInfo> entry : this.containerMap.entrySet()) {
         ContainerInfo containerInfo = entry.getValue();
         if (!inUseInstances.contains(containerInfo.getHelixParticipantId())) {
           containersToRelease.add(containerInfo.getContainer());
-          String helixTag = containerInfo.getHelixTag();
-          if (!Strings.isNullOrEmpty(helixTag)) {
-            requestedContainerCountMap.put(helixTag, requestedContainerCountMap.get(helixTag) - 1);
-          }
         }
 
         if (containersToRelease.size() == numToShutdown) {
@@ -496,7 +478,6 @@ public class YarnService extends AbstractIdleService {
       this.eventBus.post(new ContainerReleaseRequest(containersToRelease));
     }
     this.yarnContainerRequest = yarnContainerRequestBundle;
-    this.numRequestedContainers = numTargetContainers;
     LOGGER.info("Current tag-container being requested:{}, tag-container allocated: {}",
         this.requestedContainerCountMap, this.allocatedContainerCountMap);
   }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
-import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
@@ -203,7 +202,6 @@ public class YarnServiceTestWithExpiration {
         GobblinYarnTestUtils.createYarnContainerRequest(10, resource), Collections.EMPTY_SET);
 
     Assert.assertFalse(this.expiredYarnService.getMatchingRequestsList(resource).isEmpty());
-    Assert.assertEquals(this.expiredYarnService.getNumRequestedContainers(), 10);
 
     AssertWithBackoff.create().logger(LOG).timeoutMs(60000).maxSleepMs(2000).backoffFactor(1.5)
         .assertTrue(new Predicate<Void>() {
@@ -236,7 +234,7 @@ public class YarnServiceTestWithExpiration {
       completedContainers.add(containerStatus);
     }
 
-    protected ContainerLaunchContext newContainerLaunchContext(Container container, String helixInstanceName)
+    protected ContainerLaunchContext newContainerLaunchContext(ContainerInfo containerInfo)
         throws IOException {
       try {
         Thread.sleep(1000);


### PR DESCRIPTION
update unit test

update requestedContainerCountMap

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1643] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1643


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
There's a bug in "requestTargetNumberOfContainers" method in YarnService when shrinking the container size: it incorrectly updates the requestedContainerCountMap which cause the container count result in wrong number.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Passed unit tests and also tested in cluster.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

