### PR TITLE
[GOBBLIN-1786] Support Other Catalog Types for Iceberg Distcp

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetConstants.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetConstants.java
@@ -26,8 +26,6 @@ public class DatasetConstants {
   public static final String PLATFORM_SALESFORCE = "salesforce";
   public static final String PLATFORM_MYSQL = "mysql";
   public static final String PLATFORM_ICEBERG = "iceberg";
-  public static final String PLATFORM_CLUSTER = "cluster";
-
 
   /** Common metadata */
   public static final String BRANCH = "branch";

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetConstants.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetConstants.java
@@ -26,6 +26,8 @@ public class DatasetConstants {
   public static final String PLATFORM_SALESFORCE = "salesforce";
   public static final String PLATFORM_MYSQL = "mysql";
   public static final String PLATFORM_ICEBERG = "iceberg";
+  public static final String PLATFORM_CLUSTER = "cluster";
+
 
   /** Common metadata */
   public static final String BRANCH = "branch";

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.iceberg;
+
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+/**
+ * Base implementation of {@link IcebergCatalog} to access {@link IcebergTable} and the
+ * underlying concrete companion catalog e.g. {@link org.apache.iceberg.hive.HiveCatalog}
+ */
+public abstract class BaseIcebergCatalog implements IcebergCatalog {
+
+  protected final String catalogName;
+  protected final Class<? extends Catalog> companionCatalogClass;
+
+  protected BaseIcebergCatalog(String catalogName, Class<? extends Catalog> companionCatalogClass) {
+    this.catalogName = catalogName;
+    this.companionCatalogClass = companionCatalogClass;
+  }
+
+  @Override
+  public IcebergTable openTable(String dbName, String tableName) {
+    TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
+    return new IcebergTable(tableId, createTableOperations(tableId));
+  }
+
+  protected Catalog createCompanionCatalog(Map<String, String> properties, Configuration configuration) {
+    return CatalogUtil.loadCatalog(this.companionCatalogClass.getName(), this.catalogName, properties, configuration);
+  }
+
+  protected abstract TableOperations createTableOperations(TableIdentifier tableId);
+}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -41,7 +41,7 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
   @Override
   public IcebergTable openTable(String dbName, String tableName) {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
-    return new IcebergTable(tableId, createTableOperations(tableId));
+    return new IcebergTable(tableId, createTableOperations(tableId), this.getCatalogUri());
   }
 
   protected Catalog createCompanionCatalog(Map<String, String> properties, Configuration configuration) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -34,7 +34,7 @@ public interface IcebergCatalog {
   interface CatalogSpecifier {
     Class<? extends Catalog> getCatalogClass();
     Class<? extends IcebergCatalog> getIcebergCatalogClass();
-    String getCatalogType();
+    String getCatalogName();
   }
 
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -17,10 +17,23 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import org.apache.iceberg.catalog.Catalog;
+
 
 /**
  * Any catalog from which to access {@link IcebergTable}s.
  */
 public interface IcebergCatalog {
   IcebergTable openTable(String dbName, String tableName);
+
+  /**
+   * Adding a sub interface to help us provide an association between {@link Catalog} and {@link IcebergCatalog}.
+   * This helps us resolve to the Catalog type and its concrete implementation class
+   */
+  interface CatalogSpecifier {
+    Class<? extends Catalog> getCatalogClass();
+    Class<? extends IcebergCatalog> getIcebergCatalogClass();
+    String getCatalogType();
+  }
+
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.catalog.Catalog;
  */
 public interface IcebergCatalog {
   IcebergTable openTable(String dbName, String tableName);
+  String getCatalogUri();
 
   /**
    * Adding a sub interface to help us provide an association between {@link Catalog} and {@link IcebergCatalog}.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -17,7 +17,8 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
-import org.apache.iceberg.catalog.Catalog;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
 
 
 /**
@@ -26,16 +27,5 @@ import org.apache.iceberg.catalog.Catalog;
 public interface IcebergCatalog {
   IcebergTable openTable(String dbName, String tableName);
   String getCatalogUri();
-
-  /**
-   * Adding a sub interface to help us provide an association between {@link Catalog} and {@link IcebergCatalog}.
-   * This helps us resolve to the Catalog to its concrete implementation class
-   * Primarily needed to access `newTableOps` method which only certain {@link Catalog} derived classes open for public access
-   */
-  interface CatalogSpecifier {
-    Class<? extends Catalog> getCatalogClass();
-    Class<? extends IcebergCatalog> getIcebergCatalogClass();
-    String getCatalogName();
-  }
-
+  void initialize(Map<String, String> properties, Configuration configuration);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -28,7 +28,8 @@ public interface IcebergCatalog {
 
   /**
    * Adding a sub interface to help us provide an association between {@link Catalog} and {@link IcebergCatalog}.
-   * This helps us resolve to the Catalog type and its concrete implementation class
+   * This helps us resolve to the Catalog to its concrete implementation class
+   * Primarily needed to access `newTableOps` method which only certain {@link Catalog} derived classes open for public access
    */
   interface CatalogSpecifier {
     Class<? extends Catalog> getCatalogClass();

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
@@ -18,19 +18,20 @@
 package org.apache.gobblin.data.management.copy.iceberg;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.catalog.Catalog;
 
 import com.google.common.collect.Maps;
+
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
 
 /**
  * Provides an {@link IcebergCatalog}.
  */
 public class IcebergCatalogFactory {
-  public static IcebergCatalog create(Configuration configuration) {
-    HiveCatalog hcat = new HiveCatalog();
-    hcat.setConf(configuration);
-    hcat.initialize("hive", Maps.newHashMap());
-    return new IcebergHiveCatalog(hcat);
+  public static IcebergCatalog create(IcebergCatalog.CatalogSpecifier specifier, Configuration configuration) throws ReflectiveOperationException {
+    Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogType(), Maps.newHashMap(), configuration);
+    return GobblinConstructorUtils.invokeLongestConstructor(specifier.getIcebergCatalogClass(), catalog);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
@@ -33,12 +33,10 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 public class IcebergCatalogFactory {
   public static IcebergCatalog create(IcebergCatalog.CatalogSpecifier specifier, Map<String, String> properties, Configuration configuration) throws IOException {
     try {
-      Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogType(), properties, configuration);
+      Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogName(), properties, configuration);
       return GobblinConstructorUtils.invokeLongestConstructor(specifier.getIcebergCatalogClass(), catalog);
     } catch (ReflectiveOperationException ex) {
       throw new IOException(ex);
     }
-
-
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
@@ -17,11 +17,12 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import java.io.IOException;
+import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
-
-import com.google.common.collect.Maps;
 
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
@@ -30,8 +31,14 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  * Provides an {@link IcebergCatalog}.
  */
 public class IcebergCatalogFactory {
-  public static IcebergCatalog create(IcebergCatalog.CatalogSpecifier specifier, Configuration configuration) throws ReflectiveOperationException {
-    Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogType(), Maps.newHashMap(), configuration);
-    return GobblinConstructorUtils.invokeLongestConstructor(specifier.getIcebergCatalogClass(), catalog);
+  public static IcebergCatalog create(IcebergCatalog.CatalogSpecifier specifier, Map<String, String> properties, Configuration configuration) throws IOException {
+    try {
+      Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogType(), properties, configuration);
+      return GobblinConstructorUtils.invokeLongestConstructor(specifier.getIcebergCatalogClass(), catalog);
+    } catch (ReflectiveOperationException ex) {
+      throw new IOException(ex);
+    }
+
+
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
@@ -27,10 +27,10 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  * Provides an {@link IcebergCatalog}.
  */
 public class IcebergCatalogFactory {
-  public static IcebergCatalog create(String icebergCatalogType, Map<String, String> properties, Configuration configuration) throws IOException {
+  public static IcebergCatalog create(String icebergCatalogClassName, Map<String, String> properties, Configuration configuration) throws IOException {
     try {
-      Class<?> icebergCatalogClass = Class.forName(icebergCatalogType);
-      IcebergCatalog icebergCatalog = (IcebergCatalog) GobblinConstructorUtils.invokeConstructor(icebergCatalogClass, icebergCatalogType);
+      Class<?> icebergCatalogClass = Class.forName(icebergCatalogClassName);
+      IcebergCatalog icebergCatalog = (IcebergCatalog) GobblinConstructorUtils.invokeConstructor(icebergCatalogClass, icebergCatalogClassName);
       icebergCatalog.initialize(properties, configuration);
       return icebergCatalog;
     } catch (ReflectiveOperationException ex) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalogFactory.java
@@ -19,11 +19,7 @@ package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
 import java.util.Map;
-
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.catalog.Catalog;
-
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
 
@@ -31,10 +27,12 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  * Provides an {@link IcebergCatalog}.
  */
 public class IcebergCatalogFactory {
-  public static IcebergCatalog create(IcebergCatalog.CatalogSpecifier specifier, Map<String, String> properties, Configuration configuration) throws IOException {
+  public static IcebergCatalog create(String icebergCatalogType, Map<String, String> properties, Configuration configuration) throws IOException {
     try {
-      Catalog catalog = CatalogUtil.loadCatalog(specifier.getCatalogClass().getName(), specifier.getCatalogName(), properties, configuration);
-      return GobblinConstructorUtils.invokeLongestConstructor(specifier.getIcebergCatalogClass(), catalog);
+      Class<?> icebergCatalogClass = Class.forName(icebergCatalogType);
+      IcebergCatalog icebergCatalog = (IcebergCatalog) GobblinConstructorUtils.invokeConstructor(icebergCatalogClass, icebergCatalogType);
+      icebergCatalog.initialize(properties, configuration);
+      return icebergCatalog;
     } catch (ReflectiveOperationException ex) {
       throw new IOException(ex);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -72,12 +72,12 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   protected final FileSystem sourceFs;
   private final boolean shouldTolerateMissingSourceFiles = true; // TODO: make parameterizable, if desired
 
-  private final Optional<URI> sourceCatalogMetastoreURI;
-  private final Optional<URI> targetCatalogMetastoreURI;
+  private final Optional<URI> sourceCatalogURI;
+  private final Optional<URI> targetCatalogURI;
 
   /** Target metastore URI */
-  public static final String TARGET_METASTORE_URI_KEY =
-      IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.metastore.uri";
+  public static final String ICEBERG_TARGET_CATALOG_URI_KEY =
+      IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.catalog.uri";
   /** Target database name */
   public static final String TARGET_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.database";
 
@@ -87,8 +87,8 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     this.icebergTable = icebergTbl;
     this.properties = properties;
     this.sourceFs = sourceFs;
-    this.sourceCatalogMetastoreURI = getAsOptionalURI(this.properties, IcebergDatasetFinder.ICEBERG_HIVE_CATALOG_METASTORE_URI_KEY);
-    this.targetCatalogMetastoreURI = getAsOptionalURI(this.properties, TARGET_METASTORE_URI_KEY);
+    this.sourceCatalogURI = getAsOptionalURI(this.properties, IcebergDatasetFinder.ICEBERG_SRC_CATALOG_URI_KEY);
+    this.targetCatalogURI = getAsOptionalURI(this.properties, ICEBERG_TARGET_CATALOG_URI_KEY);
   }
 
   @Override
@@ -319,11 +319,11 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   protected DatasetDescriptor getSourceDataset(FileSystem sourceFs) {
-    return getDatasetDescriptor(sourceCatalogMetastoreURI, sourceFs);
+    return getDatasetDescriptor(sourceCatalogURI, sourceFs);
   }
 
   protected DatasetDescriptor getDestinationDataset(FileSystem targetFs) {
-    return getDatasetDescriptor(targetCatalogMetastoreURI, targetFs);
+    return getDatasetDescriptor(targetCatalogURI, targetFs);
   }
 
   private DatasetDescriptor getDatasetDescriptor(Optional<URI> catalogMetastoreURI, FileSystem fs) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -70,24 +69,18 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   protected final FileSystem sourceFs;
   private final boolean shouldTolerateMissingSourceFiles = true; // TODO: make parameterizable, if desired
 
-  private final Optional<URI> sourceCatalogURI;
-  private final Optional<URI> targetCatalogURI;
-
   /** Target metastore URI */
   public static final String ICEBERG_TARGET_CATALOG_URI_KEY =
       IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.catalog.uri";
   /** Target database name */
   public static final String TARGET_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.database";
 
-  public IcebergDataset(String db, String table, IcebergTable icebergTbl, String srcCatalogUri, Properties properties, FileSystem sourceFs) {
+  public IcebergDataset(String db, String table, IcebergTable icebergTbl, Properties properties, FileSystem sourceFs) {
     this.dbName = db;
     this.inputTableName = table;
     this.icebergTable = icebergTbl;
     this.properties = properties;
     this.sourceFs = sourceFs;
-    this.sourceCatalogURI = Optional.of(URI.create(srcCatalogUri));
-    //TODO: Use dest-side IcebergCatalog's getCatalogUri() method to get target catalog URI; as opposed to fetching from properties
-    this.targetCatalogURI = getAsOptionalURI(this.properties, ICEBERG_TARGET_CATALOG_URI_KEY);
   }
 
   @Override
@@ -313,15 +306,11 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     return fileStatus.getPath().getFileSystem(hadoopConfig);
   }
 
-  protected static Optional<URI> getAsOptionalURI(Properties props, String key) {
-    return Optional.ofNullable(props.getProperty(key)).map(URI::create);
-  }
-
   protected DatasetDescriptor getSourceDataset(FileSystem sourceFs) {
-    return this.icebergTable.getDatasetDescriptor(sourceCatalogURI, sourceFs);
+    return this.icebergTable.getDatasetDescriptor(sourceFs);
   }
 
   protected DatasetDescriptor getDestinationDataset(FileSystem targetFs) {
-    return this.icebergTable.getDatasetDescriptor(targetCatalogURI, targetFs);
+    return this.icebergTable.getDatasetDescriptor(targetFs);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -81,13 +81,14 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   /** Target database name */
   public static final String TARGET_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.database";
 
-  public IcebergDataset(String db, String table, IcebergTable icebergTbl, Properties properties, FileSystem sourceFs) {
+  public IcebergDataset(String db, String table, IcebergTable icebergTbl, String srcCatalogUri, Properties properties, FileSystem sourceFs) {
     this.dbName = db;
     this.inputTableName = table;
     this.icebergTable = icebergTbl;
     this.properties = properties;
     this.sourceFs = sourceFs;
-    this.sourceCatalogURI = getAsOptionalURI(this.properties, IcebergDatasetFinder.ICEBERG_SRC_CATALOG_URI_KEY);
+    this.sourceCatalogURI = Optional.of(URI.create(srcCatalogUri));
+    //TODO: Use dest-side IcebergCatalog's getCatalogUri() method to get target catalog URI; as opposed to fetching from properties
     this.targetCatalogURI = getAsOptionalURI(this.properties, ICEBERG_TARGET_CATALOG_URI_KEY);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -28,14 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-
 import java.util.function.Function;
-import javax.annotation.concurrent.NotThreadSafe;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.gobblin.util.function.CheckedExceptionFunction;
-import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -47,6 +40,10 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.CopyableDataset;
@@ -54,9 +51,10 @@ import org.apache.gobblin.data.management.copy.CopyableFile;
 import org.apache.gobblin.data.management.copy.OwnerAndPermission;
 import org.apache.gobblin.data.management.copy.prioritization.PrioritizedCopyableDataset;
 import org.apache.gobblin.data.management.partition.FileSet;
-import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.util.PathUtils;
+import org.apache.gobblin.util.function.CheckedExceptionFunction;
+import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 import org.apache.gobblin.util.request_allocation.PushDownRequestor;
 
 /**

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -320,20 +320,10 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   protected DatasetDescriptor getSourceDataset(FileSystem sourceFs) {
-    return getDatasetDescriptor(sourceCatalogURI, sourceFs);
+    return this.icebergTable.getDatasetDescriptor(sourceCatalogURI, sourceFs);
   }
 
   protected DatasetDescriptor getDestinationDataset(FileSystem targetFs) {
-    return getDatasetDescriptor(targetCatalogURI, targetFs);
-  }
-
-  private DatasetDescriptor getDatasetDescriptor(Optional<URI> catalogMetastoreURI, FileSystem fs) {
-    DatasetDescriptor descriptor = new DatasetDescriptor(
-        DatasetConstants.PLATFORM_ICEBERG,
-        catalogMetastoreURI.orElse(null),
-        this.getFileSetId()
-    );
-    descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
-    return descriptor;
+    return this.icebergTable.getDatasetDescriptor(targetCatalogURI, targetFs);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -25,17 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.IterableDatasetFinder;
 import org.apache.gobblin.util.HadoopUtils;
@@ -103,7 +100,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
 
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog icebergCatalog, Properties properties, FileSystem fs) {
     IcebergTable icebergTable = icebergCatalog.openTable(dbName, tblName);
-    return new IcebergDataset(dbName, tblName, icebergTable, icebergCatalog.getCatalogUri(), properties, fs);
+    return new IcebergDataset(dbName, tblName, icebergTable, properties, fs);
   }
 
   protected IcebergCatalog createIcebergCatalog(Properties properties) throws IOException, ClassNotFoundException {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +32,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
-import com.google.api.client.util.Maps;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -108,14 +107,14 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   }
 
   protected IcebergCatalog createIcebergCatalog(Properties properties) throws IOException, ClassNotFoundException {
-    Map<String, String> catalogProperties = Maps.newHashMap();
+    Map<String, String> catalogProperties = new HashMap<>();
     String catalogUri = properties.getProperty(ICEBERG_SRC_CATALOG_URI_KEY);
     Preconditions.checkNotNull(catalogUri, "Catalog Table Service URI is required");
     catalogProperties.put(CatalogProperties.URI, catalogUri);
     // introducing an optional property for catalogs requiring cluster specific properties
     Optional.ofNullable(properties.getProperty(ICEBERG_SRC_CLUSTER_NAME)).ifPresent(value -> catalogProperties.put(ICEBERG_CLUSTER_KEY, value));
     Configuration configuration = HadoopUtils.getConfFromProperties(properties);
-    String icebergCatalogType = properties.getProperty(ICEBERG_SRC_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);
-    return IcebergCatalogFactory.create(icebergCatalogType, catalogProperties, configuration);
+    String icebergCatalogClassName = properties.getProperty(ICEBERG_SRC_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);
+    return IcebergCatalogFactory.create(icebergCatalogClassName, catalogProperties, configuration);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -47,7 +47,7 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
 
   @Override
   public String getCatalogUri() {
-    return hc.getConf().get(CatalogProperties.URI, "");
+    return hc.getConf().get(CatalogProperties.URI, "<<not set>>");
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -18,13 +18,11 @@
 package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.util.Map;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveCatalog;
-
 import lombok.extern.slf4j.Slf4j;
 
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -38,6 +38,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
   public static class HiveSpecifier implements CatalogSpecifier {
 
     public static final String HIVE_CATALOG_NAME = "hive";
+    public static final String HIVE_CATALOG_URI = "uri";
     @Override
     public Class<? extends Catalog> getCatalogClass() {
       return HiveCatalog.class;
@@ -61,7 +62,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     if (catalog instanceof HiveCatalog) {
       hc = (HiveCatalog) catalog;
     } else {
-      throw new IllegalArgumentException(String.format("Incorrect Catalog Provided: Got %s instead of HiveCatalog " ,catalog.getClass().getName()));
+      throw new IllegalArgumentException(String.format("Incorrect Catalog Provided: Got %s instead of HiveCatalog", catalog.getClass().getName()));
     }
   }
 
@@ -69,5 +70,10 @@ public class IcebergHiveCatalog implements IcebergCatalog {
   public IcebergTable openTable(String dbName, String tableName) {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
     return new IcebergTable(tableId, hc.newTableOps(tableId));
+  }
+
+  @Override
+  public String getCatalogUri() {
+    return hc.getConf().get(HiveSpecifier.HIVE_CATALOG_URI, "");
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -56,5 +56,4 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
   protected TableOperations createTableOperations(TableIdentifier tableId) {
     return hc.newTableOps(tableId);
   }
-
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -33,11 +33,11 @@ public class IcebergHiveCatalog implements IcebergCatalog {
   /**
    * Ensures pairing between {@link IcebergCatalog} and its implementation type i.e. {@link HiveCatalog} in this case.
    * Unfortunately, {@link org.apache.iceberg.BaseMetastoreCatalog}.newTableOps is protected.
-   * Hence it necessitates this abstraction to define and access {@link IcebergTable}
+   * Hence, it necessitates this abstraction to define and access {@link IcebergTable}
    */
   public static class HiveSpecifier implements CatalogSpecifier {
 
-    public static final String HIVE_CATALOG_TYPE = "hive";
+    public static final String HIVE_CATALOG_NAME = "hive";
     @Override
     public Class<? extends Catalog> getCatalogClass() {
       return HiveCatalog.class;
@@ -49,8 +49,8 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
-    public String getCatalogType() {
-      return HIVE_CATALOG_TYPE;
+    public String getCatalogName() {
+      return HIVE_CATALOG_NAME;
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -33,7 +33,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
   /**
    * Ensures pairing between {@link IcebergCatalog} and its implementation type i.e. {@link HiveCatalog} in this case.
    * Unfortunately, {@link org.apache.iceberg.BaseMetastoreCatalog}.newTableOps is protected.
-   * Hence it necessitates this abtraction to define and access {@link IcebergTable}
+   * Hence it necessitates this abstraction to define and access {@link IcebergTable}
    */
   public static class HiveSpecifier implements CatalogSpecifier {
 
@@ -61,7 +61,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     if (catalog instanceof HiveCatalog) {
       hc = (HiveCatalog) catalog;
     } else {
-      throw new IllegalArgumentException("Incorrect Catalog Provided: Catalog cannot resolve to HiveCatalog");
+      throw new IllegalArgumentException(String.format("Incorrect Catalog Provided: Got %s instead of HiveCatalog " ,catalog.getClass().getName()));
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -70,6 +70,7 @@ public class IcebergTable {
 
   private final TableIdentifier tableId;
   private final TableOperations tableOps;
+  private final String catalogUri;
 
   /** @return metadata info limited to the most recent (current) snapshot */
   public IcebergSnapshotInfo getCurrentSnapshotInfo() throws IOException {
@@ -184,10 +185,10 @@ public class IcebergTable {
       manifestPathsIterable.close();
     }
   }
-  protected DatasetDescriptor getDatasetDescriptor(Optional<URI> catalogMetastoreURI, FileSystem fs) {
+  protected DatasetDescriptor getDatasetDescriptor(FileSystem fs) {
     DatasetDescriptor descriptor = new DatasetDescriptor(
         DatasetConstants.PLATFORM_ICEBERG,
-        catalogMetastoreURI.orElse(null),
+        URI.create(this.catalogUri),
         this.tableId.name()
     );
     descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
+import java.net.URI;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
@@ -29,6 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.Snapshot;
@@ -41,6 +43,9 @@ import org.apache.iceberg.io.FileIO;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import org.apache.gobblin.dataset.DatasetConstants;
+import org.apache.gobblin.dataset.DatasetDescriptor;
 
 import static org.apache.gobblin.data.management.copy.iceberg.IcebergSnapshotInfo.ManifestFileInfo;
 
@@ -178,5 +183,14 @@ public class IcebergTable {
     } finally {
       manifestPathsIterable.close();
     }
+  }
+  protected DatasetDescriptor getDatasetDescriptor(Optional<URI> catalogMetastoreURI, FileSystem fs) {
+    DatasetDescriptor descriptor = new DatasetDescriptor(
+        DatasetConstants.PLATFORM_ICEBERG,
+        catalogMetastoreURI.orElse(null),
+        this.tableId.name()
+    );
+    descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
+    return descriptor;
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -101,6 +101,7 @@ public class IcebergDatasetTest {
 
   private final String testDbName = "test_db_name";
   private final String testTblName = "test_tbl_name";
+  public static final String SRC_CATALOG_URI = "abc://the.source.org/catalog";
   private final Properties copyConfigProperties = new Properties();
 
   @BeforeClass
@@ -187,7 +188,7 @@ public class IcebergDatasetTest {
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI);
     FileSystem sourceFs = sourceFsBuilder.build();
-    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, SRC_CATALOG_URI, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destFsBuilder.build();
@@ -347,7 +348,7 @@ public class IcebergDatasetTest {
     optExistingSourcePaths.ifPresent(sourceFsBuilder::addPaths);
     FileSystem sourceFs = sourceFsBuilder.build();
     IcebergDataset icebergDataset =
-        new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
+        new IcebergDataset(testDbName, testTblName, icebergTable, SRC_CATALOG_URI, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     destFsBuilder.addPaths(existingDestPaths);
@@ -425,7 +426,7 @@ public class IcebergDatasetTest {
   protected static class TrickIcebergDataset extends IcebergDataset {
     public TrickIcebergDataset(String db, String table, IcebergTable icebergTbl, Properties properties,
         FileSystem sourceFs) {
-      super(db, table, icebergTbl, properties, sourceFs);
+      super(db, table, icebergTbl, SRC_CATALOG_URI, properties, sourceFs);
     }
 
     @Override // as the `static` is not mock-able

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -188,7 +188,7 @@ public class IcebergDatasetTest {
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI);
     FileSystem sourceFs = sourceFsBuilder.build();
-    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, SRC_CATALOG_URI, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destFsBuilder.build();
@@ -348,7 +348,7 @@ public class IcebergDatasetTest {
     optExistingSourcePaths.ifPresent(sourceFsBuilder::addPaths);
     FileSystem sourceFs = sourceFsBuilder.build();
     IcebergDataset icebergDataset =
-        new IcebergDataset(testDbName, testTblName, icebergTable, SRC_CATALOG_URI, new Properties(), sourceFs);
+        new IcebergDataset(testDbName, testTblName, icebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     destFsBuilder.addPaths(existingDestPaths);
@@ -426,7 +426,7 @@ public class IcebergDatasetTest {
   protected static class TrickIcebergDataset extends IcebergDataset {
     public TrickIcebergDataset(String db, String table, IcebergTable icebergTbl, Properties properties,
         FileSystem sourceFs) {
-      super(db, table, icebergTbl, SRC_CATALOG_URI, properties, sourceFs);
+      super(db, table, icebergTbl, properties, sourceFs);
     }
 
     @Override // as the `static` is not mock-able

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
@@ -70,6 +71,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
   private final String tableName = "justtesting";
   private TableIdentifier tableId;
   private Table table;
+  private String catalogUri;
   private String metadataBasePath;
 
   @BeforeClass
@@ -82,6 +84,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
   public void setUpEachTest() {
     tableId = TableIdentifier.of(dbName, tableName);
     table = catalog.createTable(tableId, icebergSchema);
+    catalogUri = catalog.getConf().get(CatalogProperties.URI);
     metadataBasePath = calcMetadataBasePath(tableId);
   }
 
@@ -101,7 +104,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     );
 
     initializeSnapshots(table, perSnapshotFilesets);
-    IcebergSnapshotInfo snapshotInfo = new IcebergTable(tableId, catalog.newTableOps(tableId)).getCurrentSnapshotInfo();
+    IcebergSnapshotInfo snapshotInfo = new IcebergTable(tableId, catalog.newTableOps(tableId), catalogUri).getCurrentSnapshotInfo();
     verifySnapshotInfo(snapshotInfo, perSnapshotFilesets, perSnapshotFilesets.size());
   }
 
@@ -109,7 +112,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
   @Test(expectedExceptions = IcebergTable.TableNotFoundException.class)
   public void testGetCurrentSnapshotInfoOnBogusTable() throws IOException {
     TableIdentifier bogusTableId = TableIdentifier.of(dbName, tableName + "_BOGUS");
-    IcebergSnapshotInfo snapshotInfo = new IcebergTable(bogusTableId, catalog.newTableOps(bogusTableId)).getCurrentSnapshotInfo();
+    IcebergSnapshotInfo snapshotInfo = new IcebergTable(bogusTableId, catalog.newTableOps(bogusTableId), catalogUri).getCurrentSnapshotInfo();
     Assert.fail("expected an exception when using table ID '" + bogusTableId + "'");
   }
 
@@ -124,7 +127,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     );
 
     initializeSnapshots(table, perSnapshotFilesets);
-    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId)).getAllSnapshotInfosIterator());
+    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId), catalogUri).getAllSnapshotInfosIterator());
     Assert.assertEquals(snapshotInfos.size(), perSnapshotFilesets.size(), "num snapshots");
 
     for (int i = 0; i < snapshotInfos.size(); ++i) {
@@ -144,7 +147,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     );
 
     initializeSnapshots(table, perSnapshotFilesets);
-    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId)).getIncrementalSnapshotInfosIterator());
+    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId), catalogUri).getIncrementalSnapshotInfosIterator());
     Assert.assertEquals(snapshotInfos.size(), perSnapshotFilesets.size(), "num snapshots");
 
     for (int i = 0; i < snapshotInfos.size(); ++i) {
@@ -164,7 +167,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     );
 
     initializeSnapshots(table, perSnapshotFilesets);
-    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId)).getIncrementalSnapshotInfosIterator());
+    List<IcebergSnapshotInfo> snapshotInfos = Lists.newArrayList(new IcebergTable(tableId, catalog.newTableOps(tableId), catalogUri).getIncrementalSnapshotInfosIterator());
     Assert.assertEquals(snapshotInfos.size(), perSnapshotFilesets.size(), "num snapshots");
 
     for (int i = 0; i < snapshotInfos.size(); ++i) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX
    - https://issues.apache.org/jira/browse/GOBBLIN-1786


### Description
Currently, we provide support for Iceberg based Distcp for Hive Catalogs. However, we now want to extend this functionality to any generic type of Iceberg Catalog and be able to perform Distcp operation from source to destination. As part of this initiative below are changes:
- [ ] Here are some details about my PR, including screenshots (if applicable):
- [ ] Introduce an abstract class called `BaseIcebergCatalog` to access` IcebergCatalog`'s companion catalog i.e. concrete implementation of `Catalog`
- [ ] Extend the `IcebergCatalogFactory` to now instantiate Catalogs based on the specifier, defaulting to Hive
- [ ] Add a layer of abstraction eg. `IcebergHiveCatalog` for pairing `IcebergCatalog` and its concrete implementation i.e. `HiveCatalog` in this case, so that methods like `newTableOps` are accessible
- [ ] Add/Update properties to accommodate any generic Iceberg Catalog (previously only HiveCatalogs)


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] Build successfully 


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

