### PR TITLE
[GOBBLIN-1787] Ability to delete multiple watermarks in a state store

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/StateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/StateStore.java
@@ -206,6 +206,20 @@ public interface StateStore<T extends State> {
       throws IOException;
 
   /**
+   * Delete a list of tables from a store.
+   *
+   * @param storeName store name
+   * @param tableNames List of table names in the state store to delete
+   * @throws IOException
+   */
+  default void delete(String storeName, List<String> tableNames)
+      throws IOException {
+    for (String tableName : tableNames) {
+      delete(storeName, tableName);
+    }
+  }
+
+  /**
    * Delete a store.
    *
    * @param storeName store name

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorage.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorage.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -55,10 +56,10 @@ public class StateStoreBasedWatermarkStorage implements WatermarkStorage {
    * A watermark prefix that is compatible with different watermark storage implementations.
    * As such, this prefix should not include any characters disallowed in a {@link java.net.URI}.
    */
-  private static final String WATERMARK_STORAGE_PREFIX="streamingWatermarks_";
+  protected static final String WATERMARK_STORAGE_PREFIX="streamingWatermarks_";
 
   public final StateStore<CheckpointableWatermarkState> _stateStore;
-  private final String _storeName;
+  protected final String _storeName;
 
   /**
    * A private method that creates a state store config
@@ -140,6 +141,10 @@ public class StateStoreBasedWatermarkStorage implements WatermarkStorage {
 
   public Iterable<CheckpointableWatermarkState> getAllCommittedWatermarks() throws IOException {
     return _stateStore.getAll(_storeName);
+  }
+
+  public void deleteWatermarks(List<String> tableNames) throws IOException {
+    _stateStore.delete(_storeName, tableNames);
   }
 
 }

--- a/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
+++ b/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
@@ -66,6 +66,14 @@ import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
  * @param <T> state object type
  **/
 public class ZkStateStore<T extends State> implements StateStore<T> {
+  /**
+   * Corresponds to {@link AccessOption}, which defines behavior for accessing znodes (get, remove, exists). The value 0 means not to
+   * throws exceptions if the znode does not exist (i.e. do not enable {@link AccessOption#THROW_EXCEPTION_IFNOTEXIST}
+   *
+   * Note: This variable is not be used for create calls like {@link HelixPropertyStore#create(String, Object, int)}
+   * which require specifying if the znode is {@link AccessOption#PERSISTENT}, {@link AccessOption#EPHEMERAL}, etc.
+   **/
+  private static final int DEFAULT_OPTION = 0;
 
   // Class of the state objects to be put into the store
   private final Class<T> stateClass;
@@ -102,7 +110,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   public boolean create(String storeName) throws IOException {
     String path = formPath(storeName);
 
-    return propStore.exists(path, 0) || propStore.create(path, ArrayUtils.EMPTY_BYTE_ARRAY,
+    return propStore.exists(path, DEFAULT_OPTION) || propStore.create(path, ArrayUtils.EMPTY_BYTE_ARRAY,
         AccessOption.PERSISTENT);
   }
 
@@ -110,7 +118,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   public boolean create(String storeName, String tableName) throws IOException {
     String path = formPath(storeName, tableName);
 
-    if (propStore.exists(path, 0)) {
+    if (propStore.exists(path, DEFAULT_OPTION)) {
       throw new IOException(String.format("State already exists for storeName %s tableName %s", storeName,
           tableName));
     }
@@ -122,7 +130,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   public boolean exists(String storeName, String tableName) throws IOException {
     String path = formPath(storeName, tableName);
 
-    return propStore.exists(path, 0);
+    return propStore.exists(path, DEFAULT_OPTION);
   }
 
   /**
@@ -146,7 +154,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   private void putData(String storeName, String tableName, byte[] data) throws IOException {
     String path = formPath(storeName, tableName);
 
-    if (!propStore.exists(path, 0)) {
+    if (!propStore.exists(path, DEFAULT_OPTION)) {
       // create with data
       if (!propStore.create(path, data, AccessOption.PERSISTENT)) {
         throw new IOException("Failed to create a state file for table " + tableName);
@@ -180,7 +188,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   @Override
   public T get(String storeName, String tableName, String stateId) throws IOException {
     String path = formPath(storeName, tableName);
-    byte[] data = propStore.get(path, null, 0);
+    byte[] data = propStore.get(path, null, DEFAULT_OPTION);
     List<T> states = Lists.newArrayList();
 
     deserialize(data, states, stateId);
@@ -188,7 +196,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
     if (states.isEmpty()) {
       return null;
     } else {
-      return states.get(0);
+      return states.get(DEFAULT_OPTION);
     }
   }
 
@@ -204,7 +212,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
     String path = formPath(storeName);
     byte[] data;
 
-    List<String> children = propStore.getChildNames(path, 0);
+    List<String> children = propStore.getChildNames(path, DEFAULT_OPTION);
 
     if (children == null) {
       return Collections.emptyList();
@@ -212,7 +220,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
 
     for (String c : children) {
       if (predicate.apply(c)) {
-        data = propStore.get(path + "/" + c, null, 0);
+        data = propStore.get(path + "/" + c, null, DEFAULT_OPTION);
         deserialize(data, states);
       }
     }
@@ -224,7 +232,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   public List<T> getAll(String storeName, String tableName) throws IOException {
     List<T> states = Lists.newArrayList();
     String path = formPath(storeName, tableName);
-    byte[] data = propStore.get(path, null, 0);
+    byte[] data = propStore.get(path, null, DEFAULT_OPTION);
 
     deserialize(data, states);
 
@@ -241,7 +249,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
     List<String> names = Lists.newArrayList();
     String path = formPath(storeName);
 
-    List<String> children = propStore.getChildNames(path, 0);
+    List<String> children = propStore.getChildNames(path, DEFAULT_OPTION);
 
     if (children != null) {
       for (String c : children) {
@@ -266,7 +274,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
     List<String> names = Lists.newArrayList();
     String path = formPath("");
 
-    List<String> children = propStore.getChildNames(path, 0);
+    List<String> children = propStore.getChildNames(path, DEFAULT_OPTION);
 
     if (children != null) {
       for (String c : children) {
@@ -284,29 +292,29 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
     String pathOriginal = formPath(storeName, original);
     byte[] data;
 
-    if (!propStore.exists(pathOriginal, 0)) {
+    if (!propStore.exists(pathOriginal, DEFAULT_OPTION)) {
       throw new IOException(String.format("State does not exist for table %s", original));
     }
 
-    data = propStore.get(pathOriginal, null, 0);
+    data = propStore.get(pathOriginal, null, DEFAULT_OPTION);
 
     putData(storeName, alias, data);
   }
 
   @Override
   public void delete(String storeName, String tableName) throws IOException {
-    propStore.remove(formPath(storeName, tableName), 0);
+    propStore.remove(formPath(storeName, tableName), DEFAULT_OPTION);
   }
 
   @Override
   public void delete(String storeName, List<String> tableNames) throws IOException {
     List<String> paths = tableNames.stream().map(table -> formPath(storeName, table)).collect(Collectors.toList());
-    propStore.remove(paths, 0);
+    propStore.remove(paths, DEFAULT_OPTION);
   }
 
   @Override
   public void delete(String storeName) throws IOException {
-    propStore.remove(formPath(storeName), 0);
+    propStore.remove(formPath(storeName), DEFAULT_OPTION);
   }
 
   /**

--- a/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
+++ b/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -295,6 +296,12 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
   @Override
   public void delete(String storeName, String tableName) throws IOException {
     propStore.remove(formPath(storeName, tableName), 0);
+  }
+
+  @Override
+  public void delete(String storeName, List<String> tableNames) throws IOException {
+    List<String> paths = tableNames.stream().map(table -> formPath(storeName, table)).collect(Collectors.toList());
+    propStore.remove(paths, 0);
   }
 
   @Override

--- a/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/ZkDatasetStateStoreTest.java
+++ b/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/ZkDatasetStateStoreTest.java
@@ -261,14 +261,14 @@ public class ZkDatasetStateStoreTest {
 
   @Test(dependsOnMethods = "testGetPreviousDatasetStatesByUrns")
   public void testDeleteDatasetJobState() throws IOException {
-    JobState.DatasetState datasetState = zkDatasetStateStore.get(TEST_JOB_NAME,
-        TEST_DATASET_URN + "-" + zkDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX +
-            zkDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX, TEST_DATASET_URN);
+    String tableName = TEST_DATASET_URN + "-" + zkDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX +
+        zkDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX;
+    JobState.DatasetState datasetState = zkDatasetStateStore.get(TEST_JOB_NAME, tableName, TEST_DATASET_URN);
 
     Assert.assertNotNull(datasetState);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
 
-    zkDatasetStateStore.delete(TEST_JOB_NAME);
+    zkDatasetStateStore.delete(TEST_JOB_NAME, Collections.singletonList(tableName));
 
     datasetState = zkDatasetStateStore.get(TEST_JOB_NAME,
         TEST_DATASET_URN + "-" + zkDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX +


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

Let's improve the interface for state stores that Gobblin uses to storing watermarks and various other pieces of state. State stores like zookeeper have native methods for batch deletes that we cannot take advantage of with the current implementation.

This is useful for cleaning up no longer used watermarks in a state store. The size of a state store has physical limitations depending on the underlying implementation (e.g. ZK supports roughly ~10k tables per state store). And even migrating to a new state store requires a lot of operational burden / doesn't clean up the old state store.

Design:
- Add a default method to the interface for backward compatibility in the OSS community
- Use this method in the watermark based storage
- Call batch delete in zk state store

Alternate designs:
- Create a new interface that extends the interface `StateStore` except it has a delete multiple tables method. The default approach is a much cleaner approach in terms of backwards compatibility / amount of code needed.
- Add batch deletes as part of the watermark based storage, but this would be a hack since we'd just be calling delete with multiple threads


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1787] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1787


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Used batch delete of a singleton collection in UT

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

