### PR TITLE
[GOBBLIN-1677] Fix timezone property to read from key correctly

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -52,6 +52,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private final String lookbackTime;
   private final String datePattern;
   private final Period lookbackPeriod;
+  private final DateTimeZone dateTimeZone;
   private final LocalDateTime currentTime;
 
   public TimeAwareRecursiveCopyableDataset(FileSystem fs, Path rootPath, Properties properties, Path glob) {
@@ -66,11 +67,9 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
         .toFormatter();
     this.lookbackPeriod = periodFormatter.parsePeriod(lookbackTime);
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
-
-    this.currentTime = properties.containsKey(DATE_PATTERN_TIMEZONE_KEY) ? LocalDateTime.now(
-        DateTimeZone.forID(properties.getProperty(DATE_PATTERN_TIMEZONE_KEY)))
-        : LocalDateTime.now(DateTimeZone.forID(DEFAULT_DATE_PATTERN_TIMEZONE));
-
+    this.dateTimeZone = DateTimeZone.forID(properties
+        .getProperty(DATE_PATTERN_TIMEZONE_KEY, DEFAULT_DATE_PATTERN_TIMEZONE));
+    this.currentTime = LocalDateTime.now(this.dateTimeZone);
     this.validateLookbackWithDatePatternFormat(this.datePattern, this.lookbackTime);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -68,7 +68,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
 
     this.currentTime = properties.containsKey(DATE_PATTERN_TIMEZONE_KEY) ? LocalDateTime.now(
-        DateTimeZone.forID(DATE_PATTERN_TIMEZONE_KEY))
+        DateTimeZone.forID(properties.getProperty(DATE_PATTERN_TIMEZONE_KEY)))
         : LocalDateTime.now(DateTimeZone.forID(DEFAULT_DATE_PATTERN_TIMEZONE));
 
     this.validateLookbackWithDatePatternFormat(this.datePattern, this.lookbackTime);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -318,6 +318,18 @@ public class TimeAwareRecursiveCopyableDatasetTest {
 
   }
 
+  @Test (expectedExceptions = IllegalArgumentException.class)
+  public void testIllegalTimezoneProperty() throws IOException {
+    //Lookback time = "4h"
+    Properties properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_HOURS_STR);
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd/HH");
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_TIMEZONE_KEY, "InvalidTimeZone");
+
+    TimeAwareRecursiveCopyableDataset dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir3, properties,
+        new Path("/tmp/src/ds2/daily"));
+  }
+
   @AfterClass
   public void clean() throws IOException {
     //Delete tmp directories


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1677


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Fix bug where TimeAwareRecursiveCopyableDataset could not read user configured timezones due to not reading the key correctly.

Line 72 : DateTimeZone.forID(DATE_PATTERN_TIMEZONE_KEY))  ===> should be DateTimeZone.forID(properties.get(DATE_PATTERN_TIMEZONE_KEY)))

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

