### PR TITLE
[GOBBLIN-1780] Refactor/rename YarnServiceIT to YarnServiceTest

### DIFF
--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
@@ -78,8 +78,8 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  * Tests for {@link YarnService}.
  */
 @Test(groups = {"gobblin.yarn", "disabledOnCI"}, singleThreaded=true)
-public class YarnServiceTest {
-  final Logger LOG = LoggerFactory.getLogger(YarnServiceTest.class);
+public class YarnServiceIT {
+  final Logger LOG = LoggerFactory.getLogger(YarnServiceIT.class);
 
   private YarnClient yarnClient;
   private MiniYARNCluster yarnCluster;
@@ -134,8 +134,8 @@ public class YarnServiceTest {
     this.yarnClient.init(this.clusterConf);
     this.yarnClient.start();
 
-    URL url = YarnServiceTest.class.getClassLoader()
-        .getResource(YarnServiceTest.class.getSimpleName() + ".conf");
+    URL url = YarnServiceIT.class.getClassLoader()
+        .getResource(YarnServiceIT.class.getSimpleName() + ".conf");
     Assert.assertNotNull(url, "Could not find resource " + url);
 
     this.config = ConfigFactory.parseURL(url).resolve();

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
@@ -88,7 +88,7 @@ public class YarnServiceIT {
   private YarnConfiguration clusterConf;
   private ApplicationId applicationId;
   private ApplicationAttemptId applicationAttemptId;
-  private final EventBus eventBus = new EventBus("YarnServiceTest");
+  private final EventBus eventBus = new EventBus("YarnServiceIT");
 
   private final Closer closer = Closer.create();
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
@@ -75,7 +75,7 @@ public class YarnServiceTestWithExpiration {
   private YarnConfiguration clusterConf;
   private ApplicationId applicationId;
   private ApplicationAttemptId applicationAttemptId;
-  private final EventBus eventBus = new EventBus("YarnServiceTest");
+  private final EventBus eventBus = new EventBus("YarnServiceIT");
 
   private final Closer closer = Closer.create();
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTestWithExpiration.java
@@ -66,7 +66,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  */
 @Test(groups = {"gobblin.yarn", "disabledOnCI"})
 public class YarnServiceTestWithExpiration {
-  final Logger LOG = LoggerFactory.getLogger(YarnServiceTest.class);
+  final Logger LOG = LoggerFactory.getLogger(YarnServiceIT.class);
 
   private YarnClient yarnClient;
   private MiniYARNCluster yarnCluster;
@@ -122,8 +122,8 @@ public class YarnServiceTestWithExpiration {
     this.yarnClient.init(this.clusterConf);
     this.yarnClient.start();
 
-    URL url = YarnServiceTest.class.getClassLoader()
-        .getResource(YarnServiceTest.class.getSimpleName() + ".conf");
+    URL url = YarnServiceIT.class.getClassLoader()
+        .getResource(YarnServiceIT.class.getSimpleName() + ".conf");
     Assert.assertNotNull(url, "Could not find resource " + url);
 
     this.config = ConfigFactory.parseURL(url).resolve();
@@ -215,7 +215,7 @@ public class YarnServiceTestWithExpiration {
 
   }
 
-  private static class TestExpiredYarnService extends YarnServiceTest.TestYarnService {
+  private static class TestExpiredYarnService extends YarnServiceIT.TestYarnService {
     public HashSet<ContainerId> startErrorContainers = new HashSet<>();
     public HashSet<ContainerStatus> completedContainers = new HashSet<>();
     public TestExpiredYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,

--- a/gobblin-yarn/src/test/resources/YarnServiceIT.conf
+++ b/gobblin-yarn/src/test/resources/YarnServiceIT.conf
@@ -16,10 +16,10 @@
 #
 
 # Yarn/Helix configuration properties
-gobblin.cluster.helix.cluster.name=YarnServiceTest
+gobblin.cluster.helix.cluster.name=YarnServiceIT
 gobblin.cluster.helixInstanceTags=GobblinKafkaStreaming
-gobblin.yarn.app.name=YarnServiceTest
-gobblin.yarn.work.dir=YarnServiceTest
+gobblin.yarn.app.name=YarnServiceIT
+gobblin.yarn.work.dir=YarnServiceIT
 
 gobblin.yarn.lib.jars.dir="build/gobblin-yarn/libs"
 gobblin.yarn.conf.dir="gobblin-yarn/src/test/resources"


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

This renaming is done as YarnServiceTest currently is disabled on CI testing. We would like to add unit tests in this file that are run during CI, but this requires removing some components. This rename is so we don't override YarnServiceTest Git history, simply a rename to YarnServiceIT. After renaming the tests to YarnServiceIT, there will be another PR that has a new file of the original name (YarnServiceTest.java) will be created, new unit tests will be created there, and those new tests will run in CI testing.

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1780


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

