### PR TITLE
[GOBBLIN-1727] Use delete API to delete the helix job instead of stop it

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -144,18 +144,15 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
       String planningJobId = getPlanningJobId(this.jobPlanningProps);
       try {
         if (this.cancellationRequested && !this.cancellationExecuted) {
-          // TODO : fix this when HELIX-1180 is completed
-          // work flow should never be deleted explicitly because it has a expiry time
-          // If cancellation is requested, we should set the job state to CANCELLED/ABORT
-          this.helixTaskDriver.waitToStop(planningJobId, this.helixJobStopTimeoutSeconds * 1000);
-          log.info("Stopped the workflow {}", planningJobId);
+          this.helixTaskDriver.deleteAndWaitForCompletion(planningJobId, this.helixJobStopTimeoutSeconds * 1000);
+          log.info("Deleted the workflow {}", planningJobId);
         }
       } catch (HelixException e) {
-        // Cancellation may throw an exception, but Helix set the job state to STOP and it should eventually stop
+        // Cancellation may throw an exception, but Helix set the job state to DELETE and it should eventually stop
         // We will keep this.cancellationExecuted and this.cancellationRequested to true and not propagate the exception
-        log.error("Failed to stop workflow {} in Helix", planningJobId, e);
+        log.error("Failed to delete workflow {} in Helix", planningJobId, e);
       } catch (InterruptedException e) {
-        log.error("Thread interrupted while trying to stop the workflow {} in Helix", planningJobId);
+        log.error("Thread interrupted while trying to delete the workflow {} in Helix", planningJobId);
         Thread.currentThread().interrupt();
       }
     }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -255,18 +255,15 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     if (this.jobSubmitted) {
       try {
         if (this.cancellationRequested && !this.cancellationExecuted) {
-          // TODO : fix this when HELIX-1180 is completed
-          // work flow should never be deleted explicitly because it has a expiry time
-          // If cancellation is requested, we should set the job state to CANCELLED/ABORT
-          this.helixTaskDriver.waitToStop(this.helixWorkFlowName, this.helixJobStopTimeoutSeconds * 1000);
-          log.info("stopped the workflow {}", this.helixWorkFlowName);
+          this.helixTaskDriver.deleteAndWaitForCompletion(this.helixWorkFlowName, this.helixJobStopTimeoutSeconds * 1000);
+          log.info("deleted the workflow {}", this.helixWorkFlowName);
         }
       } catch (RuntimeException e) {
-        // Cancellation may throw an exception, but Helix set the job state to STOP and it should eventually stop
+        // Cancellation may throw an exception, but Helix set the job state to DELETE and it should eventually stop
         // We will keep this.cancellationExecuted and this.cancellationRequested to true and not propagate the exception
-        log.error("Failed to stop workflow {} in Helix", helixWorkFlowName, e);
+        log.error("Failed to delete workflow {} in Helix", helixWorkFlowName, e);
       } catch (InterruptedException e) {
-        log.error("Thread interrupted while trying to stop the workflow {} in Helix", helixWorkFlowName);
+        log.error("Thread interrupted while trying to delete the workflow {} in Helix", helixWorkFlowName);
         Thread.currentThread().interrupt();
       }
     }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -396,12 +396,12 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
 
     if (planningJob.isPresent()) {
       LOGGER.info("Cancelling planning job helix workflow: {}", planningJob.get());
-      new TaskDriver(this.taskDriverHelixManager.get()).waitToStop(planningJob.get(), this.helixJobStopTimeoutMillis);
+      new TaskDriver(this.taskDriverHelixManager.get()).deleteAndWaitForCompletion(planningJob.get(), this.helixJobStopTimeoutMillis);
     }
 
     if (actualJob.isPresent()) {
       LOGGER.info("Cancelling actual job helix workflow: {}", actualJob.get());
-      new TaskDriver(this.jobHelixManager).waitToStop(actualJob.get(), this.helixJobStopTimeoutMillis);
+      new TaskDriver(this.jobHelixManager).deleteAndWaitForCompletion(actualJob.get(), this.helixJobStopTimeoutMillis);
     }
 
     this.jobSchedulerMetrics.numCancellationStart.decrementAndGet();
@@ -431,8 +431,9 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
       if (jobNameToWorkflowIdMap.containsKey(deleteJobArrival.getJobName())) {
         String workflowId = jobNameToWorkflowIdMap.get(deleteJobArrival.getJobName());
         TaskDriver taskDriver = new TaskDriver(this.jobHelixManager);
-        taskDriver.waitToStop(workflowId, this.helixJobStopTimeoutMillis);
-        LOGGER.info("Stopped workflow: {}", deleteJobArrival.getJobName());
+        //Instead of stop, direct cancel the workflow
+        taskDriver.deleteAndWaitForCompletion(workflowId, this.helixJobStopTimeoutMillis);
+        LOGGER.info("Cancelled workflow: {}", deleteJobArrival.getJobName());
         //Wait until the cancelled job is complete.
         waitForJobCompletion(deleteJobArrival.getJobName());
       } else {

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1727


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

