### PR TITLE
[GOBBLIN-1794] Add defaults to newly added fields in observability events

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -93,7 +93,8 @@
         "long"
       ],
       "doc": "Start time of the workunit planning phase in millis since Epoch, null if the job was never run or fails to reach this phase",
-      "compliance": "NONE"
+      "compliance": "NONE",
+      "default": null
     },
     {
       "name": "jobPlanningPhaseEndTime",
@@ -102,7 +103,8 @@
         "long"
       ],
       "doc": "End time of the workunit planning phase in millis since Epoch, null if the job was never run or fails to reach this phase",
-      "compliance": "NONE"
+      "compliance": "NONE",
+      "default": null
     },
     {
       "name": "executionUserUrn",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1794


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Fields `jobPlanningStartTime` and `jobPlanningEndTime` both are newly added fields to the avro schema for GaaSObservabilityEventExperimental. These 2 newly added fields should have defaults in order to support schema compatbility

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

