### PR TITLE
[GOBBLIN-1671] : Fix gobblin.sh script to add external jars as colon separated to HADOOP_CLASSPATH

### DIFF
--- a/bin/gobblin.sh
+++ b/bin/gobblin.sh
@@ -332,7 +332,8 @@ function build_classpath(){
     GOBBLIN_CLASSPATH=${GOBBLIN_JARS}:${GOBBLIN_HADOOP_CLASSPATH}
 
     if [[ -n "$EXTRA_JARS" ]]; then
-        GOBBLIN_CLASSPATH=${GOBBLIN_CLASSPATH}:"$EXTRA_JARS"
+        # EXTRA_JARS has comma separated jars. Replace commas with colon for the classpath.
+        GOBBLIN_CLASSPATH=${GOBBLIN_CLASSPATH}:${EXTRA_JARS//,/:}
     fi
 
     GOBBLIN_CLASSPATH=${GOBBLIN_CONF}:${GOBBLIN_CLASSPATH}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1671


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When using `mapreduce` mode in gobblin.sh, the additional jars passed to
gobblin.sh through --jars are comma separated. They are incorrectly
added to HADOOP_CLASSPATH that takes colon (:) separated jars. The fix is to convert the external jars to use colon instead of comma as delimiter when adding to the GOBBLIN_CLASSPATH, which in turn is used to set HADOOP_CLASSPATH

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally. The error was reproducible locally, which caused ClassNotFoundException.
The PR fixes the issue and jobs are able to get the dependent jars correctly.
Otherwise, this PR does not seem to need tests as it's a script change which was verified.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

