### PR TITLE
[GOBBLIN-1784] Only clean dags from the dag manager if a flow event is received

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -47,7 +47,7 @@ public class ServiceMetricNames {
   public static final String SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX + ".ScheduledFlows";
   public static final String NON_SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX + ".NonScheduledFlows";
   public static final String SKIPPED_FLOWS = GOBBLIN_SERVICE_PREFIX + ".SkippedFlows";
-  public static final String Optional = "RunningFlows";
+  public static final String RUNNING_FLOWS_COUNTER = "RunningFlows";
   public static final String SERVICE_USERS = "ServiceUsers";
   public static final String COMPILED = "Compiled";
   public static final String RUNNING_STATUS = "RunningStatus";

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -47,7 +47,7 @@ public class ServiceMetricNames {
   public static final String SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX + ".ScheduledFlows";
   public static final String NON_SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX + ".NonScheduledFlows";
   public static final String SKIPPED_FLOWS = GOBBLIN_SERVICE_PREFIX + ".SkippedFlows";
-  public static final String RUNNING_FLOWS_COUNTER = "RunningFlows";
+  public static final String Optional = "RunningFlows";
   public static final String SERVICE_USERS = "ServiceUsers";
   public static final String COMPILED = "Compiled";
   public static final String RUNNING_STATUS = "RunningStatus";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -35,7 +35,6 @@ import lombok.Setter;
 
 import org.apache.gobblin.annotation.Alpha;
 
-
 /**
  * An implementation of Dag. Assumes that nodes have unique values. Nodes with duplicate values will produce
  * unpredictable behavior.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -53,6 +53,9 @@ public class Dag<T> {
   private String message;
   @Setter
   private String flowEvent;
+  // Keep track of when the final flow status is emitted, in milliseconds to avoid many duplicate events
+  @Setter @Getter
+  private long eventEmittedTimeMillis = -1;
 
   public Dag(List<DagNode<T>> dagNodes) {
     this.nodes = dagNodes;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -481,7 +481,7 @@ public class DagManager extends AbstractIdleService {
     final Map<String, LinkedList<DagNode<JobExecutionPlan>>> dagToJobs = new HashMap<>();
     final Map<String, Long> dagToSLA = new HashMap<>();
     private final MetricContext metricContext;
-    private final Set<String> dagIdstoClean = Collections.synchronizedSet(new HashSet<>());
+    private final Set<String> dagIdstoClean = new HashSet<>();
     private final Optional<EventSubmitter> eventSubmitter;
     private final Optional<Timer> jobStatusPolledTimer;
     private final AtomicLong orchestrationDelay = new AtomicLong(0);
@@ -1184,7 +1184,6 @@ public class DagManager extends AbstractIdleService {
      * Add a dag to failed dag state store
      */
     private synchronized void addFailedDag(String dagId, Dag<JobExecutionPlan> dag) {
-      FlowId flowId = DagManagerUtils.getFlowId(dag);
       try {
         log.info("Adding dag " + dagId + " to failed dag state store");
         this.failedDagStateStore.writeCheckpoint(this.dags.get(dagId));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -17,10 +17,6 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
-import com.codahale.metrics.Meter;
-import com.google.common.base.Joiner;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -43,15 +39,19 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -77,6 +77,7 @@ import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.Dag.DagNode;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.JobStatus;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.service.monitoring.KillFlowEvent;
@@ -129,6 +130,8 @@ public class DagManager extends AbstractIdleService {
   private static final String DEFAULT_FAILED_DAG_RETENTION_TIME_UNIT = "DAYS";
   private static final String FAILED_DAG_RETENTION_TIME = FAILED_DAG_STATESTORE_PREFIX + ".retention.time";
   private static final long DEFAULT_FAILED_DAG_RETENTION_TIME = 7L;
+  // Re-emit the final flow status if not detected within 5 minutes
+  private static final long DAG_FLOW_STATUS_TOLERANCE_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
   public static final String FAILED_DAG_POLLING_INTERVAL = FAILED_DAG_STATESTORE_PREFIX + ".retention.pollingIntervalMinutes";
   public static final Integer DEFAULT_FAILED_DAG_POLLING_INTERVAL = 60;
   public static final String DAG_MANAGER_HEARTBEAT = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagManager.heartbeat-%s";
@@ -477,9 +480,8 @@ public class DagManager extends AbstractIdleService {
     // dagToJobs holds a map of dagId to running jobs of that dag
     final Map<String, LinkedList<DagNode<JobExecutionPlan>>> dagToJobs = new HashMap<>();
     final Map<String, Long> dagToSLA = new HashMap<>();
-    private final Set<String> failedDagIdsFinishRunning = new HashSet<>();
-    private final Set<String> failedDagIdsFinishAllPossible = new HashSet<>();
     private final MetricContext metricContext;
+    private final Set<String> dagIdstoClean = Collections.synchronizedSet(new HashSet<>());
     private final Optional<EventSubmitter> eventSubmitter;
     private final Optional<Timer> jobStatusPolledTimer;
     private final AtomicLong orchestrationDelay = new AtomicLong(0);
@@ -760,7 +762,6 @@ public class DagManager extends AbstractIdleService {
      * Proceed the execution of each dag node based on job status.
      */
     private void pollAndAdvanceDag() throws IOException, ExecutionException, InterruptedException {
-      this.failedDagIdsFinishRunning.clear();
       Map<String, Set<DagNode<JobExecutionPlan>>> nextSubmitted = Maps.newHashMap();
       List<DagNode<JobExecutionPlan>> nodesToCleanUp = Lists.newArrayList();
 
@@ -1048,9 +1049,6 @@ public class DagManager extends AbstractIdleService {
     /**
      * Method that defines the actions to be performed when a job finishes either successfully or with failure.
      * This method updates the state of the dag and performs clean up actions as necessary.
-     * TODO : Dag should have a status field, like JobExecutionPlan has. This method should update that field,
-     *        which should be used by cleanup(). It may also remove the need of failedDagIdsFinishRunning,
-     *        failedDagIdsFinishAllPossible.
      */
     private Map<String, Set<DagNode<JobExecutionPlan>>> onJobFinish(DagNode<JobExecutionPlan> dagNode)
         throws IOException {
@@ -1067,19 +1065,11 @@ public class DagManager extends AbstractIdleService {
       switch (jobStatus) {
         case FAILED:
           dag.setMessage("Flow failed because job " + jobName + " failed");
-          if (DagManagerUtils.getFailureOption(dag) == FailureOption.FINISH_RUNNING) {
-            this.failedDagIdsFinishRunning.add(dagId);
-          } else {
-            this.failedDagIdsFinishAllPossible.add(dagId);
-          }
+          dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_FAILED);
           dagManagerMetrics.incrementExecutorFailed(dagNode);
           return Maps.newHashMap();
         case CANCELLED:
-          if (DagManagerUtils.getFailureOption(dag) == FailureOption.FINISH_RUNNING) {
-            this.failedDagIdsFinishRunning.add(dagId);
-          } else {
-            this.failedDagIdsFinishAllPossible.add(dagId);
-          }
+          dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_CANCELLED);
           return Maps.newHashMap();
         case COMPLETE:
           dagManagerMetrics.incrementExecutorSuccess(dagNode);
@@ -1117,46 +1107,76 @@ public class DagManager extends AbstractIdleService {
      * Perform clean up. Remove a dag from the dagstore if the dag is complete and update internal state.
      */
     private void cleanUp() {
-      List<String> dagIdstoClean = new ArrayList<>();
-      //Clean up failed dags
-      for (String dagId : this.failedDagIdsFinishRunning) {
-        //Skip monitoring of any other jobs of the failed dag.
-        LinkedList<DagNode<JobExecutionPlan>> dagNodeList = this.dagToJobs.get(dagId);
-        while (!dagNodeList.isEmpty()) {
-          DagNode<JobExecutionPlan> dagNode = dagNodeList.poll();
-          deleteJobState(dagId, dagNode);
-        }
-        Dag<JobExecutionPlan> dag = this.dags.get(dagId);
-        String status = TimingEvent.FlowTimings.FLOW_FAILED;
-        addFailedDag(dagId, dag);
-        log.info("Dag {} has finished with status {}; Cleaning up dag from the state store.", dagId, status);
-        // send an event before cleaning up dag
-        DagManagerUtils.emitFlowEvent(this.eventSubmitter, this.dags.get(dagId), status);
-        dagIdstoClean.add(dagId);
-      }
+      // Approximate the time when the flow events are emitted to account for delay when the flow event is received by the job monitor
+      long cleanUpProcessingTime = System.currentTimeMillis();
 
       // Remove dags that are finished and emit their appropriate metrics
       for (Map.Entry<String, Dag<JobExecutionPlan>> dagIdKeyPair : this.dags.entrySet()) {
         String dagId = dagIdKeyPair.getKey();
+        // On service restart, we repopulate the dags that are waiting to be cleaned up
+        if (dagIdstoClean.contains(dagId)) {
+          continue;
+        }
         Dag<JobExecutionPlan> dag = dagIdKeyPair.getValue();
-        if (!hasRunningJobs(dagId) && !this.failedDagIdsFinishRunning.contains(dagId)) {
-          String status = TimingEvent.FlowTimings.FLOW_SUCCEEDED;
-          if (this.failedDagIdsFinishAllPossible.contains(dagId)) {
-            status = TimingEvent.FlowTimings.FLOW_FAILED;
-            addFailedDag(dagId, dag);
-            this.failedDagIdsFinishAllPossible.remove(dagId);
-          } else {
-            dagManagerMetrics.emitFlowSuccessMetrics(DagManagerUtils.getFlowId(this.dags.get(dagId)));
+        if ((TimingEvent.FlowTimings.FLOW_FAILED.equals(dag.getFlowEvent()) || TimingEvent.FlowTimings.FLOW_CANCELLED.equals(dag.getFlowEvent())) &&
+            DagManagerUtils.getFailureOption(dag) == FailureOption.FINISH_RUNNING) {
+          //Skip monitoring of any other jobs of the failed dag.
+          LinkedList<DagNode<JobExecutionPlan>> dagNodeList = this.dagToJobs.get(dagId);
+          while (!dagNodeList.isEmpty()) {
+            DagNode<JobExecutionPlan> dagNode = dagNodeList.poll();
+            deleteJobState(dagId, dagNode);
           }
-          log.info("Dag {} has finished with status {}; Cleaning up dag from the state store.", dagId, status);
+        }
+        if (!hasRunningJobs(dagId)) {
+          // Collect all the dagIds that are finished
+          this.dagIdstoClean.add(dagId);
+          if (dag.getFlowEvent() == null) {
+            // If the dag flow event is not set, then it is successful
+            dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_SUCCEEDED);
+          } else {
+            addFailedDag(dagId, dag);
+          }
+          log.info("Dag {} has finished with status {}; Cleaning up dag from the state store.", dagId, dag.getFlowEvent());
           // send an event before cleaning up dag
-          DagManagerUtils.emitFlowEvent(this.eventSubmitter, this.dags.get(dagId), status);
-          dagIdstoClean.add(dagId);
+          DagManagerUtils.emitFlowEvent(this.eventSubmitter, this.dags.get(dagId), dag.getFlowEvent());
+          dag.setEventEmittedTimeMillis(cleanUpProcessingTime);
         }
       }
 
-      for (String dagId: dagIdstoClean) {
-        cleanUpDag(dagId);
+      // Only clean up dags after the job status monitor processed the flow event
+      Set<String> cleanedDags = new HashSet<>();
+      for (String dagId: this.dagIdstoClean) {
+        Dag<JobExecutionPlan> dag = this.dags.get(dagId);
+        JobStatus flowStatus = pollFlowStatus(dag);
+        if (flowStatus != null && FlowStatusGenerator.FINISHED_STATUSES.contains(flowStatus.getEventName())) {
+          FlowId flowId = DagManagerUtils.getFlowId(dag);
+          switch(dag.getFlowEvent()) {
+            case TimingEvent.FlowTimings.FLOW_SUCCEEDED:
+              this.dagManagerMetrics.emitFlowSuccessMetrics(flowId);
+              this.dagManagerMetrics.conditionallyMarkFlowAsState(flowId, FlowState.SUCCESSFUL);
+              break;
+            case TimingEvent.FlowTimings.FLOW_FAILED:
+              this.dagManagerMetrics.emitFlowFailedMetrics(flowId);
+              this.dagManagerMetrics.conditionallyMarkFlowAsState(flowId, FlowState.FAILED);
+              break;
+            case TimingEvent.FlowTimings.FLOW_CANCELLED:
+              this.dagManagerMetrics.emitFlowSlaExceededMetrics(flowId);
+              this.dagManagerMetrics.conditionallyMarkFlowAsState(flowId, FlowState.FAILED);
+              break;
+            default:
+              log.warn("Unexpected flow event {} for dag {}", dag.getFlowEvent(), dagId);
+          }
+          cleanUpDag(dagId);
+          cleanedDags.add(dagId);
+        } else if (cleanUpProcessingTime > dag.getEventEmittedTimeMillis() + DAG_FLOW_STATUS_TOLERANCE_TIME_MILLIS) {
+          // Re-emit the flow event if the flow status has not been processed within the DagFlowStatusTolerance time
+          DagManagerUtils.emitFlowEvent(this.eventSubmitter, dag, dag.getFlowEvent());
+        } else {
+          log.info("Waiting for flow event {} to be emitted before cleaning up dag {}", dag.getFlowEvent(), dagId);
+        }
+      }
+      for (String dagId: cleanedDags) {
+        this.dagIdstoClean.remove(dagId);
       }
     }
 
@@ -1172,12 +1192,6 @@ public class DagManager extends AbstractIdleService {
         log.error("Failed to add dag " + dagId + " to failed dag state store", e);
       }
       this.failedDagIds.add(dagId);
-      if (TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED.equals(dag.getFlowEvent())) {
-        this.dagManagerMetrics.emitFlowSlaExceededMetrics(flowId);
-      } else if (!TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED.equals(dag.getFlowEvent())) {
-        dagManagerMetrics.emitFlowFailedMetrics(flowId);
-      }
-      this.dagManagerMetrics.conditionallyMarkFlowAsState(flowId, DagManager.FlowState.FAILED);
     }
 
     /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
@@ -215,7 +215,7 @@ public class DagManagerMetrics {
         MetricRegistry.name(
             ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
             DagManagerUtils.getSpecExecutorName(dagNode),
-            ServiceMetricNames.RUNNING_FLOWS_COUNTER));
+            ServiceMetricNames.Optional));
   }
 
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
@@ -17,16 +17,20 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
-import com.typesafe.config.Config;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.ContextAwareCounter;
 import org.apache.gobblin.metrics.ContextAwareGauge;
@@ -215,7 +219,7 @@ public class DagManagerMetrics {
         MetricRegistry.name(
             ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
             DagManagerUtils.getSpecExecutorName(dagNode),
-            ServiceMetricNames.Optional));
+            ServiceMetricNames.RUNNING_FLOWS_COUNTER));
   }
 
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -16,8 +16,6 @@
  */
 package org.apache.gobblin.service.modules.orchestration;
 
-import com.google.common.collect.ImmutableMap;
-import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,12 +26,14 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
-import java.util.stream.Collectors;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.TimingEvent;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
-import com.google.common.base.Optional;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -26,26 +25,27 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.gobblin.config.ConfigBuilder;
-import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
-import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
-import org.apache.gobblin.runtime.api.DagActionStore;
-import org.apache.gobblin.runtime.dag_action_store.MysqlDagActionStore;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 
 import javax.annotation.Nullable;
 
+import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
+import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.runtime.api.DagActionStore;
 import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.TopologySpec;
+import org.apache.gobblin.runtime.dag_action_store.MysqlDagActionStore;
 import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
@@ -168,6 +168,17 @@ public class DagManagerFlowTest {
         .when(dagManager.getJobStatusRetriever()).getJobStatusesForFlowExecution("flow2", "group2",
         flowExecutionId3, "job0", "group2");
 
+    Mockito.doReturn(DagManagerTest.getMockFlowStatus("flow0", "group0", flowExecutionId1, String.valueOf(ExecutionStatus.CANCELLED)))
+        .when(dagManager.getJobStatusRetriever()).getJobStatusesForFlowExecution("flow0", "group0",
+            flowExecutionId1, JobStatusRetriever.NA_KEY, JobStatusRetriever.NA_KEY);
+
+    Mockito.doReturn(DagManagerTest.getMockFlowStatus("flow1", "group1", flowExecutionId2, String.valueOf(ExecutionStatus.CANCELLED)))
+        .when(dagManager.getJobStatusRetriever()).getJobStatusesForFlowExecution("flow1", "group1",
+            flowExecutionId2, JobStatusRetriever.NA_KEY, JobStatusRetriever.NA_KEY);
+
+    Mockito.doReturn(DagManagerTest.getMockFlowStatus("flow2", "group2", flowExecutionId3, String.valueOf(ExecutionStatus.CANCELLED)))
+        .when(dagManager.getJobStatusRetriever()).getJobStatusesForFlowExecution("flow2", "group2",
+            flowExecutionId3, JobStatusRetriever.NA_KEY, JobStatusRetriever.NA_KEY);
     // check removal of dag in dagToJobs map
     AssertWithBackoff.create().maxSleepMs(5000).backoffFactor(1).
         assertTrue(input -> !dagManager.dagManagerThreads[queue1].dagToJobs.containsKey(dagId1), ERROR_MESSAGE);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1784


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, the DagManager will poll a dag until it receives that the *job* has been completed/failed/cancelled, and then emit the flow event and clean up the dag. However, on service restart or crash, it is possible that the flow event never gets emitted. Since the dag is already cleaned up, this job status becomes stuck, and will never progress.

To address this scenario, this PR only cleans up dags when the cleanup function polls that the *flow status* is completed. If it does not receive the flow status that the job is completed within 3 minutes of the dag finishing all of its jobs, then it will re-emit the flow event in case it was lost. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Modified existing tests to the DagManagerTest class to ensure that the cleanup is working as expected on flow events

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

