### PR TITLE
[GOBBLIN-1800] Fix bug where retries would not consider jobs that are SLA killed

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -56,7 +56,8 @@ public class JobStatus {
   private final int maxAttempts;
   private final int currentAttempts;
   private final int currentGeneration;
-  private final boolean shouldRetry;
+  @Setter
+  private boolean shouldRetry;
   private final Supplier<List<Issue>> issues;
   private final int progressPercentage;
   private final long lastProgressEventTime;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1800

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

There are 2 SLAs in GaaS flows:
1. Job Start SLA, which measures the time in between when GaaS orchestrates a job to when it receives its first event from the job execution. This can catch scenarios such as container bootstrap time taking longer, event emission through Kafka failing, unresponsive executors.
2. Flow SLA, which measures the e2e time of a flow from start to end. If the job is stuck or taking too long to run past this setting, it fails to save resources on the executor side.

When a user defines `job.maxAttempts` in their GaaS flow, the expected behavior should be that these flows are retried to increase resiliency. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests in `DagManagerFlowTest.java`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

