### PR TITLE
[GOBBLIN-1674] : Add an option in gobblin.sh to specify whether to run the Gobblin job in background or not

### DIFF
--- a/bin/gobblin.sh
+++ b/bin/gobblin.sh
@@ -47,6 +47,7 @@ VERBOSE=0
 ENABLE_GC_LOGS=0
 CMD_PARAMS=''
 LOG_TO_STDOUT=0
+RUN_IN_BACKGROUND=0
 
 # Gobblin Commands, Modes & respective Classes
 GOBBLIN_MODE_TYPE=''
@@ -134,6 +135,7 @@ function print_gobblin_service_usage() {
     echo "    --fs <file system URL>                Only for mapreduce mode: Target file system, if not set, taken from \${HADOOP_HOME}/conf."
     echo "    --job-conf-file <job-conf-file-path>  Only for mapreduce mode: configuration file for the job to run"
     echo "    --log-to-stdout                     Outputs to stdout rather than to a log file"
+    echo "    --run-in-background                   Run the Gobblin command in background (using 'nohup' and '&'). Not applicable when using --log-to-stdout."
     echo "    --help                                Display this help."
     echo "    --verbose                             Display full command used to start the process."
 }
@@ -228,6 +230,9 @@ do
         ;;
         --log-to-stdout)
             LOG_TO_STDOUT=1
+        ;;
+        --run-in-background)
+            RUN_IN_BACKGROUND=1
         ;;
         *)
             CMD_PARAMS="$CMD_PARAMS $1"
@@ -481,8 +486,11 @@ function start() {
         fi
         if [[ LOG_TO_STDOUT -eq 1 ]]; then
           $GOBBLIN_COMMAND
-        else
+        elif [[ $RUN_IN_BACKGROUND -eq 1 ]]; then
           nohup $GOBBLIN_COMMAND 1>> ${LOG_OUT_FILE} 2>> ${LOG_ERR_FILE} &
+        else
+          # do not run in background
+          $GOBBLIN_COMMAND 1>> ${LOG_OUT_FILE} 2>> ${LOG_ERR_FILE}
         fi
         PID=$!
         echo $PID >> $PID_FILE


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Currently, the command uses 'nohup' and '&' which always makes it run in background.
This makes it inconvenient in use-cases that need to do some action after the run is
completed (like curling for some logs). Hence, providing an option to choose whether
to run in background or not.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in local environment with the new flag, unit tests Not applicable.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

