### PR TITLE
[GOBBLIN-1790] Add and change appropriate job status fields for observability events

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -130,6 +130,7 @@ public class ConfigurationKeys {
    */
   public static final String FLOW_NAME_KEY = "flow.name";
   public static final String FLOW_GROUP_KEY = "flow.group";
+  public static final String FLOW_EDGE_ID_KEY = "flow.edgeId";
   public static final String FLOW_DESCRIPTION_KEY = "flow.description";
   public static final String FLOW_EXECUTION_ID_KEY = "flow.executionId";
   public static final String FLOW_FAILURE_OPTION = "flow.failureOption";
@@ -139,6 +140,7 @@ public class ConfigurationKeys {
   public static final String FLOW_EXPLAIN_KEY = "flow.explain";
   public static final String FLOW_UNSCHEDULE_KEY = "flow.unschedule";
   public static final String FLOW_OWNING_GROUP_KEY = "flow.owningGroup";
+  public static final String FLOW_SPEC_EXECUTOR = "flow.edge.specExecutors";
 
   /**
    * Common topology configuration properties.

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -87,6 +87,24 @@
       "compliance": "NONE"
     },
     {
+      "name": "jobPlanningPhaseStartTime",
+      "type": [
+        "null",
+        "long"
+      ],
+      "doc": "Start time of the workunit planning phase in millis since Epoch, null if the job was never run or fails to reach this phase",
+      "compliance": "NONE"
+    },
+    {
+      "name": "jobPlanningPhaseEndTime",
+      "type": [
+        "null",
+        "long"
+      ],
+      "doc": "End time of the workunit planning phase in millis since Epoch, null if the job was never run or fails to reach this phase",
+      "compliance": "NONE"
+    },
+    {
       "name": "executionUserUrn",
       "type": [
         "null",

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -81,6 +81,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_NAME_FIELD = "flowName";
     public static final String FLOW_GROUP_FIELD = "flowGroup";
     public static final String FLOW_EXECUTION_ID_FIELD = "flowExecutionId";
+    public static final String FLOW_EDGE_FIELD = "flowEdge";
     public static final String JOB_NAME_FIELD = "jobName";
     public static final String JOB_GROUP_FIELD = "jobGroup";
     public static final String JOB_TAG_FIELD = "jobTag";
@@ -105,6 +106,8 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
   public static final String JOB_ORCHESTRATED_TIME = "jobOrchestratedTime";
   public static final String JOB_START_TIME = "jobStartTime";
   public static final String JOB_SKIPPED_TIME = "jobSkippedTime";
+  public static final String WORKUNIT_PLAN_START_TIME = "workunitPlanStartTime";
+  public static final String WORKUNIT_PLAN_END_TIME = "workunitPlanEndTime";
   public static final String JOB_END_TIME = "jobEndTime";
   public static final String JOB_LAST_PROGRESS_EVENT_TIME = "jobLastProgressEventTime";
   public static final String JOB_COMPLETION_PERCENTAGE = "jobCompletionPercentage";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -82,6 +82,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_GROUP_FIELD = "flowGroup";
     public static final String FLOW_EXECUTION_ID_FIELD = "flowExecutionId";
     public static final String FLOW_EDGE_FIELD = "flowEdge";
+    public static final String FLOW_MODIFICATION_TIME_FIELD = "flowModificationTime";
     public static final String JOB_NAME_FIELD = "jobName";
     public static final String JOB_GROUP_FIELD = "jobGroup";
     public static final String JOB_TAG_FIELD = "jobTag";

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -68,6 +68,7 @@ import org.apache.gobblin.runtime.listeners.CompositeJobListener;
 import org.apache.gobblin.runtime.listeners.EmailNotificationJobListener;
 import org.apache.gobblin.runtime.listeners.JobListener;
 import org.apache.gobblin.runtime.services.MetricsReportingService;
+import org.apache.gobblin.service.modules.orchestration.AzkabanProjectConfig;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.HadoopUtils;
@@ -415,6 +416,7 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
         jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY, "")));
     metadataTags.add(new Tag<>(TimingEvent.METADATA_MESSAGE, jobExecutionUrl));
 
+    metadataTags.add(new Tag<>(AzkabanProjectConfig.USER_TO_PROXY, jobProps.getProperty(AzkabanProjectConfig.USER_TO_PROXY, "")));
     LOG.debug(String.format("AzkabanJobLauncher.addAdditionalMetadataTags: metadataTags %s", metadataTags));
 
     return metadataTags;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -431,8 +431,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     String jobId = this.jobContext.getJobId();
     final JobState jobState = this.jobContext.getJobState();
     boolean isWorkUnitsEmpty = false;
-    TimingEvent workUnitsCreationTimer =
-        this.eventSubmitter.getTimingEvent(TimingEvent.LauncherTimings.WORK_UNITS_CREATION);
     try {
       MDC.put(ConfigurationKeys.JOB_NAME_KEY, this.jobContext.getJobName());
       MDC.put(ConfigurationKeys.JOB_KEY_KEY, this.jobContext.getJobKey());
@@ -463,6 +461,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
             ((SourceDecorator<?, ?>) source).getEventBus().register(this);
           }
         }
+        TimingEvent workUnitsCreationTimer =
+            this.eventSubmitter.getTimingEvent(TimingEvent.LauncherTimings.WORK_UNITS_CREATION);
         WorkUnitStream workUnitStream;
         if (source instanceof WorkUnitStreamSource) {
           workUnitStream = ((WorkUnitStreamSource) source).getWorkunitStream(jobState);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
@@ -66,6 +66,8 @@ class TimingEventUtils {
     jobMetadata.put(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, Boolean.toString(false));
     jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD,
         ConfigUtils.getString(jobSpec.getConfig(), ConfigurationKeys.FLOW_EDGE_ID_KEY, ""));
+    jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD, Long.toString(
+        ConfigUtils.getLong(jobSpec.getConfig(), FlowSpec.MODIFICATION_TIME_KEY, 0L)));
 
     return jobMetadata;
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
@@ -64,7 +64,8 @@ class TimingEventUtils {
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getCurrentAttempts()));
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, Integer.toString(jobExecutionPlan.getCurrentGeneration()));
     jobMetadata.put(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, Boolean.toString(false));
-    jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.FLOW_EDGE_ID_KEY));
+    jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD,
+        ConfigUtils.getString(jobSpec.getConfig(), ConfigurationKeys.FLOW_EDGE_ID_KEY, ""));
 
     return jobMetadata;
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
@@ -59,11 +59,12 @@ class TimingEventUtils {
     jobMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.JOB_NAME_KEY));
     jobMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.JOB_GROUP_KEY));
     jobMetadata.put(TimingEvent.FlowEventConstants.JOB_TAG_FIELD, ConfigUtils.getString(jobSpec.getConfig(), ConfigurationKeys.JOB_TAG_KEY, null));
-    jobMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, specExecutor.getClass().getCanonicalName());
+    jobMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, specExecutor.getUri().toString());
     jobMetadata.put(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getMaxAttempts()));
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getCurrentAttempts()));
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD, Integer.toString(jobExecutionPlan.getCurrentGeneration()));
     jobMetadata.put(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, Boolean.toString(false));
+    jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.FLOW_EDGE_ID_KEY));
 
     return jobMetadata;
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -103,10 +103,10 @@ public class JobExecutionPlan {
       String flowFailureOption = ConfigUtils.getString(flowConfig, ConfigurationKeys.FLOW_FAILURE_OPTION, DagManager.DEFAULT_FLOW_FAILURE_OPTION);
       String flowInputPath = ConfigUtils.getString(flowConfig, DatasetDescriptorConfigKeys.FLOW_INPUT_DATASET_DESCRIPTOR_PREFIX
           + "." + DatasetDescriptorConfigKeys.PATH_KEY, "");
+      Long flowModTime = ConfigUtils.getLong(flowConfig, FlowSpec.MODIFICATION_TIME_KEY, 0L);
 
       String jobName = ConfigUtils.getString(jobConfig, ConfigurationKeys.JOB_NAME_KEY, "");
       String edgeId = ConfigUtils.getString(jobConfig, FlowGraphConfigurationKeys.FLOW_EDGE_ID_KEY, "");
-
       // Modify the job name to include the flow group, flow name, edge id, and a random string to avoid collisions since
       // job names are assumed to be unique within a dag.
       int hash = flowInputPath.hashCode();
@@ -141,6 +141,7 @@ public class JobExecutionPlan {
           //Add flow failure option
           .withValue(ConfigurationKeys.FLOW_FAILURE_OPTION, ConfigValueFactory.fromAnyRef(flowFailureOption))
           .withValue(ConfigurationKeys.FLOW_EDGE_ID_KEY, ConfigValueFactory.fromAnyRef(edgeId))
+          .withValue(FlowSpec.MODIFICATION_TIME_KEY, ConfigValueFactory.fromAnyRef(flowModTime))
       );
 
       //Add tracking config to JobSpec.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -140,6 +140,7 @@ public class JobExecutionPlan {
           .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
           //Add flow failure option
           .withValue(ConfigurationKeys.FLOW_FAILURE_OPTION, ConfigValueFactory.fromAnyRef(flowFailureOption))
+          .withValue(ConfigurationKeys.FLOW_EDGE_ID_KEY, ConfigValueFactory.fromAnyRef(edgeId))
       );
 
       //Add tracking config to JobSpec.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -91,7 +91,8 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     Long jobStartTime = jobState.contains(TimingEvent.JOB_START_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_START_TIME) : null;
     Long jobEndTime = jobState.contains(TimingEvent.JOB_END_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_END_TIME) : null;
     Long jobOrchestratedTime = jobState.contains(TimingEvent.JOB_ORCHESTRATED_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_ORCHESTRATED_TIME) : null;
-    String userToProxy = jobState.contains(AzkabanProjectConfig.USER_TO_PROXY) ? jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY) : null;
+    Long jobPlanningPhaseStartTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_START_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_START_TIME) : null;
+    Long jobPlanningPhaseEndTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_END_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_END_TIME) : null;
     GaaSObservabilityEventExperimental.Builder builder = GaaSObservabilityEventExperimental.newBuilder();
     List<Issue> issueList = null;
     try {
@@ -107,17 +108,19 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     builder.setTimestamp(System.currentTimeMillis())
         .setFlowName(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD))
         .setFlowGroup(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD))
-        .setFlowGraphEdgeId(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD))
+        .setFlowGraphEdgeId(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, ""))
         .setFlowExecutionId(jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD))
         .setJobName(jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD))
         .setExecutorUrl(jobState.getProp(TimingEvent.METADATA_MESSAGE))
-        .setExecutorId(jobState.getProp(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD))
+        .setExecutorId(jobState.getProp(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, ""))
         .setJobStartTime(jobStartTime)
         .setJobEndTime(jobEndTime)
         .setJobOrchestratedTime(jobOrchestratedTime)
+        .setJobPlanningPhaseStartTime(jobPlanningPhaseStartTime)
+        .setJobPlanningPhaseEndTime(jobPlanningPhaseEndTime)
         .setIssues(issueList)
         .setJobStatus(status)
-        .setExecutionUserUrn(userToProxy)
+        .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null))
         // TODO: Set this value when flowSpec stores its modification time
         .setLastFlowModificationTime(0);
     return builder.build();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -93,7 +93,6 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     Long jobOrchestratedTime = jobState.contains(TimingEvent.JOB_ORCHESTRATED_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_ORCHESTRATED_TIME) : null;
     Long jobPlanningPhaseStartTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_START_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_START_TIME) : null;
     Long jobPlanningPhaseEndTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_END_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_END_TIME) : null;
-    Long lastFlowModifiedTime = jobState.contains(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD) ? jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD) : null;
     GaaSObservabilityEventExperimental.Builder builder = GaaSObservabilityEventExperimental.newBuilder();
     List<Issue> issueList = null;
     try {
@@ -111,7 +110,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setFlowGroup(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD))
         .setFlowGraphEdgeId(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, ""))
         .setFlowExecutionId(jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD))
-        .setLastFlowModificationTime(lastFlowModifiedTime)
+        .setLastFlowModificationTime(jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD, 0))
         .setJobName(jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD))
         .setExecutorUrl(jobState.getProp(TimingEvent.METADATA_MESSAGE))
         .setExecutorId(jobState.getProp(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, ""))

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -93,6 +93,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     Long jobOrchestratedTime = jobState.contains(TimingEvent.JOB_ORCHESTRATED_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_ORCHESTRATED_TIME) : null;
     Long jobPlanningPhaseStartTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_START_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_START_TIME) : null;
     Long jobPlanningPhaseEndTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_END_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_END_TIME) : null;
+    Long lastFlowModifiedTime = jobState.contains(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD) ? jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD) : null;
     GaaSObservabilityEventExperimental.Builder builder = GaaSObservabilityEventExperimental.newBuilder();
     List<Issue> issueList = null;
     try {
@@ -110,6 +111,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setFlowGroup(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD))
         .setFlowGraphEdgeId(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, ""))
         .setFlowExecutionId(jobState.getPropAsLong(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD))
+        .setLastFlowModificationTime(lastFlowModifiedTime)
         .setJobName(jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD))
         .setExecutorUrl(jobState.getProp(TimingEvent.METADATA_MESSAGE))
         .setExecutorId(jobState.getProp(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, ""))
@@ -120,9 +122,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setJobPlanningPhaseEndTime(jobPlanningPhaseEndTime)
         .setIssues(issueList)
         .setJobStatus(status)
-        .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null))
-        // TODO: Set this value when flowSpec stores its modification time
-        .setLastFlowModificationTime(0);
+        .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null));
     return builder.build();
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -127,6 +127,8 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
       case TimingEvent.FlowTimings.FLOW_COMPILED:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPILED.name());
         break;
+      case TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION:
+      case TimingEvent.LauncherTimings.JOB_START:
       case TimingEvent.FlowTimings.FLOW_RUNNING:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());
         break;
@@ -141,11 +143,9 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
         properties.put(TimingEvent.JOB_ORCHESTRATED_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
-      case TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION:
       case TimingEvent.LauncherTimings.JOB_PREPARE:
-      case TimingEvent.LauncherTimings.JOB_START:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());
-        properties.put(TimingEvent.JOB_START_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
+        properties.put(TimingEvent.JOB_START_TIME, properties.getProperty(TimingEvent.METADATA_START_TIME));
         break;
       case TimingEvent.FlowTimings.FLOW_SUCCEEDED:
       case TimingEvent.LauncherTimings.JOB_SUCCEEDED:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -128,6 +128,9 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPILED.name());
         break;
       case TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION:
+        properties.put(TimingEvent.WORKUNIT_PLAN_START_TIME, properties.getProperty(TimingEvent.METADATA_START_TIME));
+        properties.put(TimingEvent.WORKUNIT_PLAN_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
+        break;
       case TimingEvent.LauncherTimings.JOB_START:
       case TimingEvent.FlowTimings.FLOW_RUNNING:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
@@ -77,6 +77,7 @@ public class JobExecutionPlanDagFactoryTest {
     properties = new Properties();
     properties.put("specStore.fs.dir", "/tmp/testSpecStoreDir");
     properties.put("specExecInstance.capabilities", "source:destination");
+    properties.put(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, "testSpecExecutorInstanceUri");
     Config specExecutorConfig = ConfigUtils.propertiesToConfig(properties);
     this.specExecutor = new InMemorySpecExecutor(specExecutorConfig);
   }
@@ -89,7 +90,8 @@ public class JobExecutionPlanDagFactoryTest {
       Config config = jobTemplate.getRawTemplateConfig()
           .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef("testFlowName"))
           .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef("testFlowGroup"))
-          .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(System.currentTimeMillis()));
+          .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(System.currentTimeMillis()))
+          .withValue(FlowGraphConfigurationKeys.FLOW_EDGE_ID_KEY, ConfigValueFactory.fromAnyRef("source:destination:edgeName1"));
 
       String jobSpecUri = Files.getNameWithoutExtension(new Path(jobTemplate.getUri()).getName());
       jobExecutionPlans.add(new JobExecutionPlan(JobSpec.builder(jobSpecUri).withConfig(config).
@@ -111,6 +113,10 @@ public class JobExecutionPlanDagFactoryTest {
     Assert.assertEquals(endNodeName, "job4");
     templateUri = new Path(dag.getEndNodes().get(0).getValue().getJobSpec().getTemplateURI().get()).getName();
     Assert.assertEquals(templateUri, "job4.job");
+    String flowEdgeId = dag.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(FlowGraphConfigurationKeys.FLOW_EDGE_ID_KEY);
+    Assert.assertEquals(flowEdgeId, "source:destination:edgeName1");
+    String specExecutorId = dag.getStartNodes().get(0).getValue().getSpecExecutor().getUri().toString();
+    Assert.assertEquals(specExecutorId, "testSpecExecutorInstanceUri");
 
     Dag.DagNode<JobExecutionPlan> startNode = dag.getStartNodes().get(0);
     List<Dag.DagNode<JobExecutionPlan>> nextNodes = dag.getChildren(startNode);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -41,6 +41,7 @@ import org.apache.gobblin.runtime.troubleshooter.IssueSeverity;
 import org.apache.gobblin.runtime.troubleshooter.MultiContextIssueRepository;
 import org.apache.gobblin.runtime.troubleshooter.TroubleshooterUtils;
 import org.apache.gobblin.service.ExecutionStatus;
+import org.apache.gobblin.service.modules.orchestration.AzkabanProjectConfig;
 
 
 public class GaaSObservabilityProducerTest {
@@ -48,7 +49,7 @@ public class GaaSObservabilityProducerTest {
   private MultiContextIssueRepository issueRepository = new InMemoryMultiContextIssueRepository();
 
   @Test
-  public void testCreateGaaSObservabilityEvent() throws Exception {
+  public void testCreateGaaSObservabilityEventWithFullMetadata() throws Exception {
     String flowGroup = "testFlowGroup1";
     String flowName = "testFlowName1";
     String jobName = String.format("%s_%s_%s", flowGroup, flowName, "testJobName1");
@@ -64,10 +65,14 @@ public class GaaSObservabilityProducerTest {
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, "1");
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobName);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, flowName);
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, "flowEdge");
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, "specExecutor");
+    gteEventMetadata.put(AzkabanProjectConfig.USER_TO_PROXY, "azkabanUser");
     gteEventMetadata.put(TimingEvent.METADATA_MESSAGE, "hostName");
-    gteEventMetadata.put(TimingEvent.METADATA_START_TIME, "1");
+    gteEventMetadata.put(TimingEvent.METADATA_START_TIME, "20");
     gteEventMetadata.put(TimingEvent.METADATA_END_TIME, "100");
     gteEventMetadata.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
+    gteEventMetadata.put(TimingEvent.JOB_ORCHESTRATED_TIME, "1");
 
     Properties jobStatusProps = new Properties();
     jobStatusProps.putAll(gteEventMetadata);
@@ -85,6 +90,59 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getJobStatus(), JobStatus.SUCCEEDED);
     Assert.assertEquals(event.getExecutorUrl(), "hostName");
     Assert.assertEquals(event.getIssues().size(), 1);
+    Assert.assertEquals(event.getFlowGraphEdgeId(), "flowEdge");
+    Assert.assertEquals(event.getExecutorId(), "specExecutor");
+    Assert.assertEquals(event.getExecutionUserUrn(), "azkabanUser");
+    Assert.assertEquals(event.getJobOrchestratedTime(), Long.valueOf(1));
+
+    AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
+        GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()
+    );
+    serializer.serializeRecord(event);
+  }
+
+  @Test
+  public void testCreateGaaSObservabilityEventWithPartialMetadata() throws Exception {
+    String flowGroup = "testFlowGroup2";
+    String flowName = "testFlowName2";
+    String jobName = String.format("%s_%s_%s", flowGroup, flowName, "testJobName1");
+    String flowExecutionId = "1";
+    this.issueRepository.put(
+        TroubleshooterUtils.getContextIdForJob(flowGroup, flowName, flowExecutionId, jobName),
+        createTestIssue("issueSummary", "issueCode", IssueSeverity.INFO)
+    );
+    MockGaaSObservabilityEventProducer producer = new MockGaaSObservabilityEventProducer(new State(), this.issueRepository);
+    Map<String, String> gteEventMetadata = Maps.newHashMap();
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, flowGroup);
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, flowName);
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, "1");
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobName);
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, flowName);
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, "flowEdge");
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, "specExecutor");
+    gteEventMetadata.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
+
+    Properties jobStatusProps = new Properties();
+    jobStatusProps.putAll(gteEventMetadata);
+    producer.emitObservabilityEvent(new State(jobStatusProps));
+
+    List<GaaSObservabilityEventExperimental> emittedEvents = producer.getTestEmittedEvents();
+
+    Assert.assertEquals(emittedEvents.size(), 1);
+    Iterator<GaaSObservabilityEventExperimental> iterator = emittedEvents.iterator();
+    GaaSObservabilityEventExperimental event = iterator.next();
+    Assert.assertEquals(event.getFlowGroup(), flowGroup);
+    Assert.assertEquals(event.getFlowName(), flowName);
+    Assert.assertEquals(event.getJobName(), jobName);
+    Assert.assertEquals(event.getFlowExecutionId(), Long.valueOf(flowExecutionId));
+    Assert.assertEquals(event.getJobStatus(), JobStatus.CANCELLED);
+    Assert.assertEquals(event.getIssues().size(), 1);
+    Assert.assertEquals(event.getFlowGraphEdgeId(), "flowEdge");
+    Assert.assertEquals(event.getExecutorId(), "specExecutor");
+    Assert.assertEquals(event.getJobOrchestratedTime(), null);
+    Assert.assertEquals(event.getJobStartTime(), null);
+    Assert.assertEquals(event.getExecutionUserUrn(), null);
+    Assert.assertEquals(event.getExecutorUrl(), null);
 
     AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
         GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -62,7 +62,7 @@ public class GaaSObservabilityProducerTest {
     Map<String, String> gteEventMetadata = Maps.newHashMap();
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, flowGroup);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, flowName);
-    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, "1");
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, flowExecutionId);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobName);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, flowName);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, "flowEdge");
@@ -94,6 +94,7 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getExecutorId(), "specExecutor");
     Assert.assertEquals(event.getExecutionUserUrn(), "azkabanUser");
     Assert.assertEquals(event.getJobOrchestratedTime(), Long.valueOf(1));
+    Assert.assertEquals(event.getJobStartTime(), Long.valueOf(20));
 
     AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
         GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -69,10 +69,11 @@ public class GaaSObservabilityProducerTest {
     gteEventMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, "specExecutor");
     gteEventMetadata.put(AzkabanProjectConfig.USER_TO_PROXY, "azkabanUser");
     gteEventMetadata.put(TimingEvent.METADATA_MESSAGE, "hostName");
-    gteEventMetadata.put(TimingEvent.METADATA_START_TIME, "20");
-    gteEventMetadata.put(TimingEvent.METADATA_END_TIME, "100");
+    gteEventMetadata.put(TimingEvent.JOB_START_TIME, "20");
+    gteEventMetadata.put(TimingEvent.JOB_END_TIME, "100");
     gteEventMetadata.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
     gteEventMetadata.put(TimingEvent.JOB_ORCHESTRATED_TIME, "1");
+    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_MODIFICATION_TIME_FIELD, "20");
 
     Properties jobStatusProps = new Properties();
     jobStatusProps.putAll(gteEventMetadata);
@@ -94,7 +95,9 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getExecutorId(), "specExecutor");
     Assert.assertEquals(event.getExecutionUserUrn(), "azkabanUser");
     Assert.assertEquals(event.getJobOrchestratedTime(), Long.valueOf(1));
+    Assert.assertEquals(event.getLastFlowModificationTime(), Long.valueOf(20));
     Assert.assertEquals(event.getJobStartTime(), Long.valueOf(20));
+    Assert.assertEquals(event.getJobEndTime(), Long.valueOf(100));
 
     AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
         GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1790


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

In GaaS, the observability events are still missing a few fields:
1. Job Orchestration time

2. Flowgraph edge ID

3. Spec executor ID

4. Azkaban user (if eligable)

Additionally, the job start time field is inaccurate as it is set from multiple GTE events. We should be tracking it from a consistent point in the Gobblin Job, otherwise it will not be accurate when measuring the job runtime.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

