### PR TITLE
[GOBBLIN-1721] Give option to cancel helix workflow through Delete API

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -175,6 +175,12 @@ public class GobblinClusterConfigurationKeys {
   public static final String CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelRunningJobOnDelete";
   public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
 
+  // By default we cancel job by calling helix stop API. In some cases, jobs just hang in STOPPING state and preventing
+  // new job being launched. We provide this config to give an option to cancel jobs by calling Delete API. Directly delete
+  // a Helix workflow should be safe in Gobblin world, as Gobblin job is stateless for Helix since we implement our own state store
+  public static final String CANCEL_HELIX_JOB_BY_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelHelixJobByDelete";
+  public static final boolean DEFAULT_CANCEL_HELIX_JOB_BY_DELETE = false;
+
   public static final String HELIX_JOB_STOPPING_STATE_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "job.stoppingStateTimeoutSeconds";
   public static final long DEFAULT_HELIX_JOB_STOPPING_STATE_TIMEOUT_SECONDS = 300;
   public static final String CONTAINER_HEALTH_METRICS_SERVICE_ENABLED = GOBBLIN_CLUSTER_PREFIX + "container.health.metrics.service.enabled" ;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1721] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1721


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Currently when we receive a job restart(handleUpdateJobConfigArrival), GobblinHelixJobLauncher will firstly call  helixTaskDriver.waitToStop to stop the workflow, then initiate the new one. We observe the behavior of Helix taking exceptionally long to stop the workflow, making the job state staying in STOPPING status. This will make waitToStop timeout and throw exception all the time, making the new flow never be able to launch.

We can utilize Delete API in this case since our job is stateless for Helix, to avoid job hanging.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in the cluster.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

