### PR TITLE
Make GobblinMCEWriter constructor public

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -138,7 +138,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
     long gmceHighWatermark;
   }
 
-  GobblinMCEWriter(DataWriterBuilder<Schema, GenericRecord> builder, State properties) throws IOException {
+  public GobblinMCEWriter(DataWriterBuilder<Schema, GenericRecord> builder, State properties) throws IOException {
     newSpecsMaps = new HashMap<>();
     oldSpecsMaps = new HashMap<>();
     metadataWriters = new ArrayList<>();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### Description
- The GobblinMCEWriter is defined as a public class, we should make its constructor `GobblinMCEWriter()` public too to allow usages outside of the package. For example, my current use case is allowing unit tests in other modules to construct a `GobblinMCEWriter` to set up a test infra, without the constructor being public, I have no other way to construct a object of it.


### Tests
`gradle :gobblin-iceberg:test`

