### PR TITLE
[GOBBLIN-1782] Fix Merge State for Flow Pending Resume statuses

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -253,18 +253,15 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
         int currentAttempts = jobStatus.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, previousAttempts);
         // Verify if the current job status is flow status. If yes, we check for its current execution status to be PENDING_RESUME (limiting to just resume flow statuses)
         // When the above two conditions satisfy, we NEED NOT check for the out-of-order events since GaaS would manage the lifecycle of these events
-        // Hence, we update the merge state so that the flow can proceed with its execution
-        if (jobName != null && jobGroup != null
-            && jobName.equals(JobStatusRetriever.NA_KEY) && jobGroup.equals(JobStatusRetriever.NA_KEY) && currentStatus.equals(ExecutionStatus.PENDING_RESUME.name())) {
-          jobStatus = mergeState(jobStatus, states.get(states.size() - 1));
-        }
+        // Hence, we update the merge state accordingly so that the flow can proceed with its execution to the next state in the DAG
+        boolean isFlowStatusAndPendingResume = isFlowStatusAndPendingResume(jobName, jobGroup, currentStatus);
         // We use three things to accurately count and thereby bound retries, even amidst out-of-order events (by skipping late arrivals).
         // The generation is monotonically increasing, while the attempts may re-initialize back to 0. this two-part form prevents the composite value from ever repeating.
         // And job status reflect the execution status in one attempt
-        else if (previousStatus != null && currentStatus != null && (previousGeneration > currentGeneration || (
+         if (!isFlowStatusAndPendingResume && (previousStatus != null && currentStatus != null && (previousGeneration > currentGeneration || (
             previousGeneration == currentGeneration && previousAttempts > currentAttempts) || (previousGeneration == currentGeneration && previousAttempts == currentAttempts
             && ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(currentStatus))
-            < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus))))) {
+            < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus)))))) {
           log.warn(String.format(
               "Received status [generation.attempts] = %s [%s.%s] when already %s [%s.%s] for flow (%s, %s, %s), job (%s, %s)",
               currentStatus, currentGeneration, currentAttempts, previousStatus, previousGeneration, previousAttempts,
@@ -285,6 +282,11 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
           + e.getStackTrace()[0].getClassName() + "line number: " + e.getStackTrace()[0].getLineNumber(), e);
       throw new IOException(e);
     }
+  }
+
+  private static boolean isFlowStatusAndPendingResume(String jobName, String jobGroup, String currentStatus) {
+    return jobName != null && jobGroup != null && jobName.equals(JobStatusRetriever.NA_KEY) && jobGroup.equals(JobStatusRetriever.NA_KEY)
+        && currentStatus.equals(ExecutionStatus.PENDING_RESUME.name());
   }
 
   private static void modifyStateIfRetryRequired(org.apache.gobblin.configuration.State state) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX
    - https://issues.apache.org/jira/browse/GOBBLIN-1782


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- [ ] Flow statuses in pending_resume state were not getting executed since we incorrectly update the merge state for such flows
- [ ] Thus, we now detect such flows and update their merge state so that they can proceed to their next state in the DAG


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] Added unit test for the fix


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

