### PR TITLE
[GOBBLIN-1668] Add audit counts for iceberg registration

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
@@ -187,9 +187,7 @@ public abstract class GobblinMCEProducer implements Closeable {
       gmceBuilder.setOldFilePrefixes(oldFilePrefixes);
     }
     gmceBuilder.setOperationType(operationType);
-    if (serializedAuditMap != null) {
-      gmceBuilder.setAuditCountMap(serializedAuditMap);
-    }
+    gmceBuilder.setAuditCountMap(serializedAuditMap);
     return gmceBuilder.build();
   }
 

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
@@ -82,6 +82,10 @@ public abstract class GobblinMCEProducer implements Closeable {
     this.metricContext = Instrumented.getMetricContext(state, this.getClass());
   }
 
+  public void sendGMCE(Map<Path, Metrics> newFiles, List<String> oldFiles, List<String> oldFilePrefixes,
+      Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource) throws IOException {
+    sendGMCE(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, null);
+  }
 
   /**
    * This method will use the files to compute the table name and dataset name, for each table it will generate one GMCE and send that to kafka so
@@ -90,17 +94,14 @@ public abstract class GobblinMCEProducer implements Closeable {
    * @param oldFiles the list of old file to be dropped
    * @param offsetRange offset range of the new data, can be null
    * @param operationType The opcode of gmce emitted by this method.
+   * @param serializedAuditCountMap Audit count map to be used by {@link org.apache.gobblin.iceberg.writer.IcebergMetadataWriter} to track iceberg
+   *                                registration counts
    * @throws IOException
    */
   public void sendGMCE(Map<Path, Metrics> newFiles, List<String> oldFiles, List<String> oldFilePrefixes,
-      Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource) throws IOException {
-    sendGMCE(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, null);
-  }
-
-  public void sendGMCE(Map<Path, Metrics> newFiles, List<String> oldFiles, List<String> oldFilePrefixes,
-      Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource, String serializedAuditMap) throws IOException {
+      Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource, String serializedAuditCountMap) throws IOException {
     GobblinMetadataChangeEvent gmce =
-        getGobblinMetadataChangeEvent(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, serializedAuditMap);
+        getGobblinMetadataChangeEvent(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, serializedAuditCountMap);
     underlyingSendGMCE(gmce);
   }
 
@@ -171,7 +172,7 @@ public abstract class GobblinMCEProducer implements Closeable {
 
   public GobblinMetadataChangeEvent getGobblinMetadataChangeEvent(Map<Path, Metrics> newFiles, List<String> oldFiles,
       List<String> oldFilePrefixes, Map<String, String> offsetRange, OperationType operationType,
-      SchemaSource schemaSource, String serializedAuditMap) {
+      SchemaSource schemaSource, String serializedAuditCountMap) {
     if (!verifyInput(newFiles, oldFiles, oldFilePrefixes, operationType)) {
       return null;
     }
@@ -187,7 +188,7 @@ public abstract class GobblinMCEProducer implements Closeable {
       gmceBuilder.setOldFilePrefixes(oldFilePrefixes);
     }
     gmceBuilder.setOperationType(operationType);
-    gmceBuilder.setAuditCountMap(serializedAuditMap);
+    gmceBuilder.setAuditCountMap(serializedAuditCountMap);
     return gmceBuilder.build();
   }
 

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/GobblinMCEProducer.java
@@ -94,8 +94,13 @@ public abstract class GobblinMCEProducer implements Closeable {
    */
   public void sendGMCE(Map<Path, Metrics> newFiles, List<String> oldFiles, List<String> oldFilePrefixes,
       Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource) throws IOException {
+    sendGMCE(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, null);
+  }
+
+  public void sendGMCE(Map<Path, Metrics> newFiles, List<String> oldFiles, List<String> oldFilePrefixes,
+      Map<String, String> offsetRange, OperationType operationType, SchemaSource schemaSource, String serializedAuditMap) throws IOException {
     GobblinMetadataChangeEvent gmce =
-        getGobblinMetadataChangeEvent(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource);
+        getGobblinMetadataChangeEvent(newFiles, oldFiles, oldFilePrefixes, offsetRange, operationType, schemaSource, serializedAuditMap);
     underlyingSendGMCE(gmce);
   }
 
@@ -166,7 +171,7 @@ public abstract class GobblinMCEProducer implements Closeable {
 
   public GobblinMetadataChangeEvent getGobblinMetadataChangeEvent(Map<Path, Metrics> newFiles, List<String> oldFiles,
       List<String> oldFilePrefixes, Map<String, String> offsetRange, OperationType operationType,
-      SchemaSource schemaSource) {
+      SchemaSource schemaSource, String serializedAuditMap) {
     if (!verifyInput(newFiles, oldFiles, oldFilePrefixes, operationType)) {
       return null;
     }
@@ -182,6 +187,9 @@ public abstract class GobblinMCEProducer implements Closeable {
       gmceBuilder.setOldFilePrefixes(oldFilePrefixes);
     }
     gmceBuilder.setOperationType(operationType);
+    if (serializedAuditMap != null) {
+      gmceBuilder.setAuditCountMap(serializedAuditMap);
+    }
     return gmceBuilder.build();
   }
 

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -78,7 +78,7 @@ public class GobblinMCEPublisher extends DataPublisher {
   private static final PathFilter HIDDEN_FILES_FILTER = new HiddenFilter();
   private static final Metrics DUMMY_METRICS = new Metrics(100000000L, null, null, null, null);
 
-  public static final String SERIALIZED_AUDIT_MAP_KEY = "serializedAuditMap";
+  public static final String SERIALIZED_AUDIT_COUNT_MAP_KEY = "serializedAuditCountMap";
 
   public GobblinMCEPublisher(State state) throws IOException {
 
@@ -101,14 +101,13 @@ public class GobblinMCEPublisher extends DataPublisher {
         newFiles = computeDummyFile(state);
         if (!newFiles.isEmpty()) {
           log.info("Dummy file: " + newFiles.keySet().iterator().next());
-          this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE,
-              state.getProp(SERIALIZED_AUDIT_MAP_KEY));
+          this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
         } else {
           log.info("No dummy file created. Not sending GMCE");
         }
       } else {
         this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY,
-            state.getProp(SERIALIZED_AUDIT_MAP_KEY));
+            state.getProp(SERIALIZED_AUDIT_COUNT_MAP_KEY));
       }
     }
   }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -78,6 +78,8 @@ public class GobblinMCEPublisher extends DataPublisher {
   private static final PathFilter HIDDEN_FILES_FILTER = new HiddenFilter();
   private static final Metrics DUMMY_METRICS = new Metrics(100000000L, null, null, null, null);
 
+  public static final String SERIALIZED_AUDIT_MAP_KEY = "serializedAuditMap";
+
   public GobblinMCEPublisher(State state) throws IOException {
 
     this(state, GobblinMCEProducer.getGobblinMCEProducer(state));
@@ -99,12 +101,14 @@ public class GobblinMCEPublisher extends DataPublisher {
         newFiles = computeDummyFile(state);
         if (!newFiles.isEmpty()) {
           log.info("Dummy file: " + newFiles.keySet().iterator().next());
-          this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE);
+          this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.change_property, SchemaSource.NONE,
+              state.getProp(SERIALIZED_AUDIT_MAP_KEY));
         } else {
           log.info("No dummy file created. Not sending GMCE");
         }
       } else {
-        this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
+        this.producer.sendGMCE(newFiles, null, null, offsetRange, OperationType.add_files, SchemaSource.SCHEMAREGISTRY,
+            state.getProp(SERIALIZED_AUDIT_MAP_KEY));
       }
     }
   }

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
@@ -172,14 +172,14 @@ public class GobblinMCEPublisherTest {
     GobblinMCEProducer producer = Mockito.mock(GobblinMCEProducer.class);
     Mockito.doCallRealMethod()
         .when(producer)
-        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any());
+        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any(), any());
     Mockito.doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         Object[] args = invocation.getArguments();
         GobblinMetadataChangeEvent gmce =
             producer.getGobblinMetadataChangeEvent((Map<Path, Metrics>) args[0], null, null,
-                (Map<String, String>) args[1], OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
+                (Map<String, String>) args[1], OperationType.add_files, SchemaSource.SCHEMAREGISTRY, null);
         Assert.assertEquals(gmce.getNewFiles().size(), 1);
         FileSystem fs = FileSystem.get(new Configuration());
         Assert.assertEquals(gmce.getNewFiles().get(0).getFilePath(),
@@ -201,14 +201,14 @@ public class GobblinMCEPublisherTest {
     GobblinMCEProducer producer = Mockito.mock(GobblinMCEProducer.class);
     Mockito.doCallRealMethod()
         .when(producer)
-        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any());
+        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any(), any());
     Mockito.doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         Object[] args = invocation.getArguments();
         GobblinMetadataChangeEvent gmce =
             producer.getGobblinMetadataChangeEvent((Map<Path, Metrics>) args[0], null, null,
-                (Map<String, String>) args[1], OperationType.add_files, SchemaSource.SCHEMAREGISTRY);
+                (Map<String, String>) args[1], OperationType.add_files, SchemaSource.SCHEMAREGISTRY, null);
         Assert.assertEquals(gmce.getNewFiles().size(), 1);
         FileSystem fs = FileSystem.get(new Configuration());
         Charset charset = Charset.forName("UTF-8");
@@ -236,14 +236,14 @@ public class GobblinMCEPublisherTest {
     GobblinMCEProducer producer = Mockito.mock(GobblinMCEProducer.class);
     Mockito.doCallRealMethod()
         .when(producer)
-        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any());
+        .getGobblinMetadataChangeEvent(anyMap(), anyList(), anyList(), anyMap(), any(), any(), any());
     Mockito.doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         Object[] args = invocation.getArguments();
         GobblinMetadataChangeEvent gmce =
             producer.getGobblinMetadataChangeEvent((Map<Path, Metrics>) args[0], null, null,
-                (Map<String, String>) args[1], OperationType.change_property, SchemaSource.NONE);
+                (Map<String, String>) args[1], OperationType.change_property, SchemaSource.NONE, null);
         Assert.assertEquals(gmce.getNewFiles().size(), 1);
         Assert.assertNull(gmce.getOldFiles());
         Assert.assertNull(gmce.getOldFilePrefixes());

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GobblinMetadataChangeEvent.avsc
@@ -286,6 +286,13 @@
         "default": null,
         "doc": "Array of the metadata writers that are allowed to consume this GMCE. If this field is missing, all metadata writers are allowed.",
         "optional": true
+      },
+      {
+        "name": "auditCountMap",
+        "type": ["null","string"],
+        "default": null,
+        "doc": "Serialized map of audit count",
+        "optional": true
       }
     ]
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1668


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Pass audit count maps from streaming through a new field in GMCE, then publish those counts to a new tier after iceberg registration is done.

- Add a new field in GMCE to contain a serialized audit map string
- Populate this in MCE publisher using key `SERIALIZED_AUDIT_MAP_KEY` (will be set internally)
- After iceberg commit, call sendAuditCounts using the map from the GMCE (will be implemented internally)
- Also use a new WhitelistBlacklist for sending these audit counts, because we may want to count only for specific dbs.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in parallel pipeline

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

