### PR TITLE
[GOBBLIN-1708] Improve TimeAwareRecursiveCopyableDataset to lookback only into datefolders that match range

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -135,7 +135,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     return recursivelyGetFilesAtDatePath(fs, path, "", fileFilter, 1, startDate, endDate, formatter);
   }
 
-  public Boolean checkPathDateTimeValidity (LocalDateTime startDate, LocalDateTime endDate, String traversedDatePath){
+  public Boolean checkPathDateTimeValidity(LocalDateTime startDate, LocalDateTime endDate, String traversedDatePath) {
     int[] startDateSplit = new int[] { startDate.getYear(), startDate.getMonthOfYear(), startDate.getDayOfMonth(),
         startDate.getHourOfDay(), startDate.getMinuteOfHour(), startDate.getSecondOfMinute(), startDate.getMillisOfSecond() };
     int[] endDateSplit = new int[] { endDate.getYear(), endDate.getMonthOfYear(), endDate.getDayOfMonth(),
@@ -143,6 +143,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
 
     String[] traversedDatePathSplit = traversedDatePath.split("/");
 
+    // Only check the number of parameters that the traversedDatePath has traversed through so far
     for (int index = 0; index < traversedDatePathSplit.length; index++) {
       try {
         if (Integer.parseInt(traversedDatePathSplit[index]) < startDateSplit[index] ||

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -42,7 +42,6 @@ import com.google.common.collect.Lists;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 
-
 @Slf4j
 public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset {
   private static final String CONFIG_PREFIX = CopyConfiguration.COPY_PREFIX + ".recursive";

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -141,6 +141,8 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
    * @param startDate
    * @param endDate
    * @param datePath
+   * @param datePathFormat (This is the user set desired format)
+   * @param level
    * @return true/false
    */
   public Boolean checkPathDateTimeValidity(LocalDateTime startDate, LocalDateTime endDate, String datePath, String datePathFormat, int level) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.iceberg.expressions.False;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.Period;
@@ -42,7 +41,6 @@ import org.joda.time.format.PeriodFormatterBuilder;
 import com.google.common.collect.Lists;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.mockito.cglib.core.Local;
 
 
 @Slf4j

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -145,12 +145,15 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
 
     // Only check the number of parameters that the traversedDatePath has traversed through so far
     for (int index = 0; index < traversedDatePathSplit.length; index++) {
-      try {
+      // Only attempt to parse the number if the entire string are digits
+      boolean onlyNumbers = traversedDatePathSplit[index].matches("^[0-9]+$");
+      if (onlyNumbers) {
         if (Integer.parseInt(traversedDatePathSplit[index]) < startDateSplit[index] ||
             Integer.parseInt(traversedDatePathSplit[index]) > endDateSplit[index]) {
           return false;
         }
-      } catch (Exception e) {
+      }
+      else {
         return false;
       }
     }
@@ -160,7 +163,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private List<FileStatus> recursivelyGetFilesAtDatePath(FileSystem fs, Path path, String traversedDatePath, PathFilter fileFilter,
       int level,  LocalDateTime startDate, LocalDateTime endDate, DateTimeFormatter formatter) throws IOException {
     List<FileStatus> fileStatuses = Lists.newArrayList();
-    if (!Objects.equals(traversedDatePath, "")) {
+    if (!traversedDatePath.equals("")) {
       if (!checkPathDateTimeValidity(startDate, endDate, traversedDatePath)) {
         return fileStatuses;
       }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -22,7 +22,6 @@ import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 
 import lombok.extern.slf4j.Slf4j;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -164,7 +164,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private List<FileStatus> recursivelyGetFilesAtDatePath(FileSystem fs, Path path, String traversedDatePath, PathFilter fileFilter,
       int level,  LocalDateTime startDate, LocalDateTime endDate, DateTimeFormatter formatter) throws IOException {
     List<FileStatus> fileStatuses = Lists.newArrayList();
-    if (!traversedDatePath.equals("")) {
+    if (!traversedDatePath.isEmpty()) {
       if (!checkPathDateTimeValidity(startDate, endDate, traversedDatePath)) {
         return fileStatuses;
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1708


### Description
- [ ] Checks for validity of the next path to traverse by seeing if it's in the range of startDate to endDate by rounding the granularity of the startDate and endDate to match the granularity of the path traversed.
- [ ] Enables for more efficient searching as we no longer have the build the entire tree, including the paths that fall outside of the range of the startDate and endDate.


### Tests
- [ ] The current tests for TimeAwareRecursiveCopyableDataset still pass as expected as nothing changes for the user side, changes are in the underlying logic 


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

