### PR TITLE
[GOBBLIN-1771] Clean up logs for dataset commit and file cleanup

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -319,7 +319,7 @@ final class SafeDatasetCommit implements Callable<Void> {
         datasetState.setState(JobState.RunningState.FAILED);
         datasetState.incrementJobFailures();
         Optional<String> taskStateException = taskState.getTaskFailureException();
-        log.warn("At least one task did not committed successfully. Setting dataset state to FAILED. "
+        log.warn("At least one task did not get committed successfully. Setting dataset state to FAILED. "
             + (taskStateException.isPresent() ? taskStateException.get() : "Exception not set."));
         return;
       }
@@ -396,11 +396,11 @@ final class SafeDatasetCommit implements Callable<Void> {
           // 2. Otherwise, the processing of the dataset is considered successful even if some tasks for the
           //    dataset failed to be committed.
           datasetState.setState(JobState.RunningState.FAILED);
-          String taskStateException = taskState.getTaskFailureException().isPresent() ? taskState.getTaskFailureException().get() : "Could not get exception.";
+          String taskStateException = taskState.getTaskFailureException().isPresent() ? taskState.getTaskFailureException().get() : "Exception not set.";
           // Only print out the unique exceptions to avoid needless logging duplication on large datasets
-          if (taskErrors.contains(taskStateException)) {
+          if (!taskErrors.contains(taskStateException)) {
             taskErrors.add(taskStateException);
-            log.warn("At least one task in {} did not committed successfully. Setting dataset state to FAILED. {}", datasetUrn,
+            log.warn("At least one task in {} did not get committed successfully. Setting dataset state to FAILED. {}", datasetUrn,
                 taskStateException);
           }
         }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/JobLauncherUtils.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -40,6 +38,8 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
@@ -144,7 +144,7 @@ public class JobLauncherUtils {
     HadoopUtils.deletePath(fs, jobStagingPath, true);
 
     if (fs.exists(jobStagingPath.getParent()) && fs.listStatus(jobStagingPath.getParent()).length == 0) {
-      logger.info("Deleting directory " + jobStagingPath.getParent());
+      logger.debug("Deleting directory " + jobStagingPath.getParent());
       HadoopUtils.deletePath(fs, jobStagingPath.getParent(), true);
     }
 
@@ -153,14 +153,14 @@ public class JobLauncherUtils {
     HadoopUtils.deletePath(fs, jobOutputPath, true);
 
     if (fs.exists(jobOutputPath.getParent()) && fs.listStatus(jobOutputPath.getParent()).length == 0) {
-      logger.info("Deleting directory " + jobOutputPath.getParent());
+      logger.debug("Deleting directory " + jobOutputPath.getParent());
       HadoopUtils.deletePath(fs, jobOutputPath.getParent(), true);
     }
 
     if (state.contains(ConfigurationKeys.ROW_LEVEL_ERR_FILE)) {
       if (state.getPropAsBoolean(ConfigurationKeys.CLEAN_ERR_DIR, ConfigurationKeys.DEFAULT_CLEAN_ERR_DIR)) {
         Path jobErrPath = new Path(state.getProp(ConfigurationKeys.ROW_LEVEL_ERR_FILE));
-        log.info("Cleaning up err directory : " + jobErrPath);
+        log.debug("Cleaning up err directory : " + jobErrPath);
         HadoopUtils.deleteIfExists(fs, jobErrPath, true);
       }
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1771


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Large datasets (multiple terabytes), depending on their jobs, can send a large number of repetitive logs for failing dataset states and cleaning up the dataset state.

For failed dataset states, this PR will only print the unique exceptions for each taskState, and not log repeated errors for each workunit on the errors in the taskstate.

When cleaning up the writer directories, we also can just log when we are deleting the parent directories, not necessarily each subdirectory which can be a large number. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

