### PR TITLE
[GOBBLIN-1712] Fail container for known transient exceptions to avoid data loss

### DIFF
--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -212,6 +212,14 @@ public class GobblinMCEWriterTest extends PowerMockTestCase {
     Assert.assertEquals(allowedWriters.get(1).getClass().getName(), exceptionWriter.getClass().getName());
   }
 
+  @Test
+  public void testDetectTransientException() {
+    IOException transientException = new IOException("Filesystem closed");
+    Assert.assertTrue(GobblinMCEWriter.isExceptionTransient(transientException));
+    IOException nonTransientException = new IOException("Write failed due to bad schema");
+    Assert.assertFalse(GobblinMCEWriter.isExceptionTransient(nonTransientException));
+  }
+
   @DataProvider(name="AllowMockMetadataWriter")
   public Object[][] allowMockMetadataWriterParams() {
     initMocks();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1712


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Transient errors during shutdown like "Filesystem closed" can cause GMCEs to get skipped when they would have succeeded on the restart. Adding a list of exceptions like this that will fail the container to avoid data loss in these cases.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

