### PR TITLE
[GOBBLIN-1775] GMIP Hive metadatawriter should gracefully fail

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -284,7 +284,19 @@ public class HiveMetadataWriter implements MetadataWriter {
     updateLatestSchemaMapWithExistingSchema(dbName, tableName, tableKey, useExistingTableSchemaAllowDenyList, hiveRegister, latestSchemaMap);
   }
 
-  // returns if latest schema map was updated with the existing schema in Hive
+
+  /**
+   * Helper method for updating the schema map with the latest existing schema from Hive if necessary
+   *
+   * @param dbName Hive DB name
+   * @param tableName Hive table name
+   * @param tableKey table key for the latest schema map
+   * @param useExistingTableSchemaAllowDenyList list of topics that should always use the latest existing schema in hive
+   * @param hiveRegister hive register for getting table info
+   * @param latestSchemaMap map containing the latest schema for all topics since last flush
+   * @return true if latest schema map was updated with the existing schema in Hive
+   * @throws IOException
+   */
   @VisibleForTesting
   protected static boolean updateLatestSchemaMapWithExistingSchema(String dbName, String tableName, String tableKey,
       WhitelistBlacklist useExistingTableSchemaAllowDenyList, HiveRegister hiveRegister,

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -351,7 +351,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
    * </ul>
    */
   @Test
-  public void  testUpdateLatestSchemaWithExistingSchema() throws IOException {
+  public void testUpdateLatestSchemaWithExistingSchema() throws IOException {
     final String tableNameAllowed = "tableAllowed";
     final String tableNameDenied = "tableDenied";
     final WhitelistBlacklist useExistingTableSchemaAllowDenyList = new WhitelistBlacklist(
@@ -374,6 +374,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
 
 
     // Tables part of deny list, schema only fetched from hive on the first time and the all future calls will use the cache
+    Assert.assertTrue(updateLatestSchema.apply(tableNameDenied));
     Assert.assertFalse(updateLatestSchema.apply(tableNameDenied));
     Assert.assertEquals(latestSchemaMap, ImmutableMap.of(
         getTableKey.apply(tableNameDenied), avroSchema
@@ -404,9 +405,12 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
   }
 
   /**
-   * Test class for exposing methods for exposing internal HiveMetaWriter functions without making them public.
+   * Test class for exposing internal {@link HiveMetadataWriter} functions without making them public.
    * Although the ultimate fix would be to break up the logic in the hive metadata writer into smaller pieces,
-   * this a stop gap way to make testing internal logic easier
+   * this a stop gap way to make testing internal logic easier.
+   *
+   * This approach was taken because the writer lives in a separate module from this test class, and dependencies make
+   * putting the test and implementation classes in the same module difficult
    */
   public static class TestHiveMetadataWriter extends HiveMetadataWriter {
     public TestHiveMetadataWriter(State state) throws IOException {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -47,6 +47,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.mockito.Mockito;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -79,7 +80,6 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaStreamingExtractor
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;
-import org.mockito.Mockito;
 
 
 public class HiveMetadataWriterTest extends HiveMetastoreTest {
@@ -182,6 +182,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
     state.setProp("gmce.metadata.writer.classes", "org.apache.gobblin.hive.writer.HiveMetadataWriter");
     gobblinMCEWriter = new GobblinMCEWriter(new GobblinMCEWriterBuilder(), state);
   }
+
   @Test
   public void testHiveWriteAddFileGMCE() throws IOException {
     gobblinMCEWriter.writeEnvelope(new RecordEnvelope<>(gmce,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1775] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1775


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

**Problem Statement:**
The way GMIP handles Hive has 2 issues:
1. `drop_file` GMCE creates a table even if it does not already currently exist. 
2. Schema issues when creating tables throws an exception and the running container fails. Upon restart, the container will resume from the same watermark and the container will again face an exception. (i.e. when there are schema issues they should be skipped over instead of aborted). These GMCE's are not possible to process, causing indefinite starvation

Other changes:
- The `HiveMetadataWriter#write` method is a bit hard to read and [mixes layers of abstraction](http://principles-wiki.net/principles:single_level_of_abstraction). I've extracted some of the different methods and added comments above methods that had subtle significance. I'm not entirely happy with the way the function looks, but I think this is an improvement from before

**Solution:**
```
ERROR [HiveMetadataWriter] Failed to create table. Skipping this event
java.io.IOException: Error in creating or altering Hive table testTable in db dbWhichDoesNotExist
	at org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister.createTableIfNotExists(HiveMetaStoreBasedRegister.java:469)
	at org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister.createTableIfNotExists(HiveMetaStoreBasedRegister.java:414)
	at org.apache.gobblin.hive.writer.HiveMetadataWriter.createTable(HiveMetadataWriter.java:252)
	at org.apache.gobblin.hive.writer.HiveMetadataWriter.write(HiveMetadataWriter.java:207)
```
### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://user-images.githubusercontent.com/35702680/217352903-ff851817-d2cd-48b8-885b-612a97ef0e29.png)



### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    4. Subject does not end with a period
    5. Subject uses the imperative mood ("add", not "adding")
    6. Body wraps at 72 characters
    7. Body explains "what" and "why", not "how"

