### PR TITLE
[GOBBLIN-1742] do not close DestinationDatasetHandlerService prematurely

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -510,10 +510,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
         // Perform work needed before writing is done
         Boolean canCleanUp = this.canCleanStagingData(this.jobContext.getJobState());
-        try (DestinationDatasetHandlerService destinationDatasetHandlerService =
-            new DestinationDatasetHandlerService(jobState, canCleanUp, this.eventSubmitter)) {
-          workUnitStream = destinationDatasetHandlerService.executeHandlers(workUnitStream);
-        }
+        workUnitStream = closer.register(new DestinationDatasetHandlerService(jobState, canCleanUp, this.eventSubmitter))
+            .executeHandlers(workUnitStream);
 
         //Initialize writer and converter(s)
         closer.register(WriterInitializerFactory.newInstace(jobState, workUnitStream)).initialize();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1742


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
when DestinationDatasetHandlerService is created using try with resources, it immediately calls the close method on the handlers that does the cleanup. But we should wait till the job completes so that cleanup happen in the end.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes, kind of rollback of https://github.com/apache/gobblin/commit/4d991a9bd872a98bc52dda2ec366ad7d77847f9a#diff-873102512dd53692aefa05b778655ebe076b5afc268439b7ad906dc740bf9b24

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

