### PR TITLE
[GOBBLIN-1657] Update completion watermark on change_property in IcebergMetadataWriter

### DIFF
--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -123,7 +123,7 @@ public class KafkaAuditCountVerifier {
     log.info(String.format("Audit counts map for %s for range [%s,%s]", datasetName, beginInMillis, endInMillis));
     countsByTier.forEach((x,y) -> log.info(String.format(" %s : %s ", x, y)));
     if (countsByTier.isEmpty() && this.returnCompleteOnNoCounts) {
-      log.info(String.format("Found empty counts map for %s, returning 100% complete", datasetName));
+      log.info(String.format("Found empty counts map for %s, returning complete", datasetName));
       return 1.0;
     }
     double percent = -1;

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -99,6 +99,8 @@ public class GobblinMCEPublisher extends DataPublisher {
         newFiles = computeDummyFile(state);
         if (!newFiles.isEmpty()) {
           this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
+        } else {
+          log.info("No dummy file created. Not sending GMCE");
         }
       } else {
         this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY);

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -98,6 +98,7 @@ public class GobblinMCEPublisher extends DataPublisher {
         // There'll be only one dummy file here. This file is parsed for DB and table name calculation.
         newFiles = computeDummyFile(state);
         if (!newFiles.isEmpty()) {
+          log.info("Dummy file: " + newFiles.keySet().iterator().next());
           this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
         } else {
           log.info("No dummy file created. Not sending GMCE");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1657] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1657

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
    - There are quiet topics where data can be generated quiet infrequently causing the completion watermark to lag. Also, a commit operation could miss completion watermark update if there is a lag in kafka audit.

To fix above issues:
- Added logic to check audit count on change_property operation type for the next window of current watermark 
If counts match or an empty map is returned then consider audit count as complete and update the watermark.
- Added a config in KafkaAuditVerifier to return complete if found an empty map (with no counts from audit system) 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  Added unit test to update completion watermark on change_property


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

