### PR TITLE
[GOBBLIN-1703] avoid double quota increase for adhoc flows

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -148,6 +148,9 @@ public class ServiceConfigKeys {
   public static final String QUOTA_MANAGER_CLASS = GOBBLIN_SERVICE_PREFIX + "quotaManager.class";
   public static final String DEFAULT_QUOTA_MANAGER = "org.apache.gobblin.service.modules.orchestration.InMemoryUserQuotaManager";
 
+  public static final String QUOTA_STORE_DB_TABLE_KEY = "quota.store.db.table";
+  public static final String DEFAULT_QUOTA_STORE_DB_TABLE = "quota_table";
+
   // Group Membership authentication service
   public static final String GROUP_OWNERSHIP_SERVICE_CLASS = GOBBLIN_SERVICE_PREFIX + "groupOwnershipService.class";
   public static final String DEFAULT_GROUP_OWNERSHIP_SERVICE = "org.apache.gobblin.service.NoopGroupOwnershipService";

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -32,7 +32,9 @@ public class ServiceConfigKeys {
   public static final String GOBBLIN_SERVICE_TOPOLOGY_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologyCatalog.enabled";
   public static final String GOBBLIN_SERVICE_FLOW_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "flowCatalog.enabled";
   public static final String GOBBLIN_SERVICE_SCHEDULER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "scheduler.enabled";
-  public static final String GOBBLIN_SERVICE_ORCHESTRATOR_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "orchestrator.enabled";
+
+  public static final String GOBBLIN_SERVICE_ADHOC_FLOW = GOBBLIN_SERVICE_PREFIX + "adhoc.flow";
+
   public static final String GOBBLIN_SERVICE_RESTLI_SERVER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "restliServer.enabled";
   public static final String GOBBLIN_SERVICE_TOPOLOGY_SPEC_FACTORY_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologySpecFactory.enabled";
   public static final String GOBBLIN_SERVICE_GIT_CONFIG_MONITOR_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "gitConfigMonitor.enabled";

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -151,6 +151,10 @@ public class ServiceConfigKeys {
   public static final String QUOTA_STORE_DB_TABLE_KEY = "quota.store.db.table";
   public static final String DEFAULT_QUOTA_STORE_DB_TABLE = "quota_table";
 
+  public static final String RUNNING_DAG_IDS_DB_TABLE_KEY = "running.dag.ids.store.db.table";
+  public static final String DEFAULT_RUNNING_DAG_IDS_DB_TABLE = "running_dag_ids";
+
+
   // Group Membership authentication service
   public static final String GROUP_OWNERSHIP_SERVICE_CLASS = GOBBLIN_SERVICE_PREFIX + "groupOwnershipService.class";
   public static final String DEFAULT_GROUP_OWNERSHIP_SERVICE = "org.apache.gobblin.service.NoopGroupOwnershipService";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
@@ -133,7 +133,7 @@ public class MysqlBaseSpecStore extends InstrumentedSpecStore {
   }
 
 
-  protected final DataSource dataSource;
+  protected final BasicDataSource dataSource;
   protected final String tableName;
   private final URI specStoreURI;
   protected final SpecSerDe specSerDe;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
@@ -36,7 +36,6 @@ import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import com.typesafe.config.Config;
 
-import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -194,9 +194,10 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     if (this.warmStandbyEnabled &&
         (!flowSpec.getConfigAsProperties().containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY) || PropertiesUtils.getPropAsBoolean(flowSpec.getConfigAsProperties(), ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false"))) {
       try {
-        // todo : we should probably check quota for all of the start nodes
-        userQuotaManager.checkQuota(dag.getNodes().get(0));
-        flowSpec.getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+        for (Dag.DagNode<JobExecutionPlan> dagNode : dag.getStartNodes()) {
+          userQuotaManager.checkQuota(dagNode);
+          flowSpec.getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+        }
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -194,10 +194,8 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     if (this.warmStandbyEnabled &&
         (!flowSpec.getConfigAsProperties().containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY) || PropertiesUtils.getPropAsBoolean(flowSpec.getConfigAsProperties(), ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false"))) {
       try {
-        for (Dag.DagNode<JobExecutionPlan> dagNode : dag.getStartNodes()) {
-          userQuotaManager.checkQuota(dagNode);
-          flowSpec.getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
-        }
+        userQuotaManager.checkQuota(dag.getStartNodes());
+        flowSpec.getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -281,6 +281,12 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
     Instrumented.markMeter(flowCompilationSuccessFulMeter);
     Instrumented.updateTimer(flowCompilationTimer, System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
 
+    if (Boolean.parseBoolean(flowSpec.getConfigAsProperties().getProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW))) {
+      // todo : we should probably set it on all of the start nodes
+      jobExecutionPlanDag.getNodes().get(0).getValue().getJobSpec().getConfigAsProperties()
+          .setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+    }
+
     return jobExecutionPlanDag;
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -282,7 +282,6 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
     Instrumented.updateTimer(flowCompilationTimer, System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
 
     if (Boolean.parseBoolean(flowSpec.getConfigAsProperties().getProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW))) {
-      // todo : we should probably set it on all of the start nodes
       for (Dag.DagNode<JobExecutionPlan> dagNode : jobExecutionPlanDag.getStartNodes()) {
         dagNode.getValue().getJobSpec().getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -283,8 +283,9 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
 
     if (Boolean.parseBoolean(flowSpec.getConfigAsProperties().getProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW))) {
       // todo : we should probably set it on all of the start nodes
-      jobExecutionPlanDag.getNodes().get(0).getValue().getJobSpec().getConfigAsProperties()
-          .setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+      for (Dag.DagNode<JobExecutionPlan> dagNode : jobExecutionPlanDag.getStartNodes()) {
+        dagNode.getValue().getJobSpec().getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+      }
     }
 
     return jobExecutionPlanDag;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -28,7 +27,6 @@ import lombok.AllArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.exception.QuotaExceededException;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
@@ -66,16 +64,7 @@ abstract public class AbstractUserQuotaManager implements UserQuotaManager {
     this.perFlowGroupQuota = flowGroupMapBuilder.build();
   }
 
-  abstract void addDagId(String dagId) throws IOException;
-
   abstract boolean containsDagId(String dagId) throws IOException;
-
-  abstract boolean removeDagId(String dagId) throws IOException;
-
-  // Implementations should return the current count and increase them by one
-  abstract int incrementJobCount(String key, CountType countType) throws IOException;
-
-  abstract void decrementJobCount(String key, CountType countType) throws IOException;
 
   public void checkQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
     QuotaCheck quotaCheck = increaseAndCheckQuota(dagNode);
@@ -88,139 +77,15 @@ abstract public class AbstractUserQuotaManager implements UserQuotaManager {
     }
   }
 
-  private void rollbackIncrements(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
-    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
-    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), ConfigurationKeys.FLOW_GROUP_KEY, "");
-    List<String> usersQuotaIncrement = DagManagerUtils.getDistinctUniqueRequesters(DagManagerUtils.getSerializedRequesterList(dagNode));
+  abstract void rollbackIncrements(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
-    decrementJobCount(DagManagerUtils.getUserQuotaKey(proxyUser, dagNode), CountType.USER_COUNT);
-    decrementQuotaUsageForUsers(usersQuotaIncrement);
-    decrementJobCount(DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), CountType.FLOWGROUP_COUNT);
-    removeDagId(DagManagerUtils.generateDagId(dagNode).toString());
-  }
+  abstract QuotaCheck increaseAndCheckQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
-  protected QuotaCheck increaseAndCheckQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
-    QuotaCheck quotaCheck = new QuotaCheck(true, true, true, "");
-    // Dag is already being tracked, no need to double increment for retries and multihop flows
-    if (containsDagId(DagManagerUtils.generateDagId(dagNode).toString())) {
-      return quotaCheck;
-    } else {
-      addDagId(DagManagerUtils.generateDagId(dagNode).toString());
-    }
-
-    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
-    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(),
-        ConfigurationKeys.FLOW_GROUP_KEY, "");
-    String specExecutorUri = DagManagerUtils.getSpecExecutorUri(dagNode);
-    StringBuilder requesterMessage = new StringBuilder();
-
-    boolean proxyUserCheck;
-
-    if (proxyUser != null && dagNode.getValue().getCurrentAttempts() <= 1) {
-      int proxyQuotaIncrement = incrementJobCountAndCheckQuota(
-          DagManagerUtils.getUserQuotaKey(proxyUser, dagNode), getQuotaForUser(proxyUser), CountType.USER_COUNT);
-      proxyUserCheck = proxyQuotaIncrement >= 0;  // proxy user quota check succeeds
-      quotaCheck.setProxyUserCheck(proxyUserCheck);
-      if (!proxyUserCheck) {
-        // add 1 to proxyUserIncrement since proxyQuotaIncrement is the count before the increment
-        requesterMessage.append(String.format(
-            "Quota exceeded for proxy user %s on executor %s : quota=%s, requests above quota=%d%n",
-            proxyUser, specExecutorUri, getQuotaForUser(proxyUser), Math.abs(proxyQuotaIncrement) + 1 - getQuotaForUser(proxyUser)));
-      }
-    }
-
-    String serializedRequesters = DagManagerUtils.getSerializedRequesterList(dagNode);
-    boolean requesterCheck = true;
-
-    if (dagNode.getValue().getCurrentAttempts() <= 1) {
-      List<String> uniqueRequesters = DagManagerUtils.getDistinctUniqueRequesters(serializedRequesters);
-      for (String requester : uniqueRequesters) {
-        int userQuotaIncrement = incrementJobCountAndCheckQuota(
-            DagManagerUtils.getUserQuotaKey(requester, dagNode), getQuotaForUser(requester), CountType.REQUESTER_COUNT);
-        boolean thisRequesterCheck = userQuotaIncrement >= 0;  // user quota check succeeds
-        requesterCheck = requesterCheck && thisRequesterCheck;
-        quotaCheck.setRequesterCheck(requesterCheck);
-        if (!thisRequesterCheck) {
-          requesterMessage.append(String.format(
-              "Quota exceeded for requester %s on executor %s : quota=%s, requests above quota=%d%n. ",
-              requester, specExecutorUri, getQuotaForUser(requester), Math.abs(userQuotaIncrement) + 1 - getQuotaForUser(requester)));
-        }
-      }
-    }
-
-    boolean flowGroupCheck;
-
-    if (dagNode.getValue().getCurrentAttempts() <= 1) {
-      int flowGroupQuotaIncrement = incrementJobCountAndCheckQuota(
-          DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), getQuotaForFlowGroup(flowGroup), CountType.FLOWGROUP_COUNT);
-      flowGroupCheck = flowGroupQuotaIncrement >= 0;
-      quotaCheck.setFlowGroupCheck(flowGroupCheck);
-      if (!flowGroupCheck) {
-        requesterMessage.append(String.format("Quota exceeded for flowgroup %s on executor %s : quota=%s, requests above quota=%d%n",
-            flowGroup, specExecutorUri, getQuotaForFlowGroup(flowGroup),
-            Math.abs(flowGroupQuotaIncrement) + 1 - getQuotaForFlowGroup(flowGroup)));
-      }
-    }
-
-    quotaCheck.setRequesterMessage(requesterMessage.toString());
-
-    return quotaCheck;
-  }
-
-  /**
-   * Decrement the quota by one for the proxy user and requesters corresponding to the provided {@link Dag.DagNode}.
-   * Returns true if the dag existed in the set of running dags and was removed successfully
-   */
-  public boolean releaseQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
-    boolean val = removeDagId(DagManagerUtils.generateDagId(dagNode).toString());
-    if (!val) {
-      return false;
-    }
-
-    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
-    if (proxyUser != null) {
-      String proxyUserKey = DagManagerUtils.getUserQuotaKey(proxyUser, dagNode);
-      decrementJobCount(proxyUserKey, CountType.USER_COUNT);
-    }
-
-    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(),
-        ConfigurationKeys.FLOW_GROUP_KEY, "");
-    decrementJobCount(DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), CountType.FLOWGROUP_COUNT);
-
-    String serializedRequesters = DagManagerUtils.getSerializedRequesterList(dagNode);
-    try {
-      for (String requester : DagManagerUtils.getDistinctUniqueRequesters(serializedRequesters)) {
-        String requesterKey = DagManagerUtils.getUserQuotaKey(requester, dagNode);
-        decrementJobCount(requesterKey, CountType.REQUESTER_COUNT);
-      }
-    } catch (IOException e) {
-      log.error("Failed to release quota for requester list " + serializedRequesters, e);
-      return false;
-    }
-
-    return true;
-  }
-
-  private int incrementJobCountAndCheckQuota(String key, int keyQuota, CountType countType) throws IOException {
-    int currentCount = incrementJobCount(key, countType);
-    if (currentCount >= keyQuota) {
-      return -currentCount;
-    } else {
-      return currentCount;
-    }
-  }
-
-  private void decrementQuotaUsageForUsers(List<String> requestersToDecreaseCount) throws IOException {
-    for (String requester : requestersToDecreaseCount) {
-      decrementJobCount(requester, CountType.REQUESTER_COUNT);
-    }
-  }
-
-  private int getQuotaForUser(String user) {
+  int getQuotaForUser(String user) {
     return this.perUserQuota.getOrDefault(user, defaultQuota);
   }
 
-  private int getQuotaForFlowGroup(String flowGroup) {
+  int getQuotaForFlowGroup(String flowGroup) {
     return this.perFlowGroupQuota.getOrDefault(flowGroup, defaultQuota);
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
@@ -27,7 +27,6 @@ import lombok.AllArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.exception.QuotaExceededException;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.util.ConfigUtils;
@@ -66,20 +65,7 @@ abstract public class AbstractUserQuotaManager implements UserQuotaManager {
 
   abstract boolean containsDagId(String dagId) throws IOException;
 
-  public void checkQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
-    QuotaCheck quotaCheck = increaseAndCheckQuota(dagNode);
-
-    // Throw errors for reach quota at the end to avoid inconsistent job counts
-    if ((!quotaCheck.proxyUserCheck || !quotaCheck.requesterCheck || !quotaCheck.flowGroupCheck)) {
-      // roll back the increased counts in this block
-      rollbackIncrements(dagNode);
-      throw new QuotaExceededException(quotaCheck.requesterMessage);
-    }
-  }
-
   abstract void rollbackIncrements(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
-
-  abstract QuotaCheck increaseAndCheckQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
   int getQuotaForUser(String user) {
     return this.perUserQuota.getOrDefault(user, defaultQuota);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
@@ -65,8 +65,6 @@ abstract public class AbstractUserQuotaManager implements UserQuotaManager {
 
   abstract boolean containsDagId(String dagId) throws IOException;
 
-  abstract void rollbackIncrements(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
-
   int getQuotaForUser(String user) {
     return this.perUserQuota.getOrDefault(user, defaultQuota);
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/AbstractUserQuotaManager.java
@@ -27,8 +27,6 @@ import lombok.AllArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.service.modules.flowgraph.Dag;
-import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.util.ConfigUtils;
 
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -73,6 +73,7 @@ import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.runtime.api.TopologySpec;
 import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.FlowId;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.Dag.DagNode;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
@@ -963,7 +964,11 @@ public class DagManager extends AbstractIdleService {
       // Run this spec on selected executor
       SpecProducer<Spec> producer;
       try {
-        quotaManager.checkQuota(dagNode);
+        if (!Boolean.parseBoolean(dagNode.getValue().getJobSpec().getConfigAsProperties().getProperty(
+            ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "false"))) {
+          quotaManager.checkQuota(dagNode);
+        }
+
         producer = DagManagerUtils.getSpecProducer(dagNode);
         TimingEvent jobOrchestrationTimer = this.eventSubmitter.isPresent() ? this.eventSubmitter.get().
             getTimingEvent(TimingEvent.LauncherTimings.JOB_ORCHESTRATED) : null;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -966,7 +966,7 @@ public class DagManager extends AbstractIdleService {
       try {
         if (!Boolean.parseBoolean(dagNode.getValue().getJobSpec().getConfigAsProperties().getProperty(
             ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "false"))) {
-          quotaManager.checkQuota(dagNode);
+          quotaManager.checkQuota(Collections.singleton(dagNode));
         }
 
         producer = DagManagerUtils.getSpecProducer(dagNode);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManager.java
@@ -22,6 +22,7 @@ import com.typesafe.config.Config;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -42,9 +43,27 @@ public class InMemoryUserQuotaManager extends AbstractUserQuotaManager {
   private final Map<String, Integer> flowGroupToJobCount = new ConcurrentHashMap<>();
   private final Map<String, Integer> requesterToJobCount = new ConcurrentHashMap<>();
 
+  private final Set<String> runningDagIds;
+
   @Inject
   public InMemoryUserQuotaManager(Config config) {
     super(config);
+    this.runningDagIds = ConcurrentHashMap.newKeySet();;
+  }
+
+  @Override
+  void addDagId(String dagId) {
+    this.runningDagIds.add(dagId);
+  }
+
+  @Override
+  boolean containsDagId(String dagId) {
+    return this.runningDagIds.contains(dagId);
+  }
+
+  @Override
+  boolean removeDagId(String dagId) {
+    return this.runningDagIds.remove(dagId);
   }
 
   public void init(Collection<Dag<JobExecutionPlan>> dags) throws IOException {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManager.java
@@ -21,14 +21,17 @@ import com.typesafe.config.Config;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.util.ConfigUtils;
 
 import static org.apache.gobblin.service.ExecutionStatus.RUNNING;
 
@@ -52,6 +55,134 @@ public class InMemoryUserQuotaManager extends AbstractUserQuotaManager {
   }
 
   @Override
+  protected QuotaCheck increaseAndCheckQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
+    QuotaCheck quotaCheck = new QuotaCheck(true, true, true, "");
+    // Dag is already being tracked, no need to double increment for retries and multihop flows
+    if (containsDagId(DagManagerUtils.generateDagId(dagNode).toString())) {
+      return quotaCheck;
+    } else {
+      addDagId(DagManagerUtils.generateDagId(dagNode).toString());
+    }
+
+    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
+    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(),
+        ConfigurationKeys.FLOW_GROUP_KEY, "");
+    String specExecutorUri = DagManagerUtils.getSpecExecutorUri(dagNode);
+    StringBuilder requesterMessage = new StringBuilder();
+
+    boolean proxyUserCheck;
+
+    if (proxyUser != null && dagNode.getValue().getCurrentAttempts() <= 1) {
+      int proxyQuotaIncrement = incrementJobCountAndCheckQuota(
+          DagManagerUtils.getUserQuotaKey(proxyUser, dagNode), getQuotaForUser(proxyUser), CountType.USER_COUNT);
+      proxyUserCheck = proxyQuotaIncrement >= 0;  // proxy user quota check succeeds
+      quotaCheck.setProxyUserCheck(proxyUserCheck);
+      if (!proxyUserCheck) {
+        // add 1 to proxyUserIncrement since proxyQuotaIncrement is the count before the increment
+        requesterMessage.append(String.format(
+            "Quota exceeded for proxy user %s on executor %s : quota=%s, requests above quota=%d%n",
+            proxyUser, specExecutorUri, getQuotaForUser(proxyUser), Math.abs(proxyQuotaIncrement) + 1 - getQuotaForUser(proxyUser)));
+      }
+    }
+
+    String serializedRequesters = DagManagerUtils.getSerializedRequesterList(dagNode);
+    boolean requesterCheck = true;
+
+    if (dagNode.getValue().getCurrentAttempts() <= 1) {
+      List<String> uniqueRequesters = DagManagerUtils.getDistinctUniqueRequesters(serializedRequesters);
+      for (String requester : uniqueRequesters) {
+        int userQuotaIncrement = incrementJobCountAndCheckQuota(
+            DagManagerUtils.getUserQuotaKey(requester, dagNode), getQuotaForUser(requester), CountType.REQUESTER_COUNT);
+        boolean thisRequesterCheck = userQuotaIncrement >= 0;  // user quota check succeeds
+        requesterCheck = requesterCheck && thisRequesterCheck;
+        quotaCheck.setRequesterCheck(requesterCheck);
+        if (!thisRequesterCheck) {
+          requesterMessage.append(String.format(
+              "Quota exceeded for requester %s on executor %s : quota=%s, requests above quota=%d%n. ",
+              requester, specExecutorUri, getQuotaForUser(requester), Math.abs(userQuotaIncrement) + 1 - getQuotaForUser(requester)));
+        }
+      }
+    }
+
+    boolean flowGroupCheck;
+
+    if (dagNode.getValue().getCurrentAttempts() <= 1) {
+      int flowGroupQuotaIncrement = incrementJobCountAndCheckQuota(
+          DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), getQuotaForFlowGroup(flowGroup), CountType.FLOWGROUP_COUNT);
+      flowGroupCheck = flowGroupQuotaIncrement >= 0;
+      quotaCheck.setFlowGroupCheck(flowGroupCheck);
+      if (!flowGroupCheck) {
+        requesterMessage.append(String.format("Quota exceeded for flowgroup %s on executor %s : quota=%s, requests above quota=%d%n",
+            flowGroup, specExecutorUri, getQuotaForFlowGroup(flowGroup),
+            Math.abs(flowGroupQuotaIncrement) + 1 - getQuotaForFlowGroup(flowGroup)));
+      }
+    }
+
+    quotaCheck.setRequesterMessage(requesterMessage.toString());
+
+    return quotaCheck;
+  }
+
+  protected void rollbackIncrements(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
+    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
+    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), ConfigurationKeys.FLOW_GROUP_KEY, "");
+    List<String> usersQuotaIncrement = DagManagerUtils.getDistinctUniqueRequesters(DagManagerUtils.getSerializedRequesterList(dagNode));
+
+    decrementJobCount(DagManagerUtils.getUserQuotaKey(proxyUser, dagNode), CountType.USER_COUNT);
+    decrementQuotaUsageForUsers(usersQuotaIncrement);
+    decrementJobCount(DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), CountType.FLOWGROUP_COUNT);
+    removeDagId(DagManagerUtils.generateDagId(dagNode).toString());
+  }
+
+  private int incrementJobCountAndCheckQuota(String key, int keyQuota, CountType countType) throws IOException {
+    int currentCount = incrementJobCount(key, countType);
+    if (currentCount >= keyQuota) {
+      return -currentCount;
+    } else {
+      return currentCount;
+    }
+  }
+
+  private void decrementQuotaUsageForUsers(List<String> requestersToDecreaseCount) throws IOException {
+    for (String requester : requestersToDecreaseCount) {
+      decrementJobCount(requester, CountType.REQUESTER_COUNT);
+    }
+  }
+
+  /**
+   * Decrement the quota by one for the proxy user and requesters corresponding to the provided {@link Dag.DagNode}.
+   * Returns true if the dag existed in the set of running dags and was removed successfully
+   */
+  public boolean releaseQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
+    boolean val = removeDagId(DagManagerUtils.generateDagId(dagNode).toString());
+    if (!val) {
+      return false;
+    }
+
+    String proxyUser = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(), AzkabanProjectConfig.USER_TO_PROXY, null);
+    if (proxyUser != null) {
+      String proxyUserKey = DagManagerUtils.getUserQuotaKey(proxyUser, dagNode);
+      decrementJobCount(proxyUserKey, CountType.USER_COUNT);
+    }
+
+    String flowGroup = ConfigUtils.getString(dagNode.getValue().getJobSpec().getConfig(),
+        ConfigurationKeys.FLOW_GROUP_KEY, "");
+    decrementJobCount(DagManagerUtils.getFlowGroupQuotaKey(flowGroup, dagNode), CountType.FLOWGROUP_COUNT);
+
+    String serializedRequesters = DagManagerUtils.getSerializedRequesterList(dagNode);
+    try {
+      for (String requester : DagManagerUtils.getDistinctUniqueRequesters(serializedRequesters)) {
+        String requesterKey = DagManagerUtils.getUserQuotaKey(requester, dagNode);
+        decrementJobCount(requesterKey, CountType.REQUESTER_COUNT);
+      }
+    } catch (IOException e) {
+      log.error("Failed to release quota for requester list " + serializedRequesters, e);
+      return false;
+    }
+
+    return true;
+  }
+
   void addDagId(String dagId) {
     this.runningDagIds.add(dagId);
   }
@@ -61,7 +192,6 @@ public class InMemoryUserQuotaManager extends AbstractUserQuotaManager {
     return this.runningDagIds.contains(dagId);
   }
 
-  @Override
   boolean removeDagId(String dagId) {
     return this.runningDagIds.remove(dagId);
   }
@@ -105,7 +235,6 @@ public class InMemoryUserQuotaManager extends AbstractUserQuotaManager {
     }
   }
 
-  @Override
   int incrementJobCount(String user, CountType countType) throws IOException {
     switch (countType) {
       case USER_COUNT:
@@ -119,7 +248,6 @@ public class InMemoryUserQuotaManager extends AbstractUserQuotaManager {
     }
   }
 
-  @Override
   void decrementJobCount(String user, CountType countType) throws IOException {
     switch (countType) {
       case USER_COUNT:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
@@ -34,8 +34,8 @@ import javax.inject.Singleton;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.MysqlStateStore;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.util.ConfigUtils;
@@ -83,15 +83,15 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
   }
 
   /**
-   * Creating an instance of StateStore.
+   * Creating an instance of MysqlQuotaStore.
    */
   protected MysqlQuotaStore createQuotaStore(Config config) throws IOException {
-    String stateStoreTableName = ConfigUtils.getString(config, ConfigurationKeys.STATE_STORE_DB_TABLE_KEY,
-        ConfigurationKeys.DEFAULT_STATE_STORE_DB_TABLE);
+    String quotaStoreTableName = ConfigUtils.getString(config, ServiceConfigKeys.QUOTA_STORE_DB_TABLE_KEY,
+        ServiceConfigKeys.DEFAULT_QUOTA_STORE_DB_TABLE);
 
     BasicDataSource basicDataSource = MysqlStateStore.newDataSource(config);
 
-    return new MysqlQuotaStore(basicDataSource, stateStoreTableName);
+    return new MysqlQuotaStore(basicDataSource, quotaStoreTableName);
   }
 
   static class MysqlQuotaStore {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
@@ -222,6 +222,7 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
         log.error("Failed to release quota for requester list " + serializedRequesters, e);
         return false;
       }
+      connection.commit();
     } catch (SQLException ex) {
       throw new IOException(ex);
     } finally {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
@@ -373,6 +373,7 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
       String selectStatement;
       String increaseStatement;
 
+
       switch(countType) {
         case USER_COUNT:
           selectStatement = GET_USER_COUNT;
@@ -397,7 +398,6 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
         statement2.setString(1, name);
         rs = statement1.executeQuery();
         statement2.executeUpdate();
-        connection.commit();
         if (rs != null && rs.next()) {
           return rs.getInt(1);
         } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManager.java
@@ -301,7 +301,7 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
   }
 
   static class MysqlQuotaStore {
-    protected final DataSource dataSource;
+    protected final BasicDataSource dataSource;
     final String tableName;
     private final String GET_USER_COUNT;
     private final String GET_REQUESTER_COUNT;
@@ -339,7 +339,9 @@ public class MysqlUserQuotaManager extends AbstractUserQuotaManager {
       try (Connection connection = dataSource.getConnection(); PreparedStatement createStatement = connection.prepareStatement(createQuotaTable)) {
         createStatement.executeUpdate();
       } catch (SQLException e) {
-        throw new IOException("Failure creation table " + tableName, e);
+        log.warn("Failure in creating table {}. Validation query is set to {} Exception is {}",
+            tableName, this.dataSource.getValidationQuery(), e);
+        throw new IOException(e);
       }
     }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/UserQuotaManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/UserQuotaManager.java
@@ -42,7 +42,7 @@ public interface UserQuotaManager {
    * It also increases the quota usage for proxy user, requester and the flowGroup of the given DagNode by one.
    * @throws QuotaExceededException if the quota is exceeded
    */
-  void checkQuota(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
+  void checkQuota(Collection<Dag.DagNode<JobExecutionPlan>> dagNode) throws IOException;
 
   /**
    * Decrement the quota by one for the proxy user and requesters corresponding to the provided {@link Dag.DagNode}.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -336,9 +336,10 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       if (quotaManager.isPresent()) {
         // QuotaManager has idempotent checks for a dagNode, so this check won't double add quotas for a flow in the DagManager
         try {
-          // todo : we should probably check quota for all of the start nodes
-          quotaManager.get().checkQuota(dag.getNodes().get(0));
-          ((FlowSpec) addedSpec).getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+          for (Dag.DagNode<JobExecutionPlan> dagNode : dag.getStartNodes()) {
+            quotaManager.get().checkQuota(dagNode);
+            ((FlowSpec) addedSpec).getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
+          }
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -335,7 +335,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       if (quotaManager.isPresent()) {
         // QuotaManager has idempotent checks for a dagNode, so this check won't double add quotas for a flow in the DagManager
         try {
+          // todo : we should probably check quota for all of the start nodes
           quotaManager.get().checkQuota(dag.getNodes().get(0));
+          ((FlowSpec) addedSpec).getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -332,6 +332,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
     // Check quota limits against run immediately flows or adhoc flows before saving the schedule
     // In warm standby mode, this quota check will happen on restli API layer when we accept the flow
     if (!this.warmStandbyEnabled && (!jobConfig.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY) || PropertiesUtils.getPropAsBoolean(jobConfig, ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false"))) {
+      // This block should be reachable only for the first execution for the adhoc flows (flows that either do not have a schedule or have runImmediately=true.
       if (quotaManager.isPresent()) {
         // QuotaManager has idempotent checks for a dagNode, so this check won't double add quotas for a flow in the DagManager
         try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -250,9 +250,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
     Properties properties = spec.getConfigAsProperties();
     properties.setProperty(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false");
     Config config = ConfigFactory.parseProperties(properties);
-    FlowSpec flowSpec = new FlowSpec(spec.getUri(), spec.getVersion(), spec.getDescription(), config, properties,
+    return new FlowSpec(spec.getUri(), spec.getVersion(), spec.getDescription(), config, properties,
         spec.getTemplateURIs(), spec.getChildSpecs());
-    return flowSpec;
   }
 
   @Override
@@ -336,10 +335,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       if (quotaManager.isPresent()) {
         // QuotaManager has idempotent checks for a dagNode, so this check won't double add quotas for a flow in the DagManager
         try {
-          for (Dag.DagNode<JobExecutionPlan> dagNode : dag.getStartNodes()) {
-            quotaManager.get().checkQuota(dagNode);
-            ((FlowSpec) addedSpec).getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
-          }
+          quotaManager.get().checkQuota(dag.getStartNodes());
+          ((FlowSpec) addedSpec).getConfigAsProperties().setProperty(ServiceConfigKeys.GOBBLIN_SERVICE_ADHOC_FLOW, "true");
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/InMemoryUserQuotaManagerTest.java
@@ -20,6 +20,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
@@ -61,9 +62,9 @@ public class InMemoryUserQuotaManagerTest {
     dags.get(0).getNodes().get(0).getValue().setCurrentAttempts(1);
     dags.get(1).getNodes().get(0).getValue().setCurrentAttempts(1);
 
-    this._quotaManager.checkQuota(dags.get(0).getNodes().get(0));
+    this._quotaManager.checkQuota(Collections.singleton(dags.get(0).getNodes().get(0)));
     Assert.assertThrows(IOException.class, () -> {
-      this._quotaManager.checkQuota(dags.get(1).getNodes().get(0));
+      this._quotaManager.checkQuota(Collections.singleton(dags.get(1).getNodes().get(0)));
     });
   }
 
@@ -76,7 +77,7 @@ public class InMemoryUserQuotaManagerTest {
     dags.get(0).getNodes().get(0).getValue().setCurrentAttempts(1);
     dags.get(1).getNodes().get(0).getValue().setCurrentAttempts(1);
 
-    this._quotaManager.checkQuota(dags.get(0).getNodes().get(0));
+    this._quotaManager.checkQuota(Collections.singleton(dags.get(0).getNodes().get(0)));
     Assert.assertTrue(this._quotaManager.releaseQuota(dags.get(0).getNodes().get(0)));
     Assert.assertFalse(this._quotaManager.releaseQuota(dags.get(0).getNodes().get(0)));
   }
@@ -91,9 +92,9 @@ public class InMemoryUserQuotaManagerTest {
     dags.get(0).getNodes().get(0).getValue().setCurrentAttempts(1);
     dags.get(1).getNodes().get(0).getValue().setCurrentAttempts(1);
 
-    this._quotaManager.checkQuota(dags.get(0).getNodes().get(0));
+    this._quotaManager.checkQuota(Collections.singleton(dags.get(0).getNodes().get(0)));
     Assert.assertThrows(IOException.class, () -> {
-      this._quotaManager.checkQuota(dags.get(1).getNodes().get(0));
+      this._quotaManager.checkQuota(Collections.singleton(dags.get(1).getNodes().get(0)));
     });
   }
 
@@ -115,20 +116,20 @@ public class InMemoryUserQuotaManagerTest {
     dag3.getNodes().get(0).getValue().setCurrentAttempts(1);
     dag4.getNodes().get(0).getValue().setCurrentAttempts(1);
 
-    this._quotaManager.checkQuota(dag1.getNodes().get(0));
-    this._quotaManager.checkQuota(dag2.getNodes().get(0));
+    this._quotaManager.checkQuota(Collections.singleton(dag1.getNodes().get(0)));
+    this._quotaManager.checkQuota(Collections.singleton(dag2.getNodes().get(0)));
 
     // Should fail due to user quota
     Assert.assertThrows(IOException.class, () -> {
-      this._quotaManager.checkQuota(dag3.getNodes().get(0));
+      this._quotaManager.checkQuota(Collections.singleton(dag3.getNodes().get(0)));
     });
     // Should fail due to flowgroup quota
     Assert.assertThrows(IOException.class, () -> {
-      this._quotaManager.checkQuota(dag4.getNodes().get(0));
+      this._quotaManager.checkQuota(Collections.singleton(dag4.getNodes().get(0)));
     });
     // should pass due to quota being released
     this._quotaManager.releaseQuota(dag2.getNodes().get(0));
-    this._quotaManager.checkQuota(dag3.getNodes().get(0));
-    this._quotaManager.checkQuota(dag4.getNodes().get(0));
+    this._quotaManager.checkQuota(Collections.singleton(dag3.getNodes().get(0)));
+    this._quotaManager.checkQuota(Collections.singleton(dag4.getNodes().get(0)));
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlUserQuotaManagerTest.java
@@ -52,6 +52,17 @@ public class MysqlUserQuotaManagerTest {
   }
 
   @Test
+  public void testRunningDagStore() throws Exception {
+    String dagId = DagManagerUtils.generateDagId(DagManagerTest.buildDag("dagId", 1234L, "", 1).getNodes().get(0)).toString();
+    Assert.assertFalse(this.quotaManager.containsDagId(dagId));
+    this.quotaManager.addDagId(dagId);
+    Assert.assertTrue(this.quotaManager.containsDagId(dagId));
+    Assert.assertTrue(this.quotaManager.removeDagId(dagId));
+    Assert.assertFalse(this.quotaManager.containsDagId(dagId));
+    Assert.assertFalse(this.quotaManager.removeDagId(dagId));
+  }
+
+    @Test
   public void testIncreaseCount() throws Exception {
     int prevCount = this.quotaManager.incrementJobCount(PROXY_USER, AbstractUserQuotaManager.CountType.USER_COUNT);
     Assert.assertEquals(prevCount, 0);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1703


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
When a gaas flow request comes, resource handler checks the quota right there.
However, if the flow has runImmediately=true, the quota will be checked again when the first job starts. This should be avoided.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

