### PR TITLE
[GOBBLIN-1779] Ability to filter datasets that contain non optional unions

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetUtils.java
@@ -74,12 +74,19 @@ public class DatasetUtils {
    * @throws IOException
    */
   @SuppressWarnings("unchecked")
-  public static <T extends org.apache.gobblin.dataset.Dataset> DatasetsFinder<T> instantiateDatasetFinder(Properties props,
-      FileSystem fs, String default_class, Object... additionalArgs)
+  public static <T extends org.apache.gobblin.dataset.Dataset> DatasetsFinder<T> instantiateDatasetFinder(
+      Properties props, FileSystem fs, String default_class, Object... additionalArgs)
       throws IOException {
+    return instantiateDatasetFinder(DATASET_PROFILE_CLASS_KEY, props, fs, default_class, additionalArgs);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends org.apache.gobblin.dataset.Dataset> DatasetsFinder<T> instantiateDatasetFinder(
+      String classKey, Properties props, FileSystem fs, String default_class, Object... additionalArgs)
+  throws IOException{
     String className = default_class;
-    if (props.containsKey(DATASET_PROFILE_CLASS_KEY)) {
-      className = props.getProperty(DATASET_PROFILE_CLASS_KEY);
+    if (props.containsKey(classKey)) {
+      className = props.getProperty(classKey);
     }
     try {
       Class<?> datasetFinderClass = Class.forName(className);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
@@ -17,19 +17,23 @@
 
 package org.apache.gobblin.data.management.dataset;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.gobblin.dataset.Dataset;
 import org.apache.gobblin.dataset.DatasetsFinder;
 import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.gobblin.util.function.CheckedExceptionPredicate;
-import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 
 /**
@@ -65,7 +69,7 @@ public class DatasetsFinderFilteringDecorator<T extends Dataset> implements Data
   @Override
   public List<T> findDatasets() throws IOException {
     List<T> datasets = datasetFinder.findDatasets();
-    List<T> allowedDatasets = null;
+    List<T> allowedDatasets = Collections.emptyList();
     try {
       allowedDatasets = datasets.parallelStream()
           .filter(dataset -> allowDatasetPredicates.stream()
@@ -93,7 +97,7 @@ public class DatasetsFinderFilteringDecorator<T extends Dataset> implements Data
     try {
       for (String className : PropertiesUtils.getPropAsList(props, key)) {
         predicates.add((CheckedExceptionPredicate<T, IOException>)
-            GobblinConstructorUtils.invokeLongestConstructor(Class.forName(className), props));
+            ConstructorUtils.invokeConstructor(Class.forName(className), props));
       }
 
       return predicates;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.dataset;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.gobblin.dataset.Dataset;
+import org.apache.gobblin.dataset.DatasetsFinder;
+import org.apache.gobblin.util.PropertiesUtils;
+import org.apache.gobblin.util.function.CheckedExceptionPredicate;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+
+/**
+ * A decorator for filtering datasets after a {@link DatasetsFinder} finds a {@link List} of {@link Dataset}s
+ */
+public class DatasetsFinderFilteringDecorator<T extends Dataset> implements DatasetsFinder<T> {
+  private static final String PREFIX = "filtering.datasets.finder.";
+  public static final String DATASET_CLASS = PREFIX + "class";
+  public static final String ALLOWED = PREFIX + "allowed.predicates";
+  public static final String DENIED = PREFIX + "denied.predicates";
+
+  protected DatasetsFinder<T> datasetFinder;
+  protected List<CheckedExceptionPredicate<T,IOException>> allowDatasetPredicates;
+  protected List<CheckedExceptionPredicate<T,IOException>> denyDatasetPredicates;
+
+  public DatasetsFinderFilteringDecorator(FileSystem fs, Properties properties) throws IOException {
+    this.datasetFinder = DatasetUtils.instantiateDatasetFinder(
+        DATASET_CLASS, properties, fs, DefaultFileSystemGlobFinder.class.getName());
+    this.allowDatasetPredicates = instantiatePredicates(ALLOWED, properties);
+    this.denyDatasetPredicates = instantiatePredicates(DENIED, properties);
+  }
+
+  @VisibleForTesting
+  DatasetsFinderFilteringDecorator(
+      DatasetsFinder<T> datasetsFinder,
+      List<CheckedExceptionPredicate<T,IOException>> allowDatasetPredicates,
+      List<CheckedExceptionPredicate<T,IOException>> denyDatasetPredicates) {
+    this.datasetFinder = datasetsFinder;
+    this.allowDatasetPredicates = allowDatasetPredicates;
+    this.denyDatasetPredicates = denyDatasetPredicates;
+  }
+
+  @Override
+  public List<T> findDatasets() throws IOException {
+    List<T> datasets = datasetFinder.findDatasets();
+    List<T> allowedDatasets = null;
+    try {
+      allowedDatasets = datasets.parallelStream()
+          .filter(dataset -> allowDatasetPredicates.stream()
+              .map(CheckedExceptionPredicate::wrapToTunneled)
+              .allMatch(p -> p.test(dataset)))
+          .filter(dataset -> denyDatasetPredicates.stream()
+              .map(CheckedExceptionPredicate::wrapToTunneled)
+              .noneMatch(predicate -> predicate.test(dataset)))
+          .collect(Collectors.toList());
+    } catch (CheckedExceptionPredicate.WrappedIOException wrappedIOException) {
+      wrappedIOException.rethrowWrapped();
+    }
+
+    return allowedDatasets;
+  }
+
+  @Override
+  public Path commonDatasetRoot() {
+    return datasetFinder.commonDatasetRoot();
+  }
+
+  private List<CheckedExceptionPredicate<T,IOException>> instantiatePredicates(String key, Properties props)
+      throws IOException {
+    List<CheckedExceptionPredicate<T,IOException>> predicates = new ArrayList<>();
+    try {
+      for (String className : PropertiesUtils.getPropAsList(props, key)) {
+        predicates.add((CheckedExceptionPredicate<T, IOException>)
+            GobblinConstructorUtils.invokeLongestConstructor(Class.forName(className), props));
+      }
+
+      return predicates;
+    } catch (ReflectiveOperationException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecoratorTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecoratorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.dataset;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import lombok.AllArgsConstructor;
+import org.apache.gobblin.dataset.DatasetsFinder;
+import org.apache.gobblin.util.function.CheckedExceptionPredicate;
+import org.apache.hadoop.fs.FileSystem;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DatasetsFinderFilteringDecoratorTest {
+  @Test
+  public void testFindDatasets_emptyAllowed() throws IOException {
+    DatasetsFinder<Dataset> mockFinder = Mockito.mock(DatasetsFinder.class);
+    Dataset mockDataset = Mockito.mock(Dataset.class);
+    Mockito.when(mockFinder.findDatasets()).thenReturn(Arrays.asList(mockDataset));
+
+    DatasetsFinderFilteringDecorator<Dataset> d = new DatasetsFinderFilteringDecorator(
+        mockFinder,Collections.emptyList(), Collections.emptyList());
+    Assert.assertEquals(d.findDatasets(), Arrays.asList(mockDataset));
+  }
+
+  @Test
+  public void testFindDatasets_allowed() throws IOException {
+    DatasetsFinder<Dataset> mockFinder = Mockito.mock(DatasetsFinder.class);
+    Dataset mockDataset = Mockito.mock(Dataset.class);
+    Mockito.when(mockFinder.findDatasets()).thenReturn(Arrays.asList(mockDataset));
+
+    DatasetsFinderFilteringDecorator<Dataset> d = new DatasetsFinderFilteringDecorator(
+        mockFinder,
+        Arrays.asList(new StubTrue(), new StubTrue()),
+        Arrays.asList(new StubFalse(), new StubFalse()));
+    Assert.assertEquals(d.findDatasets(), Arrays.asList(mockDataset));
+  }
+
+  @Test
+  public void testFindDatasets_denied() throws IOException {
+    DatasetsFinder<Dataset> mockFinder = Mockito.mock(DatasetsFinder.class);
+    Dataset mockDataset = Mockito.mock(Dataset.class);
+    Mockito.when(mockFinder.findDatasets()).thenReturn(Arrays.asList(mockDataset));
+
+    DatasetsFinderFilteringDecorator<Dataset> d = new DatasetsFinderFilteringDecorator(mockFinder,
+        Arrays.asList(new StubTrue(), new StubFalse()),
+        Arrays.asList(new StubFalse()));
+    Assert.assertEquals(d.findDatasets(), Collections.emptyList());
+
+    d = new DatasetsFinderFilteringDecorator(mockFinder,
+        Arrays.asList(new StubTrue()),
+        Arrays.asList(new StubFalse(), new StubTrue()));
+    Assert.assertEquals(d.findDatasets(), Collections.emptyList());
+  }
+
+  @Test
+  public void testFindDatasets_throwsException() throws IOException {
+    DatasetsFinder<Dataset> mockFinder = Mockito.mock(DatasetsFinder.class);
+    Dataset mockDataset = Mockito.mock(Dataset.class);
+    Mockito.when(mockFinder.findDatasets()).thenReturn(Arrays.asList(mockDataset));
+
+    DatasetsFinderFilteringDecorator<Dataset> datasetFinder_1 = new DatasetsFinderFilteringDecorator(mockFinder,
+        Arrays.asList(new StubTrue(), new ThrowsException()),
+        Arrays.asList(new StubFalse()));
+    Assert.assertThrows(IOException.class, datasetFinder_1::findDatasets);
+
+    DatasetsFinderFilteringDecorator<Dataset> datasetFinder_2 = new DatasetsFinderFilteringDecorator(mockFinder,
+        Arrays.asList(new StubTrue()),
+        Arrays.asList(new StubFalse(), new ThrowsException()));
+    Assert.assertThrows(IOException.class, datasetFinder_2::findDatasets);
+  }
+
+  @Test
+  public void testInstantiationOfPredicatesAndDatasetFinder() throws IOException {
+    DatasetsFinder<Dataset> mockFinder = Mockito.mock(DatasetsFinder.class);
+
+    Properties props = new Properties();
+    props.setProperty(DatasetsFinderFilteringDecorator.DATASET_CLASS, mockFinder.getClass().getName());
+    props.setProperty(DatasetsFinderFilteringDecorator.ALLOWED, StubTrue.class.getName());
+    props.setProperty(DatasetsFinderFilteringDecorator.DENIED, StubFalse.class.getName());
+    DatasetsFinderFilteringDecorator<Dataset>
+        testFilterDataFinder = new TestDatasetsFinderFilteringDecorator(Mockito.mock(FileSystem.class), props);
+
+    Assert.assertEquals(testFilterDataFinder.datasetFinder.getClass(), mockFinder.getClass());
+
+    Assert.assertEquals(testFilterDataFinder.allowDatasetPredicates.size(), 1);
+    CheckedExceptionPredicate<Dataset, IOException> allowListPredicate = testFilterDataFinder.allowDatasetPredicates.get(0);
+    Assert.assertEquals(allowListPredicate.getClass(), StubTrue.class);
+    Assert.assertEquals(((StubTrue) allowListPredicate).props, props);
+
+    Assert.assertEquals(testFilterDataFinder.denyDatasetPredicates.size(), 1);
+    CheckedExceptionPredicate<Dataset, IOException> denyListPredicate = testFilterDataFinder.denyDatasetPredicates.get(0);
+    Assert.assertEquals(denyListPredicate.getClass(), StubFalse.class);
+    Assert.assertEquals(((StubFalse) denyListPredicate).props, props);
+  }
+
+  static class TestDatasetsFinderFilteringDecorator extends DatasetsFinderFilteringDecorator<Dataset> {
+    public TestDatasetsFinderFilteringDecorator(FileSystem fs, Properties properties) throws IOException {
+      super(fs, properties);
+    }
+  }
+
+  @AllArgsConstructor
+  static class StubTrue implements CheckedExceptionPredicate<Dataset, IOException> {
+    Properties props;
+
+    StubTrue() {
+      this.props = null;
+    }
+
+    @Override
+    public boolean test(Dataset arg) throws IOException {
+      return true;
+    }
+  }
+
+  @AllArgsConstructor
+  static class StubFalse implements CheckedExceptionPredicate<Dataset, IOException> {
+    Properties props;
+
+    StubFalse() {
+      this.props = null;
+    }
+
+    @Override
+    public boolean test(Dataset arg) throws IOException {
+      return false;
+    }
+  }
+
+  static class ThrowsException implements CheckedExceptionPredicate<Dataset, IOException> {
+    @Override
+    public boolean test(Dataset arg) throws IOException {
+      throw new IOException("Throwing a test exception");
+    }
+  }
+}

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.iceberg.predicates;
+
+import com.google.common.base.Optional;
+import gobblin.configuration.State;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.dataset.Dataset;
+import org.apache.gobblin.hive.HiveRegister;
+import org.apache.gobblin.hive.HiveTable;
+import org.apache.gobblin.hive.metastore.HiveMetaStoreUtils;
+import org.apache.gobblin.util.function.CheckedExceptionPredicate;
+
+
+/**
+ * Determines if a dataset's hive schema contains a non optional union
+ */
+@Slf4j
+public class DatasetHiveSchemaContainsNonOptionalUnion<T extends Dataset> implements CheckedExceptionPredicate<T, IOException> {
+  private HiveRegister hiveRegister;
+  private Pattern pattern;
+
+  public static final String PREFIX = DatasetHiveSchemaContainsNonOptionalUnion.class.getName();
+  /**
+   * 1st match group is assumed to be the DB and the 2nd match group the Table for the pattern
+   */
+  public static final String PATTERN = PREFIX + ".db.table.pattern";
+
+  public DatasetHiveSchemaContainsNonOptionalUnion(Properties properties) {
+    this.hiveRegister = getHiveRegister(new State(properties));
+    this.pattern = Pattern.compile(properties.getProperty(PATTERN));
+  }
+
+  @Override
+  public boolean test(T dataset) throws IOException {
+    Optional<HiveTable> hiveTable = getTable(dataset);
+    if (!hiveTable.isPresent()) {
+      log.error("No matching table for dataset={}", dataset);
+      return false;
+    }
+
+    return containsNonOptionalUnion(hiveTable.get());
+  }
+
+  private Optional<HiveTable> getTable(T dataset) throws IOException {
+    DbAndTable dbAndTable = getDbAndTable(dataset);
+    return this.hiveRegister.getTable(dbAndTable.getDb(), dbAndTable.getTable());
+  }
+
+  private DbAndTable getDbAndTable(T dataset) {
+    Matcher m = pattern.matcher(dataset.getUrn());
+    if (!m.matches() || m.groupCount() != 2) {
+      throw new IllegalStateException(String.format("Dataset urn [%s] doesn't follow expected pattern. " +
+      "Expected pattern = %s", dataset.getUrn(), pattern.pattern()));
+    }
+    return new DbAndTable(m.group(1), m.group(2));
+  }
+
+  boolean containsNonOptionalUnion(HiveTable table) {
+    return HiveMetaStoreUtils.containsNonOptionalUnionTypeColumn(table);
+  }
+
+  private HiveRegister getHiveRegister(State state){
+    return HiveRegister.get(state);
+  }
+
+  @Data
+  private static class DbAndTable {
+    private final String db;
+    private final String table;
+  }
+}

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
@@ -17,14 +17,17 @@
 
 package org.apache.gobblin.iceberg.predicates;
 
-import com.google.common.base.Optional;
-import gobblin.configuration.State;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.google.common.base.Optional;
+
+import gobblin.configuration.State;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.dataset.Dataset;
 import org.apache.gobblin.hive.HiveRegister;
 import org.apache.gobblin.hive.HiveTable;
@@ -37,8 +40,8 @@ import org.apache.gobblin.util.function.CheckedExceptionPredicate;
  */
 @Slf4j
 public class DatasetHiveSchemaContainsNonOptionalUnion<T extends Dataset> implements CheckedExceptionPredicate<T, IOException> {
-  private HiveRegister hiveRegister;
-  private Pattern pattern;
+  private final HiveRegister hiveRegister;
+  private final Pattern pattern;
 
   public static final String PREFIX = DatasetHiveSchemaContainsNonOptionalUnion.class.getName();
   /**

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.iceberg.predicates;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.dataset.Dataset;
+import org.apache.gobblin.dataset.test.SimpleDatasetForTesting;
+import org.apache.gobblin.hive.HiveTable;
+import org.apache.gobblin.hive.metastore.HiveMetaStoreUtils;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.apache.iceberg.hive.HiveMetastoreTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(dependsOnGroups = "icebergMetadataWriterTest")
+public class DatasetHiveSchemaContainsNonOptionalUnionTest extends HiveMetastoreTest {
+
+  private static String dbName = "dbname_" +
+      DatasetHiveSchemaContainsNonOptionalUnionTest.class.getSimpleName().toLowerCase();
+  private static File tmpDir;
+  private static State state;
+  private static String dbUri;
+  private static String testTable = "test_table";
+
+  @AfterSuite
+  public void clean() throws Exception {
+    FileUtils.forceDeleteOnExit(tmpDir);
+  }
+
+  @BeforeSuite
+  public void setup() throws Exception {
+    Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
+    startMetastore();
+    tmpDir = Files.createTempDir();
+    dbUri = String.format("%s/%s/%s", tmpDir.getAbsolutePath(),"metastore", dbName);
+    try {
+      metastoreClient.getDatabase(dbName);
+    } catch (NoSuchObjectException e) {
+      metastoreClient.createDatabase(
+          new Database(dbName, "database", dbUri, Collections.emptyMap()));
+    }
+
+    final State serdeProps = new State();
+    final String avroSchema = "{\"type\": \"record\", \"name\": \"TestEvent\",\"namespace\": \"test.namespace\", \"fields\": "
+        + "[{\"name\":\"fieldName\", \"type\": %s}]}";
+    serdeProps.setProp("avro.schema.literal", String.format(avroSchema, "[\"string\", \"int\"]"));
+    HiveTable testTable = createTestHiveTable_Avro(serdeProps);
+    metastoreClient.createTable(HiveMetaStoreUtils.getTable(testTable));
+
+    state = ConfigUtils.configToState(ConfigUtils.propertiesToConfig(hiveConf.getAllProperties()));
+    state.setProp(DatasetHiveSchemaContainsNonOptionalUnion.PATTERN, "/data/(\\w+)/(\\w+)");
+    Assert.assertNotNull(metastoreClient.getTable(dbName, DatasetHiveSchemaContainsNonOptionalUnionTest.testTable));
+  }
+
+  @Test
+  public void testContainsNonOptionalUnion() throws Exception {
+    DatasetHiveSchemaContainsNonOptionalUnion predicate = new DatasetHiveSchemaContainsNonOptionalUnion(state.getProperties());
+    Dataset dataset = new SimpleDatasetForTesting("/data/" + dbName + "/" + testTable);
+    Assert.assertTrue(predicate.test(dataset));
+  }
+
+  private HiveTable createTestHiveTable_Avro(State props) {
+    HiveTable.Builder builder = new HiveTable.Builder();
+    HiveTable hiveTable = builder.withDbName(dbName).withTableName(testTable).withProps(props).build();
+    hiveTable.setInputFormat(AvroContainerInputFormat.class.getName());
+    hiveTable.setOutputFormat(AvroContainerOutputFormat.class.getName());
+    hiveTable.setSerDeType(AvroSerDe.class.getName());
+
+    // Serialize then deserialize as a way to quickly setup table object
+    Table table = HiveMetaStoreUtils.getTable(hiveTable);
+    return HiveMetaStoreUtils.getHiveTable(table);
+  }
+}

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -46,8 +46,8 @@ import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.thrift.TException;
 import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
@@ -118,14 +118,14 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
   IMetaStoreClient client;
   private static TestHiveMetastore testHiveMetastore;
 
-  @AfterClass
+  @AfterSuite
   public void clean() throws Exception {
-    //Finally stop the metaStore
-    stopMetastore();
     gobblinMCEWriter.close();
     FileUtils.forceDeleteOnExit(tmpDir);
+    //Finally stop the metaStore
+    stopMetastore();
   }
-  @BeforeClass
+  @BeforeSuite
   public void setUp() throws Exception {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
     startMetastore();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/function/CheckedExceptionPredicate.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/function/CheckedExceptionPredicate.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.function;
+
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+/**
+ * Alternative to {@link Predicate} that handles wrapping (or tunneling) a single checked {@link Exception} derived class.
+ * Based on and extremely similar to {@link CheckedExceptionFunction}.<br><br>
+ *
+ * At first glance, it appears these 2 classes could be generalized and combined without the uncomfortable amount of duplication.
+ * But this is not possible to do cleanly because:
+ *   <ul>
+ *     <li> {@link Predicate} and {@link Function} are separate types with no inheritance hierarchy relationship</li>
+ *     <li>
+ *       {@link CheckedExceptionPredicate#wrapToUnchecked(CheckedExceptionPredicate)} returns a {@link Predicate}
+ *       but {@link CheckedExceptionFunction#wrapToUnchecked(CheckedExceptionFunction)} returns a {@link Function}. And
+ *       since Java does not support higher level generics / type classes (i.e. type parameters for types that are
+ *       themselves parameterized)
+ *     </li>
+ *   </ul>
+ */
+@FunctionalInterface
+public interface CheckedExceptionPredicate<T, E extends Exception> {
+  /**
+   * Wrapper to tunnel {@link IOException} as an unchecked exception that would later be unwrapped via
+   * {@link WrappedIOException#rethrowWrapped()}.  If no expectation of unwrapping, this wrapper may simply add
+   * unnecessary obfuscation: instead use {@link CheckedExceptionPredicate#wrapToUnchecked(CheckedExceptionPredicate)}
+   *
+   * BUMMER: specific {@link IOException} hard-coded because: "generic class may not extend {@link java.lang.Throwable}"
+   */
+  @RequiredArgsConstructor
+  class WrappedIOException extends RuntimeException {
+    @Getter
+    private final IOException wrappedException;
+
+    /** CAUTION: if this be your intent, DO NOT FORGET!  Being unchecked, the compiler WILL NOT remind you. */
+    public void rethrowWrapped() throws IOException {
+      throw wrappedException;
+    }
+  }
+
+  boolean test(T arg) throws E;
+
+  /** @return {@link Predicate} proxy that catches any instance of {@link Exception} and rethrows it wrapped as {@link RuntimeException} */
+  static <T,  E extends Exception> Predicate<T> wrapToUnchecked(CheckedExceptionPredicate<T, E> f) {
+    return a -> {
+      try {
+        return f.test(a);
+      } catch (RuntimeException re) {
+        throw re; // no double wrapping
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  /**
+   * @return {@link Predicate} proxy that catches any instance of {@link IOException}, and rethrows it wrapped as {@link WrappedIOException},
+   * for easy unwrapping via {@link WrappedIOException#rethrowWrapped()}
+   */
+  static <T, E extends IOException> Predicate<T> wrapToTunneled(CheckedExceptionPredicate<T, E> f) {
+    return a -> {
+      try {
+        return f.test(a);
+      } catch (RuntimeException re) {
+        throw re; // no double wrapping
+      } catch (IOException ioe) {
+        throw new WrappedIOException(ioe);
+      }
+    };
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1779] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1779



### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Problem Statement:
Goal is to make it easy for users to filter out datasets with non optional unions. Avro and ORC flexible schema supports non optional unions. But Iceberg does not support these schemas. This can cause mismatched schemas when writing with different writers. e.g. writing with iceberg will write a struct but writing native orc writer will write as a uniontype 
- https://github.com/apache/gobblin/pull/3632

Future users may want to implement similar complex filtering on the results of their dataset finders. And this filtering may be very complex. The goal is to make it easy for users to build their own filtering predicates.

Design:
- 

- [DatasetsFinderFilteringDecorator.java](https://github.com/apache/gobblin/pull/3648/files#diff-a06c86cb0d75fff742e8b165e42a43b99283b7fd7a54e1cbc1e970d39c389f54)
  - Decorator for any `DatasetsFinder` that accepts denylist and allowlist filters. In this case, we can specify that all tables with non optional unions are excluded or should be included 
- [DatasetHiveSchemaContainsNonOptionalUnion.java](https://github.com/apache/gobblin/pull/3648/files#diff-cd091eebaee68d566e9c4f6f00a74a9f14c7cbfec6ccef202a5aacd8ddb6e3a6)
  - Predicate that fetches table from hive and performs check on if the schema contains a non optional union
- [CheckedExceptionPredicate.java](https://github.com/apache/gobblin/pull/3648/files#diff-b6c16f111a3f6af91582a5a434dcb4e6df3db0e36a1beca4e232eed38c0ea455)
  - Util functional interface for providing proper IO exceptions with these predicates (since often these predicates will be making IO calls that can fail) 
  - https://github.com/apache/gobblin/blob/585298fb5ebc074f69c1b9db87de6186c4855b26/gobblin-utility/src/main/java/org/apache/gobblin/util/function/CheckedExceptionFunction.java
  - See the above for the equivalent implementation for Function

Alternative designs:
- Alternatively, I could have directly modified any relevant sources or dataset finders to do the filtering there. The problem with that approach is that then we end up class specific configs that are niche and not generalizable.
- There is also lots of business logic involved with complex filtering. Adding this business logic into a specific dataset finder would create spaghetti  super classes.
- Gobblin is OSS and there are many implementations of dataset finders that are internal, which would require extra dev effort to implement filtering. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Hive metastore tests
![image](https://user-images.githubusercontent.com/35702680/220764654-3d437c95-1c67-4331-b344-00dcd7a1a613.png)
Dataset finder tests
![image](https://user-images.githubusercontent.com/35702680/220764943-8d35d077-d036-4bbb-84b1-7ac7e269e6f2.png)


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

