### PR TITLE
Add matching of non-transient exceptions that will avoid failing the container in GMIP

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -107,6 +107,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   public static final String GMCE_METADATA_WRITER_CLASSES = "gmce.metadata.writer.classes";
   public static final String GMCE_METADATA_WRITER_MAX_ERROR_DATASET = "gmce.metadata.writer.max.error.dataset";
   public static final String TRANSIENT_EXCEPTION_MESSAGES_KEY = "gmce.metadata.writer.transient.exception.messages";
+  public static final String NON_TRANSIENT_EXCEPTION_MESSAGES_KEY = "gmce.metadata.writer.nonTransient.exception.messages";
   public static final int DEFUALT_GMCE_METADATA_WRITER_MAX_ERROR_DATASET = 0;
   public static final int DEFAULT_ICEBERG_PARALLEL_TIMEOUT_MILLS = 60000;
   public static final String TABLE_NAME_DELIMITER = ".";
@@ -128,6 +129,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   private int maxErrorDataset;
   protected EventSubmitter eventSubmitter;
   private final Set<String> transientExceptionMessages;
+  private final Set<String> nonTransientExceptionMessages;
 
   @AllArgsConstructor
   static class TableStatus {
@@ -161,6 +163,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
     MetricContext metricContext = Instrumented.getMetricContext(state, this.getClass(), tags);
     eventSubmitter = new EventSubmitter.Builder(metricContext, GOBBLIN_MCE_WRITER_METRIC_NAMESPACE).build();
     transientExceptionMessages = new HashSet<>(properties.getPropAsList(TRANSIENT_EXCEPTION_MESSAGES_KEY, ""));
+    nonTransientExceptionMessages = new HashSet<>(properties.getPropAsList(NON_TRANSIENT_EXCEPTION_MESSAGES_KEY, ""));
   }
 
   @Override
@@ -339,7 +342,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         try {
           writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
         } catch (Exception e) {
-          if (isExceptionTransient(e, transientExceptionMessages)) {
+          if (exceptionMatches(e, transientExceptionMessages)) {
             throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
           }
           meetException = true;
@@ -389,8 +392,12 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       lastException.addedPartitionValues.addAll(((HiveMetadataWriterWithPartitionInfoException) e).addedPartitionValues);
       lastException.droppedPartitionValues.addAll(((HiveMetadataWriterWithPartitionInfoException) e).droppedPartitionValues);
     }
-    this.datasetErrorMap.put(tableStatus.datasetPath, tableErrorMap);
-    log.error(String.format("Meet exception when flush table %s", tableString), e);
+    if (!exceptionMatches(e, this.nonTransientExceptionMessages)) {
+      this.datasetErrorMap.put(tableStatus.datasetPath, tableErrorMap);
+      log.error(String.format("Meet exception when flush table %s", tableString), e);
+    } else {
+      log.error(String.format("Detected known non-transient failure for table %s", tableString), e);
+    }
     if (datasetErrorMap.size() > maxErrorDataset) {
       //Fail the job if the error size exceeds some number
       throw new IOException(String.format("Container fails to flush for more than %s dataset, last exception we met is: ", maxErrorDataset), e);
@@ -412,7 +419,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         try {
           writer.flush(dbName, tableName);
         } catch (IOException e) {
-          if (isExceptionTransient(e, transientExceptionMessages)) {
+          if (exceptionMatches(e, transientExceptionMessages)) {
             throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
           }
           meetException = true;
@@ -435,11 +442,12 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   }
 
   /**
-   * Check if exception is contained within a known list of transient exceptions. These exceptions should not be caught
-   * to avoid advancing watermarks and skipping GMCEs unnecessarily.
+   * Check if exception is contained within a known list of known exceptions. Transient exceptions should not be caught
+   * to avoid advancing watermarks and skipping GMCEs unnecessarily, while non-transient exceptions should not count
+   * towards the maximum number of failed datasets.
    */
-  public static boolean isExceptionTransient(Exception e, Set<String> transientExceptionMessages) {
-    return transientExceptionMessages.stream().anyMatch(message -> Throwables.getRootCause(e).toString().contains(message));
+  public static boolean exceptionMatches(Exception e, Set<String> exceptionMessages) {
+    return exceptionMessages.stream().anyMatch(message -> Throwables.getRootCause(e).toString().contains(message));
   }
 
   /**

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriterTest.java
@@ -213,12 +213,12 @@ public class GobblinMCEWriterTest {
     Set<String> transientExceptions = Sets.newHashSet("Filesystem closed", "Hive timeout", "RejectedExecutionException");
     IOException transientException = new IOException("test1 Filesystem closed test");
     IOException wrapperException = new IOException("wrapper exception", transientException);
-    Assert.assertTrue(GobblinMCEWriter.isExceptionTransient(transientException, transientExceptions));
-    Assert.assertTrue(GobblinMCEWriter.isExceptionTransient(wrapperException, transientExceptions));
+    Assert.assertTrue(GobblinMCEWriter.exceptionMatches(transientException, transientExceptions));
+    Assert.assertTrue(GobblinMCEWriter.exceptionMatches(wrapperException, transientExceptions));
     IOException nonTransientException = new IOException("Write failed due to bad schema");
-    Assert.assertFalse(GobblinMCEWriter.isExceptionTransient(nonTransientException, transientExceptions));
+    Assert.assertFalse(GobblinMCEWriter.exceptionMatches(nonTransientException, transientExceptions));
     RejectedExecutionException rejectedExecutionException = new RejectedExecutionException("");
-    Assert.assertTrue(GobblinMCEWriter.isExceptionTransient(rejectedExecutionException, transientExceptions));
+    Assert.assertTrue(GobblinMCEWriter.exceptionMatches(rejectedExecutionException, transientExceptions));
   }
 
   @DataProvider(name="AllowMockMetadataWriter")


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1801


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Match exceptions against a known list of non-transient/dataset-specific exceptions, and avoid counting those towards the max failed datasets in a container since they are not indicating any wider issue.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in parallel GMIP pipeline by manually throwing an exception with dataset failure limit of 0

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

