### PR TITLE
[GOBBLIN-1694] Add GMCE topic explicitly to hive commit event

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriterKeys.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/MetadataWriterKeys.java
@@ -47,6 +47,7 @@ public class MetadataWriterKeys {
   public static final String FAILED_TO_DROP_PARTITION_VALUES_KEY = "failedToDropPartitionValues";
   public static final String PARTITION_KEYS = "partitionKeys";
   public static final String HIVE_PARTITION_OPERATION_KEY = "hivePartitionOperation";
+  public static final String HIVE_EVENT_GMCE_TOPIC_NAME = "kafkaTopic";
 
   private MetadataWriterKeys() {
   }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -1082,7 +1082,8 @@ public class IcebergMetadataWriter implements MetadataWriter {
           write(gmce, newSpecsMap, oldSpecsMap, tableSpec);
           tableCurrentWatermarkMap.put(tid, currentOffset);
         } else {
-          log.warn(String.format("Skip processing record %s since it has lower watermark", genericRecord.toString()));
+          log.warn(String.format("Skip processing record for table: %s.%s, GMCE offset: %d, GMCE partition: %s since it has lower watermark",
+              dbName, tableName, currentOffset, topicPartition));
         }
       } else {
         log.info(String.format("Skip table %s.%s since it's not selected", tableSpec.getTable().getDbName(),


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1694


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

- Explicitly add the GMCE topic as a field in hive commit events. This was in the events before from gobblin framework, but in some situations (not sure why) the event submitter got reset and stopped including it in the events, so explicitly adding it now. For backwards compatibility keeping the name `kafkaTopic` for the key.
- Also updated an iceberg writer log line to avoid blowing up the logs when gmip is going through older offsets (before it printed the entire GMCE which was extremely large).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in gmip test pipeline

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

