### PR TITLE
Add error handling for timeaware finder to handle scenarios where fil…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -209,7 +209,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
       return FileListUtils
           .listFilesToCopyAtPath(fs, path, fileFilter, applyFilterToDirectories, includeEmptyDirectories);
     } catch (IOException e) {
-      log.info(String.format("Could not find any files on target path due to %s. Returning an empty list of files.", e.getClass().getCanonicalName()));
+      log.warn(String.format("Could not find any files on fs %s path %s due to the following exception. Returning an empty list of files.", fs.getUri(), path), e);
       return Lists.newArrayList();
     }
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -138,6 +138,9 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private List<FileStatus> recursivelyGetFilesAtDatePath(FileSystem fs, Path path, String traversedDatePath, PathFilter fileFilter,
       int level,  LocalDateTime startDate, LocalDateTime endDate, DateTimeFormatter formatter) throws IOException {
     List<FileStatus> fileStatuses = Lists.newArrayList();
+    if (!fs.exists(path)) {
+      return fileStatuses;
+    }
     Iterator<FileStatus> folderIterator;
     try {
       folderIterator = Arrays.asList(fs.listStatus(path)).iterator();

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -138,8 +138,13 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private List<FileStatus> recursivelyGetFilesAtDatePath(FileSystem fs, Path path, String traversedDatePath, PathFilter fileFilter,
       int level,  LocalDateTime startDate, LocalDateTime endDate, DateTimeFormatter formatter) throws IOException {
     List<FileStatus> fileStatuses = Lists.newArrayList();
-    Iterator<FileStatus> folderIterator = Arrays.asList(fs.listStatus(path)).iterator();
-
+    Iterator<FileStatus> folderIterator;
+    try {
+      folderIterator = Arrays.asList(fs.listStatus(path)).iterator();
+    } catch (IOException e) {
+      log.warn(String.format("Error while listing paths at %s due to ", path), e);
+      return fileStatuses;
+    }
     // Check if at the lowest level/granularity of the date folder
     if (this.datePattern.split(FileSystems.getDefault().getSeparator()).length == level) {
       // Truncate the start date to the most granular unit of time in the datepattern

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.data.management.copy;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -173,6 +174,10 @@ public class TimeAwareRecursiveCopyableDatasetTest {
         candidateFiles.add(filePath.toString());
       }
     }
+    // Edge case: test that files that do not match dateformat but within the folders searched by the timeaware finder is ignored
+    File f = new File(baseDir2.toString() + "/metadata.test");
+
+    f.createNewFile();
 
     properties = new Properties();
     properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_DAYS_STR);


### PR DESCRIPTION
…es do not exist or folders not matching date format

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1681] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1681


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If searching through files using the timeaware dataset finder, if there are rogue files inside of the folders that match the datetime format (i.e. metadata folders by year), then it would cause the dataset finder to error out as it expects all folders and files to conform to the date pattern.

We add a check during the listStatus step to catch these errors. Future improvements can be to also match folders against the date partition for that level before the recursive step, so that only the relevant folders will be searched.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

