### PR TITLE
[GOBBLIN-1789] Create Generic Iceberg Data Node to Support Different Types of Catalogs

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/iceberg/IcebergDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/iceberg/IcebergDataNode.java
@@ -29,13 +29,11 @@ import org.apache.gobblin.data.management.copy.iceberg.IcebergHiveCatalog;
 import org.apache.gobblin.service.modules.dataset.IcebergDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
-import org.apache.gobblin.service.modules.flowgraph.datanodes.hive.HiveMetastoreUriDataNode;
 import org.apache.gobblin.util.ConfigUtils;
 
 
 /**
- * In addition to the required properties of a {@link HiveMetastoreUriDataNode}, an {@link IcebergOnHiveDataNode}
- * must have a metastore URI specified. Specifies iceberg platform and uniquely identifies a hive catalog.
+ * Specifies iceberg platform and uniquely identifies an Iceberg Catalog based on the URI.
  * See {@link IcebergHiveCatalog} for more information
  */
 @Alpha
@@ -46,7 +44,10 @@ public class IcebergDataNode extends BaseDataNode {
 
   @Getter
   private String catalogUri;
-
+  /**
+   * Constructor. An IcebergDataNode must have iceberg.catalog.uri property specified to get information about specific catalog. eg. {@link IcebergHiveCatalog}
+   * @param nodeProps
+   */
   public IcebergDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
     try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/iceberg/IcebergDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/iceberg/IcebergDataNode.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph.datanodes.iceberg;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import joptsimple.internal.Strings;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.data.management.copy.iceberg.IcebergHiveCatalog;
+import org.apache.gobblin.service.modules.dataset.IcebergDatasetDescriptor;
+import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
+import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
+import org.apache.gobblin.service.modules.flowgraph.datanodes.hive.HiveMetastoreUriDataNode;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * In addition to the required properties of a {@link HiveMetastoreUriDataNode}, an {@link IcebergOnHiveDataNode}
+ * must have a metastore URI specified. Specifies iceberg platform and uniquely identifies a hive catalog.
+ * See {@link IcebergHiveCatalog} for more information
+ */
+@Alpha
+@EqualsAndHashCode(callSuper = true)
+public class IcebergDataNode extends BaseDataNode {
+  public static final String CATALOG_URI_KEY = FlowGraphConfigurationKeys.DATA_NODE_PREFIX + "iceberg.catalog.uri";
+  public static final String PLATFORM = "iceberg";
+
+  @Getter
+  private String catalogUri;
+
+  public IcebergDataNode(Config nodeProps) throws DataNodeCreationException {
+    super(nodeProps);
+    try {
+      this.catalogUri = ConfigUtils.getString(nodeProps, CATALOG_URI_KEY, "");
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(this.catalogUri), "iceberg.catalog.uri cannot be null or empty.");
+    } catch (Exception e) {
+      throw new DataNodeCreationException(e);
+    }
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return IcebergDatasetDescriptor.class.getCanonicalName();
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return PLATFORM;
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX
    - https://issues.apache.org/jira/browse/GOBBLIN-1789


### Description
As part of supporting multiple Iceberg Catalogs, I am defining generic `IcebergDataNode` that will represent an Iceberg node in the Flow Graph for any type of Iceberg Catalog and not just Hive. Below are the changes added as part of this PR:
- [ ] Here are some details about my PR, including screenshots (if applicable):
- [ ] Added `IcebergDataNode` which takes a catalog Uri


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] Added unit tests


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

