### PR TITLE
[GOBBLIN-1733] Support multiple node types in shared flowgraph, fix logs

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraphHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraphHelper.java
@@ -82,8 +82,8 @@ public class BaseFlowGraphHelper {
   protected MetricContext metricContext;
   final String flowGraphFolderName;
   final PullFileLoader pullFileLoader;
-  final Set<String> javaPropsExtensions;
-  final Set<String> hoconFileExtensions;
+  protected final Set<String> javaPropsExtensions;
+  protected final Set<String> hoconFileExtensions;
   protected final Optional<ContextAwareMeter> flowGraphUpdateFailedMeter;
 
   public BaseFlowGraphHelper(Optional<? extends FSFlowTemplateCatalog> flowTemplateCatalog,
@@ -133,7 +133,7 @@ public class BaseFlowGraphHelper {
         if (this.flowGraphUpdateFailedMeter.isPresent()) {
           this.flowGraphUpdateFailedMeter.get().mark();
         }
-        log.warn("Could not add DataNode defined in {} due to exception {}", path, e);
+        log.warn(String.format("Could not add DataNode defined in %s due to exception: ", path), e);
       }
     }
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
@@ -205,7 +205,7 @@ public class FsFlowGraphMonitorTest {
     // Set up node 3
     File node3Folder = new File(this.flowGraphDir, "node3");
     node3Folder.mkdirs();
-    File node3File = new File(this.sharedNodeFolder, "node3.properties");
+    File node3File = new File(this.sharedNodeFolder, "node3.conf");
     String file3Contents = FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY + "=true\nparam3=value3\n";
 
     // Have different default values for node 1


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1722


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Gobblin flowgraph supports both .conf and .properties files
SharedFlowgraph explciitly only looks for .properties files, which misses nodes that are defined in .conf files (HOCON format). 

We should support both these types.
Also fix a bug where exception outputs are not properly formatted when adding flowgraphs

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

