### PR TITLE
[GOBBLIN-1720]Add ancestors owner permissions preservations for iceberg distcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -47,9 +47,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.CopyableDataset;
@@ -149,9 +146,9 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       FileStatus srcFileStatus = entry.getValue();
       // TODO: should be the same FS each time; try creating once, reusing thereafter, to not recreate wastefully
       FileSystem actualSourceFs = getSourceFileSystemFromFileStatus(srcFileStatus, defaultHadoopConfiguration);
-      Path toPath = PathUtils.getRootPathParent(srcPath);
+      Path toPath = PathUtils.getRootPathChild(srcPath);
 
-      // preserving ancestor permissions till root between src and dest
+      // preserving ancestor permissions till root path's child between src and dest
       List<OwnerAndPermission> ancestorOwnerAndPermission =
           CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(actualSourceFs,
               srcPath.getParent(), toPath, copyConfig);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -47,6 +47,9 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.CopyableDataset;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -149,14 +149,14 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       Path greatestAncestorPath = PathUtils.getRootPathChild(srcPath);
 
       // preserving ancestor permissions till root path's child between src and dest
-      List<OwnerAndPermission> ancestorOwnerAndPermission =
+      List<OwnerAndPermission> ancestorOwnerAndPermissionList =
           CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(actualSourceFs,
               srcPath.getParent(), greatestAncestorPath, copyConfig);
       CopyableFile fileEntity = CopyableFile.fromOriginAndDestination(
           actualSourceFs, srcFileStatus, targetFs.makeQualified(srcPath), copyConfig)
           .fileSet(fileSet)
           .datasetOutputPath(targetFs.getUri().getPath())
-          .ancestorsOwnerAndPermission(ancestorOwnerAndPermission)
+          .ancestorsOwnerAndPermission(ancestorOwnerAndPermissionList)
           .build();
       fileEntity.setSourceData(getSourceDataset(this.sourceFs));
       fileEntity.setDestinationData(getDestinationDataset(targetFs));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -148,7 +148,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       FileSystem actualSourceFs = getSourceFileSystemFromFileStatus(srcFileStatus, defaultHadoopConfiguration);
       Path toPath = PathUtils.getRootPathParent(srcPath);
 
-      // TODO: Add preservation of ancestor ownership and permissions!
+      // preserving ancestor permissions till root between src and dest
       List<OwnerAndPermission> ancestorOwnerAndPermission =
           CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(actualSourceFs,
               srcPath.getParent(), toPath, copyConfig);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -146,12 +146,12 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       FileStatus srcFileStatus = entry.getValue();
       // TODO: should be the same FS each time; try creating once, reusing thereafter, to not recreate wastefully
       FileSystem actualSourceFs = getSourceFileSystemFromFileStatus(srcFileStatus, defaultHadoopConfiguration);
-      Path toPath = PathUtils.getRootPathChild(srcPath);
+      Path greatestAncestorPath = PathUtils.getRootPathChild(srcPath);
 
       // preserving ancestor permissions till root path's child between src and dest
       List<OwnerAndPermission> ancestorOwnerAndPermission =
           CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(actualSourceFs,
-              srcPath.getParent(), toPath, copyConfig);
+              srcPath.getParent(), greatestAncestorPath, copyConfig);
       CopyableFile fileEntity = CopyableFile.fromOriginAndDestination(
           actualSourceFs, srcFileStatus, targetFs.makeQualified(srcPath), copyConfig)
           .fileSet(fileSet)

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -25,7 +25,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -342,8 +342,6 @@ public class IcebergDatasetTest {
 <<<<<<< HEAD
 =======
   private void verifyFsOwnershipAndPermissionPreservation(Collection<CopyEntity> copyEntities) {
-
-
     List<JsonObject> ancestorsOwnerAndPermissionsList = new ArrayList<>();
     List<JsonObject> destinationOwnerAndPermissionsList = new ArrayList<>();
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -102,14 +102,12 @@ public class IcebergDatasetTest {
   private final Properties copyConfigProperties = new Properties();
 
   @BeforeClass
-  public void setUp()
-      throws Exception {
+  public void setUp() throws Exception {
     copyConfigProperties.setProperty("data.publisher.final.dir", "/test");
   }
 
   @Test
-  public void testGetFilePathsWhenDestEmpty()
-      throws IOException {
+  public void testGetFilePathsWhenDestEmpty() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList();
     Set<Path> expectedResultPaths = withAllSnapshotPaths(Sets.newHashSet(), SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
@@ -117,8 +115,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWhenOneManifestListAtDest()
-      throws IOException {
+  public void testGetFilePathsWhenOneManifestListAtDest() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList(MANIFEST_LIST_PATH_1);
     Set<Path> expectedResultPaths = withAllSnapshotPaths(Sets.newHashSet(), SNAPSHOT_PATHS_0);
@@ -126,8 +123,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWhenOneManifestAtDest()
-      throws IOException {
+  public void testGetFilePathsWhenOneManifestAtDest() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList(MANIFEST_PATH_1);
     Set<Path> expectedResultPaths = withAllSnapshotPaths(Sets.newHashSet(), SNAPSHOT_PATHS_0);
@@ -136,8 +132,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWhenSomeDataFilesAtDest()
-      throws IOException {
+  public void testGetFilePathsWhenSomeDataFilesAtDest() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList(MANIFEST_DATA_PATH_1B, MANIFEST_DATA_PATH_0A);
     Set<Path> expectedResultPaths = withAllSnapshotPaths(Sets.newHashSet(), SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
@@ -148,8 +143,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWillSkipMissingSourceFile()
-      throws IOException {
+  public void testGetFilePathsWillSkipMissingSourceFile() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     // pretend this path doesn't exist on source:
     Path missingPath = new Path(MANIFEST_DATA_PATH_0A);
@@ -164,8 +158,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWhenManifestListsAtDestButNotMetadata()
-      throws IOException {
+  public void testGetFilePathsWhenManifestListsAtDestButNotMetadata() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList(MANIFEST_LIST_PATH_1, MANIFEST_LIST_PATH_0);
     Set<Path> expectedResultPaths = Sets.newHashSet();
@@ -174,8 +167,7 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testGetFilePathsWhenAllAtDest()
-      throws IOException {
+  public void testGetFilePathsWhenAllAtDest() throws IOException {
     List<MockIcebergTable.SnapshotPaths> icebergSnapshots = Lists.newArrayList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0);
     List<String> existingDestPaths = Lists.newArrayList(METADATA_PATH, MANIFEST_LIST_PATH_1, MANIFEST_LIST_PATH_0);
     Set<Path> expectedResultPaths = Sets.newHashSet(); // not expecting any delta
@@ -188,19 +180,16 @@ public class IcebergDatasetTest {
 
   /** Exception wrapping is used internally--ensure that doesn't lapse into silently swallowing errors */
   @Test(expectedExceptions = IOException.class)
-  public void testGetFilePathsDoesNotSwallowDestFileSystemException()
-      throws IOException {
+  public void testGetFilePathsDoesNotSwallowDestFileSystemException() throws IOException {
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Lists.newArrayList(SNAPSHOT_PATHS_0));
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI);
     FileSystem sourceFs = sourceFsBuilder.build();
-    IcebergDataset icebergDataset =
-        new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destFsBuilder.build();
-    Mockito.doThrow(new IOException("Ha - not so fast!")).when(destFs)
-        .getFileStatus(new Path(SNAPSHOT_PATHS_0.manifestListPath));
+    Mockito.doThrow(new IOException("Ha - not so fast!")).when(destFs).getFileStatus(new Path(SNAPSHOT_PATHS_0.manifestListPath));
 
     CopyConfiguration copyConfiguration = createEmptyCopyConfiguration(destFs);
     icebergDataset.getFilePathsToFileStatus(destFs, copyConfiguration);
@@ -228,18 +217,11 @@ public class IcebergDatasetTest {
    * without calculating any difference between the source and destination
    */
   @Test
-  public void testGenerateCopyEntitiesWhenDestEmpty()
-      throws IOException {
-    Map<String, FileStatus> expectedPathsAndFileStatuses = Maps.newHashMap();
-    expectedPathsAndFileStatuses.put(METADATA_PATH, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_LIST_PATH_0, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_PATH_0, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0A, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0B, null);
-    Set<String> expectedPaths = expectedPathsAndFileStatuses.keySet();
-
+  public void testGenerateCopyEntitiesWhenDestEmpty() throws IOException {
+    List<String> expectedPaths = Arrays.asList(METADATA_PATH, MANIFEST_LIST_PATH_0,
+        MANIFEST_PATH_0, MANIFEST_DATA_PATH_0A, MANIFEST_DATA_PATH_0B);
     MockFileSystemBuilder sourceBuilder = new MockFileSystemBuilder(SRC_FS_URI);
-    sourceBuilder.addPathsAndFileStatuses(expectedPathsAndFileStatuses);
+    sourceBuilder.addPathsAndFileStatuses(expectedPaths, false);
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
@@ -258,22 +240,13 @@ public class IcebergDatasetTest {
 
   /** Test generating copy entities for a multi-snapshot iceberg; given empty dest, src-dest delta will be entirety */
   @Test
-  public void testGenerateCopyEntitiesMultiSnapshotWhenDestEmpty()
-      throws IOException {
-    Map<String, FileStatus> expectedPathsAndFileStatuses = Maps.newHashMap();
-    expectedPathsAndFileStatuses.put(METADATA_PATH, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_LIST_PATH_0, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_PATH_0, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0A, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0B, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_LIST_PATH_1, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_PATH_1, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_1A, null);
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_1B, null);
-    Set<String> expectedPaths = (expectedPathsAndFileStatuses.keySet());
+  public void testGenerateCopyEntitiesMultiSnapshotWhenDestEmpty() throws IOException {
+    List<String> expectedPaths = Arrays.asList(METADATA_PATH,
+        MANIFEST_LIST_PATH_0, MANIFEST_PATH_0, MANIFEST_DATA_PATH_0A, MANIFEST_DATA_PATH_0B,
+        MANIFEST_LIST_PATH_1, MANIFEST_PATH_1, MANIFEST_DATA_PATH_1A, MANIFEST_DATA_PATH_1B);
 
     MockFileSystemBuilder sourceBuilder = new MockFileSystemBuilder(SRC_FS_URI);
-    sourceBuilder.addPathsAndFileStatuses(expectedPathsAndFileStatuses);
+    sourceBuilder.addPathsAndFileStatuses(expectedPaths, false);
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
@@ -291,36 +264,27 @@ public class IcebergDatasetTest {
   }
 
   @Test
-  public void testFsOwnershipAndPermissionPreservationWhenDestEmpty()
-      throws IOException {
-    Map<String, FileStatus> expectedPathsAndFileStatuses = Maps.newHashMap();
-    expectedPathsAndFileStatuses.put(METADATA_PATH, createFileStatus(METADATA_PATH, null, null,
-        new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)));
-    expectedPathsAndFileStatuses.put(MANIFEST_LIST_PATH_0, createFileStatus(MANIFEST_LIST_PATH_0, null, null,
-        new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)));
-    expectedPathsAndFileStatuses.put(MANIFEST_PATH_0, createFileStatus(MANIFEST_PATH_0, null, null,
-        new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)));
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0A, createFileStatus(MANIFEST_DATA_PATH_0A, null, null,
-        new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)));
-    expectedPathsAndFileStatuses.put(MANIFEST_DATA_PATH_0B, createFileStatus(MANIFEST_DATA_PATH_0B, null, null,
-        new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)));
-
+  public void testFsOwnershipAndPermissionPreservationWhenDestEmpty() throws IOException {
+    List<String> expectedPaths = Arrays.asList(METADATA_PATH, MANIFEST_LIST_PATH_0,
+        MANIFEST_PATH_0, MANIFEST_DATA_PATH_0A, MANIFEST_DATA_PATH_0B);
     MockFileSystemBuilder sourceBuilder = new MockFileSystemBuilder(SRC_FS_URI);
-    sourceBuilder.addPathsAndFileStatuses(expectedPathsAndFileStatuses);
+    sourceBuilder.addPathsAndFileStatuses(expectedPaths, true);
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergDataset icebergDataset =
-        new TrickIcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
 
     CopyConfiguration copyConfiguration =
-        CopyConfiguration.builder(destFs, copyConfigProperties).preserve(PreserveAttributes.fromMnemonicString("ugp"))
+        CopyConfiguration.builder(destFs, copyConfigProperties)
+            // preserving attributes for owner, group and permissions respectively
+            .preserve(PreserveAttributes.fromMnemonicString("ugp"))
             .copyContext(new CopyContext()).build();
 
     Collection<CopyEntity> copyEntities = icebergDataset.generateCopyEntities(destFs, copyConfiguration);
+    Map<Path, FileStatus> expectedPathsAndFileStatuses = sourceBuilder.getPathsAndFileStatuses();
     verifyFsOwnershipAndPermissionPreservation(copyEntities, expectedPathsAndFileStatuses);
   }
 
@@ -329,8 +293,7 @@ public class IcebergDatasetTest {
    *  @return {@link IcebergTable} (mock!), for behavioral verification
    */
   protected IcebergTable validateGetFilePathsGivenDestState(List<MockIcebergTable.SnapshotPaths> sourceSnapshotPathSets,
-      List<String> existingDestPaths, Set<Path> expectedResultPaths)
-      throws IOException {
+      List<String> existingDestPaths, Set<Path> expectedResultPaths) throws IOException {
     return validateGetFilePathsGivenDestState(sourceSnapshotPathSets, Optional.empty(), existingDestPaths,
         expectedResultPaths);
   }
@@ -340,43 +303,36 @@ public class IcebergDatasetTest {
    *  @return {@link IcebergTable} (mock!), for behavioral verification
    */
   protected IcebergTable validateGetFilePathsGivenDestState(List<MockIcebergTable.SnapshotPaths> sourceSnapshotPathSets,
-      Optional<List<String>> optExistingSourcePaths, List<String> existingDestPaths, Set<Path> expectedResultPaths)
-      throws IOException {
+      Optional<List<String>> optExistingSourcePaths, List<String> existingDestPaths, Set<Path> expectedResultPaths) throws IOException {
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(sourceSnapshotPathSets);
-    Map<String, FileStatus> sourcePathAndFileStatusMap = Maps.newHashMap();
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI, !optExistingSourcePaths.isPresent());
-    optExistingSourcePaths.ifPresent((pathList) -> {
-      for (String path : pathList) {
-        sourcePathAndFileStatusMap.putIfAbsent(path, null);
-      }
-      sourceFsBuilder.addPathsAndFileStatuses(sourcePathAndFileStatusMap);
-    });
+    optExistingSourcePaths.ifPresent(sourceFsBuilder :: addPaths);
     FileSystem sourceFs = sourceFsBuilder.build();
     IcebergDataset icebergDataset =
         new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
-    Map<String, FileStatus> destPathAndFileStatusMap = Maps.newHashMap();
-    for (String destPath : existingDestPaths) {
-      destPathAndFileStatusMap.putIfAbsent(destPath, null);
-    }
-    destFsBuilder.addPathsAndFileStatuses(destPathAndFileStatusMap);
+    destFsBuilder.addPathsAndFileStatuses(existingDestPaths, false);
     FileSystem destFs = destFsBuilder.build();
     CopyConfiguration copyConfiguration = createEmptyCopyConfiguration(destFs);
 
     Map<Path, FileStatus> filePathsToFileStatus = icebergDataset.getFilePathsToFileStatus(destFs, copyConfiguration);
     Assert.assertEquals(filePathsToFileStatus.keySet(), expectedResultPaths);
     // verify solely the path portion of the `FileStatus`, since that's all mock sets up
-    Assert.assertEquals(filePathsToFileStatus.values().stream().map(FileStatus::getPath).collect(Collectors.toSet()),
+    Assert.assertEquals(
+        filePathsToFileStatus.values().stream().map(FileStatus::getPath).collect(Collectors.toSet()),
         expectedResultPaths);
     return icebergTable;
   }
 
   /** @return `paths` after adding to it all paths of every one of `snapshotDefs` */
   protected static Set<Path> withAllSnapshotPaths(Set<Path> paths, MockIcebergTable.SnapshotPaths... snapshotDefs) {
-    Arrays.stream(snapshotDefs).flatMap(snapshotDef -> snapshotDef.asSnapshotInfo().getAllPaths().stream())
-        .forEach(p -> paths.add(new Path(p)));
+    Arrays.stream(snapshotDefs).flatMap(snapshotDef ->
+            snapshotDef.asSnapshotInfo().getAllPaths().stream())
+        .forEach(p ->
+            paths.add(new Path(p))
+        );
     return paths;
   }
 
@@ -384,44 +340,39 @@ public class IcebergDatasetTest {
     return CopyConfiguration.builder(fs, copyConfigProperties).copyContext(new CopyContext()).build();
   }
 
-  private static void verifyCopyEntities(Collection<CopyEntity> copyEntities, Set<String> expected) {
+  private static void verifyCopyEntities(Collection<CopyEntity> copyEntities, List<String> expected) {
     Set<String> actual = new HashSet<>();
-    CopyEntityDeserializer copyEntityDeserializer = new CopyEntityDeserializer();
     for (CopyEntity copyEntity : copyEntities) {
       String json = copyEntity.toString();
-      String filepath = copyEntityDeserializer.getFilePathAsStringFromJson(json);
+      String filepath = CopyEntityDeserializer.getFilePathAsStringFromJson(json);
       actual.add(filepath);
     }
     Assert.assertEquals(actual.size(), expected.size(), "Set" + actual.toString() + " vs Set" + expected.toString());
     Assert.assertEqualsNoOrder(actual.toArray(), expected.toArray());
   }
 
-  private void verifyFsOwnershipAndPermissionPreservation(Collection<CopyEntity> copyEntities,
-      Map<String, FileStatus> expectedMap) {
-    CopyEntityDeserializer copyEntityDeserializer = new CopyEntityDeserializer();
+  private static void verifyFsOwnershipAndPermissionPreservation(Collection<CopyEntity> copyEntities,
+      Map<Path, FileStatus> expectedPathsAndFileStatuses) {
 
     for (CopyEntity copyEntity : copyEntities) {
       String copyEntityJson = copyEntity.toString();
 
-      JsonArray ancestorOwnerAndPermissions = copyEntityDeserializer.getAncestorOwnerAndPermissions(copyEntityJson);
-      String filePath = copyEntityDeserializer.getFilePathAsStringFromJson(copyEntityJson);
-      JsonObject destinationOwnerAndPermissions =
-          copyEntityDeserializer.getDestinationOwnerAndPermissions(copyEntityJson);
-
-      FileStatus expected = expectedMap.get(filePath);
-      Map<String, String> actual =
-          copyEntityDeserializer.getDestinationOwnerAndPermissionsFsPermissionsMap(destinationOwnerAndPermissions);
+      JsonArray ancestorOwnerAndPermissions = CopyEntityDeserializer.getAncestorOwnerAndPermissions(copyEntityJson);
+      String filePath = CopyEntityDeserializer.getFilePathAsStringFromJson(copyEntityJson);
+      CopyEntityDeserializer.DestinationOwnerAndPermissions destinationOwnerAndPermissions = CopyEntityDeserializer.getDestinationOwnerAndPermissions(copyEntityJson);
 
       Assert.assertEquals(ancestorOwnerAndPermissions.size(), new Path(filePath).getParent().depth() - 1);
-      Assert.assertEquals(expected.getPermission().getUserAction().toString(), actual.get("useraction"));
-      Assert.assertEquals(expected.getPermission().getGroupAction().toString(), actual.get("groupaction"));
-      Assert.assertEquals(expected.getPermission().getOtherAction().toString(), actual.get("otheraction"));
+      Assert.assertEquals(expectedPathsAndFileStatuses.get(new Path(filePath)).getOwner(),
+          destinationOwnerAndPermissions.owner);
+      Assert.assertEquals(expectedPathsAndFileStatuses.get(new Path(filePath)).getGroup(),
+          destinationOwnerAndPermissions.group);
+      Assert.assertEquals(expectedPathsAndFileStatuses.get(new Path(filePath)).getPermission().getUserAction().toString(),
+          destinationOwnerAndPermissions.userActionPermission);
+      Assert.assertEquals(expectedPathsAndFileStatuses.get(new Path(filePath)).getPermission().getGroupAction().toString(),
+          destinationOwnerAndPermissions.groupActionPermission);
+      Assert.assertEquals(expectedPathsAndFileStatuses.get(new Path(filePath)).getPermission().getOtherAction().toString(),
+          destinationOwnerAndPermissions.otherActionPermission);
     }
-  }
-
-  private FileStatus createFileStatus(String pathString, String owner, String group, FsPermission fsPermission) {
-    Path path = new Path(pathString);
-    return new FileStatus(0, false, 0, 0, 0, 0, fsPermission, owner, group, path);
   }
 
   /**
@@ -447,7 +398,6 @@ public class IcebergDatasetTest {
   protected static class MockFileSystemBuilder {
     private final URI fsURI;
     /** when not `.isPresent()`, all paths exist; when `.get().isEmpty()`, none exist; else only those indicated do */
-    //private final Optional<Set<Path>> optPaths; // convert it to a map<path, filestatus>
     private final Optional<Map<Path, FileStatus>> optPathsWithFileStatuses;
 
     public MockFileSystemBuilder(URI fsURI) {
@@ -456,30 +406,36 @@ public class IcebergDatasetTest {
 
     public MockFileSystemBuilder(URI fsURI, boolean shouldRepresentEveryPath) {
       this.fsURI = fsURI;
-      //this.optPaths = shouldRepresentEveryPath ? Optional.empty() : Optional.of(Sets.newHashSet());
       this.optPathsWithFileStatuses = shouldRepresentEveryPath ? Optional.empty() : Optional.of(Maps.newHashMap());
     }
 
-    public void addPathsAndFileStatuses(Map<String, FileStatus> pathStringToFsPermissionsMap) {
-      for (Map.Entry<String, FileStatus> entry : pathStringToFsPermissionsMap.entrySet()) {
-        String path = entry.getKey();
-        FileStatus fileStatus = entry.getValue();
-        addPathAndFileStatus(path, fileStatus);
+    public void addPaths(List<String> pathStrings) {
+      addPathsAndFileStatuses(pathStrings, false);
+    }
+
+    public void addPathsAndFileStatuses(List<String> pathStrings, boolean shouldCreateFileStatusWithPermissions) {
+      for (String pathString : pathStrings) {
+        addPathAndFileStatus(pathString, shouldCreateFileStatusWithPermissions);
       }
     }
 
-    public void addPathAndFileStatus(String pathString, FileStatus fileStatus) {
-      addPathAndFileStatus(new Path(pathString), fileStatus);
+    public void addPathAndFileStatus(String pathString, boolean shouldCreateFileStatusWithPermissions) {
+      addPathAndFileStatus(new Path(pathString), shouldCreateFileStatusWithPermissions);
     }
 
-    public void addPathAndFileStatus(Path path, FileStatus fileStatus) {
+    public void addPathAndFileStatus(Path path, boolean shouldCreateFileStatusWithPermissions) {
       if (!this.optPathsWithFileStatuses.isPresent()) {
         throw new IllegalStateException("unable to add paths when constructed with `shouldRepresentEveryPath == true`");
       }
+      FileStatus fileStatus = shouldCreateFileStatusWithPermissions ? createFileStatus(path, "test_owner", "test_group", new FsPermission(FsAction.WRITE_EXECUTE, FsAction.READ_EXECUTE, FsAction.NONE)) : null;
       optPathsWithFileStatuses.get().putIfAbsent(path, fileStatus);
       if (!path.isRoot()) { // recursively add ancestors of a previously unknown path
-        addPathAndFileStatus(path.getParent(), fileStatus);
+        addPathAndFileStatus(path.getParent(), shouldCreateFileStatusWithPermissions);
       }
+    }
+
+    public Map<Path, FileStatus> getPathsAndFileStatuses() {
+      return optPathsWithFileStatuses.get();
     }
 
     public FileSystem build()
@@ -496,8 +452,9 @@ public class IcebergDatasetTest {
         // WARNING: order is critical--specific paths *after* `any(Path)`; in addition, since mocking further
         // an already-mocked instance, `.doReturn/.when` is needed (vs. `.when/.thenReturn`)
         Mockito.when(fs.getFileStatus(any(Path.class))).thenThrow(new FileNotFoundException());
-        for (Path p : this.optPathsWithFileStatuses.get().keySet()) {
-          FileStatus fileStatus = this.optPathsWithFileStatuses.get().get(p);
+        for (Map.Entry<Path, FileStatus> entry : this.optPathsWithFileStatuses.get().entrySet()) {
+          Path p = entry.getKey();
+          FileStatus fileStatus = entry.getValue();
           if (fileStatus != null) {
             Mockito.doReturn(fileStatus).when(fs).getFileStatus(p);
           } else {
@@ -508,12 +465,15 @@ public class IcebergDatasetTest {
       return fs;
     }
 
-    protected static FileStatus createEmptyFileStatus(String pathString)
-        throws IOException {
+    protected static FileStatus createEmptyFileStatus(String pathString) throws IOException {
       Path path = new Path(pathString);
       FileStatus fileStatus = new FileStatus();
       fileStatus.setPath(path);
       return fileStatus;
+    }
+
+    private static FileStatus createFileStatus(Path path, String owner, String group, FsPermission fsPermission) {
+      return new FileStatus(0, false, 0, 0, 0, 0, fsPermission, owner, group, path);
     }
   }
 
@@ -535,13 +495,11 @@ public class IcebergDatasetTest {
       }
 
       public IcebergSnapshotInfo asSnapshotInfo(Long snapshotId, Instant timestamp) {
-        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath, this.manifestListPath,
-            this.manifestFiles);
+        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath, this.manifestListPath, this.manifestFiles);
       }
     }
 
-    public static IcebergTable withSnapshots(List<SnapshotPaths> snapshotPathSets)
-        throws IOException {
+    public static IcebergTable withSnapshots(List<SnapshotPaths> snapshotPathSets) throws IOException {
       IcebergTable table = Mockito.mock(IcebergTable.class);
       int lastIndex = snapshotPathSets.size() - 1;
       Mockito.when(table.getCurrentSnapshotInfoOverviewOnly())
@@ -549,8 +507,8 @@ public class IcebergDatasetTest {
       // ADMISSION: this is strictly more analogous to `IcebergTable.getAllSnapshotInfosIterator()`, as it doesn't
       // filter only the delta... nonetheless, it should work fine for the tests herein
       Mockito.when(table.getIncrementalSnapshotInfosIterator()).thenReturn(
-          IndexingStreams.transformWithIndex(snapshotPathSets.stream(), (pathSet, i) -> pathSet.asSnapshotInfo(i))
-              .iterator());
+          IndexingStreams.transformWithIndex(snapshotPathSets.stream(),
+              (pathSet, i) -> pathSet.asSnapshotInfo(i)).iterator());
       return table;
     }
   }
@@ -559,52 +517,57 @@ public class IcebergDatasetTest {
     /** @return {@link Stream} equivalent of `inputs.zipWithIndex.map(f)` in scala */
     public static <T, R> Stream<R> transformWithIndex(Stream<T> inputs, BiFunction<T, Integer, R> f) {
       // given sketchy import, sequester for now within enclosing test class, rather than adding to `gobblin-utility`
-      return org.apache.iceberg.relocated.com.google.common.collect.Streams.zip(inputs,
-          IntStream.iterate(0, i -> i + 1).boxed(), f);
+      return org.apache.iceberg.relocated.com.google.common.collect.Streams.zip(
+          inputs, IntStream.iterate(0, i -> i + 1).boxed(), f);
     }
   }
 
   private static class CopyEntityDeserializer {
 
-    public String getFilePathAsStringFromJson(String json) {
-      String filepath =
-          new Gson().fromJson(json, JsonObject.class).getAsJsonObject("object-data").getAsJsonObject("origin")
+    @Data
+    public static class DestinationOwnerAndPermissions {
+      String owner;
+      String group;
+      String userActionPermission;
+      String groupActionPermission;
+      String otherActionPermission;
+    }
+
+    public static String getFilePathAsStringFromJson(String json) {
+      String filepath = new Gson().fromJson(json, JsonObject.class)
+              .getAsJsonObject("object-data").getAsJsonObject("origin")
               .getAsJsonObject("object-data").getAsJsonObject("path").getAsJsonObject("object-data")
               .getAsJsonObject("uri").getAsJsonPrimitive("object-data").getAsString();
       return filepath;
     }
 
-    public JsonArray getAncestorOwnerAndPermissions(String json) {
-      JsonArray ancestorsOwnerAndPermissions =
-          new Gson().fromJson(json, JsonObject.class).getAsJsonObject("object-data")
+    public static JsonArray getAncestorOwnerAndPermissions(String json) {
+      JsonArray ancestorsOwnerAndPermissions = new Gson().fromJson(json, JsonObject.class)
+              .getAsJsonObject("object-data")
               .getAsJsonArray("ancestorsOwnerAndPermission");
       return ancestorsOwnerAndPermissions;
     }
 
-    public JsonObject getDestinationOwnerAndPermissions(String json) {
-      JsonObject destinationOwnerAndPermissions =
-          new Gson().fromJson(json, JsonObject.class).getAsJsonObject("object-data")
-              .getAsJsonObject("destinationOwnerAndPermission");
-      return destinationOwnerAndPermissions;
-    }
+    public static DestinationOwnerAndPermissions getDestinationOwnerAndPermissions(String json) {
+      DestinationOwnerAndPermissions destinationOwnerAndPermissions = new DestinationOwnerAndPermissions();
 
-    public Map<String, String> getDestinationOwnerAndPermissionsFsPermissionsMap(JsonObject jsonObject) {
-      Map<String, String> fsPermissionsMap = Maps.newHashMap();
-      JsonObject fsPermission = jsonObject.getAsJsonObject("object-data").getAsJsonObject("fsPermission");
+      JsonObject destinationOwnerAndPermissionsJsonObject = new Gson().fromJson(json, JsonObject.class)
+          .getAsJsonObject("object-data")
+          .getAsJsonObject("destinationOwnerAndPermission");
+      destinationOwnerAndPermissions.owner = destinationOwnerAndPermissionsJsonObject.getAsJsonObject("object-data").getAsJsonPrimitive("owner").getAsString();
+      destinationOwnerAndPermissions.group = destinationOwnerAndPermissionsJsonObject.getAsJsonObject("object-data").getAsJsonPrimitive("group").getAsString();
+
+      JsonObject fsPermission = destinationOwnerAndPermissionsJsonObject.getAsJsonObject("object-data").getAsJsonObject("fsPermission");
       JsonObject objectData = fsPermission.getAsJsonObject("object-data");
 
-      String userActionPermission =
+      destinationOwnerAndPermissions.userActionPermission =
           objectData.getAsJsonObject("useraction").getAsJsonPrimitive("object-data").getAsString();
-      String groupActionPermission =
+      destinationOwnerAndPermissions.groupActionPermission =
           objectData.getAsJsonObject("groupaction").getAsJsonPrimitive("object-data").getAsString();
-      String otherActionPermission =
+      destinationOwnerAndPermissions.otherActionPermission =
           objectData.getAsJsonObject("otheraction").getAsJsonPrimitive("object-data").getAsString();
 
-      fsPermissionsMap.put("useraction", userActionPermission);
-      fsPermissionsMap.put("groupaction", groupActionPermission);
-      fsPermissionsMap.put("otheraction", otherActionPermission);
-
-      return fsPermissionsMap;
+      return destinationOwnerAndPermissions;
     }
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -377,7 +378,7 @@ public class IcebergDatasetTest {
   }
 
   private static void verifyCopyEntities(Collection<CopyEntity> copyEntities, List<String> expected) {
-    Set<String> actual = new HashSet<>();
+    List<String> actual = new ArrayList<>();
     for (CopyEntity copyEntity : copyEntities) {
       String json = copyEntity.toString();
       String filepath = CopyEntityDeserializer.getFilePathAsStringFromJson(json);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -339,6 +339,42 @@ public class IcebergDatasetTest {
     Assert.assertEqualsNoOrder(actual.toArray(), expected.toArray());
   }
 
+<<<<<<< HEAD
+=======
+  private void verifyFsOwnershipAndPermissionPreservation(Collection<CopyEntity> copyEntities) {
+
+
+    List<JsonObject> ancestorsOwnerAndPermissionsList = new ArrayList<>();
+    List<JsonObject> destinationOwnerAndPermissionsList = new ArrayList<>();
+
+    for(CopyEntity copyEntity : copyEntities) {
+      String copyEntityJson = copyEntity.toString();
+
+      JsonArray ancestorsOwnerAndPermissions = new Gson().fromJson(copyEntityJson, JsonObject.class)
+          .getAsJsonObject("object-data").getAsJsonArray("ancestorsOwnerAndPermission");
+      JsonObject rootAncestorOwnerAndPermissions = ancestorsOwnerAndPermissions.get(ancestorsOwnerAndPermissions.size()-1)
+          .getAsJsonObject().getAsJsonObject();
+      ancestorsOwnerAndPermissionsList.add(rootAncestorOwnerAndPermissions);
+      String filePath = getFilePathAsStringFromJson(copyEntityJson);
+      Assert.assertEquals(ancestorsOwnerAndPermissions.size(), new Path(filePath).getParent().depth() -1);
+
+      JsonObject destinationOwnerAndPermissions = new Gson().fromJson(copyEntityJson, JsonObject.class)
+          .getAsJsonObject("object-data").getAsJsonObject("destinationOwnerAndPermission");
+      destinationOwnerAndPermissionsList.add(destinationOwnerAndPermissions);
+    }
+    Assert.assertEqualsNoOrder(ancestorsOwnerAndPermissionsList.toArray(), destinationOwnerAndPermissionsList.toArray());
+  }
+
+  private String getFilePathAsStringFromJson(String json) {
+    String filepath = new Gson().fromJson(json, JsonObject.class)
+        .getAsJsonObject("object-data").getAsJsonObject("origin")
+        .getAsJsonObject("object-data").getAsJsonObject("path")
+        .getAsJsonObject("object-data").getAsJsonObject("uri")
+        .getAsJsonPrimitive("object-data").getAsString();
+    return filepath;
+  }
+
+>>>>>>> 7e67f4897 (minor comment: preserving perms till root)
 
   /**
    *  Sadly, this is needed to avoid losing `FileSystem` mock to replacement from the `FileSystem.get` `static`

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -49,12 +49,15 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyContext;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.PreserveAttributes;
+import org.apache.gobblin.util.PathUtils;
+
 import org.testng.collections.Sets;
 
 import static org.mockito.Matchers.any;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -46,19 +46,19 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.collections.Sets;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import lombok.Data;
+
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyContext;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.PreserveAttributes;
-import org.apache.gobblin.util.PathUtils;
-
-import org.testng.collections.Sets;
 
 import static org.mockito.Matchers.any;
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
@@ -81,6 +81,18 @@ public class PathUtils {
   }
 
   /**
+   * Returns the root path for the specified path.
+   *
+   * @see Path
+   */
+  public static Path getRootPathParent(Path path) {
+    if (path.getParent().isRoot()) {
+      return path;
+    }
+    return getRootPathParent(path.getParent());
+  }
+
+  /**
    * Removes the leading slash if present.
    *
    */

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
@@ -82,11 +82,15 @@ public class PathUtils {
 
   /**
    * Returns the root path child for the specified path.
+   * Example: input: /a/b/c then it will return /a
    *
-   * @see Path
    */
   public static Path getRootPathChild(Path path) {
-    if (path.getParent() != null && path.getParent().isRoot()) {
+    if (path.getParent() == null) {
+      return null;
+    }
+
+    if (path.getParent().isRoot()) {
       return path;
     }
     return getRootPathChild(path.getParent());

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
@@ -81,7 +81,7 @@ public class PathUtils {
   }
 
   /**
-   * Returns the root path for the specified path.
+   * Returns the root path parent for the specified path.
    *
    * @see Path
    */

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
@@ -81,15 +81,15 @@ public class PathUtils {
   }
 
   /**
-   * Returns the root path parent for the specified path.
+   * Returns the root path child for the specified path.
    *
    * @see Path
    */
-  public static Path getRootPathParent(Path path) {
-    if (path.getParent().isRoot()) {
+  public static Path getRootPathChild(Path path) {
+    if (path.getParent() != null && path.getParent().isRoot()) {
       return path;
     }
-    return getRootPathParent(path.getParent());
+    return getRootPathChild(path.getParent());
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1720] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1720


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- Update `IcebergDataset` to add the ancestor ownership and permissions using `CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively` and preserve them between src and dest



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Augment `IcebergDatasetTest` unit test to exercise Fs ownership and permissions are preserved


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

