### PR TITLE
[GOBBLIN-1712 ] Fail GMIP container for known transient exceptions to avoid data loss

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -43,6 +43,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Iterables;
@@ -105,6 +106,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   public static final String HIVE_PARTITION_NAME = "hive.partition.name";
   public static final String GMCE_METADATA_WRITER_CLASSES = "gmce.metadata.writer.classes";
   public static final String GMCE_METADATA_WRITER_MAX_ERROR_DATASET = "gmce.metadata.writer.max.error.dataset";
+  public static final String TRANSIENT_EXCEPTION_MESSAGES_KEY = "gmce.metadata.writer.transient.exception.messages";
   public static final int DEFUALT_GMCE_METADATA_WRITER_MAX_ERROR_DATASET = 0;
   public static final int DEFAULT_ICEBERG_PARALLEL_TIMEOUT_MILLS = 60000;
   public static final String TABLE_NAME_DELIMITER = ".";
@@ -125,6 +127,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   @Setter
   private int maxErrorDataset;
   protected EventSubmitter eventSubmitter;
+  private final Set<String> transientExceptionMessages;
 
   @AllArgsConstructor
   static class TableStatus {
@@ -157,6 +160,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
     tags.add(new Tag<>(MetadataWriterKeys.CLUSTER_IDENTIFIER_KEY_NAME, clusterIdentifier));
     MetricContext metricContext = Instrumented.getMetricContext(state, this.getClass(), tags);
     eventSubmitter = new EventSubmitter.Builder(metricContext, GOBBLIN_MCE_WRITER_METRIC_NAMESPACE).build();
+    transientExceptionMessages = new HashSet<>(properties.getPropAsList(TRANSIENT_EXCEPTION_MESSAGES_KEY, ""));
   }
 
   @Override
@@ -335,6 +339,9 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         try {
           writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
         } catch (Exception e) {
+          if (isExceptionTransient(e, transientExceptionMessages)) {
+            throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
+          }
           meetException = true;
           writer.reset(dbName, tableName);
           addOrThrowException(e, tableString, dbName, tableName, getFailedWriterList(writer));
@@ -405,6 +412,9 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         try {
           writer.flush(dbName, tableName);
         } catch (IOException e) {
+          if (isExceptionTransient(e, transientExceptionMessages)) {
+            throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
+          }
           meetException = true;
           writer.reset(dbName, tableName);
           addOrThrowException(e, tableString, dbName, tableName, getFailedWriterList(writer));
@@ -422,6 +432,14 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         this.datasetErrorMap.get(datasetPath).remove(tableString);
       }
     }
+  }
+
+  /**
+   * Check if exception is contained within a known list of transient exceptions. These exceptions should not be caught
+   * to avoid advancing watermarks and skipping GMCEs unnecessarily.
+   */
+  public static boolean isExceptionTransient(Exception e, Set<String> transientExceptionMessages) {
+    return transientExceptionMessages.stream().anyMatch(message -> e.getMessage().contains(message));
   }
 
   /**
@@ -526,7 +544,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       gobblinTrackingEvent.addMetadata(MetadataWriterKeys.PARTITION_KEYS, Joiner.on(',').join(exception.partitionKeys.stream()
           .map(HiveRegistrationUnit.Column::getName).collect(Collectors.toList())));
 
-      String message = exception.getCause() == null ? exception.getMessage() : exception.getCause().getMessage();
+      String message = Throwables.getRootCause(exception).getMessage();
       gobblinTrackingEvent.addMetadata(MetadataWriterKeys.EXCEPTION_MESSAGE_KEY_NAME, message);
 
       eventSubmitter.submit(gobblinTrackingEvent);

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import lombok.SneakyThrows;
@@ -55,6 +56,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
 
 import static org.mockito.Mockito.*;
 
@@ -210,6 +213,15 @@ public class GobblinMCEWriterTest extends PowerMockTestCase {
     Assert.assertEquals(allowedWriters.size(), 2);
     Assert.assertEquals(allowedWriters.get(0).getClass().getName(), mockWriter.getClass().getName());
     Assert.assertEquals(allowedWriters.get(1).getClass().getName(), exceptionWriter.getClass().getName());
+  }
+
+  @Test
+  public void testDetectTransientException() {
+    Set<String> transientExceptions = Sets.newHashSet("Filesystem closed", "Hive timeout");
+    IOException transientException = new IOException("test1 Filesystem closed test");
+    Assert.assertTrue(GobblinMCEWriter.isExceptionTransient(transientException, transientExceptions));
+    IOException nonTransientException = new IOException("Write failed due to bad schema");
+    Assert.assertFalse(GobblinMCEWriter.isExceptionTransient(nonTransientException, transientExceptions));
   }
 
   @DataProvider(name="AllowMockMetadataWriter")


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1712


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Transient errors during shutdown like "Filesystem closed" can cause GMCEs to get skipped when they would have succeeded on the restart. Adding a list of exceptions like this that will fail the container to avoid data loss in these cases.

Also use `Throwables.getRootCause` to get a more meaningful exception message for the failure events since sometimes the events just have a generic "Flush failed" message right now.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

