### PR TITLE
[GOBBLIN-1738] move dataset handler code before cleaning up staging data

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -17,8 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import com.github.rholder.retry.RetryException;
-import com.google.common.eventbus.Subscribe;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Authenticator;
@@ -35,14 +33,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.gobblin.runtime.metrics.GobblinJobMetricReporter;
-import org.apache.gobblin.service.ServiceConfigKeys;
-import org.apache.gobblin.source.InfiniteSource;
-import org.apache.gobblin.stream.WorkUnitChangeEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import com.github.rholder.retry.RetryException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Function;
@@ -54,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -92,10 +88,13 @@ import org.apache.gobblin.runtime.locks.JobLock;
 import org.apache.gobblin.runtime.locks.JobLockEventListener;
 import org.apache.gobblin.runtime.locks.JobLockException;
 import org.apache.gobblin.runtime.locks.LegacyJobLockFactoryManager;
+import org.apache.gobblin.runtime.metrics.GobblinJobMetricReporter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooterFactory;
 import org.apache.gobblin.runtime.troubleshooter.IssueRepository;
 import org.apache.gobblin.runtime.util.JobMetrics;
+import org.apache.gobblin.service.ServiceConfigKeys;
+import org.apache.gobblin.source.InfiniteSource;
 import org.apache.gobblin.source.Source;
 import org.apache.gobblin.source.WorkUnitStreamSource;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
@@ -103,6 +102,7 @@ import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnitStream;
+import org.apache.gobblin.stream.WorkUnitChangeEvent;
 import org.apache.gobblin.util.ClusterNameTags;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.ExecutorsUtils;
@@ -508,6 +508,13 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           }
         }
 
+        // Perform work needed before writing is done
+        Boolean canCleanUp = this.canCleanStagingData(this.jobContext.getJobState());
+        try (DestinationDatasetHandlerService destinationDatasetHandlerService =
+            new DestinationDatasetHandlerService(jobState, canCleanUp, this.eventSubmitter)) {
+          workUnitStream = destinationDatasetHandlerService.executeHandlers(workUnitStream);
+        }
+
         //Initialize writer and converter(s)
         closer.register(WriterInitializerFactory.newInstace(jobState, workUnitStream)).initialize();
         closer.register(ConverterInitializerFactory.newInstance(jobState, workUnitStream)).initialize();
@@ -540,14 +547,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
               this.eventSubmitter.getTimingEvent(TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION);
           // Add task ids
           workUnitStream = prepareWorkUnits(workUnitStream, jobState);
-
-          // Perform work needed before writing is done
-          Boolean canCleanUp = this.canCleanStagingData(this.jobContext.getJobState());
-          try (DestinationDatasetHandlerService destinationDatasetHandlerService =
-              new DestinationDatasetHandlerService(jobState, canCleanUp, this.eventSubmitter)) {
-            workUnitStream = destinationDatasetHandlerService.executeHandlers(workUnitStream);
-          }
-
           // Remove skipped workUnits from the list of work units to execute.
           workUnitStream = workUnitStream.filter(new SkippedWorkUnitsFilter(jobState));
           // Add surviving tasks to jobState


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1738


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
staging directory cleanup code runs before the current position of dataset handler code execution. dataset handler code execution should happen before the cleanup so that the cleanup code gets the right configs. actually it was moved to the wrong location in this pr https://github.com/apache/gobblin/pull/3592 to put together all the code of processing and transforming workunitsStream at the same place.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

