### PR TITLE
[GOBBLIN-1743] Ensure GobblinTaskRunner works without Yarn use

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -552,9 +552,10 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
               receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
           // Remove tag assignments for the current Helix instance from a previous run
           for (String tag : existedTags) {
-            if (!desiredTags.contains(tag))
+            if (!desiredTags.contains(tag)) {
               receiverManager.getClusterManagmentTool().removeInstanceTag(this.clusterName, this.helixInstanceName, tag);
-            logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
+            }
+              logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
           }
           desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
           logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -544,23 +544,24 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   private void addInstanceTags() {
     HelixManager receiverManager = getReceiverManager();
     if (receiverManager.isConnected()) {
-      // The helix instance associated with this container should be consistent on helix tag
-      List<String> existedTags = receiverManager.getClusterManagmentTool()
-          .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
-      Set<String> desiredTags = new HashSet<>(
-          ConfigUtils.getStringList(this.clusterConfig, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY));
-      if (!desiredTags.isEmpty()) {
-        // Remove tag assignments for the current Helix instance from a previous run
-        for (String tag : existedTags) {
-          if (!desiredTags.contains(tag))
-            receiverManager.getClusterManagmentTool().removeInstanceTag(this.clusterName, this.helixInstanceName, tag);
-          logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
+      try {
+        Set<String> desiredTags = new HashSet<>(ConfigUtils.getStringList(this.clusterConfig, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY));
+        if (!desiredTags.isEmpty()) {
+          // The helix instance associated with this container should be consistent on helix tag
+          List<String> existedTags =
+              receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
+          // Remove tag assignments for the current Helix instance from a previous run
+          for (String tag : existedTags) {
+            if (!desiredTags.contains(tag))
+              receiverManager.getClusterManagmentTool().removeInstanceTag(this.clusterName, this.helixInstanceName, tag);
+            logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
+          }
+          desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
+          logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
         }
-        desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool()
-            .addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
+      } catch (HelixException e) {
+        logger.warn("some error with helix get instance config that we're ignoring and moving on: {}", e);
       }
-      logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool()
-          .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
     }
   }
 
@@ -599,6 +600,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   private Optional<ContainerMetrics> buildContainerMetrics() {
     Properties properties = ConfigUtils.configToProperties(this.clusterConfig);
     if (GobblinMetrics.isEnabled(properties)) {
+      logger.info("Container metrics are enabled");
       return Optional.of(ContainerMetrics
           .get(ConfigUtils.configToState(clusterConfig), this.applicationName, this.taskRunnerId));
     } else {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -560,7 +560,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
           logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
         }
       } catch (HelixException e) {
-        logger.warn("some error with helix get instance config that we're ignoring and moving on: {}", e);
+        logger.warn("Error with Helix getting instance config tags used in YARN cluster configuration. Ensure YARN is being used. Will ignore and attempt to move on {}", e);
       }
     }
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -545,11 +545,12 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     HelixManager receiverManager = getReceiverManager();
     if (receiverManager.isConnected()) {
       try {
-        Set<String> desiredTags = new HashSet<>(ConfigUtils.getStringList(this.clusterConfig, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY));
+        Set<String> desiredTags = new HashSet<>(
+            ConfigUtils.getStringList(this.clusterConfig, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY));
         if (!desiredTags.isEmpty()) {
           // The helix instance associated with this container should be consistent on helix tag
-          List<String> existedTags =
-              receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
+          List<String> existedTags = receiverManager.getClusterManagmentTool()
+              .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
           // Remove tag assignments for the current Helix instance from a previous run
           for (String tag : existedTags) {
             if (!desiredTags.contains(tag)) {
@@ -558,7 +559,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
             }
           }
           desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
-          logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
+          logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool()
+              .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
         }
       } catch (HelixException e) {
         logger.warn("Error with Helix getting instance config tags used in YARN cluster configuration. Ensure YARN is being used. Will ignore and attempt to move on {}", e);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -554,8 +554,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
           for (String tag : existedTags) {
             if (!desiredTags.contains(tag)) {
               receiverManager.getClusterManagmentTool().removeInstanceTag(this.clusterName, this.helixInstanceName, tag);
-            }
               logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
+            }
           }
           desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
           logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -558,7 +558,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
               logger.info("Removed unrelated helix tag {} for instance {}", tag, this.helixInstanceName);
             }
           }
-          desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
+          desiredTags.forEach(desiredTag -> receiverManager.getClusterManagmentTool()
+              .addInstanceTag(this.clusterName, this.helixInstanceName, desiredTag));
           logger.info("Actual tags binding " + receiverManager.getClusterManagmentTool()
               .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
         }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1743 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
this PR https://github.com/apache/gobblin/pull/3519/files has a call to Helix cluster contained outside of a conditional that was previously never encountered for use cases without yarn. I moved the call back inside the conditional to ensure we don't attempt to retrieve an instanceConfig that is not registered with Helix as we don't have Yarn mode enabled. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

