### PR TITLE
[GOBBLIN-1667] Create new predicate - ExistingPartitionSkipPredicate

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/ExistingPartitionSkipPredicate.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/ExistingPartitionSkipPredicate.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.data.management.copy.predicates;
+
+import com.google.common.base.Predicate;
+import javax.annotation.Nullable;
+import org.apache.gobblin.data.management.copy.hive.HivePartitionFileSet;
+
+
+/**
+ * This skip predicate will skip any partition that's already registered in the destination
+ * hive table.
+ */
+public class ExistingPartitionSkipPredicate implements Predicate<HivePartitionFileSet> {
+  @Override
+  public boolean apply(@Nullable HivePartitionFileSet input) {
+    if (input == null) {
+      return true;
+    }
+
+    return input.getExistingTargetPartition().isPresent();
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/predicates/ExistingPartitionSkipPredicateTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/predicates/ExistingPartitionSkipPredicateTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.data.management.copy.predicates;
+
+import com.google.common.base.Optional;
+import org.apache.gobblin.data.management.copy.hive.HivePartitionFileSet;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class ExistingPartitionSkipPredicateTest {
+  ExistingPartitionSkipPredicate predicate = new ExistingPartitionSkipPredicate();
+
+  @Test
+  public void shouldSkipHiveDatasetWithExistingPartition() {
+    HivePartitionFileSet fileSetWithExistingPartition = mock(HivePartitionFileSet.class);
+    HivePartitionFileSet fileSetWithoutExistingPartition = mock(HivePartitionFileSet.class);
+    Partition partition = mock(Partition.class);
+    when(fileSetWithExistingPartition.getExistingTargetPartition()).thenReturn(Optional.of(partition));
+    when(fileSetWithoutExistingPartition.getExistingTargetPartition()).thenReturn(Optional.absent());
+    Assert.assertTrue(predicate.apply(fileSetWithExistingPartition));
+    Assert.assertFalse(predicate.apply(fileSetWithoutExistingPartition));
+  }
+}

--- a/gobblin-docs/case-studies/Hive-Distcp.md
+++ b/gobblin-docs/case-studies/Hive-Distcp.md
@@ -101,7 +101,9 @@ A partition filter can be applied when copying partitioned tables. Filters can o
 
 ## Fast partition skip predicate
 
-A predicate that operates on partitions can be provided to distcp-ng to allow it to quickly skip partitions without having to list all of the source and target files and do a diff on those sets (a costly operation). To set this predicate, provide the class name of the predicate with the key `hive.dataset.copy.fast.partition.skip.predicate`. Currently only one such predicate exists:
+A predicate that operates on partitions can be provided to distcp-ng to allow it to quickly skip partitions without having to list all of the source and target files and do a diff on those sets (a costly operation). To set this predicate, provide the class name of the predicate with the key `hive.dataset.copy.fast.partition.skip.predicate`. Below are the following predicates that exist
 
 * `RegistrationTimeSkipPredicate`: This predicate compares the Hive partition attribute `registrationGenerationTimeMillis` in the target with the modification time of the partition directory in the source. The partition is skipped unless the directory was modified more recently than the registrationGenerationTime. The attribute `registrationGenerationTimeMillis` is an attribute set by distcp-ng representing (for all practical purposes) the time at which the distcp-ng job that registered that table started.
-
+* `NonPartitionTableRegistrationTimeSkipPredicate`: This predicate can be used on non partition tables and compares the `registrationGenerationTimeMillis` in the target.
+* `ExistingPartitionSkipPredicate`: This predicate can be used to skip any partition that already exists in the target table.
+* `RootDirectoryModtimeSkipPredicate`: This predicate can be used to skip any partition whose root directory modified time is later than the copy source.


### PR DESCRIPTION
Currently the hive.dataset.existing.entity.policy.ABORT will not
abort if there is an existing partition. One option to resolve this
is to support the ABORT configuration but that might be backwards
incompatible, so introducing a new skip predicate called
ExistingPartitionSkipPredicate that will skip any partition that
already exists in the target table

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1667


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

My PR introduces a new simple skip predicate called ExistingPartitionSkipPredicate which will skip the partition if it exists in the target table.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My PR adds a unit test for the new predicate

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

