### PR TITLE
[GOBBLIN-1654] Add capacity floor to avoid aggressively requesting resource and small files.

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -79,6 +80,13 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
   public static final String CONTAINER_CAPACITY_KEY = GOBBLIN_KAFKA_PREFIX + "streaming.containerCapacity";
   public static final double DEFAULT_CONTAINER_CAPACITY = 10;
 
+  // minimum container capacity to avoid bad topic schema causing us to request resources aggressively
+  public static final String MINIMUM_CONTAINER_CAPACITY = GOBBLIN_KAFKA_PREFIX + "streaming.minimum.containerCapacity";
+  public static final double DEFAULT_MINIMUM_CONTAINER_CAPACITY = 1;
+  public static final String BAD_TOPIC_PARTITION_WITH_LOW_CAPACITY_EVENT_NAME = "badTopicPartitionWithLowCapacity";
+  public static final String TOPIC_PARTITION = "topicPartition";
+  public static final String TOPIC_PARTITION_CAPACITY = "topicPartitionCapacity";
+
   //A boolean flag to enable per-topic container capacity, where "container capacity" is as defined earlier. This
   // configuration is useful in scenarios where the write performance can vary significantly across topics due to differences
   // in schema, as in the case of columnar formats such as ORC and Parquet. When enabled, the bin packing algorithm uses
@@ -125,6 +133,7 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
   private static final String NUM_CONTAINERS_EVENT_NAME = "NumContainers";
 
   private final long packingStartTimeMillis;
+  private final double minimumContainerCapacity;
   private final Optional<StateStoreBasedWatermarkStorage> watermarkStorage;
   private final Optional<MetricContext> metricContext;
   private final boolean isStatsBasedPackingEnabled;
@@ -139,6 +148,7 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
       Optional<MetricContext> metricContext) {
     super(source, state);
     this.state = state;
+    this.minimumContainerCapacity = state.getPropAsDouble(MINIMUM_CONTAINER_CAPACITY, DEFAULT_MINIMUM_CONTAINER_CAPACITY);
     this.isStatsBasedPackingEnabled =
         state.getPropAsBoolean(IS_STATS_BASED_PACKING_ENABLED_KEY, DEFAULT_IS_STATS_BASED_PACKING_ENABLED);
     this.isPerTopicContainerCapacityEnabled = state
@@ -245,7 +255,18 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
       if (this.isPerTopicContainerCapacityEnabled) {
         String topicName = KafkaUtils.getTopicNameFromTopicPartition(topicPartition);
         List<Double> capacities = capacitiesByTopic.getOrDefault(topicName, Lists.newArrayList());
-        capacities.add(watermark.getAvgConsumeRate() > 0 ? watermark.getAvgConsumeRate() : DEFAULT_CONTAINER_CAPACITY);
+        double realCapacity = watermark.getAvgConsumeRate() > 0 ? watermark.getAvgConsumeRate() : DEFAULT_CONTAINER_CAPACITY;
+        if (realCapacity < minimumContainerCapacity) {
+          if (this.metricContext.isPresent()) {
+            GobblinEventBuilder event = new GobblinEventBuilder(BAD_TOPIC_PARTITION_WITH_LOW_CAPACITY_EVENT_NAME);
+            event.addMetadata(TOPIC_PARTITION, topicPartition);
+            event.addMetadata(TOPIC_PARTITION_CAPACITY, String.valueOf(realCapacity));
+            this.eventSubmitter.submit(event);
+          }
+          log.warn(String.format("topicPartition %s has lower capacity %s, ignore that and reset capacity to be %s", topicPartition, realCapacity, minimumContainerCapacity));
+          realCapacity = minimumContainerCapacity;
+        }
+        capacities.add(realCapacity);
         capacitiesByTopic.put(topicName, capacities);
       }
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1654


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Now we calculate the capacity based on the consumer rate during peak hour, but if there are records with super bad schema during that time, our consumer rate will be super low and even after we catch up, we will not be able to release the resources because of the low consumer rate. So want provide a config to set the minimum consumer rate and avoid abusing resources and small files



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

