### PR TITLE
[GOBBLIN-1704] Purge offline helix instances during startup

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/GobblinEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/GobblinEventBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.MetricContext;
@@ -37,6 +38,7 @@ import org.apache.gobblin.metrics.MetricContext;
  *
  * Note: a {@link GobblinEventBuilder} instance is not reusable
  */
+@ToString
 public class GobblinEventBuilder {
   public static final String NAMESPACE = "gobblin.event";
   public static final String EVENT_TYPE = "eventType";

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -67,6 +67,7 @@ dependencies {
   testCompile externalDependency.hadoopYarnMiniCluster
   testCompile externalDependency.curatorFramework
   testCompile externalDependency.curatorTest
+  testCompile externalDependency.powermock
 
   testCompile ('com.google.inject:guice:3.0') {
     force = true

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -120,7 +120,7 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
       YarnConfiguration yarnConfiguration, FileSystem fs)
       throws Exception {
     return new YarnService(config, applicationName, applicationId, yarnConfiguration, fs, this.eventBus,
-        this.getMultiManager().getJobClusterHelixManager());
+        this.multiManager.getJobClusterHelixManager(), this.multiManager.getJobClusterHelixAdmin());
   }
 
   /**

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.yarn;
 
+import java.time.Duration;
+
+
 /**
  * A central place for configuration related constants of Gobblin on Yarn.
  *
@@ -83,6 +86,16 @@ public class GobblinYarnConfigurationKeys {
 
   // Helix configuration properties.
   public static final String HELIX_INSTANCE_MAX_RETRIES = GOBBLIN_YARN_PREFIX + "helix.instance.max.retries";
+
+  public static final String HELIX_PURGE_PREFIX = GOBBLIN_YARN_PREFIX + "helix.purgeOfflineHelixInstances.";
+  public static final String HELIX_PURGE_OFFLINE_INSTANCES_ENABLED = HELIX_PURGE_PREFIX + "enabled";
+  public static final boolean DEFAULT_HELIX_PURGE_OFFLINE_INSTANCES_ENABLED = true;
+
+  public static final String HELIX_PURGE_LAGGING_THRESHOLD_MILLIS = HELIX_PURGE_PREFIX + "laggingThresholdMs";
+  public static final long DEFAULT_HELIX_PURGE_LAGGING_THRESHOLD_MILLIS = Duration.ofMinutes(1).toMillis();
+
+  public static final String HELIX_PURGE_POLLING_RATE_MILLIS = HELIX_PURGE_PREFIX + "pollingRateMs";
+  public static final long DEFAULT_HELIX_PURGE_POLLING_RATE_MILLIS = Duration.ofSeconds(5).toMillis();
 
   // Security and authentication configuration properties.
   public static final String SECURITY_MANAGER_CLASS = GOBBLIN_YARN_PREFIX + "security.manager.class";

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetrics.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetrics.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.yarn;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.metrics.event.GobblinEventBuilder;
+import org.apache.helix.HelixAdmin;
+
+
+@Slf4j
+@AllArgsConstructor
+public class HelixInstancePurgerWithMetrics {
+  private final EventSubmitter eventSubmitter;
+  private final long pollingRateMs;
+  private static final String PREFIX = "HelixOfflineInstancePurge.";
+  public static final String PURGE_FAILURE_EVENT =  PREFIX + "Failure";
+  public static final String PURGE_LAGGING_EVENT = PREFIX + "Lagging";
+  public static final String PURGE_COMPLETED_EVENT = PREFIX + "Completed";
+
+
+  /**
+   * Blocking call for purging all offline helix instances. Provides boiler plate code for providing periodic updates
+   * and sending a GTE if it's an unexpected amount of time.
+   *
+   * All previous helix instances should be purged on startup. Gobblin task runners are stateless from helix
+   * perspective because all important state is persisted separately in Workunit State Store or Watermark store.
+   */
+  public void purgeAllOfflineInstances(HelixAdmin admin, String clusterName, long laggingThresholdMs, Map<String, String> gteMetadata) {
+    CompletableFuture<Void> purgeTask = CompletableFuture.supplyAsync(() -> {
+      long offlineDuration = 0; // 0 means all offline instance should be purged.
+      admin.purgeOfflineInstances(clusterName, offlineDuration);
+      return null;
+    });
+
+    long timeToPurgeMs = waitForPurgeCompletion(purgeTask, laggingThresholdMs, Stopwatch.createUnstarted(), gteMetadata);
+    log.info("Finished purging offline helix instances. It took timeToPurgeMs={}", timeToPurgeMs);
+  }
+
+  @VisibleForTesting
+  long waitForPurgeCompletion(CompletableFuture<Void> purgeTask, long laggingThresholdMs, Stopwatch watch,
+      Map<String, String> gteMetadata) {
+    watch.start();
+    try {
+      boolean haveSubmittedLaggingEvent = false; //
+      while (!purgeTask.isDone()) {
+        long elapsedTimeMs = watch.elapsed(TimeUnit.MILLISECONDS);
+        log.info("Waiting for helix to purge offline instances. Cannot proceed with execution because purging is a "
+            + "non-thread safe call. To disable purging offline instances during startup, change the flag {} "
+            + "elapsedTimeMs={}, laggingThresholdMs={}",
+            GobblinYarnConfigurationKeys.HELIX_PURGE_OFFLINE_INSTANCES_ENABLED, elapsedTimeMs, laggingThresholdMs);
+        if (!haveSubmittedLaggingEvent && elapsedTimeMs > laggingThresholdMs) {
+          submitLaggingEvent(elapsedTimeMs, laggingThresholdMs, gteMetadata);
+          haveSubmittedLaggingEvent = true;
+        }
+        Thread.sleep(this.pollingRateMs);
+      }
+
+      long timeToPurgeMs = watch.elapsed(TimeUnit.MILLISECONDS);
+      if (!haveSubmittedLaggingEvent && timeToPurgeMs > laggingThresholdMs) {
+        submitLaggingEvent(timeToPurgeMs, laggingThresholdMs, gteMetadata);
+      }
+
+      purgeTask.get(); // check for exceptions
+      submitCompletedEvent(timeToPurgeMs, gteMetadata);
+      return timeToPurgeMs;
+    } catch (ExecutionException | InterruptedException e) {
+      log.warn("The call to purge offline helix instances failed. This is not a fatal error because it is not mandatory to "
+          + "clean up old helix instances. But repeated failure to purge offline helix instances will cause an accumulation"
+          + "of offline helix instances which may cause large delays in future helix calls.", e);
+      long timeToPurgeMs = watch.elapsed(TimeUnit.MILLISECONDS);
+      submitFailureEvent(timeToPurgeMs, gteMetadata);
+      return timeToPurgeMs;
+    }
+  }
+
+  private void submitFailureEvent(long elapsedTimeMs, Map<String, String> additionalMetadata) {
+    if (eventSubmitter != null) {
+      GobblinEventBuilder eventBuilder = new GobblinEventBuilder(PURGE_FAILURE_EVENT);
+      eventBuilder.addAdditionalMetadata(additionalMetadata);
+      eventBuilder.addMetadata("elapsedTimeMs", String.valueOf(elapsedTimeMs));
+
+      log.warn("Submitting GTE because purging offline instances has failed to complete. event={}", eventBuilder);
+      eventSubmitter.submit(eventBuilder);
+    } else {
+      log.warn("Cannot submit {} GTE because eventSubmitter is null", PURGE_FAILURE_EVENT);
+    }
+  }
+
+  private void submitCompletedEvent(long timeToPurgeMs, Map<String, String> additionalMetadata) {
+    if (eventSubmitter != null) {
+      GobblinEventBuilder eventBuilder = new GobblinEventBuilder(PURGE_COMPLETED_EVENT);
+      eventBuilder.addAdditionalMetadata(additionalMetadata);
+      eventBuilder.addMetadata("timeToPurgeMs", String.valueOf(timeToPurgeMs));
+
+      log.info("Submitting GTE because purging offline instances has completed successfully. event={}", eventBuilder);
+      eventSubmitter.submit(eventBuilder);
+    } else {
+      log.warn("Cannot submit {} GTE because eventSubmitter is null", PURGE_COMPLETED_EVENT);
+    }
+  }
+
+  private void submitLaggingEvent(long elapsedTimeMs, long laggingThresholdMs,
+      Map<String, String> additionalMetadata) {
+    if (eventSubmitter != null) {
+      GobblinEventBuilder eventBuilder = new GobblinEventBuilder(PURGE_LAGGING_EVENT);
+      eventBuilder.addAdditionalMetadata(additionalMetadata);
+      eventBuilder.addMetadata("elapsedTimeMs", String.valueOf(elapsedTimeMs));
+      eventBuilder.addMetadata("laggingThresholdMs", String.valueOf(laggingThresholdMs));
+
+      log.info("Submitting GTE because purging offline instances is lagging and has exceeded lagging threshold. event={}",
+          eventBuilder);
+      eventSubmitter.submit(eventBuilder);
+    } else {
+      log.warn("Cannot submit {} GTE because eventSubmitter is null", PURGE_LAGGING_EVENT);
+    }
+  }
+}

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -527,7 +527,7 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   private static class TestYarnService extends YarnService {
     public TestYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
         FileSystem fs, EventBus eventBus) throws Exception {
-      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, null);
+      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, null, null);
     }
 
     @Override

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetricsTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetricsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.yarn;
+
+import com.google.common.base.Stopwatch;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.metrics.event.GobblinEventBuilder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+/**
+ * Test class uses PowerMockito and Testng
+ * References:
+ * https://github.com/powermock/powermock/issues/434
+ * https://www.igorkromin.net/index.php/2018/10/04/how-to-fix-powermock-exception-linkageerror-loader-constraint-violation/
+ * https://github.com/powermock/powermock/wiki/MockFinal
+ */
+@PrepareForTest(Stopwatch.class)
+@PowerMockIgnore("javax.management.*")
+public class HelixInstancePurgerWithMetricsTest extends PowerMockTestCase {
+
+  @Mock EventSubmitter eventSubmitter;
+  @Mock Stopwatch stopwatch;
+  @Mock CompletableFuture<Void> mockTask;
+  @Captor ArgumentCaptor<GobblinEventBuilder> gteCaptor;
+  HelixInstancePurgerWithMetrics sut;
+
+  private static final long LAGGING_PURGE_THRESHOLD_MS = 100;
+  private static final long PURGE_STATUS_POLLING_RATE_MS = 10;
+
+
+  @BeforeMethod
+  private void init() {
+    MockitoAnnotations.initMocks(this);
+    sut = new HelixInstancePurgerWithMetrics(eventSubmitter, PURGE_STATUS_POLLING_RATE_MS);
+  }
+
+  @Test
+  public void testPurgeOfflineInstances() throws ExecutionException, InterruptedException {
+    Mockito.when(stopwatch.start()).thenReturn(stopwatch);
+    Mockito.when(stopwatch.elapsed(TimeUnit.MILLISECONDS)).thenReturn(LAGGING_PURGE_THRESHOLD_MS);
+    Mockito.when(mockTask.isDone())
+        .thenReturn(false)
+        .thenReturn(true);
+    Mockito.when(mockTask.get()).thenReturn(null);
+    Mockito.doNothing().when(eventSubmitter).submit(Mockito.any(GobblinEventBuilder.class));
+
+    long elapsedTime = sut.waitForPurgeCompletion(mockTask, LAGGING_PURGE_THRESHOLD_MS, stopwatch, Collections.emptyMap());
+
+    assertEquals(elapsedTime, LAGGING_PURGE_THRESHOLD_MS);
+    Mockito.verify(stopwatch, times(1)).start();
+    Mockito.verify(mockTask, times(1)).get();
+    Mockito.verify(eventSubmitter, times(1)).submit(gteCaptor.capture());
+    assertEquals(gteCaptor.getValue().getName(), HelixInstancePurgerWithMetrics.PURGE_COMPLETED_EVENT);
+  }
+
+  @Test
+  public void testPurgeOfflineInstancesSendsWarningEventWhenWaiting() throws ExecutionException, InterruptedException {
+    Mockito.when(mockTask.isDone()).thenReturn(false).thenReturn(true);
+    testPurgeOfflineInstancesSendsWarningEventHelper();
+  }
+
+  @Test
+  public void testPurgeOfflineInstancesSendsWarningEventIfTaskFinishedImmediately() throws ExecutionException, InterruptedException {
+    Mockito.when(mockTask.isDone()).thenReturn(true);
+    testPurgeOfflineInstancesSendsWarningEventHelper();
+  }
+
+  private void testPurgeOfflineInstancesSendsWarningEventHelper() throws ExecutionException, InterruptedException {
+    Mockito.when(stopwatch.start()).thenReturn(stopwatch);
+    Mockito.when(stopwatch.elapsed(TimeUnit.MILLISECONDS)).thenReturn(LAGGING_PURGE_THRESHOLD_MS + 1);
+    Mockito.when(mockTask.isDone()).thenReturn(false).thenReturn(true);
+    Mockito.when(mockTask.get()).thenReturn(null);
+    Mockito.doNothing().when(eventSubmitter).submit(Mockito.any(GobblinEventBuilder.class));
+
+    long elapsedTime = sut.waitForPurgeCompletion(mockTask, LAGGING_PURGE_THRESHOLD_MS, stopwatch, Collections.emptyMap());
+    assertEquals(elapsedTime, LAGGING_PURGE_THRESHOLD_MS + 1);
+
+    Mockito.verify(stopwatch, times(1)).start();
+    Mockito.verify(mockTask, times(1)).get();
+    Mockito.verify(eventSubmitter, times(2)).submit(gteCaptor.capture());
+    assertEquals(gteCaptor.getAllValues().get(0).getName(), HelixInstancePurgerWithMetrics.PURGE_LAGGING_EVENT);
+    assertEquals(gteCaptor.getAllValues().get(1).getName(), HelixInstancePurgerWithMetrics.PURGE_COMPLETED_EVENT);
+  }
+
+  @Test
+  public void testPurgeOfflineInstancesSendsFailureEvent() throws ExecutionException, InterruptedException {
+    Mockito.when(stopwatch.start()).thenReturn(stopwatch);
+    Mockito.when(stopwatch.elapsed(TimeUnit.MILLISECONDS)).thenReturn(LAGGING_PURGE_THRESHOLD_MS + 1);
+    Mockito.when(mockTask.isDone()).thenReturn(true);
+    Mockito.when(mockTask.get()).thenThrow(new ExecutionException("Throwing exception to emulate helix failure", new RuntimeException()));
+    Mockito.doNothing().when(eventSubmitter).submit(Mockito.any(GobblinEventBuilder.class));
+
+    long elapsedTime = sut.waitForPurgeCompletion(mockTask, LAGGING_PURGE_THRESHOLD_MS, stopwatch, Collections.emptyMap());
+    assertEquals(elapsedTime, LAGGING_PURGE_THRESHOLD_MS +1);
+
+    Mockito.verify(stopwatch, times(1)).start();
+    Mockito.verify(mockTask, times(1)).get();
+    Mockito.verify(eventSubmitter, times(2)).submit(gteCaptor.capture());
+    assertEquals(gteCaptor.getAllValues().get(0).getName(), HelixInstancePurgerWithMetrics.PURGE_LAGGING_EVENT);
+    assertEquals(gteCaptor.getAllValues().get(1).getName(), HelixInstancePurgerWithMetrics.PURGE_FAILURE_EVENT);
+  }
+}

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -314,7 +314,7 @@ public class YarnServiceTest {
 
       Mockito.when(helixManager.getInstanceName()).thenReturn("helixInstance1");
       Mockito.when(helixManager.getClusterName()).thenReturn(config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY));
-//
+
       Mockito.when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
       Mockito.when(helixDataAccessor.keyBuilder()).thenReturn(propertyKeyBuilder);
       Mockito.when(propertyKeyBuilder.liveInstance(Mockito.anyString())).thenReturn(propertyKey);

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -303,25 +303,31 @@ public class YarnServiceTest {
   static class TestYarnService extends YarnService {
     public TestYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
         FileSystem fs, EventBus eventBus) throws Exception {
-      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, getMockHelixManager(config));
+      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, getMockHelixManager(config), getMockHelixAdmin());
     }
 
     private static HelixManager getMockHelixManager(Config config) {
       HelixManager helixManager = Mockito.mock(HelixManager.class);
-      HelixAdmin helixAdmin = Mockito.mock(HelixAdmin.class);
       HelixDataAccessor helixDataAccessor = Mockito.mock(HelixDataAccessor.class);
       PropertyKey propertyKey = Mockito.mock(PropertyKey.class);
       PropertyKey.Builder propertyKeyBuilder = Mockito.mock(PropertyKey.Builder.class);
 
       Mockito.when(helixManager.getInstanceName()).thenReturn("helixInstance1");
       Mockito.when(helixManager.getClusterName()).thenReturn(config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY));
-      Mockito.doNothing().when(helixAdmin).enableInstance(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean());
+//
       Mockito.when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
       Mockito.when(helixDataAccessor.keyBuilder()).thenReturn(propertyKeyBuilder);
       Mockito.when(propertyKeyBuilder.liveInstance(Mockito.anyString())).thenReturn(propertyKey);
       Mockito.when(helixDataAccessor.getProperty(propertyKey)).thenReturn(null);
 
       return helixManager;
+    }
+
+    private static HelixAdmin getMockHelixAdmin() {
+      HelixAdmin helixAdmin = Mockito.mock(HelixAdmin.class);
+      Mockito.doNothing().when(helixAdmin).purgeOfflineInstances(Mockito.anyString(), Mockito.anyLong());
+      Mockito.doNothing().when(helixAdmin).enableInstance(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean());
+      return helixAdmin;
     }
 
     protected ContainerLaunchContext newContainerLaunchContext(ContainerInfo containerInfo)


### PR DESCRIPTION
To avoid accumulation of helix instances, we should clean up over time. But we can only perform the clean up at startup because it's unsafe to call the API while instances are being created / removed.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1704] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1704


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Gobblin streaming does not currently clean up helix instances.This means that after spikes in the number of gobblin task runners, causes accumulation in the `INSTANCES` znode, which will exceed the 1MB limit. This will cause zookeeper to either have delays or drop requests completely. 

This change cleans up these offline instances on startup. We cannot periodically clean up these instances because it is not a concurrency safe API. Meaning that if we start adding helix instances while this making this call concurrently, we will see undefined behavior. 

Helix cluster with large number of offline instances
![image](https://user-images.githubusercontent.com/35702680/190070111-08cd840c-f2d2-49dd-859f-30a7b85c2f3b.png)
- Launching gobblin job with lesser number of workunits / instances leads to a smaller instances size.
<img width="519" alt="image" src="https://user-images.githubusercontent.com/35702680/190288441-38936f44-a6e8-4dd6-9025-b9a287b3553b.png">

GTE Submitted to Kafka
```

|timestamp    |namespace   |name                               |metadata                                                                                                                                                                                                                                                          |datepartition|
|-------------|------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
|1663636297193|gobblin.yarn|HelixOfflineInstancePurge.Completed|{metricContextID=8c8f105c-167c-4f9c-8997-835bb9e0e02d, elapsedTimeMs=1000, application.id=application_1661798829266_2113373, application.name=<APPLICATION_NAME>, metricContextName=application_1661798829266_2113373}|2022-09-19-00|

```

Example logs from running UT's
```
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 53 - Waiting for helix to purge offline instances. Cannot proceed with execution because purging is a non-thread safe call. To disable purging offline instances during startup, change the flag gobblin.yarn.helix.purgeOfflineHelixInstances.enabled elapsedTimeMs=100, laggingThresholdMs=100
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 101 - Submitting GTE because purging offline instances has completed successfully event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Completed, namespace=null, metadata={timeToPurgeMs=100})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 116 - Submitting GTE because purging offline instances is lagging and has exceeded lagging threshold event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Lagging, namespace=null, metadata={laggingThresholdMs=100, elapsedTimeMs=101})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 73 - The call to purge offline helix instances failed. This is not a fatal error because it is not mandatory to clean up old helix instances. But repeated failure to purge offline helix instances will cause an accumulationof offline helix instances which may cause large delays in future helix calls.
java.util.concurrent.ExecutionException: Throwing exception to emulate helix failure
	at org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics.waitForPurgeCompletion(HelixInstancePurgerWithMetrics.java:69)
	at org.apache.gobblin.yarn.HelixInstancePurgerWithMetricsTest.testPurgeOfflineInstancesSendsFailureEvent(HelixInstancePurgerWithMetricsTest.java:113)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:583)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:719)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:989)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:648)
	at org.testng.TestRunner.run(TestRunner.java:505)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:455)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:450)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:415)
	at org.testng.SuiteRunner.run(SuiteRunner.java:364)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:84)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1208)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1137)
	at org.testng.TestNG.runSuites(TestNG.java:1049)
	at org.testng.TestNG.run(TestNG.java:1017)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
Caused by: java.lang.RuntimeException
	at org.apache.gobblin.yarn.HelixInstancePurgerWithMetricsTest.testPurgeOfflineInstancesSendsFailureEvent(HelixInstancePurgerWithMetricsTest.java:110)
	... 24 more
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 88 - Submitting GTE because purging offline instances has failed to complete event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Failure, namespace=null, metadata={elapsedTimeMs=101})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 53 - Waiting for helix to purge offline instances. Cannot proceed with execution because purging is a non-thread safe call. To disable purging offline instances during startup, change the flag gobblin.yarn.helix.purgeOfflineHelixInstances.enabled elapsedTimeMs=101, laggingThresholdMs=100
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 116 - Submitting GTE because purging offline instances is lagging and has exceeded lagging threshold event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Lagging, namespace=null, metadata={laggingThresholdMs=100, elapsedTimeMs=101})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 101 - Submitting GTE because purging offline instances has completed successfully event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Completed, namespace=null, metadata={timeToPurgeMs=101})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 53 - Waiting for helix to purge offline instances. Cannot proceed with execution because purging is a non-thread safe call. To disable purging offline instances during startup, change the flag gobblin.yarn.helix.purgeOfflineHelixInstances.enabled elapsedTimeMs=101, laggingThresholdMs=100
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 116 - Submitting GTE because purging offline instances is lagging and has exceeded lagging threshold event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Lagging, namespace=null, metadata={laggingThresholdMs=100, elapsedTimeMs=101})
2022-09-20 11:56:03 PDT INFO  [main] org.apache.gobblin.yarn.HelixInstancePurgerWithMetrics 101 - Submitting GTE because purging offline instances has completed successfully event=GobblinEventBuilder(name=HelixOfflineInstancePurge.Completed, namespace=null, metadata={timeToPurgeMs=101})


```


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests added. Current tests are modified. The behavior mainly relies on helix to properly clean up instances

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

