### PR TITLE
[GOBBLIN-1778] Add house keeping thread in DagManager to periodically sync in memory state with mysql table

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/InnerMetricContext.java
@@ -299,7 +299,7 @@ public class InnerMetricContext extends MetricRegistry implements ReportableCont
   @Override
   public synchronized boolean remove(String name) {
     MetricContext metricContext = this.metricContext.get();
-    if (metricContext != null) {
+    if (metricContext != null && this.contextAwareMetrics.get(name) != null) {
       metricContext.removeFromMetrics(this.contextAwareMetrics.get(name).getContextAwareMetric());
     }
     return this.contextAwareMetrics.remove(name) != null && removeChildrenMetrics(name);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -188,6 +188,9 @@ public class DagManager extends AbstractIdleService {
   private final boolean instrumentationEnabled;
   private DagStateStore dagStateStore;
   private Map<URI, TopologySpec> topologySpecMap;
+  private int houseKeepingThreadInitialDelay = 2;
+  @Getter
+  private ScheduledExecutorService houseKeepingThreadPool;
 
   @Getter
   private final Integer numThreads;
@@ -272,6 +275,9 @@ public class DagManager extends AbstractIdleService {
    * @param setStatus if true, set all jobs in the dag to pending
    */
   synchronized void addDag(Dag<JobExecutionPlan> dag, boolean persist, boolean setStatus) throws IOException {
+    if (!this.isActive) {
+      return;
+    }
     if (persist) {
       //Persist the dag
       this.dagStateStore.writeCheckpoint(dag);
@@ -388,7 +394,7 @@ public class DagManager extends AbstractIdleService {
                 topologySpecMap);
         Set<String> failedDagIds = Collections.synchronizedSet(failedDagStateStore.getDagIds());
 
-       this.dagManagerMetrics.activate();
+        this.dagManagerMetrics.activate();
 
         UserQuotaManager quotaManager = GobblinConstructorUtils.invokeConstructor(UserQuotaManager.class,
             ConfigUtils.getString(config, ServiceConfigKeys.QUOTA_MANAGER_CLASS, ServiceConfigKeys.DEFAULT_QUOTA_MANAGER), config);
@@ -405,10 +411,15 @@ public class DagManager extends AbstractIdleService {
         }
         FailedDagRetentionThread failedDagRetentionThread = new FailedDagRetentionThread(failedDagStateStore, failedDagIds, failedDagRetentionTime);
         this.scheduledExecutorPool.scheduleAtFixedRate(failedDagRetentionThread, 0, retentionPollingInterval, TimeUnit.MINUTES);
-        List<Dag<JobExecutionPlan>> dags = dagStateStore.getDags();
-        log.info("Loading " + dags.size() + " dags from dag state store");
-        for (Dag<JobExecutionPlan> dag : dags) {
-          addDag(dag, false, false);
+        loadingDagsFromDagStateStore();
+        this.houseKeepingThreadPool = Executors.newSingleThreadScheduledExecutor();
+        for (int delay = houseKeepingThreadInitialDelay; delay < 180; delay *= 2) {
+          this.houseKeepingThreadPool.schedule(() -> {
+            try {
+              loadingDagsFromDagStateStore();
+            } catch (Exception e ) {
+              log.error("failed to sync dag state store due to ", e);
+            }}, delay, TimeUnit.MINUTES);
         }
         if (dagActionStore.isPresent()) {
           Collection<DagActionStore.DagAction> dagActions = dagActionStore.get().getDagActions();
@@ -429,6 +440,7 @@ public class DagManager extends AbstractIdleService {
         log.info("Inactivating the DagManager. Shutting down all DagManager threads");
         this.scheduledExecutorPool.shutdown();
         this.dagManagerMetrics.cleanup();
+        this.houseKeepingThreadPool.shutdown();
         try {
           this.scheduledExecutorPool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -438,6 +450,14 @@ public class DagManager extends AbstractIdleService {
     } catch (IOException e) {
       log.error("Exception encountered when activating the new DagManager", e);
       throw new RuntimeException(e);
+    }
+  }
+
+  private void loadingDagsFromDagStateStore() throws IOException {
+    List<Dag<JobExecutionPlan>> dags = dagStateStore.getDags();
+    log.info("Loading " + dags.size() + " dags from dag state store");
+    for (Dag<JobExecutionPlan> dag : dags) {
+      addDag(dag, false, false);
     }
   }
 
@@ -789,10 +809,10 @@ public class DagManager extends AbstractIdleService {
             submitJob(node);
           }
         } catch (Exception e) {
-            // Error occurred while processing dag, continue processing other dags assigned to this thread
-            log.error(String.format("Exception caught in DagManager while processing dag %s due to ",
-                DagManagerUtils.getFullyQualifiedDagName(node)), e);
-          }
+          // Error occurred while processing dag, continue processing other dags assigned to this thread
+          log.error(String.format("Exception caught in DagManager while processing dag %s due to ",
+              DagManagerUtils.getFullyQualifiedDagName(node)), e);
+        }
       }
 
       for (Map.Entry<String, Set<DagNode<JobExecutionPlan>>> entry: nextSubmitted.entrySet()) {
@@ -1170,11 +1190,11 @@ public class DagManager extends AbstractIdleService {
       log.info("Cleaning up dagId {}", dagId);
       // clears flow event after cancelled job to allow resume event status to be set
       this.dags.get(dagId).setFlowEvent(null);
-       try {
-         this.dagStateStore.cleanUp(dags.get(dagId));
-       } catch (IOException ioe) {
-         log.error(String.format("Failed to clean %s from backStore due to:", dagId), ioe);
-       }
+      try {
+        this.dagStateStore.cleanUp(dags.get(dagId));
+      } catch (IOException ioe) {
+        log.error(String.format("Failed to clean %s from backStore due to:", dagId), ioe);
+      }
       this.dags.remove(dagId);
       this.dagToJobs.remove(dagId);
     }
@@ -1222,7 +1242,7 @@ public class DagManager extends AbstractIdleService {
           }
         }
 
-      log.info("Cleaned " + numCleaned + " dags from the failed dag state store");
+        log.info("Cleaned " + numCleaned + " dags from the failed dag state store");
       } catch (Exception e) {
         log.error("Failed to run retention on failed dag state store", e);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
@@ -244,8 +244,11 @@ public class DagManagerMetrics {
   }
 
   public void cleanup() {
-    // The DMThread's metrics mappings follow the lifecycle of the DMThread itself and so are lost by DM deactivation-reactivation but the RootMetricContext is a (persistent) singleton.
-    // To avoid IllegalArgumentException by the RMC preventing (re-)add of a metric already known, remove all metrics that a new DMThread thread would attempt to add (in DagManagerThread::initialize) whenever running post-re-enablement
-    RootMetricContext.get().removeMatching(getMetricsFilterForDagManager());
+    // Add null check so that unit test will not affect each other when we de-active non-instrumented DagManager
+    if(this.metricContext != null) {
+      // The DMThread's metrics mappings follow the lifecycle of the DMThread itself and so are lost by DM deactivation-reactivation but the RootMetricContext is a (persistent) singleton.
+      // To avoid IllegalArgumentException by the RMC preventing (re-)add of a metric already known, remove all metrics that a new DMThread thread would attempt to add (in DagManagerThread::initialize) whenever running post-re-enablement
+      RootMetricContext.get().removeMatching(getMetricsFilterForDagManager());
+    }
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -33,6 +33,7 @@ import org.apache.gobblin.runtime.api.DagActionStore;
 import org.apache.gobblin.runtime.dag_action_store.MysqlDagActionStore;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -95,6 +96,12 @@ public class DagManagerFlowTest {
     Thread.sleep(10000);
     // On active, should proceed request and delete action entry
     Assert.assertEquals(dagActionStore.getDagActions().size(), 0);
+  }
+
+  @AfterClass
+  public void cleanUp() throws Exception {
+    dagManager.setActive(false);
+    Assert.assertEquals(dagManager.getHouseKeepingThreadPool().isShutdown(), true);
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1778


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Now dag managers have the assumption that it is the only process that can update mysql table and the in-memory state is always in sync with mysql. But we do notice that during the leader transforms period, it's possible that two dag manager can run concurrently and update the mysql db at the same time. 

To address that, we need either add a lock to make sure only one dag manager is working at one time, or we need to have a housekeeping thread to periodically sync the in-memory state with the mysql table. After discussion, we choose to go with the later approach and we do have the assumption that GaaS submit jobs without specifying job.id, so jobs with same flow execution id will not share the staging dir and can be executed concurrently. 

Besides that, during adding test, I figure out there will be NPE if we try to set the dag manager as inactive, add a small fix for that as well. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just add a single thread for housekeeping so will not affect other functions. Also add unit test to make sure we close the thread when de-active DagManager to avoid memory leak 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

