### PR TITLE
[GOBBLIN-1816] Add job properties and GaaS instance ID to observability event

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -32,7 +32,7 @@ public class ServiceConfigKeys {
   public static final String GOBBLIN_SERVICE_TOPOLOGY_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologyCatalog.enabled";
   public static final String GOBBLIN_SERVICE_FLOW_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "flowCatalog.enabled";
   public static final String GOBBLIN_SERVICE_SCHEDULER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "scheduler.enabled";
-
+  public static final String GOBBLIN_SERVICE_INSTANCE_NAME = GOBBLIN_SERVICE_PREFIX + "instance.name";
 
   public static final String GOBBLIN_SERVICE_RESTLI_SERVER_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "restliServer.enabled";
   public static final String GOBBLIN_SERVICE_TOPOLOGY_SPEC_FACTORY_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologySpecFactory.enabled";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -131,6 +131,22 @@
       "compliance": "NONE"
     },
     {
+      "name": "gaasId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "doc": "The instance of GaaS that is sending the event (if multiple GaaS instances are running)"
+    },
+    {
+      "name":"jobProperties",
+      "type": [
+        "null",
+        "string"
+      ],
+      "doc": "The job properties GaaS sends to the job executor. This is a JSON string of the job properties"
+    },
+    {
       "name": "issues",
       "type": [
         "null",

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -1029,7 +1029,8 @@ public class DagManager extends AbstractIdleService {
         addSpecFuture.get();
 
         jobMetadata.put(TimingEvent.METADATA_MESSAGE, producer.getExecutionLink(addSpecFuture, specExecutorUri));
-
+        // Add serialized job properties as part of the orchestrated job event metadata
+        jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, dagNode.getValue().toString());
         if (jobOrchestrationTimer != null) {
           jobOrchestrationTimer.stop(jobMetadata);
         }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -60,6 +60,7 @@ import static org.apache.gobblin.runtime.AbstractJobLauncher.GOBBLIN_JOB_TEMPLAT
 @EqualsAndHashCode(exclude = {"executionStatus", "currentAttempts", "jobFuture", "flowStartTime"})
 public class JobExecutionPlan {
   public static final String JOB_MAX_ATTEMPTS = "job.maxAttempts";
+  public static final String JOB_PROPS_KEY = "job.props";
   private static final int MAX_JOB_NAME_LENGTH = 255;
 
   private final JobSpec jobSpec;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -136,7 +136,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setIssues(issueList)
         .setJobStatus(status)
         .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null))
-        .setDatasetsWritten(datasetMetrics);
+        .setDatasetsWritten(datasetMetrics)
         .setGaasId(this.state.getProp(ServiceConfigKeys.GOBBLIN_SERVICE_INSTANCE_NAME, null))
         .setJobProperties(jobState.getProp(JobExecutionPlan.JOB_PROPS_KEY, null));
     return builder.build();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -46,7 +46,9 @@ import org.apache.gobblin.runtime.troubleshooter.TroubleshooterException;
 import org.apache.gobblin.runtime.troubleshooter.TroubleshooterUtils;
 import org.apache.gobblin.runtime.util.GsonUtils;
 import org.apache.gobblin.service.ExecutionStatus;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.orchestration.AzkabanProjectConfig;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
 
 /**
@@ -135,6 +137,8 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
         .setJobStatus(status)
         .setExecutionUserUrn(jobState.getProp(AzkabanProjectConfig.USER_TO_PROXY, null))
         .setDatasetsWritten(datasetMetrics);
+        .setGaasId(this.state.getProp(ServiceConfigKeys.GOBBLIN_SERVICE_INSTANCE_NAME, null))
+        .setJobProperties(jobState.getProp(JobExecutionPlan.JOB_PROPS_KEY, null));
     return builder.build();
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1816


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

GaaSObservabilityEvents can add the following fields to increase its effectiveness:
1. Job properties, serialized in JSON. This enables the querying of specific job properties, which used to only be possible through MySQL on scheduled flows. Now it is possible to query for properties to solve questions such as `"How much memory are GaaS pipelines requesting from Azkaban on average?"`
2. GaaS Instance ID, to differentiate between different clusters of GaaS which write to the same observability topic.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

