### PR TITLE
[GOBBLIN-1711] Replace Jcenter with maven central

### DIFF
--- a/gradle/scripts/buildscript.gradle
+++ b/gradle/scripts/buildscript.gradle
@@ -19,10 +19,8 @@
 
 repositories {
     repositories {
-        maven {
-            // For gradle-nexus-plugin
-            url 'https://jcenter.bintray.com/'
-        }
+        // For gradle-nexus-plugin
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1711] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1711


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

gradle build works. CI should catch the rest of the issues since this is just a repo change. I am cleaning up a missed reference to jcentral.
- Related to  https://github.com/apache/gobblin/pull/3554


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
None because we are just changing the repo from jcenter to maven central

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

