### PR TITLE
[GOBBLIN-1761] Update Gobblin OSS Slack channel link to a never-expire link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The distribution will be created in build/gobblin-distribution/distributions dir
     * [Running Gobblin on Docker from your laptop](https://github.com/apache/gobblin/blob/master/gobblin-docs/user-guide/Docker-Integration.md)
     * [Getting started guide](https://gobblin.apache.org/docs/Getting-Started/)
     * [Gobblin architecture](https://gobblin.apache.org/docs/Gobblin-Architecture/)
-  * Community Slack: [Get your invite](https://join.slack.com/t/apache-gobblin/shared_invite/zt-1723tsdhd-ITcAEsaQNpQvuQUFOgfHbQ)
+  * Community Slack: [Get your invite](https://join.slack.com/t/apache-gobblin/shared_invite/zt-1bjgp38mq-ZLozP9rEic6Odvhxoqtbkg)
   * [List of companies known to use Gobblin](https://gobblin.apache.org/docs/Powered-By/) 
   * [Sample project](https://github.com/apache/gobblin/tree/master/gobblin-example)
   * [How to build Gobblin from source code](https://gobblin.apache.org/docs/user-guide/Building-Gobblin/)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX
Updates the slack invite link

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Updates the slack link. It should never expire this time.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

