### PR TITLE
[GOBBLIN-1798] Add backoff retry when we access mysql db for flow spec or dag action

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/dag_action_store/MysqlDagActionStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/dag_action_store/MysqlDagActionStore.java
@@ -36,11 +36,15 @@ import org.apache.gobblin.metastore.MysqlDataSourceFactory;
 import org.apache.gobblin.runtime.api.DagActionStore;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.ExponentialBackoff;
 
 
 public class MysqlDagActionStore implements DagActionStore {
 
   public static final String CONFIG_PREFIX = "MysqlDagActionStore";
+  public static final String GET_DAG_ACTION_MAX_RETRIES = "get.dagAction.max.retries";
+  public static final int DEFAULT_GET_DAG_ACTION_MAX_RETRIES = 3;
+  private static final long GET_DAG_ACTION_INITIAL_WAIT_AFTER_FAILURE = 1000L;
 
 
   protected final DataSource dataSource;
@@ -58,6 +62,8 @@ public class MysqlDagActionStore implements DagActionStore {
       + "dag_action varchar(100) NOT NULL, modified_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP  on update CURRENT_TIMESTAMP NOT NULL, "
       + "PRIMARY KEY (flow_group,flow_name,flow_execution_id))";
 
+  private final int getDagActionMaxRetries;
+
   @Inject
   public MysqlDagActionStore(Config config) throws IOException {
     if (config.hasPath(CONFIG_PREFIX)) {
@@ -67,9 +73,10 @@ public class MysqlDagActionStore implements DagActionStore {
     }
     this.tableName = ConfigUtils.getString(config, ConfigurationKeys.STATE_STORE_DB_TABLE_KEY,
         ConfigurationKeys.DEFAULT_STATE_STORE_DB_TABLE);
+    this.getDagActionMaxRetries = ConfigUtils.getInt(config, GET_DAG_ACTION_MAX_RETRIES, DEFAULT_GET_DAG_ACTION_MAX_RETRIES);
 
     this.dataSource = MysqlDataSourceFactory.get(config,
-        SharedResourcesBrokerFactory.getImplicitBroker());;
+        SharedResourcesBrokerFactory.getImplicitBroker());
     try (Connection connection = dataSource.getConnection();
         PreparedStatement createStatement = connection.prepareStatement(String.format(CREATE_TABLE_STATEMENT, tableName))) {
       createStatement.executeUpdate();
@@ -136,8 +143,7 @@ public class MysqlDagActionStore implements DagActionStore {
     }
   }
 
-  @Override
-  public DagAction getDagAction(String flowGroup, String flowName, String flowExecutionId)
+  private DagAction getDagActionWithRetry(String flowGroup, String flowName, String flowExecutionId, ExponentialBackoff exponentialBackoff)
       throws IOException, SQLException {
     ResultSet rs = null;
     try (Connection connection = this.dataSource.getConnection();
@@ -149,9 +155,14 @@ public class MysqlDagActionStore implements DagActionStore {
       rs = getStatement.executeQuery();
       if (rs.next()) {
         return new DagAction(rs.getString(1), rs.getString(2), rs.getString(3), DagActionValue.valueOf(rs.getString(4)));
+      } else {
+        if (exponentialBackoff.awaitNextRetryIfAvailable()) {
+          return getDagActionWithRetry(flowGroup, flowName, flowExecutionId, exponentialBackoff);
+        } else {
+          return null;
+        }
       }
-      return null;
-    } catch (SQLException e) {
+    } catch (SQLException | InterruptedException e) {
       throw new IOException(String.format("Failure get dag action from table %s of flow with flow group:%s, flow name:%s and flow execution id:%s",
           tableName, flowGroup, flowName, flowExecutionId), e);
     } finally {
@@ -159,6 +170,14 @@ public class MysqlDagActionStore implements DagActionStore {
         rs.close();
       }
     }
+
+  }
+
+  @Override
+  public DagAction getDagAction(String flowGroup, String flowName, String flowExecutionId)
+      throws IOException, SQLException {
+    ExponentialBackoff exponentialBackoff = ExponentialBackoff.builder().initialDelay(GET_DAG_ACTION_INITIAL_WAIT_AFTER_FAILURE).maxRetries(this.getDagActionMaxRetries).build();
+    return getDagActionWithRetry(flowGroup, flowName, flowExecutionId, exponentialBackoff);
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import javax.inject.Named;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.gobblin.runtime.util.InjectionNames;
+import org.apache.gobblin.util.ExponentialBackoff;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,12 +83,16 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
   public static final String DEFAULT_FLOWSPEC_STORE_CLASS = FSSpecStore.class.getCanonicalName();
   public static final String FLOWSPEC_SERDE_CLASS_KEY = "flowSpec.serde.class";
   public static final String DEFAULT_FLOWSPEC_SERDE_CLASS = JavaSpecSerDe.class.getCanonicalName();
+  public static final String FLOWCATALOG_GET_SPEC_MAX_RETRIES = "flowCatalog.get.spec.max.retries";
+  public static final int DEFAULT_FLOWCATALOG_GET_SPEC_MAX_RETRIES = 3;
+  private static final long FLOWCATALOG_GET_SPEC_INITIAL_WAIT_AFTER_FAILURE = 1000L;
 
   protected final SpecCatalogListenersList listeners;
   protected final Logger log;
   protected final MetricContext metricContext;
   protected final MutableStandardMetrics metrics;
   protected final boolean isWarmStandbyEnabled;
+  protected final int maxRetriesWhenGetSpec;
   @Getter
   protected final SpecStore specStore;
   // a map which keeps a handle of condition variables for each spec being added to the flow catalog
@@ -127,6 +132,7 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
     this.isWarmStandbyEnabled = isWarmStandbyEnabled;
 
     this.aliasResolver = new ClassAliasResolver<>(SpecStore.class);
+    this.maxRetriesWhenGetSpec = ConfigUtils.getInt(config, FLOWCATALOG_GET_SPEC_MAX_RETRIES, DEFAULT_FLOWCATALOG_GET_SPEC_MAX_RETRIES);
 
     try {
       Config newConfig = config;
@@ -340,11 +346,27 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
    */
   public Spec getSpecWrapper(URI uri) {
     Spec spec = null;
+    ExponentialBackoff exponentialBackoff = ExponentialBackoff.builder().maxRetries(this.maxRetriesWhenGetSpec).initialDelay(
+        FLOWCATALOG_GET_SPEC_INITIAL_WAIT_AFTER_FAILURE).build();
+    try {
+      spec = getSpecHelper(uri, exponentialBackoff);
+    } catch (InterruptedException e) {
+      log.error(String.format("Failed to get %s in SpecStore", uri), e);
+    }
+    return spec;
+  }
+
+  private Spec getSpecHelper(URI uri, ExponentialBackoff exponentialBackoff)
+      throws InterruptedException {
+    Spec spec= null;
     try {
       spec = getSpecs(uri);
     } catch (SpecNotFoundException snfe) {
-      log.error(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog"
-          + ", suspecting current modification on SpecStore", uri), snfe);
+      if (exponentialBackoff.awaitNextRetryIfAvailable()) {
+        return getSpecHelper(uri, exponentialBackoff);
+      } else {
+        log.error(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog" + ", suspecting current modification on SpecStore", uri), snfe);
+      }
     }
     return spec;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1798


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable)
**Problem:**
Now with warm standby mode, we will write to mysql and read from mysql on separate hosts. Since we turn on the read replica for mysql databases, we do see read after write return null value and miss the processing for random flow request.
Sample error log: 

> "The URI gobblin-flow:/gobblin-test discovered in SpecStore is missing in FlowCatalog, suspecting current modification on SpecStore"

**Solutions**
We want to add a backoff retry logic when we try to read from MySQL databases.  



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

