### PR TITLE
[GOBBLIN-1686] Allow all iceberg exceptions to be fault tolerant

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -871,7 +871,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
         log.info("There's no transaction initiated for the table {}", tid.toString());
       }
     } catch (RuntimeException e) {
-      throw new RuntimeException(String.format("Fail to flush table %s %s", dbName, tableName), e);
+      throw new IOException(String.format("Fail to flush table %s %s", dbName, tableName), e);
     } catch (Exception e) {
       throw new IOException(String.format("Fail to flush table %s %s", dbName, tableName), e);
     } finally {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1686


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently we catch `RuntimeException` in `IcebergMetadataWriter.flush()` and rethrow another `RuntimeException`. We should throw `IOException` in all cases so that MCE writer will catch and be able to skip it in the case of a single dataset issue.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

