### PR TITLE
[GOBBLIN-1792] Upgrade Mockito to 4.* 

### DIFF
--- a/gobblin-aws/build.gradle
+++ b/gobblin-aws/build.gradle
@@ -69,7 +69,6 @@ dependencies {
   testCompile externalDependency.curatorFramework
   testCompile externalDependency.curatorTest
   testCompile externalDependency.mockito
-  testCompile externalDependency.powermock
   testCompile externalDependency.slf4jToLog4j
 }
 

--- a/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSClusterLauncher.java
+++ b/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSClusterLauncher.java
@@ -319,7 +319,7 @@ public class GobblinAWSClusterLauncher {
   }
 
   @VisibleForTesting
-  AWSSdkClient createAWSSdkClient() {
+  protected AWSSdkClient createAWSSdkClient() {
     return new AWSSdkClient(this.awsClusterSecurityManager,
         Region.getRegion(Regions.fromName(this.awsRegion)));
   }

--- a/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
+++ b/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
@@ -17,33 +17,13 @@
 
 package org.apache.gobblin.aws;
 
-import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
-import com.amazonaws.services.autoscaling.model.Tag;
-import com.amazonaws.services.autoscaling.model.TagDescription;
-import com.amazonaws.services.ec2.model.AvailabilityZone;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.common.io.Closer;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
-import org.apache.gobblin.cluster.GobblinHelixConstants;
-import org.apache.gobblin.cluster.HelixMessageSubTypes;
-import org.apache.gobblin.cluster.HelixMessageTestBase;
-import org.apache.gobblin.cluster.HelixUtils;
-import org.apache.gobblin.cluster.TestHelper;
-import org.apache.gobblin.cluster.TestShutdownMessageHandlerFactory;
-import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
@@ -57,6 +37,29 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.Tag;
+import com.amazonaws.services.autoscaling.model.TagDescription;
+import com.amazonaws.services.ec2.model.AvailabilityZone;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.cluster.GobblinHelixConstants;
+import org.apache.gobblin.cluster.HelixMessageSubTypes;
+import org.apache.gobblin.cluster.HelixMessageTestBase;
+import org.apache.gobblin.cluster.HelixUtils;
+import org.apache.gobblin.cluster.TestHelper;
+import org.apache.gobblin.cluster.TestShutdownMessageHandlerFactory;
+import org.apache.gobblin.testing.AssertWithBackoff;
 
 
 /**

--- a/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
+++ b/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
@@ -187,7 +187,7 @@ public class GobblinAWSClusterLauncherTest extends PowerMockTestCase implements 
             TestHelper.TEST_HELIX_INSTANCE_NAME, InstanceType.CONTROLLER, zkConnectionString);
 
     // Gobblin AWS Cluster Launcher to test
-    this.gobblinAwsClusterLauncher = new GobblinAWSClusterLauncher(this.config);
+    this.gobblinAwsClusterLauncher = new TestGobblinAWSClusterLauncher(this.config);
   }
 
   @Test

--- a/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
+++ b/gobblin-aws/src/test/java/org/apache/gobblin/aws/GobblinAWSClusterLauncherTest.java
@@ -17,31 +17,6 @@
 
 package org.apache.gobblin.aws;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
-
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.test.TestingServer;
-import org.apache.helix.HelixManager;
-import org.apache.helix.HelixManagerFactory;
-import org.apache.helix.InstanceType;
-import org.apache.helix.model.Message;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
 import com.amazonaws.services.autoscaling.model.Tag;
 import com.amazonaws.services.autoscaling.model.TagDescription;
@@ -55,7 +30,12 @@ import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
-
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.TestingServer;
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.cluster.GobblinHelixConstants;
 import org.apache.gobblin.cluster.HelixMessageSubTypes;
@@ -64,6 +44,19 @@ import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.TestHelper;
 import org.apache.gobblin.cluster.TestShutdownMessageHandlerFactory;
 import org.apache.gobblin.testing.AssertWithBackoff;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.model.Message;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 
 /**
@@ -72,9 +65,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  * @author Abhishek Tiwari
  */
 @Test(groups = { "gobblin.aws" })
-@PrepareForTest({ AWSSdkClient.class, GobblinAWSClusterLauncher.class})
-@PowerMockIgnore({"javax.*", "org.apache.helix.*", "org.apache.curator.*", "org.apache.zookeeper.*", "org.w3c.*", "org.xml.*"})
-public class GobblinAWSClusterLauncherTest extends PowerMockTestCase implements HelixMessageTestBase  {
+public class GobblinAWSClusterLauncherTest implements HelixMessageTestBase  {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinAWSClusterLauncherTest.class);
 
   private CuratorFramework curatorFramework;
@@ -115,9 +106,7 @@ public class GobblinAWSClusterLauncherTest extends PowerMockTestCase implements 
   public void setUp() throws Exception {
 
     // Mock AWS SDK calls
-    MockitoAnnotations.initMocks(this);
-
-    PowerMockito.whenNew(AWSSdkClient.class).withAnyArguments().thenReturn(awsSdkClient);
+    MockitoAnnotations.openMocks(this);
 
     Mockito.doNothing()
         .when(awsSdkClient)
@@ -263,6 +252,16 @@ public class GobblinAWSClusterLauncherTest extends PowerMockTestCase implements 
   public void assertMessageReception(Message message) {
     Assert.assertEquals(message.getMsgType(), GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE);
     Assert.assertEquals(message.getMsgSubType(), HelixMessageSubTypes.APPLICATION_MASTER_SHUTDOWN.toString());
+  }
+
+  class TestGobblinAWSClusterLauncher extends GobblinAWSClusterLauncher {
+    public TestGobblinAWSClusterLauncher(Config config) throws IOException {
+      super(config);
+    }
+
+    protected AWSSdkClient createAWSSdkClient() {
+      return awsSdkClient;
+    }
   }
 
   static class GetControllerMessageNumFunc implements Function<Void, Integer> {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
@@ -89,7 +89,7 @@ public class FsJobConfigurationManagerTest {
         throw new IOException("Unexpected event type");
       }
       return null;
-    }).when(this.eventBus).post(Mockito.anyObject());
+    }).when(this.eventBus).post(Mockito.any());
 
     this.fs = FileSystem.getLocal(new Configuration(false));
     Path jobConfDirPath = new Path(jobConfDir);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
@@ -31,7 +31,7 @@ import org.apache.gobblin.util.GobblinProcessBuilder;
 import org.apache.gobblin.util.SystemPropertiesWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
@@ -31,7 +31,7 @@ import org.apache.gobblin.util.GobblinProcessBuilder;
 import org.apache.gobblin.util.SystemPropertiesWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDatasetFinder.java
@@ -17,17 +17,20 @@
 
 package org.apache.gobblin.data.management.copy;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.apache.gobblin.dataset.IterableDatasetFinder;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+
+import org.apache.gobblin.dataset.IterableDatasetFinder;
 
 
 public class ManifestBasedDatasetFinder implements IterableDatasetFinder<ManifestBasedDataset> {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/util/test/RetentionTestHelper.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/util/test/RetentionTestHelper.java
@@ -41,7 +41,7 @@ import org.apache.gobblin.dataset.DatasetsFinder;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/util/test/RetentionTestHelper.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/util/test/RetentionTestHelper.java
@@ -41,7 +41,7 @@ import org.apache.gobblin.dataset.DatasetsFinder;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -492,11 +492,11 @@ public class IcebergDatasetTest {
       FileSystem fs = Mockito.mock(FileSystem.class);
       Mockito.when(fs.getUri()).thenReturn(fsURI);
       Mockito.when(fs.makeQualified(any(Path.class)))
-          .thenAnswer(invocation -> invocation.getArgumentAt(0, Path.class).makeQualified(fsURI, new Path("/")));
+          .thenAnswer(invocation -> invocation.getArgument(0, Path.class).makeQualified(fsURI, new Path("/")));
 
       if (!this.optPathsWithFileStatuses.isPresent()) {
         Mockito.when(fs.getFileStatus(any(Path.class)))
-            .thenAnswer(invocation -> createEmptyFileStatus(invocation.getArgumentAt(0, Path.class).toString()));
+            .thenAnswer(invocation -> createEmptyFileStatus(invocation.getArgument(0, Path.class).toString()));
       } else {
         // WARNING: order is critical--specific paths *after* `any(Path)`; in addition, since mocking further
         // an already-mocked instance, `.doReturn/.when` is needed (vs. `.when/.thenReturn`)

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -62,7 +62,7 @@ import org.apache.gobblin.data.management.copy.CopyContext;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.PreserveAttributes;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 
 /** Tests for {@link org.apache.gobblin.data.management.copy.iceberg.IcebergDataset} */

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -62,7 +62,7 @@ import org.apache.gobblin.data.management.copy.CopyContext;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.PreserveAttributes;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 
 
 /** Tests for {@link org.apache.gobblin.data.management.copy.iceberg.IcebergDataset} */

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 
 
 public class ManifestBasedDatasetFinderTest {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 
 public class ManifestBasedDatasetFinderTest {

--- a/gobblin-iceberg/build.gradle
+++ b/gobblin-iceberg/build.gradle
@@ -56,8 +56,6 @@ dependencies {
     testCompile project(path: ':gobblin-modules:gobblin-kafka-common', configuration: 'tests')
     testCompile externalDependency.testng
     testCompile externalDependency.mockito
-    // Added to mock static methods for GobblinMCEWriterTest
-    testCompile externalDependency.powermock
 }
 
 configurations {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
@@ -17,44 +17,28 @@
 
 package org.apache.gobblin.iceberg.publisher;
 
-import azkaban.jobExecutor.AbstractJob;
-import com.google.common.io.Closer;
-import com.google.common.io.Files;
-import java.io.InputStream;
-import java.util.ArrayList;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.io.Decoder;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.gobblin.hive.policy.HiveSnapshotRegistrationPolicy;
-import org.apache.gobblin.iceberg.GobblinMCEProducer;
-import org.apache.gobblin.metadata.GobblinMetadataChangeEvent;
-import org.apache.gobblin.metadata.OperationType;
-import org.apache.gobblin.metadata.SchemaSource;
-import gobblin.configuration.WorkUnitState;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.commons.io.FileUtils;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.source.workunit.WorkUnit;
-import org.apache.gobblin.writer.FsDataWriterBuilder;
-import org.apache.gobblin.writer.GobblinOrcWriter;
-import org.apache.gobblin.writer.PartitionedDataWriter;
-import org.apache.gobblin.writer.partitioner.TimeBasedWriterPartitioner;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -67,8 +51,29 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+
+import azkaban.jobExecutor.AbstractJob;
+import gobblin.configuration.WorkUnitState;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.hive.policy.HiveSnapshotRegistrationPolicy;
+import org.apache.gobblin.iceberg.GobblinMCEProducer;
+import org.apache.gobblin.metadata.GobblinMetadataChangeEvent;
+import org.apache.gobblin.metadata.OperationType;
+import org.apache.gobblin.metadata.SchemaSource;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.writer.FsDataWriterBuilder;
+import org.apache.gobblin.writer.GobblinOrcWriter;
+import org.apache.gobblin.writer.PartitionedDataWriter;
+import org.apache.gobblin.writer.partitioner.TimeBasedWriterPartitioner;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.when;
 
 
 public class GobblinMCEPublisherTest {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisherTest.java
@@ -67,7 +67,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -81,14 +81,14 @@ public class GobblinMCEWriterTest {
 
   @Mock
   private HiveTable mockTable;
-  private MockedStatic<GobblinConstructorUtils> _mockConstructorUtils;
-  private MockedStatic<FileSystem> _mockedFileSystem;
+  private MockedStatic<GobblinConstructorUtils> mockConstructorUtils;
+  private MockedStatic<FileSystem> mockedFileSystem;
 
   @AfterMethod
   public void clean() throws Exception {
     gobblinMCEWriter.close();
-    _mockConstructorUtils.close();
-    _mockedFileSystem.close();
+    mockConstructorUtils.close();
+    mockedFileSystem.close();
   }
 
   @BeforeMethod
@@ -119,16 +119,16 @@ public class GobblinMCEWriterTest {
         .writeEnvelope(
             any(RecordEnvelope.class), anyMap(), anyMap(), any(HiveSpec.class));
 
-    _mockConstructorUtils = Mockito.mockStatic(GobblinConstructorUtils.class);
-    _mockConstructorUtils.when(() -> GobblinConstructorUtils.invokeConstructor(
+    mockConstructorUtils = Mockito.mockStatic(GobblinConstructorUtils.class);
+    mockConstructorUtils.when(() -> GobblinConstructorUtils.invokeConstructor(
             eq(MetadataWriter.class), eq(mockWriter.getClass().getName()), any(State.class)))
         .thenReturn(mockWriter);
     when(GobblinConstructorUtils.invokeConstructor(
         eq(MetadataWriter.class), eq(exceptionWriter.getClass().getName()), any(State.class)))
         .thenReturn(exceptionWriter);
 
-    _mockedFileSystem = Mockito.mockStatic(FileSystem.class);
-    _mockedFileSystem.when(() -> FileSystem.get(any()))
+    mockedFileSystem = Mockito.mockStatic(FileSystem.class);
+    mockedFileSystem.when(() -> FileSystem.get(any()))
         .thenReturn(fs);
 
     when(mockTable.getDbName()).thenReturn(dbName);

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.iceberg.writer;
 
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,7 +26,22 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiConsumer;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
+
 import lombok.SneakyThrows;
+
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.hive.HiveTable;
 import org.apache.gobblin.hive.spec.HiveSpec;
@@ -42,22 +56,8 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaStreamingExtractor
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 public class GobblinMCEWriterTest {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -340,7 +340,7 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
     gmce.setOperationType(OperationType.drop_files);
     gmce.setOldFilePrefixes(null);
     hiveWriter.write(gmce, null, null, spec, "someTopicPartition");
-    Mockito.verifyZeroInteractions(mockRegister);
+    Mockito.verifyNoInteractions(mockRegister);
   }
 
   /**

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -85,7 +85,7 @@ import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.function.CheckedExceptionFunction;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 
 
 public class HiveMetadataWriterTest extends HiveMetastoreTest {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
 import java.util.Map;
 import java.util.function.Function;
+
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -33,7 +33,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -45,6 +44,7 @@ import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.iceberg.hive.HiveMetastoreTest;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.thrift.TException;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -63,6 +63,7 @@ import org.apache.gobblin.hive.HivePartition;
 import org.apache.gobblin.hive.HiveRegister;
 import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveTable;
+import org.apache.gobblin.hive.metastore.HiveMetaStoreBasedRegister;
 import org.apache.gobblin.hive.policy.HiveRegistrationPolicyBase;
 import org.apache.gobblin.hive.spec.HiveSpec;
 import org.apache.gobblin.hive.spec.SimpleHiveSpec;
@@ -83,9 +84,8 @@ import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.function.CheckedExceptionFunction;
-import org.mockito.Mockito;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.eq;
 
 
 public class HiveMetadataWriterTest extends HiveMetastoreTest {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -177,7 +177,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
         SchemaBuilder.record("partitionTest").fields().name("ds").type().optional().stringType().endRecord();
 
     gobblinMCEWriter.eventSubmitter = Mockito.mock(EventSubmitter.class);
-    Mockito.doAnswer(invocation -> eventsSent.add(invocation.getArgumentAt(0, GobblinEventBuilder.class)))
+    Mockito.doAnswer(invocation -> eventsSent.add(invocation.getArgument(0, GobblinEventBuilder.class)))
         .when(gobblinMCEWriter.eventSubmitter).submit(Mockito.any(GobblinEventBuilder.class));
   }
 

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -64,8 +64,8 @@ import org.apache.gobblin.hive.HivePartition;
 import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveTable;
 import org.apache.gobblin.hive.policy.HiveRegistrationPolicyBase;
-import org.apache.gobblin.hive.writer.MetadataWriterKeys;
 import org.apache.gobblin.hive.writer.MetadataWriter;
+import org.apache.gobblin.hive.writer.MetadataWriterKeys;
 import org.apache.gobblin.metadata.DataFile;
 import org.apache.gobblin.metadata.DataMetrics;
 import org.apache.gobblin.metadata.DataOrigin;
@@ -83,6 +83,7 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaStreamingExtractor
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;
+
 import static org.apache.gobblin.iceberg.writer.IcebergMetadataWriterConfigKeys.*;
 
 public class IcebergMetadataWriterTest extends HiveMetastoreTest {

--- a/gobblin-iceberg/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gobblin-iceberg/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/reporter/FileFailureEventReporterTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/reporter/FileFailureEventReporterTest.java
@@ -19,9 +19,6 @@ package org.apache.gobblin.metrics.reporter;
 
 import java.io.IOException;
 
-import org.apache.gobblin.metrics.GobblinTrackingEvent;
-import org.apache.gobblin.metrics.MetricContext;
-import org.apache.gobblin.metrics.event.FailureEventBuilder;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -29,7 +26,10 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Maps;
 
-import static org.mockito.ArgumentMatchers.any;
+import org.apache.gobblin.metrics.GobblinTrackingEvent;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.event.FailureEventBuilder;
+
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/reporter/FileFailureEventReporterTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/org/apache/gobblin/metrics/reporter/FileFailureEventReporterTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Maps;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-azkaban/build.gradle
+++ b/gobblin-modules/gobblin-azkaban/build.gradle
@@ -44,7 +44,6 @@ dependencies {
   compile externalDependency.findBugsAnnotations
 
   testCompile externalDependency.mockito
-  testCompile externalDependency.powermock
 }
 
 test {

--- a/gobblin-modules/gobblin-compliance/src/test/java/org/apache/gobblin/compliance/purger/HivePurgerConverterTest.java
+++ b/gobblin-modules/gobblin-compliance/src/test/java/org/apache/gobblin/compliance/purger/HivePurgerConverterTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.configuration.WorkUnitState;
 
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.anyList;
 
 
 @Test

--- a/gobblin-modules/gobblin-compliance/src/test/java/org/apache/gobblin/compliance/purger/HivePurgerConverterTest.java
+++ b/gobblin-modules/gobblin-compliance/src/test/java/org/apache/gobblin/compliance/purger/HivePurgerConverterTest.java
@@ -23,6 +23,8 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.configuration.WorkUnitState;
 
+import static org.mockito.ArgumentMatchers.anyList;
+
 
 @Test
 public class HivePurgerConverterTest {
@@ -44,6 +46,6 @@ public class HivePurgerConverterTest {
 
   public void convertRecordTest() {
     this.hivePurgerConverterMock.convertRecord(this.schemaMock, this.datasetMock, this.stateMock);
-    Mockito.verify(this.datasetMock).setPurgeQueries(Mockito.anyListOf(String.class));
+    Mockito.verify(this.datasetMock).setPurgeQueries(anyList());
   }
 }

--- a/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/BatchedEventhubDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/BatchedEventhubDataWriterTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
-import org.apache.gobblin.writer.*;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -32,7 +31,9 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.isA;
+import org.apache.gobblin.writer.WriteCallback;
+import org.apache.gobblin.writer.WriteResponse;
+
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/BatchedEventhubDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/BatchedEventhubDataWriterTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/EventhubDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/EventhubDataWriterTest.java
@@ -36,7 +36,7 @@ import org.apache.gobblin.writer.Batch;
 import org.apache.gobblin.writer.WriteCallback;
 import org.apache.gobblin.writer.WriteResponse;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/EventhubDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/org/apache/gobblin/eventhub/writer/EventhubDataWriterTest.java
@@ -31,12 +31,10 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
 import org.apache.gobblin.writer.Batch;
 import org.apache.gobblin.writer.WriteCallback;
 import org.apache.gobblin.writer.WriteResponse;
 
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-kafka-08/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-08/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
@@ -59,11 +59,7 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaDeserializerExtrac
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.PropertiesUtils;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 @Test(groups = { "gobblin.source.extractor.extract.kafka" })

--- a/gobblin-modules/gobblin-kafka-08/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-08/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
@@ -59,7 +59,7 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaDeserializerExtrac
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.PropertiesUtils;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
@@ -43,14 +43,14 @@ import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.kafka.KafkaTestBase;
 import org.apache.gobblin.source.extractor.CheckpointableWatermark;
 import org.apache.gobblin.source.extractor.DataRecordException;
-import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingExtractor;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingSource;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.writer.WatermarkStorage;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
@@ -50,7 +50,7 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingSou
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.writer.WatermarkStorage;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/writer/Kafka09DataWriterTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/writer/Kafka09DataWriterTest.java
@@ -36,18 +36,13 @@ import org.apache.gobblin.kafka.KafkaTestBase;
 import org.apache.gobblin.kafka.schemareg.ConfigDrivenMd5SchemaRegistry;
 import org.apache.gobblin.kafka.schemareg.KafkaSchemaRegistryConfigurationKeys;
 import org.apache.gobblin.kafka.schemareg.SchemaRegistryException;
-//import org.apache.gobblin.kafka.serialize.LiAvroDeserializer;
 import org.apache.gobblin.kafka.serialize.LiAvroDeserializer;
 import org.apache.gobblin.kafka.serialize.LiAvroSerializer;
 import org.apache.gobblin.test.TestUtils;
 import org.apache.gobblin.writer.WriteCallback;
 import org.apache.gobblin.writer.WriteResponse;
 
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @Slf4j

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/writer/Kafka09DataWriterTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/kafka/writer/Kafka09DataWriterTest.java
@@ -43,7 +43,7 @@ import org.apache.gobblin.test.TestUtils;
 import org.apache.gobblin.writer.WriteCallback;
 import org.apache.gobblin.writer.WriteResponse;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/gobblin-modules/gobblin-kafka-1/src/test/java/org/apache/gobblin/kafka/writer/Kafka1DataWriterTest.java
+++ b/gobblin-modules/gobblin-kafka-1/src/test/java/org/apache/gobblin/kafka/writer/Kafka1DataWriterTest.java
@@ -17,9 +17,21 @@
 
 package org.apache.gobblin.kafka.writer;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
 import kafka.message.MessageAndMetadata;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.generic.GenericRecord;
+
 import org.apache.gobblin.kafka.KafkaTestBase;
 import org.apache.gobblin.kafka.schemareg.ConfigDrivenMd5SchemaRegistry;
 import org.apache.gobblin.kafka.schemareg.KafkaSchemaRegistryConfigurationKeys;
@@ -30,18 +42,7 @@ import org.apache.gobblin.kafka.serialize.SerializationException;
 import org.apache.gobblin.test.TestUtils;
 import org.apache.gobblin.writer.WriteCallback;
 import org.apache.gobblin.writer.WriteResponse;
-import org.testng.Assert;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-kafka-1/src/test/java/org/apache/gobblin/kafka/writer/Kafka1DataWriterTest.java
+++ b/gobblin-modules/gobblin-kafka-1/src/test/java/org/apache/gobblin/kafka/writer/Kafka1DataWriterTest.java
@@ -41,7 +41,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadConverterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadConverterTest.java
@@ -28,16 +28,17 @@ import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.FileUtils;
-import org.apache.gobblin.configuration.WorkUnitState;
-import org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistryFactory;
-import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
-import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 
-import static org.mockito.ArgumentMatchers.any;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistryFactory;
+import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
+import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
+
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadConverterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadConverterTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadExtractingConverterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadExtractingConverterTest.java
@@ -22,20 +22,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.commons.io.FileUtils;
-import org.apache.gobblin.configuration.WorkUnitState;
-import org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistryFactory;
-import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 
-import static org.mockito.ArgumentMatchers.any;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistryFactory;
+import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
+
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadExtractingConverterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/converter/EnvelopePayloadExtractingConverterTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
@@ -45,7 +45,7 @@ import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_FILTER;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_BLACKLIST;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_WHITELIST;
-import static org.mockito.Matchers.anyList;
+import static org.mockito.ArgumentMatchers.anyList;
 
 
 /**

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
@@ -45,7 +45,7 @@ import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_FILTER;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_BLACKLIST;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_WHITELIST;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.anyList;
 
 
 /**

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ZipConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ZipConfigStoreUtilsTest.java
@@ -48,7 +48,7 @@ import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_FILTER;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_BLACKLIST;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_WHITELIST;
-import static org.mockito.Matchers.anyList;
+import static org.mockito.ArgumentMatchers.anyList;
 
 
 /**

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ZipConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ZipConfigStoreUtilsTest.java
@@ -26,12 +26,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.gobblin.config.client.ConfigClient;
-import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
-import org.apache.gobblin.config.store.api.ConfigStoreCreationException;
-import org.apache.gobblin.config.store.zip.SimpleLocalIvyConfigStoreFactory;
-import org.apache.gobblin.config.store.zip.ZipFileConfigStore;
-import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -42,13 +36,20 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
+import org.apache.gobblin.config.client.ConfigClient;
+import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
+import org.apache.gobblin.config.store.api.ConfigStoreCreationException;
+import org.apache.gobblin.config.store.zip.SimpleLocalIvyConfigStoreFactory;
+import org.apache.gobblin.config.store.zip.ZipFileConfigStore;
+import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
+
 import static org.apache.gobblin.configuration.ConfigurationKeys.CONFIG_MANAGEMENT_STORE_ENABLED;
 import static org.apache.gobblin.configuration.ConfigurationKeys.CONFIG_MANAGEMENT_STORE_URI;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_COMMONPATH;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_FILTER;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_BLACKLIST;
 import static org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils.GOBBLIN_CONFIG_TAGS_WHITELIST;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.anyList;
 
 
 /**

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterInitializerTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterInitializerTest.java
@@ -142,7 +142,7 @@ public class JdbcWriterInitializerTest {
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     when(this.conn.getMetaData()).thenReturn(metadata);
     ResultSet rs = mock(ResultSet.class);
-    when(metadata.getTables(anyString(), anyString(), anyString(), any(String[].class))).thenReturn(rs);
+    when(metadata.getTables(any(), anyString(), anyString(), any(String[].class))).thenReturn(rs);
     when(rs.next()).thenReturn(Boolean.FALSE);
 
     this.initializer.initialize();

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterTest.java
@@ -20,18 +20,14 @@ package org.apache.gobblin.writer;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.writer.commands.JdbcWriterCommands;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.writer.commands.JdbcWriterCommands;
+
+import static org.mockito.Mockito.*;
 
 @Test(groups = {"gobblin.writer"})
 public class JdbcWriterTest {

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/JdbcWriterTest.java
@@ -20,15 +20,18 @@ package org.apache.gobblin.writer;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.writer.commands.JdbcWriterCommands;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.converter.jdbc.JdbcEntryData;
-import org.apache.gobblin.writer.commands.JdbcWriterCommands;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @Test(groups = {"gobblin.writer"})
 public class JdbcWriterTest {
@@ -49,7 +52,7 @@ public class JdbcWriterTest {
       Assert.assertEquals(writer.recordsWritten(), writeCount);
     }
 
-    verify(writerCommands, times(writeCount)).insert(anyString(), anyString(), any(JdbcEntryData.class));
+    verify(writerCommands, times(writeCount)).insert(anyString(), anyString(), any());
     verify(conn, times(1)).commit();
     verify(conn, never()).rollback();
     verify(writerCommands, times(1)).flush();
@@ -62,7 +65,7 @@ public class JdbcWriterTest {
     final String table = "users";
     JdbcWriterCommands writerCommands = mock(JdbcWriterCommands.class);
     Connection conn = mock(Connection.class);
-    doThrow(RuntimeException.class).when(writerCommands).insert(anyString(), anyString(), any(JdbcEntryData.class));
+    doThrow(RuntimeException.class).when(writerCommands).insert(anyString(), anyString(), any());
     JdbcWriter writer = new JdbcWriter(writerCommands, new State(), database, table, conn);
 
     try {
@@ -73,7 +76,7 @@ public class JdbcWriterTest {
     }
     writer.close();
 
-    verify(writerCommands, times(1)).insert(anyString(), anyString(), any(JdbcEntryData.class));
+    verify(writerCommands, times(1)).insert(anyString(), anyString(), any());
     verify(conn, times(1)).rollback();
     verify(conn, never()).commit();
     verify(conn, times(1)).close();

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
@@ -31,11 +31,16 @@ import org.apache.gobblin.writer.commands.MySqlBufferedInserter;
 
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_MAX_PARAM_SIZE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.matches;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 
 @Test(groups = {"gobblin.writer"}, singleThreaded=true)
 public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
@@ -63,7 +68,7 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
     verify(conn, times(2)).prepareStatement(matches("INSERT INTO .*"));
     verify(pstmt, times(11)).clearParameters();
     verify(pstmt, times(11)).execute();
-    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), anyObject());
+    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), any());
     reset(pstmt);
   }
 
@@ -90,7 +95,7 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
     verify(conn, times(2)).prepareStatement(matches("REPLACE INTO .*"));
     verify(pstmt, times(11)).clearParameters();
     verify(pstmt, times(11)).execute();
-    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), anyObject());
+    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), any());
     reset(pstmt);
   }
 
@@ -121,7 +126,7 @@ public class MySqlBufferedInserterTest extends JdbcBufferedInserterTestBase {
     verify(conn, times(2)).prepareStatement(matches("INSERT INTO .*"));
     verify(pstmt, times(expectedExecuteCount)).clearParameters();
     verify(pstmt, times(expectedExecuteCount)).execute();
-    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), anyObject());
+    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), any());
     reset(pstmt);
   }
 

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
@@ -31,10 +31,10 @@ import org.apache.gobblin.writer.commands.MySqlBufferedInserter;
 
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_MAX_PARAM_SIZE;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.matches;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.*;
 
 @Test(groups = {"gobblin.writer"}, singleThreaded=true)

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/MySqlBufferedInserterTest.java
@@ -31,15 +31,7 @@ import org.apache.gobblin.writer.commands.MySqlBufferedInserter;
 
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_MAX_PARAM_SIZE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.matches;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 @Test(groups = {"gobblin.writer"}, singleThreaded=true)

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
@@ -17,26 +17,23 @@
 
 package org.apache.gobblin.writer;
 
-import com.mockrunner.mock.jdbc.MockParameterMetaData;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import com.mockrunner.mock.jdbc.MockParameterMetaData;
+
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.converter.jdbc.JdbcEntryData;
 import org.apache.gobblin.writer.commands.JdbcBufferedInserter;
 import org.apache.gobblin.writer.commands.TeradataBufferedInserter;
-import org.mockito.Mockito;
-import org.testng.annotations.Test;
 
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 @Test(groups = { "gobblin.writer" }, singleThreaded = true)

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
@@ -18,9 +18,9 @@
 package org.apache.gobblin.writer;
 
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/writer/TeradataBufferedInserterTest.java
@@ -17,29 +17,26 @@
 
 package org.apache.gobblin.writer;
 
+import com.mockrunner.mock.jdbc.MockParameterMetaData;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.converter.jdbc.JdbcEntryData;
+import org.apache.gobblin.writer.commands.JdbcBufferedInserter;
+import org.apache.gobblin.writer.commands.TeradataBufferedInserter;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
 import static org.apache.gobblin.writer.commands.JdbcBufferedInserter.WRITER_JDBC_INSERT_BATCH_SIZE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.List;
-
-import org.mockito.Mockito;
-import org.testng.annotations.Test;
-
-import com.mockrunner.mock.jdbc.MockParameterMetaData;
-
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.converter.jdbc.JdbcEntryData;
-import org.apache.gobblin.writer.commands.JdbcBufferedInserter;
-import org.apache.gobblin.writer.commands.TeradataBufferedInserter;
 
 
 @Test(groups = { "gobblin.writer" }, singleThreaded = true)
@@ -75,7 +72,7 @@ public class TeradataBufferedInserterTest extends JdbcBufferedInserterTestBase {
     verify(pstmt, times(107)).addBatch();
     verify(pstmt, times((int) Math.ceil((double) entryCount / batchSize))).executeBatch();
     verify(pstmt, times(entryCount)).clearParameters();
-    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), anyObject());
+    verify(pstmt, times(colNums * entryCount)).setObject(anyInt(), any());
     reset(pstmt);
   }
 

--- a/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
+++ b/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
@@ -30,7 +30,7 @@ import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooterFactory;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
+++ b/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
@@ -30,11 +30,7 @@ import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooterFactory;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 
 @Test(groups = {"gobblin.source.extractor.extract.google.webmaster"})

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
@@ -40,7 +40,7 @@ public class GoogleWebmasterDataFetcherImplTest {
     GoogleWebmasterClient client = Mockito.mock(GoogleWebmasterClient.class);
     List<String> retVal = Arrays.asList("abc", "def");
 
-    Mockito.when(client.getPages(eq(_property), any(String.class), any(String.class), eq("ALL"), any(Integer.class),
+    Mockito.when(client.getPages(eq(_property), any(), any(), eq("ALL"), any(Integer.class),
         any(List.class), any(List.class), eq(0))).thenReturn(retVal);
 
     WorkUnitState workUnitState = new WorkUnitState();
@@ -56,7 +56,7 @@ public class GoogleWebmasterDataFetcherImplTest {
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(retVal, pageStrings));
     Mockito.verify(client, Mockito.times(1))
-        .getPages(eq(_property), any(String.class), any(String.class), eq("ALL"), any(Integer.class), any(List.class),
+        .getPages(eq(_property), any(), any(), eq("ALL"), any(Integer.class), any(List.class),
             any(List.class), eq(0));
   }
 
@@ -67,7 +67,7 @@ public class GoogleWebmasterDataFetcherImplTest {
     for (int i = 0; i < 10; ++i) {
       allPages.add(Integer.toString(i));
     }
-    Mockito.when(client.getPages(eq(_property), any(String.class), any(String.class), eq("ALL"), any(Integer.class),
+    Mockito.when(client.getPages(eq(_property), any(), any(), eq("ALL"), any(Integer.class),
         any(List.class), any(List.class), eq(0))).thenReturn(allPages);
 
     WorkUnitState workUnitState = new WorkUnitState();
@@ -83,7 +83,7 @@ public class GoogleWebmasterDataFetcherImplTest {
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(pageStrings, allPages));
     Mockito.verify(client, Mockito.times(2))
-        .getPages(eq(_property), any(String.class), any(String.class), eq("ALL"), any(Integer.class), any(List.class),
+        .getPages(eq(_property), any(), any(), eq("ALL"), any(Integer.class), any(List.class),
             any(List.class), eq(0));
   }
 
@@ -99,16 +99,16 @@ public class GoogleWebmasterDataFetcherImplTest {
     }
 
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(0))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(0))).thenReturn(list5000);
     GoogleWebmasterDataFetcherImpl dataFetcher = new GoogleWebmasterDataFetcherImpl(_property, client, workUnitState);
     Assert.assertEquals(dataFetcher.getPagesSize("start_date", "end_date", "country", null, null), 5000);
 
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(5000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(5000))).thenReturn(list5000);
     Assert.assertEquals(dataFetcher.getPagesSize("start_date", "end_date", "country", null, null), 10000);
 
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(10000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(10000))).thenReturn(list5000);
     Assert.assertEquals(dataFetcher.getPagesSize("start_date", "end_date", "country", null, null), 15000);
   }
 
@@ -124,7 +124,7 @@ public class GoogleWebmasterDataFetcherImplTest {
     }
 
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(0))).thenReturn(list2);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(0))).thenReturn(list2);
     GoogleWebmasterDataFetcherImpl dataFetcher = new GoogleWebmasterDataFetcherImpl(_property, client, workUnitState);
     int size = dataFetcher.getPagesSize("start_date", "end_date", "country", null, null);
     Assert.assertEquals(size, 2);
@@ -142,24 +142,24 @@ public class GoogleWebmasterDataFetcherImplTest {
     }
 
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(0))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(0))).thenReturn(list5000);
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(5000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(5000))).thenReturn(list5000);
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(10000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(10000))).thenReturn(list5000);
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(15000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(15000))).thenReturn(list5000);
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(20000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(20000))).thenReturn(list5000);
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(25000))).thenReturn(list5000);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(25000))).thenReturn(list5000);
 
     List<String> list2 = new ArrayList<>();
     for (int i = 0; i < 2; ++i) {
       list2.add(null);
     }
     Mockito.when(client.getPages(any(String.class), any(String.class), any(String.class), any(String.class),
-        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(List.class), any(List.class), eq(30000))).thenReturn(list2);
+        eq(GoogleWebmasterClient.API_ROW_LIMIT), any(), any(), eq(30000))).thenReturn(list2);
 
     GoogleWebmasterDataFetcherImpl dataFetcher = new GoogleWebmasterDataFetcherImpl(_property, client, workUnitState);
     int size = dataFetcher.getPagesSize("start_date", "end_date", "country", null, null);

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 
 
 @Test(groups = {"gobblin.source.extractor.extract.google.webmaster"})

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 
 
-class CollectionEquals extends ArgumentMatcher<Collection> {
+class CollectionEquals implements ArgumentMatcher<Collection> {
 
   private final Collection _expected;
 
@@ -48,8 +48,8 @@ class CollectionEquals extends ArgumentMatcher<Collection> {
   }
 
   @Override
-  public boolean matches(Object actual) {
-    return CollectionUtils.isEqualCollection((Collection) actual, _expected);
+  public boolean matches(Collection actual) {
+    return CollectionUtils.isEqualCollection(actual, _expected);
   }
 }
 

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
@@ -35,8 +35,8 @@ import com.google.api.services.webmasters.model.ApiDimensionFilter;
 
 import org.apache.gobblin.configuration.WorkUnitState;
 
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 
 
 class CollectionEquals extends ArgumentMatcher<Collection> {

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIteratorTest.java
@@ -35,8 +35,8 @@ import com.google.api.services.webmasters.model.ApiDimensionFilter;
 
 import org.apache.gobblin.configuration.WorkUnitState;
 
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
 
 
 class CollectionEquals implements ArgumentMatcher<Collection> {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -22,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.gobblin.runtime.api.SpecCatalogListener;
-import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -47,11 +45,14 @@ import com.typesafe.config.Config;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.restli.EmbeddedRestliServer;
+import org.apache.gobblin.runtime.api.SpecCatalogListener;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_store.FSSpecStore;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 @Test(groups = { "gobblin.service" }, singleThreaded = true)

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -50,7 +50,7 @@ import org.apache.gobblin.restli.EmbeddedRestliServer;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_store.FSSpecStore;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.gobblin.runtime.api.SpecCatalogListener;
-import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.mortbay.jetty.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -54,11 +52,14 @@ import lombok.Setter;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.restli.EmbeddedRestliServer;
+import org.apache.gobblin.runtime.api.SpecCatalogListener;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_store.FSSpecStore;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 @Test(groups = { "gobblin.service" }, singleThreaded = true)

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -57,7 +57,7 @@ import org.apache.gobblin.restli.EmbeddedRestliServer;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_store.FSSpecStore;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
@@ -32,7 +32,7 @@ import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.util.CompletedFuture;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
@@ -32,7 +32,7 @@ import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.util.CompletedFuture;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +29,19 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.fork.IdentityForkOperator;
@@ -53,13 +61,9 @@ import org.apache.gobblin.util.TestUtils;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.WatermarkAwareWriter;
 import org.apache.gobblin.writer.WatermarkStorage;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.gobblin.runtime;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,39 +33,30 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.apache.gobblin.runtime.util.TaskMetrics;
-import org.apache.gobblin.util.TestUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.fork.IdentityForkOperator;
 import org.apache.gobblin.publisher.TaskPublisher;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
-import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyChecker;
+import org.apache.gobblin.runtime.util.TaskMetrics;
 import org.apache.gobblin.source.extractor.CheckpointableWatermark;
 import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.DefaultCheckpointableWatermark;
 import org.apache.gobblin.source.extractor.Extractor;
-import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.source.extractor.StreamingExtractor;
 import org.apache.gobblin.source.extractor.extract.LongWatermark;
+import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ExecutorsUtils;
+import org.apache.gobblin.util.TestUtils;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.WatermarkAwareWriter;
 import org.apache.gobblin.writer.WatermarkStorage;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -273,7 +268,7 @@ public class TaskContinuousTest {
       // Create a mock TaskPublisher
       TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
       when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
-      when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class))).thenReturn(mockTaskPublisher);
+      when(mockTaskContext.getTaskPublisher(any(TaskState.class), any())).thenReturn(mockTaskPublisher);
 
       // Create a mock TaskStateTracker
       TaskStateTracker mockTaskStateTracker = mock(TaskStateTracker.class);
@@ -360,7 +355,7 @@ public class TaskContinuousTest {
     when(mockTaskContext.getWatermarkStorage()).thenReturn(mockWatermarkStorage);
     when(mockTaskContext.getForkOperator()).thenReturn(new IdentityForkOperator());
     when(mockTaskContext.getTaskState()).thenReturn(taskState);
-    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any()))
         .thenReturn(mockTaskPublisher);
     when(mockTaskContext.getRowLevelPolicyChecker()).thenReturn(mockRowLevelPolicyChecker);
     when(mockTaskContext.getRowLevelPolicyChecker(anyInt())).thenReturn(mockRowLevelPolicyChecker);

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskContinuousTest.java
@@ -63,8 +63,8 @@ import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.WatermarkAwareWriter;
 import org.apache.gobblin.writer.WatermarkStorage;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
@@ -62,8 +62,8 @@ import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,7 +31,19 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -51,18 +60,8 @@ import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 /**

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TaskTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.runtime;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,19 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -52,7 +43,6 @@ import org.apache.gobblin.fork.IdentityForkOperator;
 import org.apache.gobblin.publisher.TaskPublisher;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
-import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyChecker;
 import org.apache.gobblin.runtime.util.TaskMetrics;
 import org.apache.gobblin.source.extractor.Extractor;
@@ -61,6 +51,11 @@ import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -128,7 +123,7 @@ public class TaskTest {
     // Create a mock TaskPublisher
     TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
     when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
-    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any()))
         .thenReturn(mockTaskPublisher);
 
     // Create a mock TaskStateTracker
@@ -176,7 +171,7 @@ public class TaskTest {
     when(mockTaskContext.getRawSourceExtractor()).thenReturn(mockExtractor);
     when(mockTaskContext.getForkOperator()).thenReturn(mockForkOperator);
     when(mockTaskContext.getTaskState()).thenReturn(taskState);
-    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any()))
         .thenReturn(mockTaskPublisher);
     when(mockTaskContext.getRowLevelPolicyChecker()).thenReturn(mockRowLevelPolicyChecker);
     when(mockTaskContext.getRowLevelPolicyChecker(anyInt())).thenReturn(mockRowLevelPolicyChecker);

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -17,9 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import io.reactivex.Flowable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,7 +25,18 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+import io.reactivex.Flowable;
 import lombok.AllArgsConstructor;
+
 import org.apache.gobblin.ack.Ackable;
 import org.apache.gobblin.ack.BasicAckableForTesting;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -57,17 +65,8 @@ import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 /**

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -64,8 +64,8 @@ import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 import io.reactivex.Flowable;
 import lombok.AllArgsConstructor;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.runtime;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import io.reactivex.Flowable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,15 +28,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-
+import lombok.AllArgsConstructor;
 import org.apache.gobblin.ack.Ackable;
 import org.apache.gobblin.ack.BasicAckableForTesting;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -45,7 +40,6 @@ import org.apache.gobblin.fork.IdentityForkOperator;
 import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.publisher.TaskPublisher;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
-import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyChecker;
 import org.apache.gobblin.records.ControlMessageHandler;
 import org.apache.gobblin.records.FlushControlMessageHandler;
@@ -63,12 +57,17 @@ import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
-import io.reactivex.Flowable;
-import lombok.AllArgsConstructor;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -280,7 +279,7 @@ public class TestRecordStream {
     // Create a mock TaskPublisher
     TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
     when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
-    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any()))
         .thenReturn(mockTaskPublisher);
 
     // Create a mock TaskStateTracker
@@ -341,7 +340,7 @@ public class TestRecordStream {
     // Create a mock TaskPublisher
     TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
     when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
-    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any()))
         .thenReturn(mockTaskPublisher);
 
     // Create a mock TaskStateTracker

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/TestJobExecutionState.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/TestJobExecutionState.java
@@ -16,11 +16,6 @@
  */
 package org.apache.gobblin.runtime.api;
 
-import static org.apache.gobblin.configuration.ConfigurationKeys.JOB_NAME_KEY;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 import java.util.Properties;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
@@ -41,6 +36,11 @@ import org.apache.gobblin.runtime.JobState.RunningState;
 import org.apache.gobblin.runtime.std.JobExecutionUpdatable;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.util.ExecutorsUtils;
+
+import static org.apache.gobblin.configuration.ConfigurationKeys.JOB_NAME_KEY;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link JobExecutionState}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/TestJobExecutionState.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/TestJobExecutionState.java
@@ -17,7 +17,7 @@
 package org.apache.gobblin.runtime.api;
 
 import static org.apache.gobblin.configuration.ConfigurationKeys.JOB_NAME_KEY;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_catalog/TestFSJobCatalog.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_catalog/TestFSJobCatalog.java
@@ -41,6 +41,8 @@ import org.apache.gobblin.util.filesystem.PathAlterationObserver;
 
 import org.testng.Assert;
 
+import static org.mockito.ArgumentMatchers.any;
+
 
 /**
  * Test interaction between (Mutable)FsJobCatalog and its listeners.
@@ -83,7 +85,7 @@ public class TestFSJobCatalog {
         specs.put(spec.getUri(), spec);
         return null;
       }
-    }).when(l).onAddJob(Mockito.any(JobSpec.class));
+    }).when(l).onAddJob(any(JobSpec.class));
     Mockito.doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation)
@@ -92,7 +94,7 @@ public class TestFSJobCatalog {
         specs.put(spec.getUri(), spec);
         return null;
       }
-    }).when(l).onUpdateJob(Mockito.any(JobSpec.class));
+    }).when(l).onUpdateJob(any(JobSpec.class));
 
     Mockito.doAnswer(new Answer<Void>() {
       @Override
@@ -102,7 +104,7 @@ public class TestFSJobCatalog {
         specs.remove(uri);
         return null;
       }
-    }).when(l).onDeleteJob(Mockito.any(URI.class), Mockito.anyString());
+    }).when(l).onDeleteJob(any(URI.class), any());
 
     JobSpec js1_1 = JobSpec.builder("test_job1").withVersion("1").build();
     JobSpec js1_2 = JobSpec.builder("test_job1").withVersion("2").build();

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_catalog/TestFSJobCatalog.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_catalog/TestFSJobCatalog.java
@@ -17,8 +17,6 @@
 
 package org.apache.gobblin.runtime.job_catalog;
 
-import org.apache.gobblin.config.ConfigBuilder;
-import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 import java.io.File;
 import java.io.PrintWriter;
 import java.net.URI;
@@ -31,17 +29,18 @@ import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.JobCatalogListener;
 import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.filesystem.PathAlterationObserver;
 
-import org.testng.Assert;
-
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 
 
 /**

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestFilteredJobLifecycleListener.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestFilteredJobLifecycleListener.java
@@ -16,11 +16,6 @@
  */
 package org.apache.gobblin.runtime.std;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
@@ -34,6 +29,11 @@ import org.apache.gobblin.runtime.api.JobExecutionState;
 import org.apache.gobblin.runtime.api.JobExecutionStateListener;
 import org.apache.gobblin.runtime.api.JobLifecycleListener;
 import org.apache.gobblin.runtime.api.JobSpec;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link FilteredJobLifecycleListener}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestFilteredJobLifecycleListener.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestFilteredJobLifecycleListener.java
@@ -16,7 +16,7 @@
  */
 package org.apache.gobblin.runtime.std;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestJobLifecycleListenersList.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestJobLifecycleListenersList.java
@@ -16,7 +16,7 @@
  */
 package org.apache.gobblin.runtime.std;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestJobLifecycleListenersList.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/std/TestJobLifecycleListenersList.java
@@ -16,11 +16,6 @@
  */
 package org.apache.gobblin.runtime.std;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -30,6 +25,11 @@ import org.apache.gobblin.runtime.api.JobExecutionDriver;
 import org.apache.gobblin.runtime.api.JobExecutionState;
 import org.apache.gobblin.runtime.api.JobLifecycleListener;
 import org.apache.gobblin.runtime.api.JobSpecSchedulerListenersContainer;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link JobLifecycleListenersList}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/troubleshooter/JobIssueEventHandlerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/troubleshooter/JobIssueEventHandlerTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.metrics.event.TimingEvent;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/troubleshooter/JobIssueEventHandlerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/troubleshooter/JobIssueEventHandlerTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.metrics.event.TimingEvent;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -54,10 +54,7 @@ import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 public class DagManagerFlowTest {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -54,7 +54,7 @@ import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
@@ -16,12 +16,6 @@
  */
 package org.apache.gobblin.service.modules.scheduler;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.io.Files;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,6 +24,21 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.io.Files;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.api.FlowSpec;
@@ -40,6 +49,7 @@ import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
 import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
+import org.apache.gobblin.runtime.spec_catalog.FlowCatalogTest;
 import org.apache.gobblin.runtime.spec_catalog.TopologyCatalog;
 import org.apache.gobblin.runtime.spec_executorInstance.InMemorySpecExecutor;
 import org.apache.gobblin.scheduler.SchedulerService;
@@ -50,23 +60,15 @@ import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.orchestration.AbstractUserQuotaManager;
 import org.apache.gobblin.service.modules.orchestration.InMemoryUserQuotaManager;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
-import org.apache.gobblin.runtime.spec_catalog.FlowCatalogTest;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
 import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.util.ConfigUtils;
 
-import org.mockito.Mockito;
-import org.mockito.invocation.Invocation;
-import org.mockito.stubbing.Answer;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import static org.apache.gobblin.runtime.spec_catalog.FlowCatalog.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.apache.gobblin.runtime.spec_catalog.FlowCatalog.FLOWSPEC_STORE_DIR_KEY;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 
 public class GobblinServiceJobSchedulerTest {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
@@ -65,7 +65,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.gobblin.runtime.spec_catalog.FlowCatalog.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GitConfigMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GitConfigMonitorTest.java
@@ -28,9 +28,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.gobblin.runtime.api.SpecCatalogListener;
-import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
-import org.apache.gobblin.service.ServiceConfigKeys;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -56,10 +53,14 @@ import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.runtime.api.SpecCatalogListener;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
+import org.apache.gobblin.service.ServiceConfigKeys;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class GitConfigMonitorTest {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GitConfigMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GitConfigMonitorTest.java
@@ -58,7 +58,7 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -67,7 +67,6 @@ dependencies {
   testCompile externalDependency.hadoopYarnMiniCluster
   testCompile externalDependency.curatorFramework
   testCompile externalDependency.curatorTest
-  testCompile externalDependency.powermock
 
   testCompile ('com.google.inject:guice:3.0') {
     force = true

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetricsTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/HelixInstancePurgerWithMetricsTest.java
@@ -29,26 +29,14 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.testng.Assert.assertEquals;
 
 
-/**
- * Test class uses PowerMockito and Testng
- * References:
- * https://github.com/powermock/powermock/issues/434
- * https://www.igorkromin.net/index.php/2018/10/04/how-to-fix-powermock-exception-linkageerror-loader-constraint-violation/
- * https://github.com/powermock/powermock/wiki/MockFinal
- */
-@PrepareForTest(Stopwatch.class)
-@PowerMockIgnore("javax.management.*")
-public class HelixInstancePurgerWithMetricsTest extends PowerMockTestCase {
+public class HelixInstancePurgerWithMetricsTest {
 
   @Mock EventSubmitter eventSubmitter;
   @Mock Stopwatch stopwatch;
@@ -62,7 +50,7 @@ public class HelixInstancePurgerWithMetricsTest extends PowerMockTestCase {
 
   @BeforeMethod
   private void init() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
     sut = new HelixInstancePurgerWithMetrics(eventSubmitter, PURGE_STATUS_POLLING_RATE_MS);
   }
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -18,11 +18,10 @@
 package org.apache.gobblin.yarn;
 
 import java.io.IOException;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
@@ -42,7 +41,9 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import static org.mockito.ArgumentMatchers.*;
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnSecurityManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnSecurityManagerTest.java
@@ -59,7 +59,7 @@ import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.TestHelper;
 import org.apache.gobblin.testing.AssertWithBackoff;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 
 /**

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnSecurityManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnSecurityManagerTest.java
@@ -59,7 +59,7 @@ import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.TestHelper;
 import org.apache.gobblin.testing.AssertWithBackoff;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 
 
 /**

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -17,15 +17,12 @@
 
 package org.apache.gobblin.yarn;
 
-import com.google.common.eventbus.EventBus;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
@@ -43,13 +40,13 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import com.google.common.eventbus.EventBus;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+
+import static org.mockito.Mockito.*;
 
 
 /**

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -25,43 +25,37 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
-import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
-import org.apache.hadoop.yarn.client.api.async.impl.AMRMClientAsyncImpl;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockObjectFactory;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.IObjectFactory;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
-import org.testng.annotations.Test;
-
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
-
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
+import org.apache.hadoop.yarn.client.api.async.impl.AMRMClientAsyncImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 
 /**
  * Tests for {@link YarnService}.
  */
-@PrepareForTest({AMRMClientAsync.class, RegisterApplicationMasterResponse.class})
-@PowerMockIgnore({"javax.management.*"})
-public class YarnServiceTest extends PowerMockTestCase{
+public class YarnServiceTest {
   final Logger LOG = LoggerFactory.getLogger(YarnServiceTest.class);
   private TestYarnService yarnService;
   private Config config;
@@ -75,10 +69,10 @@ public class YarnServiceTest extends PowerMockTestCase{
 
   @BeforeClass
   public void setUp() throws Exception {
-    mockAMRMClient = Mockito.mock(AMRMClientAsync.class);
-    mockRegisterApplicationMasterResponse = Mockito.mock(RegisterApplicationMasterResponse.class);
-    mockResource = Mockito.mock(Resource.class);
-    mockFs = Mockito.mock(FileSystem.class);
+    mockAMRMClient = mock(AMRMClientAsync.class);
+    mockRegisterApplicationMasterResponse = mock(RegisterApplicationMasterResponse.class);
+    mockResource = mock(Resource.class);
+    mockFs = mock(FileSystem.class);
 
     URL url = YarnServiceTest.class.getClassLoader()
         .getResource(YarnServiceTest.class.getSimpleName() + ".conf");
@@ -86,12 +80,13 @@ public class YarnServiceTest extends PowerMockTestCase{
 
     this.config = ConfigFactory.parseURL(url).resolve();
 
-    PowerMockito.mockStatic(AMRMClientAsync.class);
-    PowerMockito.mockStatic(AMRMClientAsyncImpl.class);
+    MockedStatic<AMRMClientAsync> amrmClientAsyncMockStatic = mockStatic(AMRMClientAsync.class);
+    MockedStatic<AMRMClientAsyncImpl> amrmClientAsyncImplMockStatic = mockStatic(AMRMClientAsyncImpl.class);
 
-    when(AMRMClientAsync.createAMRMClientAsync(anyInt(), any(AMRMClientAsync.CallbackHandler.class)))
+    amrmClientAsyncMockStatic.when(() -> AMRMClientAsync.createAMRMClientAsync(anyInt(), any(AMRMClientAsync.CallbackHandler.class)))
         .thenReturn(mockAMRMClient);
     doNothing().when(mockAMRMClient).init(any(YarnConfiguration.class));
+
     when(mockAMRMClient.registerApplicationMaster(anyString(), anyInt(), anyString()))
         .thenReturn(mockRegisterApplicationMasterResponse);
     when(mockRegisterApplicationMasterResponse.getMaximumResourceCapability())
@@ -125,13 +120,13 @@ public class YarnServiceTest extends PowerMockTestCase{
     }
 
     private static HelixManager getMockHelixManager(Config config) {
-      HelixManager helixManager = Mockito.mock(HelixManager.class);
-      Mockito.when(helixManager.getClusterName()).thenReturn(config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY));
-      Mockito.when(helixManager.getMetadataStoreConnectionString()).thenReturn("stub");
+      HelixManager helixManager = mock(HelixManager.class);
+      when(helixManager.getClusterName()).thenReturn(config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY));
+      when(helixManager.getMetadataStoreConnectionString()).thenReturn("stub");
       return helixManager;
     }
 
-    private static HelixAdmin getMockHelixAdmin() { return Mockito.mock(HelixAdmin.class); }
+    private static HelixAdmin getMockHelixAdmin() { return mock(HelixAdmin.class); }
 
     protected ContainerLaunchContext newContainerLaunchContext(ContainerInfo containerInfo)
         throws IOException {
@@ -141,10 +136,5 @@ public class YarnServiceTest extends PowerMockTestCase{
 
     @Override
     protected ByteBuffer getSecurityTokens() throws IOException { return mock(ByteBuffer.class); }
-  }
-
-  @ObjectFactory
-  public IObjectFactory getObjectFactory() {
-    return new PowerMockObjectFactory();
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -52,7 +52,7 @@ import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 

--- a/gobblin-yarn/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gobblin-yarn/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -123,7 +123,7 @@ ext.externalDependency = [
     "guiceMultibindings": "com.google.inject.extensions:guice-multibindings:4.0",
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",
     "derby": "org.apache.derby:derby:10.12.1.1",
-    "mockito": "org.mockito:mockito-core:1.10.19",
+    "mockito": "org.mockito:mockito-core:4.11.0",
     "powermock": "org.powermock:powermock-mockito-release-full:1.6.2",
     "salesforceWsc": "com.force.api:force-wsc:" + salesforceVersion,
     "salesforcePartner": "com.force.api:force-partner-api:" + salesforceVersion,

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -124,7 +124,6 @@ ext.externalDependency = [
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",
     "derby": "org.apache.derby:derby:10.12.1.1",
     "mockito": "org.mockito:mockito-core:4.11.0",
-    "powermock": "org.powermock:powermock-mockito-release-full:1.6.2",
     "salesforceWsc": "com.force.api:force-wsc:" + salesforceVersion,
     "salesforcePartner": "com.force.api:force-partner-api:" + salesforceVersion,
     "scala": "org.scala-lang:scala-library:2.11.8",

--- a/gradle/scripts/globalDependencies.gradle
+++ b/gradle/scripts/globalDependencies.gradle
@@ -57,6 +57,7 @@ subprojects {
         }
       }
       all*.exclude group: 'org.apache.calcite', module: 'calcite-avatica' // replaced by org.apache.calcite.avatica:avatica-core
+      all*.exclude group: 'org.mockito', module: 'mockito-all'
       //exclude this jar in test class path because we are using log4j implementation to test
       testCompile.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
     }

--- a/gradle/scripts/globalDependencies.gradle
+++ b/gradle/scripts/globalDependencies.gradle
@@ -57,7 +57,6 @@ subprojects {
         }
       }
       all*.exclude group: 'org.apache.calcite', module: 'calcite-avatica' // replaced by org.apache.calcite.avatica:avatica-core
-      all*.exclude group: 'org.mockito', module: 'mockito-all'
       //exclude this jar in test class path because we are using log4j implementation to test
       testCompile.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

Our version of mockito is ancient (last updated 7 years ago!). The industry has moved on, and it's time to use a newer version of mockito. This updates to 4.11.0, the latest version of Mockito 4. Mockito 5.* requires Java 11 at a minimum.

I've split up the diff into 3 sections to make reviewing easier. I can squash before merging after things have been reviewed:
1. Initial commit updates the `Mockito` dependency, and excludes `mockito-all`. `Mockito-all` the deprecated naming for `mockito` that used to include utilities like `hamcrest` for argument `matchers`. `Mockito-core` 4.* has everything we need.
  a.   Also as part of this commit, I replaced all instances of [deprecated `Matcher`](https://javadoc.io/static/org.mockito/mockito-core/3.3.3/org/mockito/Matchers.html) to the new `ArgumentMatcher`
  b. There was an instance where a class extended Matcher. The new way to do it is to instead `class FooBar implements ArgumentMatcher<...>`
>Deprecated. 
Use [ArgumentMatchers](https://javadoc.io/static/org.mockito/mockito-core/3.3.3/org/mockito/ArgumentMatchers.html). This class is now deprecated in order to avoid a name clash with Hamcrest org.hamcrest.Matchers class. This class will likely be removed in version 3.0.

2. All instances of `anyObject` are now `any`. And any mocks that expected a null object are now just `any()` without a specified class. This is because the default behavior for `any` when a class is specified disallows null values.
3. Update tests to deprecate powermock and remove all dependencies on powermock. (powermock doesn't work past mockito 2.* anyways since all its features were merged into `mockito-core`

### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1792] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1792


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

Short list of quality of life improvements in Mockito 4:
1. Features from PowerMock and Hamcrest are AFAIK all integrated natively in Mockito 4. For example, we had to use some nasty hacks to get powermock to work (since it itself is a bit of a hack). Those have since been removed and our tests are much cleaner
2.  Strictness. Mocks by default are stricter (and configurable) so that unexpected stubs are caught (or can be configured to be lenient).
3. final class mocking
4. Subtly less buggy mocking engine (ByteBuddy over CGLIB)
5. Improved type inference leveraging Java 8 and thus ability to check for type safety

https://github.com/mockito/mockito/releases/tag/v4.0.0
https://chromium.googlesource.com/external/github.com/dart-lang/mockito/+/refs/heads/master/upgrading-to-mockito-3.md
https://github.com/mockito/mockito/wiki/What's-new-in-mockito-2

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests were updated accordingly. This is a scenario where we need to trust the CI :)

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    6. Subject is limited to 50 characters
    7. Subject does not end with a period
    8. Subject uses the imperative mood ("add", not "adding")
    9. Body wraps at 72 characters
    10. Body explains "what" and "why", not "how"

