### PR TITLE
[GOBBLIN-1648] Complete use of JDBC `DataSource` 'read-only' validation query by incorporating where previously omitted

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
@@ -54,10 +54,10 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.metadata.StateStoreEntryManager;
 import org.apache.gobblin.metastore.predicates.StateStorePredicate;
 import org.apache.gobblin.metastore.predicates.StoreNamePredicate;
-import org.apache.gobblin.metastore.util.MysqlDataSourceUtils;
 import org.apache.gobblin.password.PasswordManager;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.io.StreamUtils;
+import org.apache.gobblin.util.jdbc.MysqlDataSourceUtils;
 
 /**
  * An implementation of {@link StateStore} backed by MySQL.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
@@ -20,6 +20,9 @@ package org.apache.gobblin.service.modules.db;
 import java.time.Duration;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.commons.dbcp2.BasicDataSource;
 
 import com.typesafe.config.Config;
@@ -38,6 +41,7 @@ import org.apache.gobblin.util.ConfigUtils;
 
 
 public class ServiceDatabaseProviderImpl implements ServiceDatabaseProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceDatabaseProviderImpl.class);
 
   private final Configuration configuration;
   private BasicDataSource dataSource;
@@ -63,8 +67,10 @@ public class ServiceDatabaseProviderImpl implements ServiceDatabaseProvider {
     dataSource.setUsername(configuration.getUserName());
     dataSource.setPassword(configuration.getPassword());
 
-    // MySQL server can timeout a connection so we need to validate connections.
-    dataSource.setValidationQuery(MysqlDataSourceUtils.QUERY_CONNECTION_IS_VALID_AND_NOT_READONLY);
+    // MySQL server can timeout a connection so need to validate connections before use
+    final String validationQuery = MysqlDataSourceUtils.QUERY_CONNECTION_IS_VALID_AND_NOT_READONLY;
+    LOG.info("setting `DataSource` validation query: '" + validationQuery + "'");
+    dataSource.setValidationQuery(validationQuery);
     dataSource.setValidationQueryTimeout(5);
 
     // To improve performance, we only check connections on creation, and set a maximum connection lifetime

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/db/ServiceDatabaseProviderImpl.java
@@ -31,7 +31,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import org.apache.gobblin.metastore.util.MysqlDataSourceUtils;
+import org.apache.gobblin.util.jdbc.MysqlDataSourceUtils;
 import org.apache.gobblin.password.PasswordManager;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.util.ConfigUtils;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/jdbc/DataSourceProvider.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/jdbc/DataSourceProvider.java
@@ -41,6 +41,7 @@ public class DataSourceProvider implements Provider<DataSource> {
 
   public static final String USERNAME = GOBBLIN_UTIL_JDBC_PREFIX + "username";
   public static final String PASSWORD = GOBBLIN_UTIL_JDBC_PREFIX + "password";
+  public static final String SKIP_VALIDATION_QUERY = GOBBLIN_UTIL_JDBC_PREFIX + "skip.validation.query";
   public static final String MAX_IDLE_CONNS = GOBBLIN_UTIL_JDBC_PREFIX + "max.idle.connections";
   public static final String MAX_ACTIVE_CONNS = GOBBLIN_UTIL_JDBC_PREFIX + "max.active.connections";
   public static final String DEFAULT_CONN_DRIVER = "com.mysql.jdbc.Driver";
@@ -51,6 +52,10 @@ public class DataSourceProvider implements Provider<DataSource> {
   public DataSourceProvider(@Named("dataSourceProperties") Properties properties) {
     this.basicDataSource = new BasicDataSource();
     this.basicDataSource.setDriverClassName(properties.getProperty(CONN_DRIVER, DEFAULT_CONN_DRIVER));
+    // the validation query should work beyond mysql; still, to bypass for any reason, heed directive
+    if (!Boolean.parseBoolean(properties.getProperty(SKIP_VALIDATION_QUERY, "false"))) {
+      this.basicDataSource.setValidationQuery(MysqlDataSourceUtils.QUERY_CONNECTION_IS_VALID_AND_NOT_READONLY);
+    }
     this.basicDataSource.setUrl(properties.getProperty(CONN_URL));
     if (properties.containsKey(USERNAME) && properties.containsKey(PASSWORD)) {
       this.basicDataSource.setUsername(properties.getProperty(USERNAME));

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/jdbc/MysqlDataSourceUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/jdbc/MysqlDataSourceUtils.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.metastore.util;
+package org.apache.gobblin.util.jdbc;
 
 public final class MysqlDataSourceUtils {
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1648

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

To avoid Gobblin Cluster Manager downtime, observed during DB failover (when the currently connected instance which was active becomes a follower), detect once the connection on hand becomes read-only.  Enforce verification when this happens, so we know to create new, replacement connections (to a read-write host).

This addresses the one code path where this wasn't happening.  in addition, it adds logging to trace when the validation query was successfully initialized, just in case the code we believe to be executing is not in fact.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

