### PR TITLE
[GOBBLIN-1770] Allow null values for fields in GaaSObservabilityEvent.Issue fields which are optional

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -153,16 +153,16 @@
               },
               {
                 "name": "details",
-                "type": "string",
-                "doc": "Human-readable issue details that can include exception stack trace and additional information about the problem."
+                "type": ["null","string"],
+                "doc": "Optional human-readable issue details that can include exception stack trace and additional information about the problem."
               },
               {
                 "name": "properties",
-                "type": {
+                "type": ["null", {
                   "type": "map",
                   "values": "string"
-                },
-                "doc": "Additional machine-readable properties of the issue.\n"
+                }],
+                "doc": "Optional additional machine-readable properties of the issue.\n"
               }
             ]
           }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -57,7 +57,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
   protected MetricContext metricContext;
   protected State state;
   protected MultiContextIssueRepository issueRepository;
-  boolean instrumentationEnabled;
+  protected boolean instrumentationEnabled;
   ContextAwareMeter getIssuesFailedMeter;
 
   public GaaSObservabilityEventProducer(State state, MultiContextIssueRepository issueRepository, boolean instrumentationEnabled) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -32,6 +32,9 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metrics.GaaSObservabilityEventExperimental;
 import org.apache.gobblin.metrics.JobStatus;
 import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.metrics.reporter.util.AvroBinarySerializer;
+import org.apache.gobblin.metrics.reporter.util.AvroSerializer;
+import org.apache.gobblin.metrics.reporter.util.NoopSchemaVersionWriter;
 import org.apache.gobblin.runtime.troubleshooter.InMemoryMultiContextIssueRepository;
 import org.apache.gobblin.runtime.troubleshooter.Issue;
 import org.apache.gobblin.runtime.troubleshooter.IssueSeverity;
@@ -82,6 +85,11 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getJobStatus(), JobStatus.SUCCEEDED);
     Assert.assertEquals(event.getExecutorUrl(), "hostName");
     Assert.assertEquals(event.getIssues().size(), 1);
+
+    AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
+        GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()
+    );
+    serializer.serializeRecord(event);
   }
 
   private Issue createTestIssue(String summary, String code, IssueSeverity severity) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1770


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When looking into the IssueRepository before the creation of GaaSObservabilityEvents, many issues do not populate their fields for details and summary. This is because the Issue details are composed of a stack trace, but since Issues can be composed of warn/error logs and stack traces, it is not guaranteed that every issue has a corresponding stack trace.

However, from investigation it looks like the automated troubleshooter will always populate the issue severity, code, and summary.

This PR accounts for this when creating a GaaSObservabilityEvent by modifying the schema to allow both null and String/Map values.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The unit test will take the generate the event and attempt to serialize this against the schema. Previously, this would fail with a `NullPointerException`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

