### PR TITLE
[GOBBLIN-1749] Add dependency for handling xz-compressed Avro file

### DIFF
--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -57,6 +57,7 @@ dependencies {
   compile externalDependency.oltu
   compile externalDependency.opencsv
   compile externalDependency.hadoopHdfs
+  compile externalDependency.xz
   runtimeOnly externalDependency.protobuf
 
   testRuntime externalDependency.hadoopAws

--- a/gobblin-docs/sinks/AvroHdfsDataWriter.md
+++ b/gobblin-docs/sinks/AvroHdfsDataWriter.md
@@ -15,8 +15,8 @@ For more info, see [`AvroHdfsDataWriter`](https://github.com/apache/gobblin/sear
 # Configuration
 
 
-| Key | Type | Description | Default Value |
-|-----|------|-------------|---------------|
-| writer.codec.type | One of null,deflate,snappy,bzip2,xz | Type of the compression codec | deflate |
-| writer.deflate.level | 1-9 | The compression level for the "deflate" codec | 9 |
+| Key                  | Type                                          | Description                                   | Default Value |
+|----------------------|-----------------------------------------------|-----------------------------------------------|---------------|
+| writer.codec.type    | One of null,deflate,snappy,bzip2,xz,zstandard | Type of the compression codec                 | deflate       |
+| writer.deflate.level | 1-9                                           | The compression level for the "deflate" codec | 9             |
 

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -211,7 +211,8 @@ ext.externalDependency = [
     ],
     "postgresConnector": "org.postgresql:postgresql:42.1.4",
     "testContainers": "org.testcontainers:testcontainers:1.17.3",
-    "testContainersMysql": "org.testcontainers:mysql:1.17.3"
+    "testContainersMysql": "org.testcontainers:mysql:1.17.3",
+    "xz": "org.tukaani:xz:1.8"
 ]
 
 if (!isDefaultEnvironment)


### PR DESCRIPTION
* Add dependency on xz for handling xz-compressed Avro files

* Fix unit test to ensure all codecs are correctly supported

* Update AvroHdfsDataWriter's document for covering all compression codecs

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1749


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

After upgrading Avro to 1.9.2, reading and writing xz-compressed Avro file fails by default. This PR fixes it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I updated AvroHdfsDataWriterTest to ensure that all codecs are supported


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

