### PR TITLE
[GOBBLIN-1724] Support a shared flowgraph layout in GaaS

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -52,6 +52,7 @@ public class ServiceConfigKeys {
   public static final String HELIX_INSTANCE_NAME_KEY = GOBBLIN_SERVICE_PREFIX + "helixInstanceName";
   public static final String GOBBLIN_SERVICE_FLOWSPEC = GOBBLIN_SERVICE_PREFIX + "flowSpec";
   public static final String GOBBLIN_SERVICE_FLOWGRAPH_CLASS_KEY = GOBBLIN_SERVICE_PREFIX + "flowGraph.class";
+  public static final String GOBBLIN_SERVICE_FLOWGRAPH_HELPER_KEY = GOBBLIN_SERVICE_PREFIX + "flowGraphHelper.class";
 
   // Helix message sub types for FlowSpec
   public static final String HELIX_FLOWSPEC_ADD = "FLOWSPEC_ADD";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraphHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraphHelper.java
@@ -57,6 +57,16 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  * Provides the common set of functionalities needed by {@link FlowGraphMonitor} to read changes in files and
  * apply them to a {@link FlowGraph}
  * Assumes that the directory structure between flowgraphs configuration files are the same.
+ *
+ * Assumes that the flowgraph follows this format
+ *  /gobblin-flowgraph
+ *    /nodeA
+ *      /nodeB
+ *        edgeAB.properties
+ *      A.properties
+ *    /nodeB
+ *      B.properties
+ *
  */
 @Slf4j
 public class BaseFlowGraphHelper {
@@ -197,7 +207,7 @@ public class BaseFlowGraphHelper {
     for (int i = 0; i < depth - 1; i++) {
       path = path.getParent();
     }
-    return path.getName().equals(flowGraphFolderName);
+    return path != null ? path.getName().equals(flowGraphFolderName) : false;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
@@ -43,16 +43,16 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  * Node definitions are shared between each subgraph, but can be overwritten within the subgraph
  * Edge definitions are only defined in the subgraphs
  * e.g.
- * /gobblin-flowgraph
+ * /gobblin-flowgraph-absolute-dir
  *   /subgraphA
- *     /nodeA
+ *     /nodeA (NODE_FOLDER_DEPTH)
  *       /nodeB
  *         edgeAB.properties
  *   /subgraphB
  *     /nodeA
  *       /nodeB
- *         edgeAB.properties
- *       A.properties
+ *         edgeAB.properties (EDGE_FILE_DEPTH)
+ *       A.properties (NODE_FILE_DEPTH)
  *  /nodes
  *    A.properties
  *    B.properties
@@ -108,7 +108,7 @@ public class SharedFlowGraphHelper extends BaseFlowGraphHelper {
       if (this.flowGraphUpdateFailedMeter.isPresent()) {
         this.flowGraphUpdateFailedMeter.get().mark();
       }
-      log.warn("Could not add DataNode defined in {} due to exception {}", path, e);
+      log.warn("Could not add DataNode {} defined in {} due to exception {}", path, e);
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.runtime.api.TopologySpec;
+import org.apache.gobblin.service.modules.template_catalog.FSFlowTemplateCatalog;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+
+
+/**
+ * Supports a configuration of a flowgraph where it can support multiple sub-flowgraphs within its directory
+ * Node definitions are shared between each subgraph, but can be overwritten within the subgraph
+ * Edge definitions are only defined in the subgraphs
+ * e.g.
+ * /gobblin-flowgraph
+ *   /subgraphA
+ *     /nodeA
+ *       /nodeB
+ *         edgeAB.properties
+ *   /subgraphB
+ *     /nodeA
+ *       /nodeB
+ *         edgeAB.properties
+ *       A.properties
+ *  /nodes
+ *    A.properties
+ *    B.properties
+ */
+@Slf4j
+public class SharedFlowGraphHelper extends BaseFlowGraphHelper {
+
+  protected String sharedNodeFolder;
+  private static String NODE_FILE_SUFFIX = ".properties";
+
+  public SharedFlowGraphHelper(Optional<? extends FSFlowTemplateCatalog> flowTemplateCatalog,
+      Map<URI, TopologySpec> topologySpecMap, String baseDirectory, String flowGraphFolderName,
+      String javaPropsExtentions, String hoconFileExtensions, boolean instrumentationEnabled, Config config) {
+    super(flowTemplateCatalog, topologySpecMap, baseDirectory, flowGraphFolderName, javaPropsExtentions, hoconFileExtensions, instrumentationEnabled, config);
+    this.sharedNodeFolder = baseDirectory + File.separator + "nodes";
+  }
+
+  /**
+   * Looks into the sharedNodeFolder to use those configurations as fallbacks for the node to add
+   * Otherwise if the shared node does not exist, attempt to add the node in the same manner as {@link BaseFlowGraphHelper}
+   * @param graph
+   * @param path of node folder in the subgraph, so path is expected to be a directory
+   */
+  @Override
+  protected void addDataNode(FlowGraph graph, java.nio.file.Path path) {
+    try {
+      // Load node from shared folder first if it exists
+      Config sharedNodeConfig = ConfigFactory.empty();
+      String nodePropertyFile = path.getFileName().toString() + NODE_FILE_SUFFIX;
+      File sharedNodeFile = new File(this.sharedNodeFolder, nodePropertyFile);
+      if (sharedNodeFile.exists()) {
+        sharedNodeConfig = loadNodeFileWithOverrides(new Path(sharedNodeFile.getPath()));
+      }
+      File nodeFilePath = new File(path.toString(), nodePropertyFile);
+      Config nodeConfig = sharedNodeConfig;
+      if (nodeFilePath.exists()) {
+        nodeConfig = loadNodeFileWithOverrides(new Path(nodeFilePath.getPath())).withFallback(sharedNodeConfig);
+      }
+      if (nodeConfig.isEmpty()) {
+        throw new IOException(String.format("Cannot find expected property file %s in %s or %s", nodePropertyFile, sharedNodeFolder, path));
+      }
+      Class dataNodeClass = Class.forName(ConfigUtils.getString(nodeConfig, FlowGraphConfigurationKeys.DATA_NODE_CLASS,
+          FlowGraphConfigurationKeys.DEFAULT_DATA_NODE_CLASS));
+      DataNode dataNode = (DataNode) GobblinConstructorUtils.invokeLongestConstructor(dataNodeClass, nodeConfig);
+      if (!graph.addDataNode(dataNode)) {
+        log.warn("Could not add DataNode {} to FlowGraph; skipping", dataNode.getId());
+      } else {
+        log.info("Added Datanode {} to FlowGraph", dataNode.getId());
+      }
+    } catch (Exception e) {
+      if (this.flowGraphUpdateFailedMeter.isPresent()) {
+        this.flowGraphUpdateFailedMeter.get().mark();
+      }
+      log.warn("Could not add DataNode defined in {} due to exception {}", path, e);
+    }
+  }
+
+  @Override
+  protected Config getNodeConfigWithOverrides(Config nodeConfig, Path nodeFilePath) {
+    String nodeId = FilenameUtils.removeExtension(nodeFilePath.getName().toString());
+    return nodeConfig.withValue(FlowGraphConfigurationKeys.DATA_NODE_ID_KEY, ConfigValueFactory.fromAnyRef(nodeId));
+  }
+
+  @Override
+  protected int getNodeFileDepth() {
+    return 2;
+  }
+}
+

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/SharedFlowGraphHelper.java
@@ -62,12 +62,14 @@ public class SharedFlowGraphHelper extends BaseFlowGraphHelper {
 
   protected String sharedNodeFolder;
   private static String NODE_FILE_SUFFIX = ".properties";
+  private static String SHARED_NODE_FOLDER_NAME = "nodes";
+  private static int NODE_FOLDER_DEPTH = 2;
 
   public SharedFlowGraphHelper(Optional<? extends FSFlowTemplateCatalog> flowTemplateCatalog,
       Map<URI, TopologySpec> topologySpecMap, String baseDirectory, String flowGraphFolderName,
       String javaPropsExtentions, String hoconFileExtensions, boolean instrumentationEnabled, Config config) {
     super(flowTemplateCatalog, topologySpecMap, baseDirectory, flowGraphFolderName, javaPropsExtentions, hoconFileExtensions, instrumentationEnabled, config);
-    this.sharedNodeFolder = baseDirectory + File.separator + "nodes";
+    this.sharedNodeFolder = baseDirectory + File.separator + SHARED_NODE_FOLDER_NAME;
   }
 
   /**
@@ -118,7 +120,7 @@ public class SharedFlowGraphHelper extends BaseFlowGraphHelper {
 
   @Override
   protected int getNodeFileDepth() {
-    return 2;
+    return NODE_FOLDER_DEPTH;
   }
 }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
@@ -82,7 +82,7 @@ public class FsFlowGraphMonitorTest {
   @BeforeClass
   public void setUp() throws Exception {
     cleanUpDir(TEST_DIR.toString());
-
+    TEST_DIR.mkdirs();
 
     URI topologyCatalogUri = this.getClass().getClassLoader().getResource("topologyspec_catalog").toURI();
     this.topologySpecMap = MultiHopFlowCompilerTest.buildTopologySpecMap(topologyCatalogUri);
@@ -256,7 +256,6 @@ public class FsFlowGraphMonitorTest {
     //delete node files
     FileUtils.deleteDirectory(node1FlowGraphFile);
     FileUtils.deleteDirectory(node2FlowGraphFile);
-    FileUtils.deleteDirectory(node2FlowGraphFile);
     // Let the monitor pick up the edges that were recently deleted
     Thread.sleep(3000);
 
@@ -334,13 +333,13 @@ public class FsFlowGraphMonitorTest {
   }
 
   private void cleanUpDir(String dir) {
-    File specStoreDir = new File(dir);
+    File dirToDelete = new File(dir);
 
     // cleanup is flaky on Travis, so retry a few times and then suppress the error if unsuccessful
     for (int i = 0; i < 5; i++) {
       try {
-        if (specStoreDir.exists()) {
-          FileUtils.deleteDirectory(specStoreDir);
+        if (dirToDelete.exists()) {
+          FileUtils.deleteDirectory(dirToDelete);
         }
         // if delete succeeded then break out of loop
         break;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
@@ -23,6 +23,8 @@ import com.google.common.base.Optional;
 import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -68,6 +70,7 @@ public class FsFlowGraphMonitorTest {
   private final File node2File = new File(node2Dir, NODE_2_FILE);
   private final File edge1Dir = new File(node1Dir, "node2");
   private final File edge1File = new File(edge1Dir, "edge1.properties");
+  private final File sharedNodeFolder = new File(TEST_DIR, "nodes");
 
   private RefSpec masterRefSpec = new RefSpec("master");
   private Optional<FSFlowTemplateCatalog> flowCatalog;
@@ -86,7 +89,7 @@ public class FsFlowGraphMonitorTest {
 
     this.config = ConfigBuilder.create()
         .addPrimitive(FsFlowGraphMonitor.FS_FLOWGRAPH_MONITOR_PREFIX + "."
-            + ConfigurationKeys.FLOWGRAPH_ABSOLUTE_DIR, this.flowGraphDir.getAbsolutePath())
+            + ConfigurationKeys.FLOWGRAPH_ABSOLUTE_DIR, TEST_DIR.getAbsolutePath())
         .addPrimitive(FsFlowGraphMonitor.FS_FLOWGRAPH_MONITOR_PREFIX + "." + ConfigurationKeys.FLOWGRAPH_BASE_DIR, "gobblin-flowgraph")
         .addPrimitive(FsFlowGraphMonitor.FS_FLOWGRAPH_MONITOR_PREFIX + "." + ConfigurationKeys.FLOWGRAPH_POLLING_INTERVAL, 1)
         .build();
@@ -173,6 +176,7 @@ public class FsFlowGraphMonitorTest {
   @Test (dependsOnMethods = "testUpdateNode")
   public void testSetUpExistingGraph() throws Exception {
     // Create a FlowGraph instance with defaults
+    this.flowGraphMonitor.shutDown();
     this.flowGraph = new AtomicReference<>(new BaseFlowGraph());
     MultiHopFlowCompiler mhfc = new MultiHopFlowCompiler(config, this.flowGraph);
 
@@ -186,10 +190,43 @@ public class FsFlowGraphMonitorTest {
     Assert.assertNotNull(this.flowGraph.get().getNode("node1"));
     Assert.assertNotNull(this.flowGraph.get().getNode("node2"));
     Assert.assertEquals(this.flowGraph.get().getEdges("node1").size(), 1);
-
   }
 
   @Test (dependsOnMethods = "testSetUpExistingGraph")
+  public void testSharedFlowgraphHelper() throws Exception {
+    this.flowGraphMonitor.shutDown();
+    Config sharedFlowgraphConfig = ConfigFactory.empty()
+        .withValue(ServiceConfigKeys.GOBBLIN_SERVICE_FLOWGRAPH_HELPER_KEY, ConfigValueFactory.fromAnyRef("org.apache.gobblin.service.modules.flowgraph.SharedFlowGraphHelper"))
+        .withFallback(this.config);
+
+
+    this.flowGraph = new AtomicReference<>(new BaseFlowGraph());
+    MultiHopFlowCompiler mhfc = new MultiHopFlowCompiler(config, this.flowGraph);
+    // Set up node 3
+    File node3Folder = new File(this.flowGraphDir, "node3");
+    node3Folder.mkdirs();
+    File node3File = new File(this.sharedNodeFolder, "node3.properties");
+    String file3Contents = FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY + "=true\nparam3=value3\n";
+
+    // Have different default values for node 1
+    File node1File = new File(this.sharedNodeFolder, "node1.properties");
+    String file1Contents = FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY + "=true\nparam2=value10\n";
+
+    createNewFile(this.sharedNodeFolder, node3File, file3Contents);
+    createNewFile(this.sharedNodeFolder, node1File, file1Contents);
+
+    this.flowGraphMonitor = new FsFlowGraphMonitor(sharedFlowgraphConfig, this.flowCatalog, mhfc, this.topologySpecMap, new CountDownLatch(1), true);
+    this.flowGraphMonitor.startUp();
+    this.flowGraphMonitor.setActive(true);
+    // Let the monitor repopulate the flowgraph
+    Thread.sleep(3000);
+    Assert.assertNotNull(this.flowGraph.get().getNode("node3"));
+    DataNode node1 = this.flowGraph.get().getNode("node1");
+    Assert.assertTrue(node1.isActive());
+    Assert.assertEquals(node1.getRawConfig().getString("param2"), "value10");
+  }
+
+  @Test (dependsOnMethods = "testSharedFlowgraphHelper")
   public void testRemoveEdge() throws Exception {
     //Node1 has 1 edge before delete
     Collection<FlowEdge> edgeSet = this.flowGraph.get().getEdges("node1");
@@ -219,7 +256,7 @@ public class FsFlowGraphMonitorTest {
     //delete node files
     FileUtils.deleteDirectory(node1FlowGraphFile);
     FileUtils.deleteDirectory(node2FlowGraphFile);
-
+    FileUtils.deleteDirectory(node2FlowGraphFile);
     // Let the monitor pick up the edges that were recently deleted
     Thread.sleep(3000);
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1724


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Support a flowgraph format where nodes can be shared between subgraphs. This allows for less repetition and cleaner hierarchies within the flowgraph.
It will follow the following structure
```
/flowgraph
../nodeA
..../nodeB
......edgeAB.properties
../nodeB
....nodeB.properties
/nodes
..nodeA.properties
..nodeB.properties

```
Where nodeA will use the shared properties, and nodeB will use the union of the properties in nodeB from /flowgraph and the shared properties.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

