### PR TITLE
[GOBBLIN-1807] Replaces conjars.org with conjars.wensel.net

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -25,11 +25,20 @@ subprojects {
     maven {
       url "https://repository.cloudera.com/artifactory/cloudera-repos/"
     }
+
+    // Conjars is a read only repository that hosts older artifacts, necessary for hive 1.0.1 and hadoop 2.10
     maven {
         url "https://conjars.wensel.net/repo/"
         content {
+          // Required for:
+          //  com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating > net.hydromatic:linq4j:0.4
+          //  com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating > net.hydromatic:quidem:0.1.1
           includeGroup "net.hydromatic"
+          // Required for:
+          //  com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating > eigenbase:eigenbase-properties:1.1.4.
           includeGroup "eigenbase"
+          // Required for:
+          //  org.apache.hadoop:hadoop-common:2.10.0 > org.apache.hadoop:hadoop-auth:2.10.0 > com.nimbusds:nimbus-jose-jwt:4.41.1 > net.minidev:json-smart:[1.3.1,2.3]
           includeGroup "net.minidev"
         }
     }

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -26,7 +26,12 @@ subprojects {
       url "https://repository.cloudera.com/artifactory/cloudera-repos/"
     }
     maven {
-      url "http://conjars.org/repo"
+        url "https://conjars.wensel.net/repo/"
+        content {
+          includeGroup "net.hydromatic"
+          includeGroup "eigenbase"
+          includeGroup "net.minidev"
+        }
     }
   }
 

--- a/gobblin-admin/build.gradle
+++ b/gobblin-admin/build.gradle
@@ -19,9 +19,6 @@ apply plugin: 'java'
 
 repositories {
     mavenCentral()
-    maven {
-        url "http://conjars.org/repo"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1807] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1807


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Context: https://groups.google.com/g/cascading-user/c/qAQvajapawI

The repo conjars.org is not reliably available and has issues with not being able to build due to dependency failure. Gobblin OSS relies on an older version of Apache Calcite that does not exist on mvnrepository. So we must continue to use conjars as our repo.

The repo https://conjars.wensel.net/ is more reliable and does not cause our github actions to fail

Dependency on hive 1.0.1 which has a dependency on calcite-core 0.9.2 means we have no choice in using this repo
```
project :gobblin-hive-registration > com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating
```

To find the necessary dependencies, I selectively added the necessary packages 1 by 1 using the `includeGroups` in gradle.

<details>
<summary> Example stack trace </summary>
```
> Could not resolve all files for configuration ':gobblin-binary-management:compileClasspath'.
   > Could not find eigenbase:eigenbase-properties:1.1.4.
 	Searched in the following locations:
   	- https://repo.maven.apache.org/maven2/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://repo.maven.apache.org/maven2/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- https://plugins.gradle.org/m2/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://plugins.gradle.org/m2/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- http://packages.confluent.io/maven/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- http://packages.confluent.io/maven/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- https://repository.apache.org/content/repositories/snapshots/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://repository.apache.org/content/repositories/snapshots/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- https://linkedin.jfrog.io/artifactory/open-source/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://linkedin.jfrog.io/artifactory/open-source/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- file:/Users/mho/.m2/repository/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- file:/Users/mho/.m2/repository/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
   	- https://repository.cloudera.com/artifactory/cloudera-repos/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.pom
   	- https://repository.cloudera.com/artifactory/cloudera-repos/eigenbase/eigenbase-properties/1.1.4/eigenbase-properties-1.1.4.jar
 	Required by:
     	project :gobblin-binary-management > com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating
   > Could not find net.hydromatic:linq4j:0.4.
 	Searched in the following locations:
   	- https://repo.maven.apache.org/maven2/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://repo.maven.apache.org/maven2/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- https://plugins.gradle.org/m2/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://plugins.gradle.org/m2/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- http://packages.confluent.io/maven/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- http://packages.confluent.io/maven/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- https://repository.apache.org/content/repositories/snapshots/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://repository.apache.org/content/repositories/snapshots/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- https://linkedin.jfrog.io/artifactory/open-source/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://linkedin.jfrog.io/artifactory/open-source/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- file:/Users/mho/.m2/repository/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- file:/Users/mho/.m2/repository/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
   	- https://repository.cloudera.com/artifactory/cloudera-repos/net/hydromatic/linq4j/0.4/linq4j-0.4.pom
   	- https://repository.cloudera.com/artifactory/cloudera-repos/net/hydromatic/linq4j/0.4/linq4j-0.4.jar
 	Required by:
     	project :gobblin-binary-management > com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating
   > Could not find net.hydromatic:quidem:0.1.1.
 	Searched in the following locations:
   	- https://repo.maven.apache.org/maven2/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://repo.maven.apache.org/maven2/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- https://plugins.gradle.org/m2/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://plugins.gradle.org/m2/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- http://packages.confluent.io/maven/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- http://packages.confluent.io/maven/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- https://repository.apache.org/content/repositories/snapshots/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://repository.apache.org/content/repositories/snapshots/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- https://linkedin.jfrog.io/artifactory/open-source/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://linkedin.jfrog.io/artifactory/open-source/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://linkedin.jfrog.io/artifactory/gobblin-hive/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- file:/Users/mho/.m2/repository/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- file:/Users/mho/.m2/repository/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
   	- https://repository.cloudera.com/artifactory/cloudera-repos/net/hydromatic/quidem/0.1.1/quidem-0.1.1.pom
   	- https://repository.cloudera.com/artifactory/cloudera-repos/net/hydromatic/quidem/0.1.1/quidem-0.1.1.jar
 	Required by:
     	project :gobblin-binary-management > com.linkedin.hive:hive-exec:1.0.1-avro > org.apache.calcite:calcite-core:0.9.2-incubating
```
</details>


After testing on my local, I also tested using github actions to catch the below error https://github.com/homatthew/gobblin/actions/runs/4613637500/jobs/8155833022#step:5:273
```
    > Could not resolve net.minidev:json-smart:[1.3.1,2.3].
     Required by:
         project :gobblin-api > org.apache.hadoop:hadoop-common:2.10.0 > org.apache.hadoop:hadoop-auth:2.10.0 > com.nimbusds:nimbus-jose-jwt:4.41.1
      > Failed to list versions for net.minidev:json-smart.
```
### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Github Actions CI will cover this. Since this is a dependency change. Regressions will be caught by current tests.
- https://github.com/homatthew/gobblin/actions/runs/4612715766

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

