### PR TITLE
[GOBBLIN-1795] Make Manifest based copy to support facl

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -46,16 +46,20 @@ import org.apache.hadoop.fs.Path;
 public class ManifestBasedDataset implements IterableCopyableDataset {
 
   private static final String DELETE_FILE_NOT_EXIST_ON_SOURCE = ManifestBasedDatasetFinder.CONFIG_PREFIX + ".deleteFileNotExistOnSource";
+  private static final String COMMON_FILES_PARENT = ManifestBasedDatasetFinder.CONFIG_PREFIX + ".commonFilesParent";
+  private static final String DEFAULT_COMMON_FILES_PARENT = "/";
   private final FileSystem fs;
   private final Path manifestPath;
   private final Properties properties;
   private final boolean deleteFileThatNotExistOnSource;
+  private final String commonFilesParent;
 
   public ManifestBasedDataset(final FileSystem fs, Path manifestPath, Properties properties) {
     this.fs = fs;
     this.manifestPath = manifestPath;
     this.properties = properties;
     this.deleteFileThatNotExistOnSource = Boolean.parseBoolean(properties.getProperty(DELETE_FILE_NOT_EXIST_ON_SOURCE, "false"));
+    this.commonFilesParent = properties.getProperty(COMMON_FILES_PARENT, DEFAULT_COMMON_FILES_PARENT);
   }
 
   @Override
@@ -87,14 +91,14 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
         if (this.fs.exists(fileToCopy)) {
           boolean existOnTarget = targetFs.exists(fileToCopy);
           FileStatus srcFile = this.fs.getFileStatus(fileToCopy);
-          if (!existOnTarget || shouldCopy(this.fs, srcFile, targetFs.getFileStatus(fileToCopy), configuration)) {
+          if (!existOnTarget || shouldCopy(this.fs, targetFs, srcFile, targetFs.getFileStatus(fileToCopy), configuration)) {
             CopyableFile copyableFile =
                 CopyableFile.fromOriginAndDestination(this.fs, srcFile, fileToCopy, configuration)
                     .fileSet(datasetURN())
                     .datasetOutputPath(fileToCopy.toString())
                     .ancestorsOwnerAndPermission(CopyableFile
                         .resolveReplicatedOwnerAndPermissionsRecursively(this.fs, fileToCopy.getParent(),
-                            new Path("/"), configuration))
+                            new Path(this.commonFilesParent), configuration))
                     .build();
             copyableFile.setFsDatasets(this.fs, targetFs);
             copyEntities.add(copyableFile);
@@ -130,12 +134,12 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
     return Collections.singleton(new FileSet.Builder<>(datasetURN(), this).add(copyEntities).build()).iterator();
   }
 
-  private static boolean shouldCopy(FileSystem srcFs, FileStatus fileInSource, FileStatus fileInTarget, CopyConfiguration copyConfiguration)
+  private static boolean shouldCopy(FileSystem srcFs,FileSystem targetFs, FileStatus fileInSource, FileStatus fileInTarget, CopyConfiguration copyConfiguration)
       throws IOException {
     if (fileInSource.isDirectory() || fileInSource.getModificationTime() == fileInTarget.getModificationTime()) {
       // if source is dir or source and dst has same version, we compare the permission to determine whether it needs another sync
       OwnerAndPermission replicatedPermission = CopyableFile.resolveReplicatedOwnerAndPermission(srcFs, fileInSource, copyConfiguration);
-      return !replicatedPermission.hasSameOwnerAndPermission(fileInTarget);
+      return !replicatedPermission.hasSameOwnerAndPermission(targetFs, fileInTarget);
     }
     return fileInSource.getModificationTime() > fileInTarget.getModificationTime();
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/OwnerAndPermission.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/OwnerAndPermission.java
@@ -27,6 +27,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
@@ -82,8 +83,8 @@ public class OwnerAndPermission implements Writable {
    * @param file the file status that need to be evaluated
    * @return true if the metadata for the file match the current owner and permission
    */
-  public boolean hasSameOwnerAndPermission(FileStatus file) {
-    return this.hasSameFSPermission(file) && this.hasSameGroup(file) && this.hasSameOwner(file);
+  public boolean hasSameOwnerAndPermission(FileSystem fs, FileStatus file) throws IOException {
+    return this.hasSameFSPermission(file) && this.hasSameGroup(file) && this.hasSameOwner(file) && this.hasSameAcls(fs.getAclStatus(file.getPath()).getEntries());
   }
 
   private boolean hasSameGroup(FileStatus file) {
@@ -96,5 +97,9 @@ public class OwnerAndPermission implements Writable {
 
   private boolean hasSameFSPermission(FileStatus file) {
     return this.fsPermission == null || file.getPermission().equals(this.fsPermission);
+  }
+
+  private boolean hasSameAcls(List<AclEntry> acls) {
+    return this.aclEntries.isEmpty() || acls.equals(aclEntries);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -511,9 +511,13 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       String group = ownerAndPermission.getGroup();
       String owner = ownerAndPermission.getOwner();
       List<AclEntry> aclEntries = ownerAndPermission.getAclEntries();
-      if (group != null || owner != null) {
-        log.debug("Applying owner {} and group {} to path {}.", owner, group, path);
-        fs.setOwner(path, owner, group);
+      try {
+        if (group != null || owner != null) {
+          log.debug("Applying owner {} and group {} to path {}.", owner, group, path);
+          fs.setOwner(path, owner, group);
+        }
+      } catch (IOException ioe) {
+        log.warn("Failed to set owner and/or group for path " + path + " to " + owner + ":" + group, ioe);
       }
       if (!aclEntries.isEmpty()) {
         fs.setAcl(path, aclEntries);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemDecorator.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemDecorator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
 
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.ContentSummary;
@@ -37,6 +38,8 @@ import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
@@ -98,6 +101,14 @@ class FileSystemDecorator extends FileSystem implements Decorator {
   public FileStatus getFileLinkStatus(Path f) throws java.io.IOException {
     return replaceScheme(this.underlyingFs.getFileLinkStatus(replaceScheme(f, this.replacementScheme, this.underlyingScheme)),
         this.underlyingScheme, this.replacementScheme);
+  }
+
+  public AclStatus getAclStatus(Path path) throws IOException {
+    return this.underlyingFs.getAclStatus(path);
+  }
+
+  public void setAcl(Path path, List<AclEntry> aclSpec) throws IOException {
+    this.underlyingFs.setAcl(path, aclSpec);
   }
 
   public FsStatus getStatus() throws java.io.IOException {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1795


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
1. Compare facl when we compare and determine whether the file has the desired owner and permissions
2. Make the common path configurable so that we won't try to set the owner and permission for the root dir every time 
3. Add setAcl and getAcl support in FileSystemDecorator so that we won't fail with operation not support exception
4. Catch the exception when we fail to set the owner or group for the directory. Now we will fail the first container, and the second container will see dir exist and won't try to set it again, so we essentially succeed even if we fail to set the owner nowadays. And this behavior is the same as safeSetPathPermission() method for file permission. So change the code to directly catch the exception in the first place and log out the warning message. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    5. Subject does not end with a period
    6. Subject uses the imperative mood ("add", not "adding")
    7. Body wraps at 72 characters
    8. Body explains "what" and "why", not "how"

