### PR TITLE
[GOBBLIN-1796] Log startup command when container fails to startup

### DIFF
--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceIT.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
-import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.Priority;
@@ -266,28 +265,6 @@ public class YarnServiceIT {
     // give some time for element to expire
     Thread.sleep(4000);
     Assert.assertTrue(yarnService.getReleasedContainerCache().getIfPresent(containerId1) == null);
-  }
-
-  @Test(groups = {"gobblin.yarn", "disabledOnCI"}, dependsOnMethods = "testReleasedContainerCache")
-  public void testBuildContainerCommand() throws Exception {
-    Config modifiedConfig = this.config
-        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, ConfigValueFactory.fromAnyRef("10"))
-        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef("0.8"));
-    TestYarnService yarnService =
-        new TestYarnService(modifiedConfig, "testApp2", "appId2",
-            this.clusterConf, FileSystem.getLocal(new Configuration()), this.eventBus);
-
-    ContainerId containerId = ContainerId.newInstance(ApplicationAttemptId.newInstance(ApplicationId.newInstance(1, 0),
-        0), 0);
-    Resource resource = Resource.newInstance(2048, 1);
-    Container container = Container.newInstance(containerId, null, null, resource, null, null);
-    YarnService.ContainerInfo
-        containerInfo = new YarnService.ContainerInfo(container, "helixInstance1", "helixTag");
-
-    String command = yarnService.buildContainerCommand(containerInfo);
-
-    // 1628 is from 2048 * 0.8 - 10
-    Assert.assertTrue(command.contains("-Xmx1628"));
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1796] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1796


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

In the event that container launch fails, Gobblin logs unhelpful information about the failure  and there is no observability with what went wrong. This code change will at least tell us what the command was for starting up the container. We will only print this if exit code `1`. See https://komodor.com/learn/how-to-fix-container-terminated-with-exit-code-1/ for a high level description of what this code tends to mean (ignore that it is for K8s, the same principle applies).

> 
> Exit Code 1 indicates that a container shut down, either because of an application failure or because the image pointed to an invalid file. In a Unix/Linux operating system, when an application terminates with Exit Code 1, the operating system ends the process using Signal 7, known as SIGHUP.
> 
> ...
> 
> If you see containers terminated with Exit Code 1, you’ll need to investigate the container and its applications more closely to see what caused the failure. 

Example:
```
Exception from container-launch.
Container id: container_e45_1673332572982_1770008_01_034818
Exit code: 1
Shell output: main : command provided 1
main : run as user is gobblin
main : requested yarn user is gobblin
Getting exit code file...
Creating script paths...
Writing pid file...
Writing to tmp file /grid/g/tmp/yarn/nmPrivate/application_1673332572982_1770008/container_e45_1673332572982_1770008_01_034818/container_e45_1673332572982_1770008_01_034818.pid.tmp
Writing to cgroup task files...
Creating local dirs...
Launching container...
Getting exit code file...
```

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My tests ensure no regressions in build container command. The path for 
![image](https://user-images.githubusercontent.com/35702680/223578118-a38ef3d6-2388-470a-9c32-153b7686c5e1.png)

I ran the YarnService Integration Test locally (which isn't executed in CI)
![image](https://user-images.githubusercontent.com/35702680/223579479-cd463a04-63f4-4ea7-80c7-fed74a031cb8.png)




### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

