### PR TITLE
[GOBBLIN-1783] Initialize scheduler with batch gets instead of individual get per flow

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -89,6 +89,8 @@ public class ConfigurationKeys {
   // Job retriggering
   public static final String JOB_RETRIGGERING_ENABLED = "job.retriggering.enabled";
   public static final String DEFAULT_JOB_RETRIGGERING_ENABLED = "true";
+  public static final String LOAD_SPEC_BATCH_SIZE = "load.spec.batch.size";
+  public static final int DEFAULT_LOAD_SPEC_BATCH_SIZE = 100;
 
   // Job executor thread pool size
   public static final String JOB_EXECUTOR_THREAD_POOL_SIZE_KEY = "jobexecutor.threadpool.size";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/InstrumentedSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/InstrumentedSpecStore.java
@@ -93,7 +93,6 @@ public abstract class InstrumentedSpecStore implements SpecStore {
   private OptionallyTimingInvoker getSizeTimer;
   private OptionallyTimingInvoker getURIsTimer;
   private OptionallyTimingInvoker getURIsWithTagTimer;
-  // TODO: do i need to do anything else before adding this timer?
   private OptionallyTimingInvoker getSortedURIsTimer;
   private OptionallyTimingInvoker getBatchedSpecsTimer;
   private MetricContext metricContext;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/InstrumentedSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/InstrumentedSpecStore.java
@@ -208,7 +208,7 @@ public abstract class InstrumentedSpecStore implements SpecStore {
   public abstract Collection<Spec> getSpecsImpl() throws IOException;
   public abstract Iterator<URI> getSpecURIsImpl() throws IOException;
   public abstract Iterator<URI> getSpecURIsWithTagImpl(String tag) throws IOException;
-  public abstract <T> T getSortedSpecURIsImpl() throws IOException;
+  public abstract List<URI> getSortedSpecURIsImpl() throws IOException;
   public abstract Iterator<Spec> getBatchedSpecsImpl(URI startSpecUri, int batchSize) throws IOException;
   public abstract int getSizeImpl() throws IOException;
   public abstract Collection<Spec> getSpecsImpl(int start, int count) throws IOException;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecStore.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.base.Optional;
 
@@ -104,6 +105,16 @@ public interface SpecStore {
   Collection<Spec> getSpecs(SpecSearchObject specSearchObject) throws IOException;
 
   /***
+   * Retrieve a batch of {@link Spec}s of at most size batchSize using the maxSpecUri {@link URI} to dilineate the
+   * starting point of the specs to retrieve. Note that this assumes that the URI is an unique identifier key of the
+   * table.
+   * @param startSpecUri starting value to batch the specs returned from
+   * @param batchSize max number of specs returned in the batch
+   * @throws IOException Exception in retrieving the {@link Spec}
+   */
+  Iterator<Spec> getBatchedSpecs(URI startSpecUri, int batchSize) throws IOException;
+
+  /***
    * Retrieve specified version of the {@link Spec} by URI from the {@link SpecStore}.
    * @param specUri URI for the {@link Spec} to be retrieved.
    * @param version Version for the {@link Spec} to be retrieved.
@@ -148,6 +159,11 @@ public interface SpecStore {
    *
    */
   Iterator<URI> getSpecURIsWithTag(String tag) throws IOException;
+
+  /**
+   * Return a sorted list of Spec URIs in ascending order.
+   */
+  List<URI> getSortedSpecURIs() throws IOException;
 
   /**
    * @return A URI to identify the SpecStore itself.

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -54,6 +54,9 @@ public class RuntimeMetrics {
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_QUOTA_REQUESTS_EXCEEDED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.quotaRequests.exceeded";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_TIME_TO_CHECK_QUOTA = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.time.to.check.quota";
 
+  public static final String GOBBLIN_JOB_SCHEDULER_AVERAGE_GET_SPEC_SPEED_WHILE_LOADING_ALL_SPECS_MILLIS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".jobScheduler.average.get.spec.speed.while.loading.all.specs.millis";
+  public static final String GOBBLIN_JOB_SCHEDULER_LOAD_SPECS_BATCH_SIZE = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".load.spec.batch.size";
+  public static final String GOBBLIN_JOB_SCHEDULER_TIME_TO_INITIALIZE_SCHEDULER_MILLIS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "time.to.initialize.scheduler.millis";
   // Metadata keys
   public static final String TOPIC = "topic";
   public static final String GROUP_ID = "groupId";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -254,6 +254,10 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
     return specStore.getSpecURIsWithTag(tag);
   }
 
+  public List<URI> getSortedSpecURIS() throws IOException {
+    return specStore.getSortedSpecURIs();
+  }
+
   /**
    * Get all specs from {@link SpecStore}
    * Not suggested for {@link FlowCatalog} where the total amount of space that all {@link FlowSpec}s occupied
@@ -268,6 +272,10 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
     } catch (IOException e) {
       throw new RuntimeException("Cannot retrieve Specs from Spec store", e);
     }
+  }
+
+  public Iterator<Spec> getBatchedSpecs(URI maxSpecURI, int batchSize) throws IOException {
+    return specStore.getBatchedSpecs(maxSpecURI, batchSize);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/FSSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/FSSpecStore.java
@@ -272,6 +272,18 @@ public class FSSpecStore extends InstrumentedSpecStore {
     throw new UnsupportedOperationException("Loading specs with tag is not supported in FS-Implementation of SpecStore");
   }
 
+  // TODO: do these make sense to be implemented for FSSpecStore?
+  @Override
+  public <T> T getSortedSpecURIsImpl() throws IOException {
+    throw new UnsupportedOperationException("Loading sorted spec uris is not supported in FS-Implementation of SpecStore");
+  }
+
+  @Override
+  public Iterator<Spec> getBatchedSpecsImpl(URI startSpecUri, int batchSize) throws IOException {
+    // get specs implementation sort and then return from maxSpecURI to batch size
+    throw new UnsupportedOperationException("Loading batch specs is not supported in FS-Implementation of SpecStore");
+  }
+
   @Override
   public Optional<URI> getSpecStoreURI() {
     return Optional.of(this.fsSpecStoreDirPath.toUri());

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStore.java
@@ -84,6 +84,8 @@ public class MysqlBaseSpecStore extends InstrumentedSpecStore {
   private static final String GET_ALL_STATEMENT = "SELECT spec_uri, spec FROM %s";
   private static final String GET_ALL_URIS_STATEMENT = "SELECT spec_uri FROM %s";
   private static final String GET_ALL_URIS_WITH_TAG_STATEMENT = "SELECT spec_uri FROM %s WHERE tag = ?";
+  // TODO check if i need the spec uri too
+  private static final String GET_BATCH_SPEC_URIS_STATEMENT = "SELECT spec FROM %s WHERE spec_uri >= %s ORDER BY spec_uri ASC LIMIT %s";
   private static final String GET_SIZE_STATEMENT = "SELECT COUNT(*) FROM %s ";
   // NOTE: using max length of a `FlowSpec` URI, as it's believed to be the longest of existing `Spec` types
   private static final String CREATE_TABLE_STATEMENT = "CREATE TABLE IF NOT EXISTS %s (spec_uri VARCHAR(" + FlowSpec.Utils.maxFlowSpecUriLength()
@@ -103,6 +105,7 @@ public class MysqlBaseSpecStore extends InstrumentedSpecStore {
     public final String getAllStatement = String.format(getTablelessGetAllStatement(), MysqlBaseSpecStore.this.tableName);
     public final String getAllURIsStatement = String.format(getTablelessGetAllURIsStatement(), MysqlBaseSpecStore.this.tableName);
     public final String getAllURIsWithTagStatement = String.format(getTablelessGetAllURIsWithTagStatement(), MysqlBaseSpecStore.this.tableName);
+    public final String getBatchSpecUrisStatement = String.format(getTablelessGetBatchSpecUrisStatement(), MysqlBaseSpecStore.this.tableName);
     public final String getSizeStatement = String.format(getTablelessGetSizeStatement(), MysqlBaseSpecStore.this.tableName);
     public final String createTableStatement = String.format(getTablelessCreateTableStatement(), MysqlBaseSpecStore.this.tableName);
 
@@ -127,6 +130,7 @@ public class MysqlBaseSpecStore extends InstrumentedSpecStore {
     protected String getTablelessGetAllStatement() { return MysqlBaseSpecStore.GET_ALL_STATEMENT; }
     protected String getTablelessGetAllURIsStatement() { return MysqlBaseSpecStore.GET_ALL_URIS_STATEMENT; }
     protected String getTablelessGetAllURIsWithTagStatement() { return MysqlBaseSpecStore.GET_ALL_URIS_WITH_TAG_STATEMENT; }
+    protected String getTablelessGetBatchSpecUrisStatement() { return MysqlBaseSpecStore.GET_BATCH_SPEC_URIS_STATEMENT; }
     protected String getTablelessGetSizeStatement() { return MysqlBaseSpecStore.GET_SIZE_STATEMENT; }
     protected String getTablelessCreateTableStatement() { return MysqlBaseSpecStore.CREATE_TABLE_STATEMENT; }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1783 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We seek to improve initialization time of the `GobblinServiceJobScheduler` upon restart or new leadership change by batching the mysql queries to get flow specs. Instead of making 1 mysql get call for each flow execution id, which scales extremely poorly with number of flows, we should group them to reduce number of calls and downtime.

This implementation adds two new functions to the `SpecStore` interface, `getSortedSpecURIs` and `getBatchedSpecs`, that we use to achieve the batching. Because these two functionalities are generic enough to be used in derived classes of the `SpecStore` we add them to the base class. Although this requires any child classes to implement these functions, it allows any consumer of the parent class `SpecStore` to use this functionality without caring about the specific implementation of the `SpecStore` used (as `GobblinServiceJobScheduler` does). Additionally, the `getBatchedSpecs` requires an `offset` or starting point to obtain the batches from so the consumer has to do some book keeping of where in the paginated gets we are but this again separates the functionality from the use case of the consumer. the entirety of the flow catalog is too large to load into memory for the `GobblinServiceJobScheduler`, so we use this batch functionality. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The main testing for this functionality will be empirical testing to determine the batch size which results in decreasing the time needed for all the gets above. In general, the time should go down with a larger batch size but there may be an inflection point where we see diminishing returns or the memory required to store a large batch is excessive. I propose testing with batch size 100, 250, and 750 incrementally and using the time metrics emitted to settle on an appropriate size.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

