### PR TITLE
Fix the type of default values to match what Schema.parse() does.

### DIFF
--- a/gobblin-core-base/src/test/java/org/apache/gobblin/converter/filter/AvroSchemaFieldRemoverTest.java
+++ b/gobblin-core-base/src/test/java/org/apache/gobblin/converter/filter/AvroSchemaFieldRemoverTest.java
@@ -37,16 +37,16 @@ public class AvroSchemaFieldRemoverTest {
   public void testRemoveFields() throws IllegalArgumentException, IOException {
     Schema convertedSchema1 = convertSchema("/converter/recursive_schema_1.avsc", "YwchQiH.OjuzrLOtmqLW");
     Schema expectedSchema1 = parseSchema("/converter/recursive_schema_1_converted.avsc");
-    Assert.assertEquals(convertedSchema1.toString(), expectedSchema1.toString());
+    Assert.assertEquals(convertedSchema1, expectedSchema1);
 
     Schema convertedSchema2 =
         convertSchema("/converter/recursive_schema_2.avsc", "FBuKC.wIINqII.lvaerUEKxBQUWg,eFQjDj.TzuYZajb");
     Schema expectedSchema2 = parseSchema("/converter/recursive_schema_2_converted.avsc");
-    Assert.assertEquals(convertedSchema2.toString(), expectedSchema2.toString());
+    Assert.assertEquals(convertedSchema2, expectedSchema2);
 
     Schema convertedSchema3 = convertSchema("/converter/recursive_schema_2.avsc", "field.that.does.not.exist");
     Schema expectedSchema3 = parseSchema("/converter/recursive_schema_2_not_converted.avsc");
-    Assert.assertEquals(convertedSchema3.toString(), expectedSchema3.toString());
+    Assert.assertEquals(convertedSchema3, expectedSchema3);
   }
 
   private Schema parseSchema(String schemaFile) throws IOException {

--- a/gobblin-core-base/src/test/java/org/apache/gobblin/converter/filter/GobblinTrackingEventFlattenFilterConverterTest.java
+++ b/gobblin-core-base/src/test/java/org/apache/gobblin/converter/filter/GobblinTrackingEventFlattenFilterConverterTest.java
@@ -51,7 +51,7 @@ public class GobblinTrackingEventFlattenFilterConverterTest {
             + "{\"name\":\"namespace\",\"type\":[\"string\",\"null\"],\"doc\":\"Namespace used for filtering of events.\"},"
             + "{\"name\":\"name\",\"type\":\"string\",\"doc\":\"Event name.\"},{\"name\":\"field1\",\"type\":\"string\",\"doc\":\"\"},"
             + "{\"name\":\"field2\",\"type\":\"string\",\"doc\":\"\"}]}");
-    Assert.assertEquals(output.toString(), parsedSchema.toString());
+    Assert.assertEquals(output, parsedSchema);
 
     props.put(GobblinTrackingEventFlattenFilterConverter.class.getSimpleName() + "."
         + GobblinTrackingEventFlattenFilterConverter.FIELDS_RENAME_MAP, "name:eventName,field1:field3");
@@ -68,6 +68,6 @@ public class GobblinTrackingEventFlattenFilterConverterTest {
             + "{\"name\":\"namespace\",\"type\":[\"string\",\"null\"],\"doc\":\"Namespace used for filtering of events.\"},"
             + "{\"name\":\"eventName\",\"type\":\"string\",\"doc\":\"Event name.\"},{\"name\":\"field3\",\"type\":\"string\",\"doc\":\"\"},"
             + "{\"name\":\"field2\",\"type\":\"string\",\"doc\":\"\"}]}");
-    Assert.assertEquals(output2.toString(), parsedSchema.toString());
+    Assert.assertEquals(output2, parsedSchema);
   }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -1128,7 +1128,7 @@ public class AvroUtils {
   @Nullable
   public static Object getCompatibleDefaultValue(Schema.Field field) {
     return AvroCompatibilityHelper.fieldHasDefault(field)
-        ? AvroCompatibilityHelper.getGenericDefaultValue(field)
+        ? Schema.parseJsonToObject(AvroCompatibilityHelper.getDefaultValueAsJsonString(field))
         : null;
   }
 

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
@@ -114,7 +114,7 @@ public class AvroFlattenerTest {
 
     Schema originalSchema = readSchemaFromJsonFile("optionWithinOptionWithinRecord_original.json");
     Schema expectedSchema = readSchemaFromJsonFile("optionWithinOptionWithinRecord_flattened.json");
-    Assert.assertEquals(new AvroFlattener().flatten(originalSchema, false).toString(), expectedSchema.toString());
+    Assert.assertEquals(new AvroFlattener().flatten(originalSchema, false), expectedSchema);
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -150,7 +150,7 @@ public class AvroUtilsTest {
                 + "{\"name\": \"number\", \"type\": [\"null\", {\"type\": \"string\"}, {\"type\": \"array\", \"items\": \"string\"}], \"default\": null}]}"
                 + "]}");
 
-    Assert.assertEquals(expectedOutputSchema1.toString(), AvroUtils.nullifyFieldsForSchemaMerge(oldSchema1, newSchema1).toString());
+    Assert.assertEquals(expectedOutputSchema1, AvroUtils.nullifyFieldsForSchemaMerge(oldSchema1, newSchema1));
 
     Schema oldSchema2 =
         new Schema.Parser().parse("{\"type\":\"record\", \"name\":\"test\", " + "\"fields\":["
@@ -166,7 +166,7 @@ public class AvroUtilsTest {
             + "{\"name\": \"name\", \"type\": \"string\"}, "
             + "{\"name\": \"number\", \"type\": [\"null\", {\"type\": \"array\", \"items\": \"string\"}], \"default\": null}" + "]}");
 
-    Assert.assertEquals(expectedOutputSchema2.toString(), AvroUtils.nullifyFieldsForSchemaMerge(oldSchema2, newSchema2).toString());
+    Assert.assertEquals(expectedOutputSchema2, AvroUtils.nullifyFieldsForSchemaMerge(oldSchema2, newSchema2));
   }
 
   /**
@@ -194,7 +194,7 @@ public class AvroUtilsTest {
                 + "{\"name\": \"color\", \"type\": [\"null\", \"string\"], \"default\": null}, "
                 + "{\"name\": \"number\", \"type\": [\"null\", {\"type\": \"string\"}, {\"type\": \"array\", \"items\": \"string\"}], \"default\": null}]}"
                 + "]}");
-    Assert.assertEquals(expectedOutputSchema.toString(), AvroUtils.nullifyFieldsForSchemaMerge(oldSchema, newSchema).toString());
+    Assert.assertEquals(expectedOutputSchema, AvroUtils.nullifyFieldsForSchemaMerge(oldSchema, newSchema));
   }
 
   /**


### PR DESCRIPTION
When calling field.defaultVal() (or equivalent compat helper methods)
under Avro 1.9.2+, we get back a type that's not consistent with what
Schema.parse() creates internally. This causes two Schemas constructed
in these two different ways (Schema.parse vs Schema.createRecord) to
be considered unequal, even though their toString() representations
are identical.

Fix this situation by calling parseJsonToObject(), which results in
the default value being interpreted similar to Schema.parse().

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

