### PR TITLE
[GOBBLIN-1752] Fix race condition where FSTemplateCatalog would update at the same t…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -103,6 +103,7 @@ public class ServiceConfigKeys {
 
   // Template Catalog Keys
   public static final String TEMPLATE_CATALOGS_FULLY_QUALIFIED_PATH_KEY = GOBBLIN_SERVICE_PREFIX + "templateCatalogs.fullyQualifiedPath";
+  public static final String TEMPLATE_CATALOGS_CLASS_KEY = GOBBLIN_SERVICE_PREFIX + "templateCatalogs.class";
 
   // Keys related to user-specified policy on route selection.
   // Undesired connection to form an executable JobSpec.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.service.modules.flow;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
@@ -67,6 +67,7 @@ public class UpdatableFSFlowTemplateCatalog extends FSFlowTemplateCatalog {
 
     if (jobTemplates == null) {
       jobTemplates = super.getJobTemplatesForFlow(flowTemplateDirURI);
+      log.info("Loading flow template directly from {} and caching it.", flowTemplateDirURI);
       jobTemplateMap.put(flowTemplateDirURI, jobTemplates);
     }
 
@@ -78,7 +79,7 @@ public class UpdatableFSFlowTemplateCatalog extends FSFlowTemplateCatalog {
    */
   public void clearTemplates() {
     this.rwLock.writeLock().lock();
-    log.info("Change detected, reloading flow templates.");
+    log.info("Change detected, clearing flow template cache.");
     flowTemplateMap.clear();
     jobTemplateMap.clear();
     this.rwLock.writeLock().unlock();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
@@ -32,10 +32,15 @@ import org.apache.gobblin.runtime.api.JobTemplate;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
 import org.apache.gobblin.service.modules.template.FlowTemplate;
 
+/**
+ * {@link FSFlowTemplateCatalog} that keeps a cache of flow and job templates. It provides a public method clearTemplates()
+ * for other classes to invoke, so that other classes can reload the job templates before they make a change. E.g. The
+ * {@link org.apache.gobblin.service.monitoring.FsFlowGraphMonitor} has a configuration to clear the template cache before updating the flowgraph.
+ */
 public class UpdatableFSFlowTemplateCatalog extends FSFlowTemplateCatalog {
-  private Map<URI, FlowTemplate> flowTemplateMap = new ConcurrentHashMap<>();
-  private Map<URI, List<JobTemplate>> jobTemplateMap = new ConcurrentHashMap<>();
-  private ReadWriteLock rwLock;
+  private final Map<URI, FlowTemplate> flowTemplateMap = new ConcurrentHashMap<>();
+  private final Map<URI, List<JobTemplate>> jobTemplateMap = new ConcurrentHashMap<>();
+  private final ReadWriteLock rwLock;
 
   public UpdatableFSFlowTemplateCatalog(Config sysConfig, ReadWriteLock rwLock) throws IOException {
     super(sysConfig);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFlowTemplateCatalog.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.template_catalog;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+
+
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.runtime.api.JobTemplate;
+import org.apache.gobblin.runtime.api.SpecNotFoundException;
+import org.apache.gobblin.service.modules.template.FlowTemplate;
+
+public class UpdatableFSFlowTemplateCatalog extends FSFlowTemplateCatalog {
+  private Map<URI, FlowTemplate> flowTemplateMap = new ConcurrentHashMap<>();
+  private Map<URI, List<JobTemplate>> jobTemplateMap = new ConcurrentHashMap<>();
+  private ReadWriteLock rwLock;
+
+  public UpdatableFSFlowTemplateCatalog(Config sysConfig, ReadWriteLock rwLock) throws IOException {
+    super(sysConfig);
+    this.rwLock = rwLock;
+  }
+
+  @Override
+  public FlowTemplate getFlowTemplate(URI flowTemplateDirURI)
+      throws SpecNotFoundException, JobTemplate.TemplateException, IOException, URISyntaxException {
+    FlowTemplate flowTemplate = flowTemplateMap.getOrDefault(flowTemplateDirURI, null);
+
+    if (flowTemplate == null) {
+      flowTemplate = super.getFlowTemplate(flowTemplateDirURI);
+      flowTemplateMap.put(flowTemplateDirURI, flowTemplate);
+    }
+
+    return flowTemplate;
+  }
+
+  @Override
+  public List<JobTemplate> getJobTemplatesForFlow(URI flowTemplateDirURI)
+      throws IOException, SpecNotFoundException, JobTemplate.TemplateException, URISyntaxException {
+    List<JobTemplate> jobTemplates = jobTemplateMap.getOrDefault(flowTemplateDirURI, null);
+
+    if (jobTemplates == null) {
+      jobTemplates = super.getJobTemplatesForFlow(flowTemplateDirURI);
+      jobTemplateMap.put(flowTemplateDirURI, jobTemplates);
+    }
+
+    return jobTemplates;
+  }
+
+  /**
+   * Clear cached templates so they will be reloaded next time {@link #getFlowTemplate(URI)} is called.
+   */
+  public void clearTemplates() {
+    this.rwLock.writeLock().lock();
+    log.info("Change detected, reloading flow templates.");
+    flowTemplateMap.clear();
+    jobTemplateMap.clear();
+    this.rwLock.writeLock().unlock();
+  }
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
@@ -18,9 +18,7 @@
 package org.apache.gobblin.service.modules.template_catalog;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
@@ -31,20 +29,15 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Function;
 import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.runtime.api.JobTemplate;
-import org.apache.gobblin.runtime.api.SpecNotFoundException;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.template.FlowTemplate;
-import org.apache.gobblin.testing.AssertWithBackoff;
 
 
 @Slf4j
@@ -86,24 +79,7 @@ public class UpdatableFSFFlowTemplateCatalogTest {
     }
     java.nio.file.Files.write(flowConfPath, lines);
     catalog.clearTemplates();
-    Function testFunction = new GetFlowTemplateConfigFunction(new URI(FSFlowTemplateCatalogTest.TEST_TEMPLATE_DIR_URI), catalog,
-        "gobblin.flow.edge.input.dataset.descriptor.0.format");
-    AssertWithBackoff.create().timeoutMs(10000).assertEquals(testFunction, "any", "flow template updated");
-  }
-
-  @AllArgsConstructor
-  private class GetFlowTemplateConfigFunction implements Function<Void, String> {
-    private URI flowTemplateCatalogUri;
-    private FSFlowTemplateCatalog flowTemplateCatalog;
-    private String configKey;
-
-    @Override
-    public String apply(Void input) {
-      try {
-        return this.flowTemplateCatalog.getFlowTemplate(this.flowTemplateCatalogUri).getRawTemplateConfig().getString(this.configKey);
-      } catch (SpecNotFoundException | JobTemplate.TemplateException | IOException | URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
-    }
+    Assert.assertEquals(catalog.getFlowTemplate(new URI(FSFlowTemplateCatalogTest.TEST_TEMPLATE_DIR_URI)).
+            getRawTemplateConfig().getString("gobblin.flow.edge.input.dataset.descriptor.0.format"), "any");
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.template_catalog;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.ServiceManager;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.JobTemplate;
+import org.apache.gobblin.runtime.api.SpecNotFoundException;
+import org.apache.gobblin.service.ServiceConfigKeys;
+import org.apache.gobblin.service.modules.template.FlowTemplate;
+import org.apache.gobblin.testing.AssertWithBackoff;
+
+
+@Slf4j
+public class UpdatableFSFFlowTemplateCatalogTest {
+
+  private File templateDir;
+  private Config templateCatalogCfg;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    URI flowTemplateCatalogUri = this.getClass().getClassLoader().getResource("template_catalog").toURI();
+    this.templateDir = Files.createTempDir();
+    FileUtils.forceDeleteOnExit(templateDir);
+    FileUtils.copyDirectory(new File(flowTemplateCatalogUri.getPath()), templateDir);
+    Properties properties = new Properties();
+    properties.put(ServiceConfigKeys.TEMPLATE_CATALOGS_FULLY_QUALIFIED_PATH_KEY, templateDir.toURI().toString());
+    Config config = ConfigFactory.parseProperties(properties);
+    this.templateCatalogCfg = config.withValue(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY,
+        config.getValue(ServiceConfigKeys.TEMPLATE_CATALOGS_FULLY_QUALIFIED_PATH_KEY));
+  }
+
+  @Test
+  public void testModifyFlowTemplate() throws Exception {
+    UpdatableFSFlowTemplateCatalog catalog = new UpdatableFSFlowTemplateCatalog(this.templateCatalogCfg, new ReentrantReadWriteLock());
+
+    // Check cached flow template is returned
+    FlowTemplate flowTemplate1 = catalog.getFlowTemplate(new URI(FSFlowTemplateCatalogTest.TEST_TEMPLATE_DIR_URI));
+    FlowTemplate flowTemplate2 = catalog.getFlowTemplate(new URI(FSFlowTemplateCatalogTest.TEST_TEMPLATE_DIR_URI));
+    Assert.assertSame(flowTemplate1, flowTemplate2);
+
+    // Update a file flow catalog and check that the getFlowTemplate returns the new value
+    Path flowConfPath = new File(new File(this.templateDir, FSFlowTemplateCatalogTest.TEST_TEMPLATE_NAME), "flow.conf").toPath();
+    List<String> lines = java.nio.file.Files.readAllLines(flowConfPath);
+    for (int i = 0; i < lines.size(); i++) {
+      if (lines.get(i).equals("gobblin.flow.edge.input.dataset.descriptor.0.format=avro")) {
+        lines.set(i, "gobblin.flow.edge.input.dataset.descriptor.0.format=any");
+        break;
+      }
+    }
+    java.nio.file.Files.write(flowConfPath, lines);
+    catalog.clearTemplates();
+    Function testFunction = new GetFlowTemplateConfigFunction(new URI(FSFlowTemplateCatalogTest.TEST_TEMPLATE_DIR_URI), catalog,
+        "gobblin.flow.edge.input.dataset.descriptor.0.format");
+    AssertWithBackoff.create().timeoutMs(10000).assertEquals(testFunction, "any", "flow template updated");
+  }
+
+  @AllArgsConstructor
+  private class GetFlowTemplateConfigFunction implements Function<Void, String> {
+    private URI flowTemplateCatalogUri;
+    private FSFlowTemplateCatalog flowTemplateCatalog;
+    private String configKey;
+
+    @Override
+    public String apply(Void input) {
+      try {
+        return this.flowTemplateCatalog.getFlowTemplate(this.flowTemplateCatalogUri).getRawTemplateConfig().getString(this.configKey);
+      } catch (SpecNotFoundException | JobTemplate.TemplateException | IOException | URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/UpdatableFSFFlowTemplateCatalogTest.java
@@ -24,7 +24,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.commons.io.FileUtils;
@@ -33,9 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
-import com.google.common.util.concurrent.ServiceManager;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsFlowGraphMonitorTest.java
@@ -237,12 +237,13 @@ public class FsFlowGraphMonitorTest {
   public void testUpdateOnlyTemplates() throws Exception {
     Assert.assertEquals(this.flowGraph.get().getEdges("node1").size(), 1);
 
-    //If deleting all the templates, no edges should be able to be added
+    //If deleting all the templates, the cache of flow templates will be cleared and the flowgraph will be unable to add edges on reload.
     cleanUpDir(this.flowTemplateCatalogFolder.getAbsolutePath());
     Thread.sleep(3000);
     Assert.assertEquals(this.flowGraph.get().getEdges("node1").size(), 0);
 
     URI flowTemplateCatalogUri = this.getClass().getClassLoader().getResource("template_catalog").toURI();
+    // Adding the flowtemplates back will make the edges eligible to be added again on reload.
     FileUtils.copyDirectory(new File(flowTemplateCatalogUri.getPath()), this.flowTemplateCatalogFolder);
 
     Thread.sleep(3000);


### PR DESCRIPTION
…ime as the FSFlowGraph if their files are updated at the same time as the flowgraph monitor

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1752

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

`FSFlowGraphMonitor` and the `ObservingFsFlowTemplateCatalog` have a race condition if they are updated at the same time, the FSFlowGraphMonitor will not reload itself and can be put into a bad state where there are jobs or edges that are incomplete due to deleting the cache mid-update.

Instead, we should have `FSFlowGraphMonitor` control the updates to both the flowgraph and the templateCatalog through a configuration `gobblin.service.fsFlowGraphMonitor.monitorTemplateChanges`, which assumes that the templateCatalog is colocated with the flowgraph in the same parent folder.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

