### PR TITLE
[GOBBLIN-1667] Supporting for true ABORT on existing entity

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/util/TestUtils.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/util/TestUtils.java
@@ -25,6 +25,8 @@ import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Table;
 
 
 /**
@@ -42,4 +44,13 @@ public class TestUtils {
         newSubscopedBuilder(new JobScopeInstance("jobName", "testJob")));
   }
 
+  public static Table createTestTable() {
+    Table table = new Table("testDb","table1");
+    table.setDataLocation(createTestPath());
+    return table;
+  }
+
+  public static Path createTestPath() {
+    return new Path("/testPath/db/table");
+  }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSetTest.java
@@ -1,0 +1,91 @@
+package org.apache.gobblin.data.management.copy.hive;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.data.management.copy.CopyConfiguration;
+import org.apache.gobblin.source.extractor.JobCommitPolicy;
+import org.apache.gobblin.util.TestUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+
+
+public class HivePartitionFileSetTest {
+  @Mock HiveCopyEntityHelper helper;
+  @Mock Partition partition;
+  @Mock HiveDataset dataset;
+  @Mock FileSystem fileSystem;
+  @Mock org.apache.hadoop.hive.metastore.api.Partition tPartition;
+  @Mock StorageDescriptor storageDescriptor;
+  Properties properties = newPropertiesWithRequiredFields();
+
+  @BeforeMethod
+  public void setup() {
+    initMocks(this);
+    when(helper.getDataset()).thenReturn(dataset);
+    when(helper.getTargetTable()).thenReturn(TestUtils.createTestTable());
+    when(helper.getTargetFs()).thenReturn(fileSystem);
+
+    when(partition.getCompleteName()).thenReturn("A dummy partition for testing");
+    when(partition.getTPartition()).thenReturn(tPartition);
+    when(partition.getDataLocation()).thenReturn(TestUtils.createTestPath());
+
+    when(tPartition.getSd()).thenReturn(storageDescriptor);
+    when(tPartition.deepCopy()).thenReturn(tPartition);
+
+    when(storageDescriptor.getSerdeInfo()).thenReturn(new SerDeInfo("Fake Serializer", "Fake Version",
+        Collections.emptyMap()));
+
+    when(helper.getTargetLocation(eq(fileSystem), eq(TestUtils.createTestPath()), any(Optional.class)))
+        .thenReturn(TestUtils.createTestPath());
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void shouldFailIfExistingEntityPolicyIsAbortAndEntityExistsAndPartialSuccessNotAllowed() throws IOException {
+    List<String> partitions = ImmutableList.of("foo");
+    // Given an existing entity policy of abort
+    when(helper.getExistingEntityPolicy()).thenReturn(HiveCopyEntityHelper.ExistingEntityPolicy.ABORT);
+    when(helper.getConfiguration()).thenReturn(CopyConfiguration.builder(fileSystem, properties).build());
+    when(partition.getValues()).thenReturn(partitions);
+    // And an existing entity
+    when(helper.getTargetPartitions()).thenReturn(ImmutableMap.of(partitions, partition));
+    HivePartitionFileSet fileSet = new HivePartitionFileSet(helper, partition, properties);
+    // When generating the copy entities
+    fileSet.generateCopyEntities();
+    // Then we should have failed with an exception
+    Assert.fail("Should have failed with an IOException due to existing entity.");
+  }
+
+  @Test
+  public void shouldReturnEmptyIfExistingEntityPolicyIsAbortAndEntityExistsAndPartialSuccessAllowed() throws IOException {
+    List<String> partitions = ImmutableList.of("foo");
+    Properties properties = newPropertiesWithRequiredFields();
+    properties.put(ConfigurationKeys.JOB_COMMIT_POLICY_KEY, JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS.toString());
+    when(helper.getExistingEntityPolicy()).thenReturn(HiveCopyEntityHelper.ExistingEntityPolicy.ABORT);
+    when(helper.getConfiguration()).thenReturn(CopyConfiguration.builder(fileSystem, properties).build());
+    when(partition.getValues()).thenReturn(partitions);
+    when(helper.getTargetPartitions()).thenReturn(ImmutableMap.of(partitions, partition));
+    HivePartitionFileSet fileSet = new HivePartitionFileSet(helper, partition, properties);
+    Assert.assertEquals(fileSet.generateCopyEntities(), Collections.emptyList());
+  }
+
+  private static Properties newPropertiesWithRequiredFields() {
+    Properties properties = new Properties();
+    properties.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/tmp");
+    return properties;
+  }
+}


### PR DESCRIPTION
There is currently a configuration for existing entity conflict
policy called 'ABORT', but its never referenced anywhere. This commit
provides full support for 'ABORT' existing entity policy.

https://issues.apache.org/jira/browse/GOBBLIN-1667

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1667


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
I would like to have full support for hive.dataset.existing.entity.conflict.policy for partitions

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My PR adds a unit test for HivePartitionFileSet

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

