### PR TITLE
[GOBBLIN-1806] Submit dataset summary event post commit and integrate them into GaaSObservabilityEvent

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -438,6 +438,7 @@ public class ConfigurationKeys {
   public static final String WRITER_BYTES_WRITTEN = WRITER_PREFIX + ".bytes.written";
   public static final String WRITER_EARLIEST_TIMESTAMP = WRITER_PREFIX + ".earliest.timestamp";
   public static final String WRITER_AVERAGE_TIMESTAMP = WRITER_PREFIX + ".average.timestamp";
+  public static final String WRITER_COUNT_METRICS_FROM_FAILED_TASKS = WRITER_PREFIX + ".jobTaskSummary.countMetricsFromFailedTasks";
 
   /**
    * Configuration properties used by the quality checker.
@@ -465,7 +466,6 @@ public class ConfigurationKeys {
   public static final String EXTRACTOR_ROWS_EXPECTED = QUALITY_CHECKER_PREFIX + ".rows.expected";
   public static final String WRITER_ROWS_WRITTEN = QUALITY_CHECKER_PREFIX + ".rows.written";
   public static final String ROW_COUNT_RANGE = QUALITY_CHECKER_PREFIX + ".row.count.range";
-
   /**
    * Configuration properties for the task status.
    */

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -466,6 +466,7 @@ public class ConfigurationKeys {
   public static final String EXTRACTOR_ROWS_EXPECTED = QUALITY_CHECKER_PREFIX + ".rows.expected";
   public static final String WRITER_ROWS_WRITTEN = QUALITY_CHECKER_PREFIX + ".rows.written";
   public static final String ROW_COUNT_RANGE = QUALITY_CHECKER_PREFIX + ".row.count.range";
+
   /**
    * Configuration properties for the task status.
    */

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -188,6 +188,38 @@
           }
         }
       ]
-    }]
+    },
+    {
+      "name": "datasetsWritten",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "DatasetMetric",
+            "doc": "DatasetMetric contains bytes and records written by Gobblin writers for the dataset URN.",
+            "fields": [
+              {
+                "name": "datasetUrn",
+                "type": "string",
+                "doc": "URN of the dataset"
+              },
+              {
+                "name": "bytesWritten",
+                "type": "long",
+                "doc": "Number of bytes written for the dataset"
+              },
+              {
+                "name": "recordsWritten",
+                "type": "long",
+                "doc": "Number of records written for the dataset"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
 }
 

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -208,12 +208,17 @@
               {
                 "name": "bytesWritten",
                 "type": "long",
-                "doc": "Number of bytes written for the dataset"
+                "doc": "Number of bytes written for the dataset, can be -1 if unsupported by the writer (e.g. jdbc writer)"
               },
               {
-                "name": "recordsWritten",
+                "name": "entitiesWritten",
                 "type": "long",
-                "doc": "Number of records written for the dataset"
+                "doc": "Number of entities written for the dataset by the Gobblin writer"
+              },
+              {
+                "name": "datasetCommitSucceeded",
+                "type": "boolean",
+                "doc": "Whether the dataset was successfully committed by Gobblin and fully successful, useful when users configure pipelines to allow for partial failures or non-atomic writes"
               }
             ]
           }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -213,10 +213,10 @@
               {
                 "name": "entitiesWritten",
                 "type": "long",
-                "doc": "Number of entities written for the dataset by the Gobblin writer"
+                "doc": "Number of entities written (e.g. files or records) for the dataset by the Gobblin writer"
               },
               {
-                "name": "datasetCommitSucceeded",
+                "name": "successfullyCommitted",
                 "type": "boolean",
                 "doc": "Whether the dataset was successfully committed by Gobblin and fully successful, useful when users configure pipelines to allow for partial failures or non-atomic writes"
               }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -113,6 +113,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
   public static final String JOB_END_TIME = "jobEndTime";
   public static final String JOB_LAST_PROGRESS_EVENT_TIME = "jobLastProgressEventTime";
   public static final String JOB_COMPLETION_PERCENTAGE = "jobCompletionPercentage";
+  public static final String DATASET_TASK_SUMMARIES = "datasetTaskSummaries";
 
   @Getter
   private Long startTime;

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -46,6 +46,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String JOB_START = "JobStartTimer";
     public static final String JOB_RUN = "JobRunTimer";
     public static final String JOB_COMMIT = "JobCommitTimer";
+    public static final String JOB_SUMMARY = "JobSummaryTimer";
     public static final String JOB_CLEANUP = "JobCleanupTimer";
     public static final String JOB_CANCEL = "JobCancelTimer";
     public static final String JOB_COMPLETE = "JobCompleteTimer";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/test/MetricsAssert.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/test/MetricsAssert.java
@@ -20,10 +20,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.Nonnull;
-
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
 
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.MetricContext;
@@ -106,4 +107,7 @@ public class MetricsAssert implements Function<Notification, Void> {
     };
   }
 
+  public ImmutableList<GobblinTrackingEvent> getEvents() {
+    return ImmutableList.copyOf(_events);
+  }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -92,6 +92,7 @@ import org.apache.gobblin.runtime.metrics.GobblinJobMetricReporter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooter;
 import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooterFactory;
 import org.apache.gobblin.runtime.troubleshooter.IssueRepository;
+import org.apache.gobblin.runtime.util.GsonUtils;
 import org.apache.gobblin.runtime.util.JobMetrics;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.source.InfiniteSource;
@@ -728,6 +729,38 @@ public abstract class AbstractJobLauncher implements JobLauncher {
    */
   protected void postProcessJobState(JobState jobState) {
     postProcessTaskStates(jobState.getTaskStates());
+    if (!GobblinMetrics.isEnabled(this.jobProps)) {
+      return;
+    }
+    List<DatasetTaskSummary> datasetTaskSummaries = new ArrayList<>();
+    Map<String, JobState.DatasetState> datasetStates = this.jobContext.getDatasetStatesByUrns();
+    // Only process successful datasets unless configuration to process failed datasets is set
+    for (JobState.DatasetState datasetState : datasetStates.values()) {
+      if (datasetState.getState() == JobState.RunningState.COMMITTED
+        || (datasetState.getState() == JobState.RunningState.FAILED && this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS)) {
+        long totalBytesWritten = 0;
+        long totalRecordsWritten = 0;
+        for (TaskState taskState : datasetState.getTaskStates()) {
+          if (taskState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED
+              && taskState.contains(ConfigurationKeys.WRITER_BYTES_WRITTEN)
+              && taskState.contains(ConfigurationKeys.WRITER_RECORDS_WRITTEN)) {
+            totalBytesWritten += taskState.getPropAsLong(ConfigurationKeys.WRITER_BYTES_WRITTEN);
+            totalRecordsWritten += taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN);
+          }
+        }
+        LOG.info("Reporting that " + totalRecordsWritten + " records and " + totalBytesWritten + " bytes were written for " + datasetState.getDatasetUrn());
+        datasetTaskSummaries.add(new DatasetTaskSummary(datasetState.getDatasetUrn(), totalRecordsWritten, totalBytesWritten));
+      } else if (datasetState.getState() == JobState.RunningState.FAILED) {
+        // Check if config is turned on for submitting writer metrics on failure due to non-atomic write semantics
+        if (this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
+          LOG.info("Due to task failure, will report that no records or bytes were written for " + datasetState.getDatasetUrn());
+          datasetTaskSummaries.add(new DatasetTaskSummary(datasetState.getDatasetUrn(), 0, 0));
+        }
+      }
+    }
+    TimingEvent jobSummaryTimer = this.eventSubmitter.getTimingEvent(TimingEvent.LauncherTimings.JOB_SUMMARY);
+    jobSummaryTimer.addMetadata("datasetTaskSummaries", GsonUtils.GSON_WITH_DATE_HANDLING.toJson(datasetTaskSummaries));
+    jobSummaryTimer.stop();
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -741,7 +741,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         long totalBytesWritten = 0;
         long totalRecordsWritten = 0;
         for (TaskState taskState : datasetState.getTaskStates()) {
-          if (taskState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED
+          if ((taskState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED
+                || PropertiesUtils.getPropAsBoolean(jobProps, ConfigurationKeys.WRITER_COUNT_METRICS_FROM_FAILED_TASKS, "false"))
               && taskState.contains(ConfigurationKeys.WRITER_BYTES_WRITTEN)
               && taskState.contains(ConfigurationKeys.WRITER_RECORDS_WRITTEN)) {
             totalBytesWritten += taskState.getPropAsLong(ConfigurationKeys.WRITER_BYTES_WRITTEN);
@@ -759,7 +760,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       }
     }
     TimingEvent jobSummaryTimer = this.eventSubmitter.getTimingEvent(TimingEvent.LauncherTimings.JOB_SUMMARY);
-    jobSummaryTimer.addMetadata("datasetTaskSummaries", GsonUtils.GSON_WITH_DATE_HANDLING.toJson(datasetTaskSummaries));
+    jobSummaryTimer.addMetadata(TimingEvent.DATASET_TASK_SUMMARIES, GsonUtils.GSON_WITH_DATE_HANDLING.toJson(datasetTaskSummaries));
     jobSummaryTimer.stop();
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime;
+
+/**
+ * A class returned by {@link org.apache.gobblin.runtime.SafeDatasetCommit} to provide metrics for the dataset
+ * that can be reported as a single event in the commit phase.
+ */
+public class DatasetTaskSummary {
+  private final String datasetUrn;
+  private final long recordsWritten;
+  private final long bytesWritten;
+
+  public DatasetTaskSummary(String datasetUrn, long recordsWritten, long bytesWritten) {
+    this.datasetUrn = datasetUrn;
+    this.recordsWritten = recordsWritten;
+    this.bytesWritten = bytesWritten;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public long getRecordsWritten() {
+    return recordsWritten;
+  }
+
+  public long getBytesWritten() {
+    return bytesWritten;
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
@@ -17,30 +17,26 @@
 
 package org.apache.gobblin.runtime;
 
+import lombok.Data;
+
+import org.apache.gobblin.metrics.DatasetMetric;
+
+
 /**
  * A class returned by {@link org.apache.gobblin.runtime.SafeDatasetCommit} to provide metrics for the dataset
  * that can be reported as a single event in the commit phase.
  */
+@Data
 public class DatasetTaskSummary {
   private final String datasetUrn;
   private final long recordsWritten;
   private final long bytesWritten;
+  private final boolean datasetCommitSucceeded;
 
-  public DatasetTaskSummary(String datasetUrn, long recordsWritten, long bytesWritten) {
-    this.datasetUrn = datasetUrn;
-    this.recordsWritten = recordsWritten;
-    this.bytesWritten = bytesWritten;
-  }
-
-  public String getDatasetUrn() {
-    return datasetUrn;
-  }
-
-  public long getRecordsWritten() {
-    return recordsWritten;
-  }
-
-  public long getBytesWritten() {
-    return bytesWritten;
+  /**
+   * Convert a {@link DatasetTaskSummary} to a {@link DatasetMetric}.
+   */
+  public static DatasetMetric toDatasetMetric(DatasetTaskSummary datasetTaskSummary) {
+    return new DatasetMetric(datasetTaskSummary.getDatasetUrn(), datasetTaskSummary.getBytesWritten(), datasetTaskSummary.getRecordsWritten(), datasetTaskSummary.isDatasetCommitSucceeded());
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
@@ -31,12 +31,12 @@ public class DatasetTaskSummary {
   private final String datasetUrn;
   private final long recordsWritten;
   private final long bytesWritten;
-  private final boolean datasetCommitSucceeded;
+  private final boolean successfullyCommitted;
 
   /**
    * Convert a {@link DatasetTaskSummary} to a {@link DatasetMetric}.
    */
   public static DatasetMetric toDatasetMetric(DatasetTaskSummary datasetTaskSummary) {
-    return new DatasetMetric(datasetTaskSummary.getDatasetUrn(), datasetTaskSummary.getBytesWritten(), datasetTaskSummary.getRecordsWritten(), datasetTaskSummary.isDatasetCommitSucceeded());
+    return new DatasetMetric(datasetTaskSummary.getDatasetUrn(), datasetTaskSummary.getBytesWritten(), datasetTaskSummary.getRecordsWritten(), datasetTaskSummary.isSuccessfullyCommitted());
   }
 }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestWorkUnitStreamSource.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestWorkUnitStreamSource.java
@@ -31,6 +31,8 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.runtime.api.JobExecutionDriver;
@@ -42,8 +44,6 @@ import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnitStream;
 import org.apache.gobblin.task.EventBusPublishingTaskFactory;
 import org.apache.gobblin.writer.test.TestingEventBuses;
-
-import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -19,16 +19,20 @@ package org.apache.gobblin.service.monitoring;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.gson.reflect.TypeToken;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.ContextAwareMeter;
+import org.apache.gobblin.metrics.DatasetMetric;
 import org.apache.gobblin.metrics.GaaSObservabilityEventExperimental;
 import org.apache.gobblin.metrics.Issue;
 import org.apache.gobblin.metrics.IssueSeverity;
@@ -36,9 +40,11 @@ import org.apache.gobblin.metrics.JobStatus;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.runtime.DatasetTaskSummary;
 import org.apache.gobblin.runtime.troubleshooter.MultiContextIssueRepository;
 import org.apache.gobblin.runtime.troubleshooter.TroubleshooterException;
 import org.apache.gobblin.runtime.troubleshooter.TroubleshooterUtils;
+import org.apache.gobblin.runtime.util.GsonUtils;
 import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.modules.orchestration.AzkabanProjectConfig;
 
@@ -93,6 +99,12 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     Long jobOrchestratedTime = jobState.contains(TimingEvent.JOB_ORCHESTRATED_TIME) ? jobState.getPropAsLong(TimingEvent.JOB_ORCHESTRATED_TIME) : null;
     Long jobPlanningPhaseStartTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_START_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_START_TIME) : null;
     Long jobPlanningPhaseEndTime = jobState.contains(TimingEvent.WORKUNIT_PLAN_END_TIME) ? jobState.getPropAsLong(TimingEvent.WORKUNIT_PLAN_END_TIME) : null;
+    Type datasetTaskSummaryType = new TypeToken<ArrayList<DatasetTaskSummary>>(){}.getType();
+    List<DatasetTaskSummary> datasetTaskSummaries = jobState.contains(TimingEvent.DATASET_TASK_SUMMARIES) ?
+        GsonUtils.GSON_WITH_DATE_HANDLING.fromJson(jobState.getProp(TimingEvent.DATASET_TASK_SUMMARIES), datasetTaskSummaryType) : null;
+    List<DatasetMetric> datasetMetrics = datasetTaskSummaries != null ? datasetTaskSummaries.stream().map(summary ->
+        new DatasetMetric(summary.getDatasetUrn(), summary.getBytesWritten(), summary.getRecordsWritten())).collect(Collectors.toList()) : null;
+
     GaaSObservabilityEventExperimental.Builder builder = GaaSObservabilityEventExperimental.newBuilder();
     List<Issue> issueList = null;
     try {
@@ -121,7 +133,8 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setJobPlanningPhaseEndTime(jobPlanningPhaseEndTime)
         .setIssues(issueList)
         .setJobStatus(status)
-        .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null));
+        .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null))
+        .setDatasetsWritten(datasetMetrics);
     return builder.build();
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -102,8 +102,8 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
     Type datasetTaskSummaryType = new TypeToken<ArrayList<DatasetTaskSummary>>(){}.getType();
     List<DatasetTaskSummary> datasetTaskSummaries = jobState.contains(TimingEvent.DATASET_TASK_SUMMARIES) ?
         GsonUtils.GSON_WITH_DATE_HANDLING.fromJson(jobState.getProp(TimingEvent.DATASET_TASK_SUMMARIES), datasetTaskSummaryType) : null;
-    List<DatasetMetric> datasetMetrics = datasetTaskSummaries != null ? datasetTaskSummaries.stream().map(summary ->
-        new DatasetMetric(summary.getDatasetUrn(), summary.getBytesWritten(), summary.getRecordsWritten())).collect(Collectors.toList()) : null;
+    List<DatasetMetric> datasetMetrics = datasetTaskSummaries != null ? datasetTaskSummaries.stream().map(
+       DatasetTaskSummary::toDatasetMetric).collect(Collectors.toList()) : null;
 
     GaaSObservabilityEventExperimental.Builder builder = GaaSObservabilityEventExperimental.newBuilder();
     List<Issue> issueList = null;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -133,6 +133,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         break;
       case TimingEvent.LauncherTimings.JOB_START:
       case TimingEvent.FlowTimings.FLOW_RUNNING:
+      case TimingEvent.LauncherTimings.JOB_SUMMARY:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());
         break;
       case TimingEvent.LauncherTimings.JOB_PENDING:

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -62,8 +62,10 @@ public class GaaSObservabilityProducerTest {
         createTestIssue("issueSummary", "issueCode", IssueSeverity.INFO)
     );
     List<DatasetTaskSummary> summaries = new ArrayList<>();
-    summaries.add(new DatasetTaskSummary("/testFolder", 100, 1000));
-    summaries.add(new DatasetTaskSummary("/testFolder2", 1000, 10000));
+    DatasetTaskSummary dataset1 = new DatasetTaskSummary("/testFolder", 100, 1000, true);
+    DatasetTaskSummary dataset2 = new DatasetTaskSummary("/testFolder2", 1000, 10000, false);
+    summaries.add(dataset1);
+    summaries.add(dataset2);
 
     MockGaaSObservabilityEventProducer producer = new MockGaaSObservabilityEventProducer(new State(), this.issueRepository);
     Map<String, String> gteEventMetadata = Maps.newHashMap();
@@ -106,12 +108,14 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getJobStartTime(), Long.valueOf(20));
     Assert.assertEquals(event.getJobEndTime(), Long.valueOf(100));
     Assert.assertEquals(event.getDatasetsWritten().size(), 2);
-    Assert.assertEquals(event.getDatasetsWritten().get(0).getDatasetUrn(), "/testFolder");
-    Assert.assertEquals(event.getDatasetsWritten().get(0).getRecordsWritten(), Long.valueOf(100));
-    Assert.assertEquals(event.getDatasetsWritten().get(0).getBytesWritten(), Long.valueOf(1000));
-    Assert.assertEquals(event.getDatasetsWritten().get(1).getDatasetUrn(), "/testFolder2");
-    Assert.assertEquals(event.getDatasetsWritten().get(1).getRecordsWritten(), Long.valueOf(1000));
-    Assert.assertEquals(event.getDatasetsWritten().get(1).getBytesWritten(), Long.valueOf(10000));
+    Assert.assertEquals(event.getDatasetsWritten().get(0).getDatasetUrn(), dataset1.getDatasetUrn());
+    Assert.assertEquals(event.getDatasetsWritten().get(0).getEntitiesWritten(), Long.valueOf(dataset1.getRecordsWritten()));
+    Assert.assertEquals(event.getDatasetsWritten().get(0).getBytesWritten(), Long.valueOf(dataset1.getBytesWritten()));
+    Assert.assertEquals(event.getDatasetsWritten().get(0).getDatasetCommitSucceeded(), Boolean.valueOf(dataset1.isDatasetCommitSucceeded()));
+    Assert.assertEquals(event.getDatasetsWritten().get(1).getDatasetUrn(), dataset2.getDatasetUrn());
+    Assert.assertEquals(event.getDatasetsWritten().get(1).getEntitiesWritten(), Long.valueOf(dataset2.getRecordsWritten()));
+    Assert.assertEquals(event.getDatasetsWritten().get(1).getBytesWritten(), Long.valueOf(dataset2.getBytesWritten()));
+    Assert.assertEquals(event.getDatasetsWritten().get(1).getDatasetCommitSucceeded(), Boolean.valueOf(dataset2.isDatasetCommitSucceeded()));
 
     AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
         GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSObservabilityProducerTest.java
@@ -111,11 +111,11 @@ public class GaaSObservabilityProducerTest {
     Assert.assertEquals(event.getDatasetsWritten().get(0).getDatasetUrn(), dataset1.getDatasetUrn());
     Assert.assertEquals(event.getDatasetsWritten().get(0).getEntitiesWritten(), Long.valueOf(dataset1.getRecordsWritten()));
     Assert.assertEquals(event.getDatasetsWritten().get(0).getBytesWritten(), Long.valueOf(dataset1.getBytesWritten()));
-    Assert.assertEquals(event.getDatasetsWritten().get(0).getDatasetCommitSucceeded(), Boolean.valueOf(dataset1.isDatasetCommitSucceeded()));
+    Assert.assertEquals(event.getDatasetsWritten().get(0).getSuccessfullyCommitted(), Boolean.valueOf(dataset1.isSuccessfullyCommitted()));
     Assert.assertEquals(event.getDatasetsWritten().get(1).getDatasetUrn(), dataset2.getDatasetUrn());
     Assert.assertEquals(event.getDatasetsWritten().get(1).getEntitiesWritten(), Long.valueOf(dataset2.getRecordsWritten()));
     Assert.assertEquals(event.getDatasetsWritten().get(1).getBytesWritten(), Long.valueOf(dataset2.getBytesWritten()));
-    Assert.assertEquals(event.getDatasetsWritten().get(1).getDatasetCommitSucceeded(), Boolean.valueOf(dataset2.isDatasetCommitSucceeded()));
+    Assert.assertEquals(event.getDatasetsWritten().get(1).getSuccessfullyCommitted(), Boolean.valueOf(dataset2.isSuccessfullyCommitted()));
 
     AvroSerializer<GaaSObservabilityEventExperimental> serializer = new AvroBinarySerializer<>(
         GaaSObservabilityEventExperimental.SCHEMA$, new NoopSchemaVersionWriter()


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1806


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

This PR adds a `JobSummaryTimer` which is emitted right before the `JobCommitTimer`, after the datasets are written and published to the destination.

Collection of the records/bytes is dependent on the DataWriter implementing `bytesWritten()` and `recordsWritten()`, which is implemented by most writers and those that extend from the `InstrumentedDataWriter`. 

Gobblin-as-a-Service ingests these JobSummaryTimer events and serializes them into the GaaSObservabilityEvent


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added unit tests to test that every job with writers emits a JobSummaryTimer and the serializer/deserialization in the GaaSObservabilityEvent

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

