### PR TITLE
[GOBBLIN-1689] Decouple compiler from scheduler in warm standby mode

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -26,6 +26,7 @@ public class ServiceConfigKeys {
 
   public static final String GOBBLIN_SERVICE_PREFIX = "gobblin.service.";
   public static final String GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS = "org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler";
+  public static final String GOBBLIN_ORCHESTRATOR_LISTENER_CLASS = "org.apache.gobblin.service.modules.orchestration.Orchestratotar";
 
   // Gobblin Service Manager Keys
   public static final String GOBBLIN_SERVICE_TOPOLOGY_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologyCatalog.enabled";
@@ -38,6 +39,7 @@ public class ServiceConfigKeys {
   public static final String GOBBLIN_SERVICE_DAG_MANAGER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "dagManager.enabled";
   public static final boolean DEFAULT_GOBBLIN_SERVICE_DAG_MANAGER_ENABLED = false;
   public static final String GOBBLIN_SERVICE_JOB_STATUS_MONITOR_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "jobStatusMonitor.enabled";
+  public static final String GOBBLIN_SERVICE_WARM_STANDBY_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "warmStandby.enabled";
   // If true, will mark up/down d2 servers on leadership so that all requests will be routed to the leader node
   public static final String GOBBLIN_SERVICE_D2_ONLY_ANNOUNCE_LEADER = GOBBLIN_SERVICE_PREFIX + "d2.onlyAnnounceLeader";
 
@@ -56,6 +58,7 @@ public class ServiceConfigKeys {
   // Flow Compiler Keys
   public static final String GOBBLIN_SERVICE_FLOWCOMPILER_CLASS_KEY = GOBBLIN_SERVICE_PREFIX + "flowCompiler.class";
   public static final String COMPILATION_SUCCESSFUL = "compilation.successful";
+  public static final String COMPILATION_RESPONSE = "compilation.response";
 
   // Flow Catalog Keys
   public static final String GOBBLIN_SERVICE_FLOW_CATALOG_LOCAL_COMMIT = GOBBLIN_SERVICE_PREFIX + "flowCatalog.localCommit";

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -26,7 +26,7 @@ public class ServiceConfigKeys {
 
   public static final String GOBBLIN_SERVICE_PREFIX = "gobblin.service.";
   public static final String GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS = "org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler";
-  public static final String GOBBLIN_ORCHESTRATOR_LISTENER_CLASS = "org.apache.gobblin.service.modules.orchestration.Orchestratotar";
+  public static final String GOBBLIN_ORCHESTRATOR_LISTENER_CLASS = "org.apache.gobblin.service.modules.orchestration.Orchestrator";
 
   // Gobblin Service Manager Keys
   public static final String GOBBLIN_SERVICE_TOPOLOGY_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologyCatalog.enabled";

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
@@ -95,7 +95,7 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
       //This is an Explain request. So no resource is actually created.
       //Enrich original FlowConfig entity by adding the compiledFlow to the properties map.
       StringMap props = flowConfig.getProperties();
-      AddSpecResponse<String> addSpecResponse = responseMap.getOrDefault(ServiceConfigKeys.GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS, null);
+      AddSpecResponse<String> addSpecResponse = responseMap.getOrDefault(ServiceConfigKeys.COMPILATION_RESPONSE, null);
       props.put("gobblin.flow.compiled",
           addSpecResponse != null && addSpecResponse.getValue() != null ? StringEscapeUtils.escapeJson(addSpecResponse.getValue()) : "");
       flowConfig.setProperties(props);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -133,6 +133,7 @@ public class FlowSpec implements Configurable, Spec {
   public static class CompilationError {
     public int errorPriority;
     public String errorMessage;
+
     public CompilationError(Config config, String src, String dst, String errorMessage) {
       errorPriority = 0;
       if (!src.equals(ConfigUtils.getString(config, ServiceConfigKeys.FLOW_SOURCE_IDENTIFIER_KEY, ""))){
@@ -144,6 +145,7 @@ public class FlowSpec implements Configurable, Spec {
       }
       this.errorMessage = errorMessage;
     }
+
     public CompilationError(int errorPriority, String errorMessage) {
       this.errorPriority = errorPriority;
       this.errorMessage = errorMessage;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -133,7 +133,7 @@ public class FlowSpec implements Configurable, Spec {
   public static class CompilationError {
     public int errorPriority;
     public String errorMessage;
-    CompilationError(Config config, String src, String dst, String errorMessage) {
+    public CompilationError(Config config, String src, String dst, String errorMessage) {
       errorPriority = 0;
       if (!src.equals(ConfigUtils.getString(config, ServiceConfigKeys.FLOW_SOURCE_IDENTIFIER_KEY, ""))){
         errorPriority++;
@@ -144,7 +144,12 @@ public class FlowSpec implements Configurable, Spec {
       }
       this.errorMessage = errorMessage;
     }
+    public CompilationError(int errorPriority, String errorMessage) {
+      this.errorPriority = errorPriority;
+      this.errorMessage = errorMessage;
+    }
   }
+
 
   public String toShortString() {
     return getUri().toString() + "/" + getVersion();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -402,7 +402,6 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
         try {
           if (!flowSpec.isExplain()) {
             long startTime = System.currentTimeMillis();
-            System.out.println("here");
             specStore.addSpec(spec);
             metrics.updatePutSpecTime(startTime);
           }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -402,6 +402,7 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
         try {
           if (!flowSpec.isExplain()) {
             long startTime = System.currentTimeMillis();
+            System.out.println("here");
             specStore.addSpec(spec);
             metrics.updatePutSpecTime(startTime);
           }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/InjectionNames.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/InjectionNames.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.service.modules.utils;
+package org.apache.gobblin.runtime.util;
 
 /**
  * These names are used for dependency injection, when we need to inject different instances of the same type,
@@ -25,4 +25,5 @@ public final class InjectionNames {
   public static final String SERVICE_NAME = "serviceName";
   public static final String FORCE_LEADER = "forceLeader";
   public static final String FLOW_CATALOG_LOCAL_COMMIT = "flowCatalogLocalCommit";
+  public static final String WARM_STANDBY_ENABLED = "statelessRestAPIEnabled";
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceConfiguration.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceConfiguration.java
@@ -41,6 +41,9 @@ public class GobblinServiceConfiguration {
   private final String serviceId;
 
   @Getter
+  private final boolean isWarmStandbyEnabled;
+
+  @Getter
   private final boolean isTopologyCatalogEnabled;
 
   @Getter
@@ -102,6 +105,8 @@ public class GobblinServiceConfiguration {
       flowCatalogLocalCommit = false;
       isGitConfigMonitorEnabled = false;
     }
+
+    this.isWarmStandbyEnabled = ConfigUtils.getBoolean(config, ServiceConfigKeys.GOBBLIN_SERVICE_WARM_STANDBY_ENABLED_KEY, false);
 
     this.isHelixManagerEnabled = config.hasPath(ServiceConfigKeys.ZK_CONNECTION_STRING_KEY);
     this.isDagManagerEnabled =

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -72,7 +72,7 @@ import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 import org.apache.gobblin.service.modules.topology.TopologySpecFactory;
 import org.apache.gobblin.service.modules.troubleshooter.MySqlMultiContextIssueRepository;
 import org.apache.gobblin.service.modules.utils.HelixUtils;
-import org.apache.gobblin.service.modules.utils.InjectionNames;
+import org.apache.gobblin.runtime.util.InjectionNames;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.FsJobStatusRetriever;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
@@ -135,6 +135,9 @@ public class GobblinServiceGuiceModule implements Module {
     binder.bindConstant()
         .annotatedWith(Names.named(InjectionNames.FLOW_CATALOG_LOCAL_COMMIT))
         .to(serviceConfig.isFlowCatalogLocalCommit());
+    binder.bindConstant()
+        .annotatedWith(Names.named(InjectionNames.WARM_STANDBY_ENABLED))
+        .to(serviceConfig.isWarmStandbyEnabled());
 
     binder.bind(FlowConfigsResourceHandler.class).to(GobblinServiceFlowConfigResourceHandler.class);
     binder.bind(FlowConfigsV2ResourceHandler.class).to(GobblinServiceFlowConfigV2ResourceHandler.class);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -393,7 +393,8 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
     registerServicesInLauncher();
 
     // Register Scheduler to listen to changes in Flows
-    if (configuration.isSchedulerEnabled()) {
+    // In warm standby mode, instead of scheduler we will add orchestrator as listener
+    if (configuration.isSchedulerEnabled() && !configuration.isWarmStandbyEnabled()) {
       this.flowCatalog.addListener(this.scheduler);
     }
   }
@@ -479,6 +480,9 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
     //Activate the SpecCompiler, after the topologyCatalog has been initialized.
     this.orchestrator.getSpecCompiler().setActive(true);
+    if(configuration.isWarmStandbyEnabled()) {
+      this.flowCatalog.addListener(this.orchestrator);
+    }
 
     //Activate the DagManager service, after the topologyCatalog has been initialized.
     if (!this.helixManager.isPresent() || this.helixManager.get().isLeader()){

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -394,7 +394,9 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
     // Register Scheduler to listen to changes in Flows
     // In warm standby mode, instead of scheduler we will add orchestrator as listener
-    if (configuration.isSchedulerEnabled() && !configuration.isWarmStandbyEnabled()) {
+    if(configuration.isWarmStandbyEnabled()) {
+      this.flowCatalog.addListener(this.orchestrator);
+    } else if (configuration.isSchedulerEnabled()) {
       this.flowCatalog.addListener(this.scheduler);
     }
   }
@@ -480,9 +482,6 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
     //Activate the SpecCompiler, after the topologyCatalog has been initialized.
     this.orchestrator.getSpecCompiler().setActive(true);
-    if(configuration.isWarmStandbyEnabled()) {
-      this.flowCatalog.addListener(this.orchestrator);
-    }
 
     //Activate the DagManager service, after the topologyCatalog has been initialized.
     if (!this.helixManager.isPresent() || this.helixManager.get().isLeader()){

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -162,7 +162,12 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
 
   private  AddSpecResponse onAddFlowSpec(FlowSpec flowSpec) {
     Properties flowSpecProperties = flowSpec.getConfigAsProperties();
-    if (flowSpecProperties.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY) && org.apache.commons.lang.StringUtils.isNotBlank(
+    if (topologySpecMap.containsKey(flowSpec.getUri())) {
+      log.error("flow spec uir: {} is the same as one of the spec executors uris, ignore the flow", flowSpec.getUri());
+      flowSpec.getCompilationErrors().add(new FlowSpec.CompilationError(0, "invalid flow spec uri " + flowSpec.getUri() + " because it is the same as one of the spec executors uri"));
+      return null;
+    }
+    if (flowSpecProperties.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY) && StringUtils.isNotBlank(
         flowSpecProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY))) {
       try {
         new CronExpression(flowSpecProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -183,6 +183,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     // todo: should we check quota here?
     return new AddSpecResponse<>(response);
   }
+
   @Override
   public AddSpecResponse onAddSpec(Spec addedSpec) {
     if (addedSpec instanceof FlowSpec) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -163,7 +163,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
   private  AddSpecResponse onAddFlowSpec(FlowSpec flowSpec) {
     Properties flowSpecProperties = flowSpec.getConfigAsProperties();
     if (topologySpecMap.containsKey(flowSpec.getUri())) {
-      log.error("flow spec uir: {} is the same as one of the spec executors uris, ignore the flow", flowSpec.getUri());
+      log.error("flow spec URI: {} is the same as one of the spec executors uris, ignore the flow", flowSpec.getUri());
       flowSpec.getCompilationErrors().add(new FlowSpec.CompilationError(0, "invalid flow spec uri " + flowSpec.getUri() + " because it is the same as one of the spec executors uri"));
       return null;
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -169,6 +169,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     if (addedSpec instanceof TopologySpec) {
       _log.info("New Spec detected of type TopologySpec: " + addedSpec);
       this.specCompiler.onAddSpec(addedSpec);
+    } else if (addedSpec instanceof FlowSpec) {
+      _log.info("New Spec detected of type FlowSpec: " + addedSpec);
+      return this.specCompiler.onAddSpec(addedSpec);
     }
     return new AddSpecResponse(null);
   }
@@ -183,6 +186,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     _log.info("Spec deletion detected: " + deletedSpecURI + "/" + deletedSpecVersion);
 
     if (topologyCatalog.isPresent()) {
+      //todo: de-risk: flow spec and topology spec share same uri?
       this.specCompiler.onDeleteSpec(deletedSpecURI, deletedSpecVersion, headers);
     }
   }
@@ -191,6 +195,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
   @Override
   public void onUpdateSpec(Spec updatedSpec) {
     _log.info("Spec changed: " + updatedSpec);
+    if (updatedSpec instanceof FlowSpec) {
+      onAddSpec(updatedSpec);
+    }
 
     if (!(updatedSpec instanceof TopologySpec)) {
       return;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -75,7 +75,8 @@ import org.apache.gobblin.util.ConfigUtils;
 
 /**
  * Orchestrator that is a {@link SpecCatalogListener}. It listens to changes
- * to {@link TopologyCatalog} and updates {@link SpecCompiler} state.
+ * to {@link TopologyCatalog} and updates {@link SpecCompiler} state
+ * Also it listens to {@link org.apache.gobblin.runtime.spec_catalog.FlowCatalog} and use the compiler to compile the new flow spec.
  */
 @Alpha
 @Singleton
@@ -186,7 +187,6 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     _log.info("Spec deletion detected: " + deletedSpecURI + "/" + deletedSpecVersion);
 
     if (topologyCatalog.isPresent()) {
-      //todo: de-risk: flow spec and topology spec share same uri?
       this.specCompiler.onDeleteSpec(deletedSpecURI, deletedSpecVersion, headers);
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigResourceHandler.java
@@ -50,7 +50,7 @@ import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 import org.apache.gobblin.service.modules.utils.HelixUtils;
-import org.apache.gobblin.service.modules.utils.InjectionNames;
+import org.apache.gobblin.runtime.util.InjectionNames;
 
 
 /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigV2ResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigV2ResourceHandler.java
@@ -27,7 +27,7 @@ import javax.inject.Named;
 import org.apache.gobblin.service.FlowConfigV2ResourceLocalHandler;
 import org.apache.gobblin.service.FlowConfigsV2ResourceHandler;
 import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
-import org.apache.gobblin.service.modules.utils.InjectionNames;
+import org.apache.gobblin.runtime.util.InjectionNames;
 
 
 public class GobblinServiceFlowConfigV2ResourceHandler extends GobblinServiceFlowConfigResourceHandler

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
@@ -40,7 +40,7 @@ import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.FlowStatusId;
 import org.apache.gobblin.service.modules.core.GobblinServiceManager;
 import org.apache.gobblin.service.modules.utils.HelixUtils;
-import org.apache.gobblin.service.modules.utils.InjectionNames;
+import org.apache.gobblin.runtime.util.InjectionNames;
 import org.apache.gobblin.service.monitoring.KillFlowEvent;
 import org.apache.gobblin.service.monitoring.ResumeFlowEvent;
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -177,6 +177,7 @@ public class OrchestratorTest {
   }
 
   private FlowSpec initBadFlowSpec() {
+    // Bad Flow Spec as we don't set the job name,  and will fail the compilation
     Properties properties = new Properties();
     properties.put("specStore.fs.dir", FLOW_SPEC_STORE_DIR);
     properties.put("specExecInstance.capabilities", "source:destination");

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -31,7 +31,6 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.runtime.api.SpecCatalogListener;
-import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +49,6 @@ import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.api.TopologySpec;
 import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
-import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_catalog.TopologyCatalog;
 import org.apache.gobblin.runtime.spec_executorInstance.InMemorySpecExecutor;
@@ -59,7 +57,6 @@ import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -103,14 +103,10 @@ public class OrchestratorTest {
         Optional.of(logger));
     this.serviceLauncher.addService(topologyCatalog);
 
+    // Test warm standby flow catalog, which has orchestrator as listener
     this.flowCatalog = new FlowCatalog(ConfigUtils.propertiesToConfig(flowProperties),
-        Optional.of(logger));
+        Optional.of(logger), Optional.<MetricContext>absent(), true, true);
 
-    this.mockListener = mock(SpecCatalogListener.class);
-    when(mockListener.getName()).thenReturn(ServiceConfigKeys.GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS);
-    when(mockListener.onAddSpec(any())).thenReturn(new AddSpecResponse(""));
-
-    this.flowCatalog.addListener(mockListener);
     this.serviceLauncher.addService(flowCatalog);
     this.mockStatusGenerator = mock(FlowStatusGenerator.class);
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1689


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Now, when add/update flow spec, we rely on scheduler to compile the flow and return status, but in warm standby mode, where every host can accept and process request but not running the flow, we should be able to compile flow without scheduler. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

