### PR TITLE
[GOBBLIN-1734] make DestinationDatasetHandler work on streaming sources

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
@@ -25,16 +25,18 @@ import org.apache.gobblin.source.workunit.WorkUnitStream;
 
 
 /**
- * Performs work related to initializing the target environment before the files are written and published
+ * Performs work related to initializing the target environment before the files are written and published.
+ * Implementations should be aware that a {@link WorkUnitStream} may be of streaming type.
  */
 public interface DestinationDatasetHandler extends Closeable {
 
   /**
    * Handle destination setup before workunits are sent to writer and publisher
+   * This method is deprecated in favor of {@link #handle(WorkUnitStream)}.
    * @param workUnits
    */
   @Deprecated
-  void handle(Collection<WorkUnit> workUnits) throws IOException;
+  default void handle(Collection<WorkUnit> workUnits) throws IOException {}
 
   default WorkUnitStream handle(WorkUnitStream workUnitStream) throws IOException {
     return workUnitStream;

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandler.java
@@ -21,6 +21,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
+
 
 /**
  * Performs work related to initializing the target environment before the files are written and published
@@ -31,7 +33,12 @@ public interface DestinationDatasetHandler extends Closeable {
    * Handle destination setup before workunits are sent to writer and publisher
    * @param workUnits
    */
+  @Deprecated
   void handle(Collection<WorkUnit> workUnits) throws IOException;
+
+  default WorkUnitStream handle(WorkUnitStream workUnitStream) throws IOException {
+    return workUnitStream;
+  }
 
   /**
    * Perform cleanup if needed

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
@@ -20,14 +20,12 @@ package org.apache.gobblin.destination;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.metrics.event.EventSubmitter;
-import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnitStream;
-import org.apache.gobblin.util.JobLauncherUtils;
 
 
 /**

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
@@ -52,21 +52,24 @@ public class DestinationDatasetHandlerService implements Closeable {
    * Executes handlers
    * @param workUnitStream
    */
-  public void executeHandlers(WorkUnitStream workUnitStream) {
-    if (handlers.size() > 0) {
-      if (workUnitStream.isSafeToMaterialize()) {
-        Collection<WorkUnit> workUnits = JobLauncherUtils.flattenWorkUnits(workUnitStream.getMaterializedWorkUnitCollection());
-          for (DestinationDatasetHandler handler : this.handlers) {
-            try {
-              handler.handle(workUnits);
-            } catch (IOException e) {
-              throw new RuntimeException(String.format("Handler %s failed to execute", handler.getClass().getName()), e);
-            }
-          }
-      } else {
-        throw new RuntimeException(DestinationDatasetHandlerService.class.getName() + " does not support work unit streams");
+  public WorkUnitStream executeHandlers(WorkUnitStream workUnitStream) {
+    Collection<WorkUnit> workUnits = workUnitStream.isSafeToMaterialize()
+        ? JobLauncherUtils.flattenWorkUnits(workUnitStream.getMaterializedWorkUnitCollection())
+        : null;
+
+    for (DestinationDatasetHandler handler : this.handlers) {
+      try {
+        if (workUnitStream.isSafeToMaterialize()) {
+          handler.handle(workUnits);
+        } else {
+          workUnitStream = handler.handle(workUnitStream);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(String.format("Handler %s failed to execute", handler.getClass().getName()), e);
       }
     }
+
+    return workUnitStream;
   }
 
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/destination/DestinationDatasetHandlerService.java
@@ -53,17 +53,9 @@ public class DestinationDatasetHandlerService implements Closeable {
    * @param workUnitStream
    */
   public WorkUnitStream executeHandlers(WorkUnitStream workUnitStream) {
-    Collection<WorkUnit> workUnits = workUnitStream.isSafeToMaterialize()
-        ? JobLauncherUtils.flattenWorkUnits(workUnitStream.getMaterializedWorkUnitCollection())
-        : null;
-
     for (DestinationDatasetHandler handler : this.handlers) {
       try {
-        if (workUnitStream.isSafeToMaterialize()) {
-          handler.handle(workUnits);
-        } else {
-          workUnitStream = handler.handle(workUnitStream);
-        }
+       workUnitStream = handler.handle(workUnitStream);
       } catch (IOException e) {
         throw new RuntimeException(String.format("Handler %s failed to execute", handler.getClass().getName()), e);
       }

--- a/gobblin-core/src/test/java/org/apache/gobblin/destination/TestDestinationDatasetHandler.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/destination/TestDestinationDatasetHandler.java
@@ -18,23 +18,22 @@
 package org.apache.gobblin.destination;
 
 import java.io.IOException;
-import java.util.Collection;
+
 import org.apache.gobblin.configuration.SourceState;
-import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
 
 
 public class TestDestinationDatasetHandler implements DestinationDatasetHandler {
   public static String TEST_COUNTER_KEY = "counter";
-  private Boolean canCleanUp;
   public TestDestinationDatasetHandler(SourceState state, Boolean canCleanUp){
-    this.canCleanUp = canCleanUp;
   }
 
   @Override
-  public void handle(Collection<WorkUnit> workUnits) {
-    for (WorkUnit wu: workUnits) {
+  public WorkUnitStream handle(WorkUnitStream workUnitSteam) {
+    return workUnitSteam.transform(wu -> {
       wu.setProp(TEST_COUNTER_KEY, wu.getPropAsInt(TEST_COUNTER_KEY, 0) + 1);
-    }
+      return wu;
+    });
   }
 
   @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1734


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Rich now DestinationDatasetHandler does not support streaming sources, this PR will provide an interface to include streaming sources as well.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

