### PR TITLE
[GOBBLIN-1730] Include flow execution id when try to cancel/submit job using SimpleKafkaSpecProducer

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecProducer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecProducer.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.service;
 
-import com.esotericsoftware.minlog.Log;
 import com.google.common.base.Joiner;
 import java.io.Closeable;
 import java.io.IOException;
@@ -113,7 +112,7 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
         newSpec.setUri(new URI(Joiner.on("/").
             join(spec.getUri().toString(), newSpec.getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY))));
       } catch (URISyntaxException e) {
-        Log.error("Cannot create job uri to cancel job", e);
+        log.error("Cannot create job uri to cancel job", e);
       }
     }
     return newSpec;
@@ -125,7 +124,7 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
         originalURI = new URI(Joiner.on("/").
             join(originalURI.toString(), props.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
       } catch (URISyntaxException e) {
-        Log.error("Cannot create job uri to cancel job", e);
+        log.error("Cannot create job uri to cancel job", e);
       }
     }
     return originalURI;

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecProducer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecProducer.java
@@ -17,15 +17,19 @@
 
 package org.apache.gobblin.service;
 
+import com.esotericsoftware.minlog.Log;
+import com.google.common.base.Joiner;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.Properties;
 
 import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.slf4j.Logger;
 
 import com.codahale.metrics.Meter;
@@ -102,11 +106,37 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
     return this.metricContext.meter(MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, getClass().getSimpleName(), suffix));
   }
 
+  private Spec addExecutionIdToJobSpecUri(Spec spec) {
+    JobSpec newSpec = (JobSpec)spec;
+    if (newSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      try {
+        newSpec.setUri(new URI(Joiner.on("/").
+            join(spec.getUri().toString(), newSpec.getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY))));
+      } catch (URISyntaxException e) {
+        Log.error("Cannot create job uri to cancel job", e);
+      }
+    }
+    return newSpec;
+  }
+
+  private URI getURIWithExecutionId(URI originalURI, Properties props) {
+    if (props.contains(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      try {
+        originalURI = new URI(Joiner.on("/").
+            join(originalURI.toString(), props.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
+      } catch (URISyntaxException e) {
+        Log.error("Cannot create job uri to cancel job", e);
+      }
+    }
+    return originalURI;
+  }
+
   @Override
   public Future<?> addSpec(Spec addedSpec) {
-    AvroJobSpec avroJobSpec = convertToAvroJobSpec(addedSpec, SpecExecutor.Verb.ADD);
+    Spec spec = addExecutionIdToJobSpecUri(addedSpec);
+    AvroJobSpec avroJobSpec = convertToAvroJobSpec(spec, SpecExecutor.Verb.ADD);
 
-    log.info("Adding Spec: " + addedSpec + " using Kafka.");
+    log.info("Adding Spec: " + spec + " using Kafka.");
     this.addSpecMeter.mark();
 
     return getKafkaProducer().write(_serializer.serializeRecord(avroJobSpec), new KafkaWriteCallback(avroJobSpec));
@@ -114,9 +144,10 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
 
   @Override
   public Future<?> updateSpec(Spec updatedSpec) {
-    AvroJobSpec avroJobSpec = convertToAvroJobSpec(updatedSpec, SpecExecutor.Verb.UPDATE);
+    Spec spec = addExecutionIdToJobSpecUri(updatedSpec);
+    AvroJobSpec avroJobSpec = convertToAvroJobSpec(spec, SpecExecutor.Verb.UPDATE);
 
-    log.info("Updating Spec: " + updatedSpec + " using Kafka.");
+    log.info("Updating Spec: " + spec + " using Kafka.");
     this.updateSpecMeter.mark();
 
     return getKafkaProducer().write(_serializer.serializeRecord(avroJobSpec), new KafkaWriteCallback(avroJobSpec));
@@ -124,6 +155,7 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
 
   @Override
   public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
+    deletedSpecURI = getURIWithExecutionId(deletedSpecURI, headers);
 
     AvroJobSpec avroJobSpec = AvroJobSpec.newBuilder().setUri(deletedSpecURI.toString())
         .setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.DELETE.name()))
@@ -137,6 +169,7 @@ public class SimpleKafkaSpecProducer implements SpecProducer<Spec>, Closeable  {
 
   @Override
   public Future<?> cancelJob(URI deletedSpecURI, Properties properties) {
+    deletedSpecURI = getURIWithExecutionId(deletedSpecURI, properties);
     AvroJobSpec avroJobSpec = AvroJobSpec.newBuilder().setUri(deletedSpecURI.toString())
         .setMetadata(ImmutableMap.of(SpecExecutor.VERB_KEY, SpecExecutor.Verb.CANCEL.name()))
         .setProperties(Maps.fromProperties(properties)).build();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import org.apache.gobblin.runtime.api.DagActionStore;
 import org.apache.gobblin.runtime.dag_action_store.MysqlDagActionStore;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
-//import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigV2ResourceHandlerWithWarmStandby;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigV2ResourceHandlerWithWarmStandby;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowExecutionResourceHandlerWithWarmStandby;
 import org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -666,8 +666,10 @@ public class DagManager extends AbstractIdleService {
         props.put(ConfigurationKeys.SPEC_PRODUCER_SERIALIZED_FUTURE, serializedFuture);
         sendCancellationEvent(dagNodeToCancel.getValue());
       }
-      props.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
-          ConfigUtils.getString(dagNodeToCancel.getValue().getJobSpec().getConfig(), ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ""));
+      if (dagNodeToCancel.getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+        props.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
+            dagNodeToCancel.getValue().getJobSpec().getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY));
+      }
       DagManagerUtils.getSpecProducer(dagNodeToCancel).cancelJob(dagNodeToCancel.getValue().getJobSpec().getUri(), props);
     }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -398,9 +398,12 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     // Delete all compiled JobSpecs on their respective Executor
     for (Dag.DagNode<JobExecutionPlan> dagNode : jobExecutionPlanDag.getNodes()) {
       JobExecutionPlan jobExecutionPlan = dagNode.getValue();
-      Spec jobSpec = jobExecutionPlan.getJobSpec();
+      JobSpec jobSpec = jobExecutionPlan.getJobSpec();
       try {
         SpecProducer<Spec> producer = jobExecutionPlan.getSpecExecutor().getProducer().get();
+        if (jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+          headers.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, jobSpec.getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY));
+        }
         _log.info(String.format("Going to delete JobSpec: %s on Executor: %s", jobSpec, producer));
         producer.deleteSpec(jobSpec.getUri(), headers);
       } catch (Exception e) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1730


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Include flow execution id when try to cancel/submit job using SimpleKafkaSpecProducer

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test;
Test on local service and verify that we job spec uri contains the flow execution id

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

