### PR TITLE
[GOBBLIN-1719] Replace moveToTrash with moveToAppropriateTrash for hadoop trash 

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
@@ -221,8 +221,7 @@ public class HadoopUtils {
    * @throws IOException
    */
   public static void moveToTrash(FileSystem fs, Path path, Configuration conf) throws IOException {
-    Trash trash = new Trash(fs, conf);
-    trash.moveToTrash(path);
+    Trash.moveToAppropriateTrash(fs, path, conf);
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/HadoopUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/HadoopUtilsTest.java
@@ -324,11 +324,12 @@ public class HadoopUtilsTest {
     FileSystem fs = FileSystem.getLocal(conf);
     Trash trash = new Trash(fs, conf);
     TrashPolicy trashPolicy = TrashPolicy.getInstance(conf, fs, fs.getHomeDirectory());
-    Path trashPath = trashPolicy.getCurrentTrashDir();
+    Path trashPath = Path.mergePaths(trashPolicy.getCurrentTrashDir(), hadoopUtilsTestDir);
 
     fs.mkdirs(hadoopUtilsTestDir);
     Assert.assertTrue(fs.exists(hadoopUtilsTestDir));
-    trash.moveToTrash(hadoopUtilsTestDir.getParent());
+    // Move the parent dir to trash because we created it at the beginning of this function.
+    HadoopUtils.moveToTrash(fs, hadoopUtilsTestDir.getParent(), conf);
     Assert.assertFalse(fs.exists(hadoopUtilsTestDir));
     Assert.assertTrue(fs.exists(trashPath));
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [GOBBLIN-1719](https://issues.apache.org/jira/browse/GOBBLIN-1719) 


### Description
- [ ] Replaced moveToTrash with moveToAppropriateTrash and updated the unit test.


### Tests
org.apache.gobblin.util.HadoopUtilsTest.testMoveToTrash

```
Gradle suite > Gradle test > org.apache.gobblin.util.HadoopUtilsTest > testMoveToTrash STARTED
Gradle suite > Gradle test > org.apache.gobblin.util.HadoopUtilsTest > testMoveToTrash PASSED
Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.6.4/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 2s
7 actionable tasks: 2 executed, 5 up-to-date
3:31:11 PM: Execution finished ':gobblin-utility:test --tests "org.apache.gobblin.util.HadoopUtilsTest.testMoveToTrash"'
```


