### PR TITLE
[GOBBLIN-1802]Register iceberg table metadata update with destination side catalog

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -17,7 +17,9 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import java.io.IOException;
 import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.TableOperations;
@@ -39,7 +41,7 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
   }
 
   @Override
-  public IcebergTable openTable(String dbName, String tableName) {
+  public IcebergTable openTable(String dbName, String tableName) throws IOException {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
     return new IcebergTable(tableId, createTableOperations(tableId), this.getCatalogUri());
   }
@@ -48,5 +50,5 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
     return CatalogUtil.loadCatalog(this.companionCatalogClass.getName(), this.catalogName, properties, configuration);
   }
 
-  protected abstract TableOperations createTableOperations(TableIdentifier tableId);
+  protected abstract TableOperations createTableOperations(TableIdentifier tableId) throws IOException;
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -41,7 +41,7 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
   }
 
   @Override
-  public IcebergTable openTable(String dbName, String tableName) throws IOException {
+  public IcebergTable openTable(String dbName, String tableName) {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
     return new IcebergTable(tableId, createTableOperations(tableId), this.getCatalogUri());
   }
@@ -50,5 +50,5 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
     return CatalogUtil.loadCatalog(this.companionCatalogClass.getName(), this.catalogName, properties, configuration);
   }
 
-  protected abstract TableOperations createTableOperations(TableIdentifier tableId) throws IOException;
+  protected abstract TableOperations createTableOperations(TableIdentifier tableId);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -17,11 +17,9 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.catalog.TableIdentifier;
 
 
 /**
@@ -31,5 +29,5 @@ public interface IcebergCatalog {
   IcebergTable openTable(String dbName, String tableName);
   String getCatalogUri();
   void initialize(Map<String, String> properties, Configuration configuration);
-  boolean tableAlreadyExists(TableIdentifier tableIdentifier);
+  boolean tableAlreadyExists(IcebergTable icebergTable);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 
 /**
@@ -30,4 +31,5 @@ public interface IcebergCatalog {
   IcebergTable openTable(String dbName, String tableName) throws IOException;
   String getCatalogUri();
   void initialize(Map<String, String> properties, Configuration configuration);
+  boolean tableAlreadyExists(TableIdentifier tableIdentifier);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -17,7 +17,9 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import java.io.IOException;
 import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 
 
@@ -25,7 +27,7 @@ import org.apache.hadoop.conf.Configuration;
  * Any catalog from which to access {@link IcebergTable}s.
  */
 public interface IcebergCatalog {
-  IcebergTable openTable(String dbName, String tableName);
+  IcebergTable openTable(String dbName, String tableName) throws IOException;
   String getCatalogUri();
   void initialize(Map<String, String> properties, Configuration configuration);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
  * Any catalog from which to access {@link IcebergTable}s.
  */
 public interface IcebergCatalog {
-  IcebergTable openTable(String dbName, String tableName) throws IOException;
+  IcebergTable openTable(String dbName, String tableName);
   String getCatalogUri();
   void initialize(Map<String, String> properties, Configuration configuration);
   boolean tableAlreadyExists(TableIdentifier tableIdentifier);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -66,7 +66,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   private final String dbName;
   private final String inputTableName;
   private final IcebergTable srcIcebergTable;
-  private final IcebergTable existingTargetIcebergTable;
+  private final IcebergTable existingDestinationIcebergTable;
   protected final Properties properties;
   protected final FileSystem sourceFs;
   private final boolean shouldTolerateMissingSourceFiles = true; // TODO: make parameterizable, if desired
@@ -74,11 +74,11 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   /** Target database name */
   public static final String TARGET_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.database";
 
-  public IcebergDataset(String db, String table, IcebergTable srcIcebergTable, IcebergTable existingTargetIcebergTable, Properties properties, FileSystem sourceFs) {
+  public IcebergDataset(String db, String table, IcebergTable srcIcebergTable, IcebergTable existingDestinationIcebergTable, Properties properties, FileSystem sourceFs) {
     this.dbName = db;
     this.inputTableName = table;
     this.srcIcebergTable = srcIcebergTable;
-    this.existingTargetIcebergTable = existingTargetIcebergTable;
+    this.existingDestinationIcebergTable = existingDestinationIcebergTable;
     this.properties = properties;
     this.sourceFs = sourceFs;
   }
@@ -153,8 +153,9 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       fileEntity.setSourceData(getSourceDataset(this.sourceFs));
       fileEntity.setDestinationData(getDestinationDataset(targetFs));
       copyEntities.add(fileEntity);
+
     }
-    addPostPublishStep(copyEntities);
+    copyEntities.add(addPostPublishStep(this.srcIcebergTable, this.existingDestinationIcebergTable));
     log.info("~{}.{}~ generated {} copy entities", dbName, inputTableName, copyEntities.size());
     return copyEntities;
   }
@@ -312,11 +313,11 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   protected DatasetDescriptor getDestinationDataset(FileSystem targetFs) {
-    return this.srcIcebergTable.getDatasetDescriptor(targetFs);
+    return this.existingDestinationIcebergTable.getDatasetDescriptor(targetFs);
   }
 
-  private void addPostPublishStep(List<CopyEntity> copyEntities) {
-    IcebergRegisterStep icebergRegisterStep = new IcebergRegisterStep(this.getSrcIcebergTable(), this.getExistingTargetIcebergTable());
-    copyEntities.add(new PostPublishStep(getFileSetId(), Maps.newHashMap(), icebergRegisterStep, 0));
+  private PostPublishStep addPostPublishStep(IcebergTable srcIcebergTable, IcebergTable dstIcebergTable) {
+    IcebergRegisterStep icebergRegisterStep = new IcebergRegisterStep(srcIcebergTable, dstIcebergTable);
+    return new PostPublishStep(getFileSetId(), Maps.newHashMap(), icebergRegisterStep, 0);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -154,7 +154,6 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       fileEntity.setSourceData(getSourceDataset(this.sourceFs));
       fileEntity.setDestinationData(getDestinationDataset(targetFs));
       copyEntities.add(fileEntity);
-
     }
     copyEntities.add(createPostPublishStep(this.srcIcebergTable, this.destIcebergTable));
     log.info("~{}.{}~ generated {} copy entities", dbName, inputTableName, copyEntities.size());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -72,8 +72,8 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   protected final FileSystem sourceFs;
   private final boolean shouldTolerateMissingSourceFiles = true; // TODO: make parameterizable, if desired
 
-  /** Target database name */
-  public static final String TARGET_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.target.database";
+  /** Destination database name */
+  public static final String DESTINATION_DATABASE_KEY = IcebergDatasetFinder.ICEBERG_DATASET_PREFIX + ".copy.destination.database";
 
   public IcebergDataset(String db, String table, IcebergTable srcIcebergTable, IcebergTable destIcebergTable, Properties properties, FileSystem sourceFs) {
     this.dbName = db;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 import lombok.RequiredArgsConstructor;
@@ -54,9 +55,9 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   public static final String DEFAULT_ICEBERG_CATALOG_CLASS = "org.apache.gobblin.data.management.copy.iceberg.IcebergHiveCatalog";
   public static final String ICEBERG_SRC_CATALOG_URI_KEY = ICEBERG_DATASET_PREFIX + ".source.catalog.uri";
   public static final String ICEBERG_SRC_CLUSTER_NAME = ICEBERG_DATASET_PREFIX + ".source.cluster.name";
-  public static final String ICEBERG_DEST_CATALOG_CLASS_KEY = ICEBERG_DATASET_PREFIX + ".target.catalog.class";
-  public static final String ICEBERG_DEST_CATALOG_URI_KEY = ICEBERG_DATASET_PREFIX + ".copy.target.catalog.uri";
-  public static final String ICEBERG_DEST_CLUSTER_NAME = ICEBERG_DATASET_PREFIX + ".target.cluster.name";
+  public static final String ICEBERG_DEST_CATALOG_CLASS_KEY = ICEBERG_DATASET_PREFIX + ".destination.catalog.class";
+  public static final String ICEBERG_DEST_CATALOG_URI_KEY = ICEBERG_DATASET_PREFIX + ".copy.destination.catalog.uri";
+  public static final String ICEBERG_DEST_CLUSTER_NAME = ICEBERG_DATASET_PREFIX + ".destination.cluster.name";
   public static final String ICEBERG_DB_NAME = ICEBERG_DATASET_PREFIX + ".database.name";
   public static final String ICEBERG_TABLE_NAME = ICEBERG_DATASET_PREFIX + ".table.name";
 
@@ -92,7 +93,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
      */
     matchingDatasets.add(createIcebergDataset(dbName, tblName, sourceIcebergCatalog, destinationIcebergCatalog, properties, sourceFs));
     log.info("Found {} matching datasets: {} for the database name: {} and table name: {}", matchingDatasets.size(),
-        matchingDatasets, dbName, tblName);
+        matchingDatasets, dbName, tblName); // until future support added to specify multiple icebergs, count expected always to be one
     return matchingDatasets;
   }
 
@@ -114,6 +115,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
     IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(dbName, tblName);
     IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(dbName, tblName);
+    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(TableIdentifier.of(dbName, tblName)), "Missing Destination Iceberg Table!");
     return new IcebergDataset(dbName, tblName, srcIcebergTable, destIcebergTable, properties, fs);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -107,6 +107,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   /**
    * Requires both source and destination catalogs to connect to their respective {@link IcebergTable}
    * Note: the destination side {@link IcebergTable} should be present before initiating replication
+   * TODO: Rethink strategy to enforce dest iceberg table
    * @return {@link IcebergDataset} with its corresponding source and destination {@link IcebergTable}
    */
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
@@ -125,14 +126,14 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
     switch (location) {
       case SOURCE:
         catalogUri = properties.getProperty(ICEBERG_SRC_CATALOG_URI_KEY);
-        Preconditions.checkNotNull(catalogUri, "Source Catalog Table Service URI is required");
+        Preconditions.checkNotNull(catalogUri, "Provided: {%s} Source Catalog Table Service URI is required", catalogUri);
         // introducing an optional property for catalogs requiring cluster specific properties
         Optional.ofNullable(properties.getProperty(ICEBERG_SRC_CLUSTER_NAME)).ifPresent(value -> catalogProperties.put(ICEBERG_CLUSTER_KEY, value));
         icebergCatalogClassName = properties.getProperty(ICEBERG_SRC_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);
         break;
       case DESTINATION:
         catalogUri = properties.getProperty(ICEBERG_DEST_CATALOG_URI_KEY);
-        Preconditions.checkNotNull(catalogUri, "Destination Catalog Table Service URI is required");
+        Preconditions.checkNotNull(catalogUri, "Provided: {%s} Destination Catalog Table Service URI is required", catalogUri);
         // introducing an optional property for catalogs requiring cluster specific properties
         Optional.ofNullable(properties.getProperty(ICEBERG_DEST_CLUSTER_NAME)).ifPresent(value -> catalogProperties.put(ICEBERG_CLUSTER_KEY, value));
         icebergCatalogClassName = properties.getProperty(ICEBERG_DEST_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -126,14 +126,14 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
     switch (location) {
       case SOURCE:
         catalogUri = properties.getProperty(ICEBERG_SRC_CATALOG_URI_KEY);
-        Preconditions.checkNotNull(catalogUri, "Provided: {%s} Source Catalog Table Service URI is required", catalogUri);
+        Preconditions.checkNotNull(catalogUri, "Provide: {%s} as Source Catalog Table Service URI is required", ICEBERG_SRC_CATALOG_URI_KEY);
         // introducing an optional property for catalogs requiring cluster specific properties
         Optional.ofNullable(properties.getProperty(ICEBERG_SRC_CLUSTER_NAME)).ifPresent(value -> catalogProperties.put(ICEBERG_CLUSTER_KEY, value));
         icebergCatalogClassName = properties.getProperty(ICEBERG_SRC_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);
         break;
       case DESTINATION:
         catalogUri = properties.getProperty(ICEBERG_DEST_CATALOG_URI_KEY);
-        Preconditions.checkNotNull(catalogUri, "Provided: {%s} Destination Catalog Table Service URI is required", catalogUri);
+        Preconditions.checkNotNull(catalogUri, "Provide: {%s} as Destination Catalog Table Service URI is required", ICEBERG_DEST_CATALOG_URI_KEY);
         // introducing an optional property for catalogs requiring cluster specific properties
         Optional.ofNullable(properties.getProperty(ICEBERG_DEST_CLUSTER_NAME)).ifPresent(value -> catalogProperties.put(ICEBERG_CLUSTER_KEY, value));
         icebergCatalogClassName = properties.getProperty(ICEBERG_DEST_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -87,9 +87,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
 
     IcebergCatalog sourceIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.SOURCE);
     IcebergCatalog destinationIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.DESTINATION);
-    /* Each Iceberg dataset maps to an Iceberg table
-     * TODO: The user provided database and table names needs to be pre-checked and verified against the existence of a valid Iceberg table
-     */
+    /* Each Iceberg dataset maps to an Iceberg table */
     matchingDatasets.add(createIcebergDataset(dbName, tblName, sourceIcebergCatalog, destinationIcebergCatalog, properties, sourceFs));
     log.info("Found {} matching datasets: {} for the database name: {} and table name: {}", matchingDatasets.size(),
         matchingDatasets, dbName, tblName); // until future support added to specify multiple icebergs, count expected always to be one
@@ -113,6 +111,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
    */
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
     IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(dbName, tblName);
+    Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Missing Source Iceberg Table: {%s}.{%s}", dbName, tblName));
     IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(dbName, tblName);
     Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", dbName, tblName));
     return new IcebergDataset(dbName, tblName, srcIcebergTable, destIcebergTable, properties, fs);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 import lombok.RequiredArgsConstructor;
@@ -115,7 +114,7 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
     IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(dbName, tblName);
     IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(dbName, tblName);
-    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(TableIdentifier.of(dbName, tblName)), "Missing Destination Iceberg Table!");
+    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", dbName, tblName));
     return new IcebergDataset(dbName, tblName, srcIcebergTable, destIcebergTable, properties, fs);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -107,13 +107,13 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   /**
    * Requires both source and destination catalogs to connect to their respective {@link IcebergTable}
    * Note: the destination side {@link IcebergTable} should be present before initiating replication
-   * TODO: Rethink strategy to enforce dest iceberg table
    * @return {@link IcebergDataset} with its corresponding source and destination {@link IcebergTable}
    */
   protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
     IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(dbName, tblName);
     Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Missing Source Iceberg Table: {%s}.{%s}", dbName, tblName));
     IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(dbName, tblName);
+    // TODO: Rethink strategy to enforce dest iceberg table
     Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", dbName, tblName));
     return new IcebergDataset(dbName, tblName, srcIcebergTable, destIcebergTable, properties, fs);
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
@@ -54,10 +53,12 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
   }
 
   @Override
-  protected TableOperations createTableOperations(TableIdentifier tableId) throws IOException {
-    if (!hc.tableExists(tableId)) {
-      throw new IcebergTable.TableNotFoundException(tableId);
-    }
+  protected TableOperations createTableOperations(TableIdentifier tableId) {
     return hc.newTableOps(tableId);
+  }
+
+  @Override
+  public boolean tableAlreadyExists(TableIdentifier tableId) {
+    return hc.tableExists(tableId);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -20,7 +20,7 @@ package org.apache.gobblin.data.management.copy.iceberg;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.CatalogProperties;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -49,7 +49,7 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
 
   @Override
   public String getCatalogUri() {
-    return hc.getConf().get(CatalogProperties.URI, "<<not set>>");
+    return hc.getConf().get(HiveConf.ConfVars.METASTOREURIS.varname, "<<not set>>");
   }
 
   @Override
@@ -58,7 +58,7 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
   }
 
   @Override
-  public boolean tableAlreadyExists(TableIdentifier tableId) {
-    return hc.tableExists(tableId);
+  public boolean tableAlreadyExists(IcebergTable icebergTable) {
+    return hc.tableExists(icebergTable.getTableId());
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergHiveCatalog.java
@@ -17,12 +17,15 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import java.io.IOException;
 import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveCatalog;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -51,7 +54,10 @@ public class IcebergHiveCatalog extends BaseIcebergCatalog {
   }
 
   @Override
-  protected TableOperations createTableOperations(TableIdentifier tableId) {
+  protected TableOperations createTableOperations(TableIdentifier tableId) throws IOException {
+    if (!hc.tableExists(tableId)) {
+      throw new IcebergTable.TableNotFoundException(tableId);
+    }
     return hc.newTableOps(tableId);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -35,7 +35,7 @@ import org.apache.gobblin.commit.CommitStep;
 public class IcebergRegisterStep implements CommitStep {
 
   private final IcebergTable srcIcebergTable;
-  private final IcebergTable existingDestinationIcebergTable;
+  private final IcebergTable destIcebergTable;
 
   @Override
   public boolean isCompleted() throws IOException {
@@ -46,10 +46,10 @@ public class IcebergRegisterStep implements CommitStep {
   public void execute() throws IOException {
     TableMetadata destinationMetadata = null;
     try {
-      destinationMetadata = this.existingDestinationIcebergTable.accessTableMetadata();
+      destinationMetadata = this.destIcebergTable.accessTableMetadata();
     } catch (IcebergTable.TableNotFoundException tnfe) {
-      log.warn("Destination TableMetadata doesn't exist because : {}" , tnfe);
+      log.warn("Destination TableMetadata doesn't exist because: " , tnfe);
     }
-    this.existingDestinationIcebergTable.registerIcebergTable(this.srcIcebergTable.accessTableMetadata(), destinationMetadata);
+    this.destIcebergTable.registerIcebergTable(this.srcIcebergTable.accessTableMetadata(), destinationMetadata);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.iceberg;
+
+import java.io.IOException;
+
+import org.apache.iceberg.TableMetadata;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.commit.CommitStep;
+
+/**
+ * {@link CommitStep} to perform Iceberg registration.
+ */
+
+@Slf4j
+@AllArgsConstructor
+public class IcebergRegisterStep implements CommitStep {
+
+  private final IcebergTable srcIcebergTable;
+  private final IcebergTable existingTargetIcebergTable;
+
+  @Override
+  public boolean isCompleted() throws IOException {
+    return false;
+  }
+
+  @Override
+  public void execute() throws IOException {
+    TableMetadata targetMetadata = null;
+    try {
+      targetMetadata = this.existingTargetIcebergTable.accessTableMetadata();
+    } catch (IcebergTable.TableNotFoundException tnfe) {
+      log.warn("Target TableMetadata doesn't exist because : {}" , tnfe);
+    }
+    this.srcIcebergTable.registerIcebergTable(this.srcIcebergTable.accessTableMetadata(), targetMetadata);
+  }
+}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -29,7 +29,6 @@ import org.apache.gobblin.commit.CommitStep;
 /**
  * {@link CommitStep} to perform Iceberg registration.
  */
-
 @Slf4j
 @AllArgsConstructor
 public class IcebergRegisterStep implements CommitStep {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -35,7 +35,7 @@ import org.apache.gobblin.commit.CommitStep;
 public class IcebergRegisterStep implements CommitStep {
 
   private final IcebergTable srcIcebergTable;
-  private final IcebergTable existingTargetIcebergTable;
+  private final IcebergTable existingDestinationIcebergTable;
 
   @Override
   public boolean isCompleted() throws IOException {
@@ -44,12 +44,12 @@ public class IcebergRegisterStep implements CommitStep {
 
   @Override
   public void execute() throws IOException {
-    TableMetadata targetMetadata = null;
+    TableMetadata destinationMetadata = null;
     try {
-      targetMetadata = this.existingTargetIcebergTable.accessTableMetadata();
+      destinationMetadata = this.existingDestinationIcebergTable.accessTableMetadata();
     } catch (IcebergTable.TableNotFoundException tnfe) {
-      log.warn("Target TableMetadata doesn't exist because : {}" , tnfe);
+      log.warn("Destination TableMetadata doesn't exist because : {}" , tnfe);
     }
-    this.srcIcebergTable.registerIcebergTable(this.srcIcebergTable.accessTableMetadata(), targetMetadata);
+    this.existingDestinationIcebergTable.registerIcebergTable(this.srcIcebergTable.accessTableMetadata(), destinationMetadata);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -26,10 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
@@ -43,6 +39,10 @@ import org.apache.iceberg.io.FileIO;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.DatasetDescriptor;
@@ -193,5 +193,10 @@ public class IcebergTable {
     );
     descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
     return descriptor;
+  }
+  /** Registers {@link IcebergTable} after publishing data.
+   * @param dstMetadata is null if target {@link IcebergTable} is absent */
+  protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {
+    this.tableOps.commit(srcMetadata, dstMetadata);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -195,8 +195,10 @@ public class IcebergTable {
     return descriptor;
   }
   /** Registers {@link IcebergTable} after publishing data.
-   * @param dstMetadata is null if target {@link IcebergTable} is absent */
+   * @param dstMetadata is null if destination {@link IcebergTable} is absent, in which case registration is skipped */
   protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {
-    this.tableOps.commit(srcMetadata, dstMetadata);
+    if (dstMetadata != null) {
+      this.tableOps.commit(srcMetadata, dstMetadata);
+    }
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -67,7 +67,7 @@ public class IcebergTable {
       this.tableId = tableId;
     }
   }
-
+  @Getter
   private final TableIdentifier tableId;
   private final TableOperations tableOps;
   private final String catalogUri;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -226,10 +226,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset =
-        new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
+        new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -252,10 +252,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset =
-        new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
+        new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -283,9 +283,9 @@ public class IcebergDatasetTest {
     sourceBuilder.addPathsAndFileStatuses(expectedPathsAndFileStatuses);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -311,9 +311,9 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -449,9 +449,9 @@ public class IcebergDatasetTest {
    *  Without this, so to lose the mock, we'd be unable to set up any source paths as existing.
    */
   protected static class TrickIcebergDataset extends IcebergDataset {
-    public TrickIcebergDataset(String db, String table, IcebergTable icebergTbl, IcebergTable targetIcebergTbl, Properties properties,
+    public TrickIcebergDataset(String db, String table, IcebergTable srcIcebergTbl, IcebergTable destIcebergTbl, Properties properties,
         FileSystem sourceFs) {
-      super(db, table, icebergTbl, targetIcebergTbl, properties, sourceFs);
+      super(db, table, srcIcebergTbl, destIcebergTbl, properties, sourceFs);
     }
 
     @Override // as the `static` is not mock-able

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -62,10 +61,8 @@ import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyContext;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.PreserveAttributes;
-import org.apache.gobblin.data.management.copy.entities.PostPublishStep;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mockConstruction;
 
 
 /** Tests for {@link org.apache.gobblin.data.management.copy.iceberg.IcebergDataset} */
@@ -101,10 +98,6 @@ public class IcebergDatasetTest {
       new MockIcebergTable.SnapshotPaths(Optional.empty(), MANIFEST_LIST_PATH_1, Arrays.asList(
           new IcebergSnapshotInfo.ManifestFileInfo(MANIFEST_PATH_1,
               Arrays.asList(MANIFEST_DATA_PATH_1A, MANIFEST_DATA_PATH_1B))));
-  private static final MockIcebergTable.SnapshotPaths SNAPSHOT_PATHS_2 =
-      new MockIcebergTable.SnapshotPaths(Optional.empty(), Strings.EMPTY, Arrays.asList(
-          new IcebergSnapshotInfo.ManifestFileInfo(Strings.EMPTY,
-              Arrays.asList(Strings.EMPTY))));
 
   private final String testDbName = "test_db_name";
   private final String testTblName = "test_tbl_name";
@@ -234,7 +227,7 @@ public class IcebergDatasetTest {
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_2));
+    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset =
         new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
 
@@ -244,9 +237,6 @@ public class IcebergDatasetTest {
     CopyConfiguration copyConfiguration =
         CopyConfiguration.builder(destFs, copyConfigProperties).preserve(PreserveAttributes.fromMnemonicString(""))
             .copyContext(new CopyContext()).build();
-   try (MockedConstruction<PostPublishStep> mockedPostPublishStep = mockConstruction(PostPublishStep.class)) {
-     PostPublishStep step = new PostPublishStep(icebergDataset.getFileSetId(), Maps.newHashMap(), new IcebergRegisterStep(icebergTable, targetTable), 0);
-   }
     Collection<CopyEntity> copyEntities = icebergDataset.generateCopyEntities(destFs, copyConfiguration);
     verifyCopyEntities(copyEntities, expectedPaths);
   }
@@ -263,7 +253,7 @@ public class IcebergDatasetTest {
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_2));
+    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset =
         new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
 
@@ -273,9 +263,6 @@ public class IcebergDatasetTest {
     CopyConfiguration copyConfiguration =
         CopyConfiguration.builder(destFs, copyConfigProperties).preserve(PreserveAttributes.fromMnemonicString(""))
             .copyContext(new CopyContext()).build();
-    try (MockedConstruction<PostPublishStep> mockedPostPublishStep = mockConstruction(PostPublishStep.class)) {
-      PostPublishStep step = new PostPublishStep(icebergDataset.getFileSetId(), Maps.newHashMap(), new IcebergRegisterStep(icebergTable, targetTable), 0);
-    }
     Collection<CopyEntity> copyEntities = icebergDataset.generateCopyEntities(destFs, copyConfiguration);
     verifyCopyEntities(copyEntities, expectedPaths);
   }
@@ -297,7 +284,7 @@ public class IcebergDatasetTest {
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_2));
+    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
@@ -308,9 +295,6 @@ public class IcebergDatasetTest {
             // preserving attributes for owner, group and permissions respectively
             .preserve(PreserveAttributes.fromMnemonicString("ugp"))
             .copyContext(new CopyContext()).build();
-    try (MockedConstruction<PostPublishStep> mockedPostPublishStep = mockConstruction(PostPublishStep.class)) {
-      PostPublishStep step = new PostPublishStep(icebergDataset.getFileSetId(), Maps.newHashMap(), new IcebergRegisterStep(icebergTable, targetTable), 0);
-    }
     Collection<CopyEntity> copyEntities = icebergDataset.generateCopyEntities(destFs, copyConfiguration);
     verifyFsOwnershipAndPermissionPreservation(copyEntities, sourceBuilder.getPathsAndFileStatuses());
   }
@@ -328,7 +312,7 @@ public class IcebergDatasetTest {
     FileSystem sourceFs = sourceBuilder.build();
 
     IcebergTable icebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_2));
+    IcebergTable targetTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
     IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, icebergTable, targetTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
@@ -339,9 +323,6 @@ public class IcebergDatasetTest {
             // without preserving attributes for owner, group and permissions
             .preserve(PreserveAttributes.fromMnemonicString(""))
             .copyContext(new CopyContext()).build();
-    try (MockedConstruction<PostPublishStep> mockedPostPublishStep = mockConstruction(PostPublishStep.class)) {
-      PostPublishStep step = new PostPublishStep(icebergDataset.getFileSetId(), Maps.newHashMap(), new IcebergRegisterStep(icebergTable, targetTable), 0);
-    }
     Collection<CopyEntity> copyEntities = icebergDataset.generateCopyEntities(destFs, copyConfiguration);
     verifyFsOwnershipAndPermissionPreservation(copyEntities, expectedPathsAndFileStatuses);
   }
@@ -405,6 +386,8 @@ public class IcebergDatasetTest {
       if (isCopyableFile(json)) {
         String filepath = CopyEntityDeserializer.getFilePathAsStringFromJson(json);
         actual.add(filepath);
+      } else{
+        verifyPostPublishStep(json);
       }
     }
     Assert.assertEquals(actual.size(), expected.size(), "Set" + actual.toString() + " vs Set" + expected.toString());
@@ -431,6 +414,8 @@ public class IcebergDatasetTest {
         // providing path's parent to verify ancestor owner and permissions
         verifyAncestorPermissions(ancestorFileOwnerAndPermissionsList, filePath.getParent(),
             expectedPathsAndFileStatuses);
+      } else {
+        verifyPostPublishStep(copyEntityJson);
       }
     }
   }
@@ -450,6 +435,13 @@ public class IcebergDatasetTest {
       verifyFileStatus(actual, expected);
       path = path.getParent();
     }
+  }
+
+  private static void verifyPostPublishStep(String json) {
+    String expectedCommitStep = "org.apache.gobblin.data.management.copy.iceberg.IcebergRegisterStep";
+    String actualCommitStep = new Gson().fromJson(json, JsonObject.class)
+        .getAsJsonObject("object-data").getAsJsonObject("step").getAsJsonPrimitive("object-type").getAsString();
+    Assert.assertEquals(actualCommitStep, expectedCommitStep);
   }
 
   /**

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
@@ -40,7 +40,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveMetastoreTest;
 import org.apache.iceberg.shaded.org.apache.avro.SchemaBuilder;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -123,7 +123,7 @@ ext.externalDependency = [
     "guiceMultibindings": "com.google.inject.extensions:guice-multibindings:4.0",
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",
     "derby": "org.apache.derby:derby:10.12.1.1",
-    "mockito": "org.mockito:mockito-core:4.11.0",
+    "mockito": "org.mockito:mockito-inline:4.11.0",
     "salesforceWsc": "com.force.api:force-wsc:" + salesforceVersion,
     "salesforcePartner": "com.force.api:force-partner-api:" + salesforceVersion,
     "scala": "org.scala-lang:scala-library:2.11.8",

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -123,7 +123,7 @@ ext.externalDependency = [
     "guiceMultibindings": "com.google.inject.extensions:guice-multibindings:4.0",
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",
     "derby": "org.apache.derby:derby:10.12.1.1",
-    "mockito": "org.mockito:mockito-inline:4.11.0",
+    "mockito": "org.mockito:mockito-inline:4.11.0", // upgraded to allow mocking for constructors, static and final methods; specifically for iceberg distcp
     "salesforceWsc": "com.force.api:force-wsc:" + salesforceVersion,
     "salesforcePartner": "com.force.api:force-partner-api:" + salesforceVersion,
     "scala": "org.scala-lang:scala-library:2.11.8",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
Implementing the capability to register iceberg tables based on table metadata updates after the data has been published. Below are the changes as part of this PR:
- [ ] Here are some details about my PR, including screenshots (if applicable):
- [ ] Accept properties for instantiating both source and target `IcebergCatalog` 
- [ ] Added `IcebergRegisterStep` to perform post publish `CommitStep`
- [ ] Extended `IcebergTable` class to support `registerIcebergTable` which relies on the underlying `TableOperations`'s`commit` method for registration


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] Updated unit tests 


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

