### PR TITLE
[GOBBLIN-1644] Log assigned participant when helix participant check fails

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -239,7 +239,7 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   /**
    * Configure Helix quota-based task scheduling.
    * This config controls the number of tasks that are concurrently assigned to a single Helix instance.
-   * Reference: https://helix.apache.org/0.9.1-docs/quota_scheduling.html
+   * Reference: https://helix.apache.org/1.0.3-docs/quota_scheduling.html
    */
   @VisibleForTesting
   void configureHelixQuotaBasedTaskScheduling() {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixAssignedParticipantCheck.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixAssignedParticipantCheck.java
@@ -140,7 +140,13 @@ public class HelixAssignedParticipantCheck implements CommitStep {
       if (jobContext != null) {
         String participant = jobContext.getAssignedParticipant(partitionNum);
         if (participant != null) {
-          return participant.equalsIgnoreCase(helixInstanceName);
+          boolean isAssignedParticipant = participant.equalsIgnoreCase(helixInstanceName);
+          if (!isAssignedParticipant) {
+            log.info("The current helix instance is not the assigned participant. helixInstanceName={}, assignedParticipant={}",
+                helixInstanceName, participant);
+          }
+
+          return isAssignedParticipant;
         }
       }
       return false;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1644] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1644


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Added log line for the current instance name and the assigned participant if the participant check fails
```
2022-05-10 18:42:23 PDT INFO  [pool-35-thread-1] org.apache.gobblin.cluster.HelixAssignedParticipantCheck 145 - The current helix instance is not the assigned participant. helixInstanceName=WorkerInstance_0, assignedParticipant=WorkerInstance_0
```
Ignore how the names are the same. I added some temp code to trigger the log line in the UT

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Doesn't need tests. its just a log line

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

