### PR TITLE
[GOBBLIN-1813] Helix workflows submission timeouts are configurable

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -158,6 +158,9 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_TASK_TIMEOUT_SECONDS = "helix.task.timeout.seconds";
   public static final String HELIX_TASK_MAX_ATTEMPTS_KEY = "helix.task.maxAttempts";
 
+  public static final String HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowSubmissionTimeoutSeconds";
+  public static final long DEFAULT_HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS = 300;
+
   public static final String HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowDeleteTimeoutSeconds";
   public static final long DEFAULT_HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = 300;
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -258,7 +258,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
         jobId,
         taskDriver,
         this.planningJobHelixManager,
-        this.workFlowExpiryTimeSeconds,
+        Duration.ofSeconds(this.workFlowExpiryTimeSeconds),
         Duration.ofSeconds(this.helixWorkflowSubmissionTimeoutSeconds));
     this.jobSubmitted = true;
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.cluster;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,6 +97,8 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
 
   private final long helixJobStopTimeoutSeconds;
 
+  private final long helixWorkflowSubmissionTimeoutSeconds;
+
   private boolean jobSubmitted;
 
   // A conditional variable for which the condition is satisfied if a cancellation is requested
@@ -135,6 +138,9 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
     this.helixJobStopTimeoutSeconds = ConfigUtils.getLong(this.combinedConfigs,
         GobblinClusterConfigurationKeys.HELIX_JOB_STOP_TIMEOUT_SECONDS,
         GobblinClusterConfigurationKeys.DEFAULT_HELIX_JOB_STOP_TIMEOUT_SECONDS);
+    this.helixWorkflowSubmissionTimeoutSeconds = ConfigUtils.getLong(this.combinedConfigs,
+        GobblinClusterConfigurationKeys.HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS,
+        GobblinClusterConfigurationKeys.DEFAULT_HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS);
   }
 
   @Override
@@ -252,7 +258,8 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
         jobId,
         taskDriver,
         this.planningJobHelixManager,
-        this.workFlowExpiryTimeSeconds);
+        this.workFlowExpiryTimeSeconds,
+        Duration.ofSeconds(this.helixWorkflowSubmissionTimeoutSeconds));
     this.jobSubmitted = true;
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -441,7 +441,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
    */
   private void submitJobToHelix(JobConfig.Builder jobConfigBuilder) throws Exception {
     HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixWorkFlowName, this.jobContext.getJobId(),
-        this.helixTaskDriver, this.helixManager, this.workFlowExpiryTimeSeconds,
+        this.helixTaskDriver, this.helixManager,
+        Duration.ofSeconds(this.workFlowExpiryTimeSeconds),
         Duration.ofSeconds(this.helixWorkflowSubmissionTimeoutSeconds));
   }
 
@@ -459,7 +460,9 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
       } else {
         LOGGER.warn("Job {} will not be executed because other jobs are still running.", this.jobContext.getJobId());
       }
-      // TODO: Better error handling. The current impl swallows exceptions for jobs that were started by this method call
+
+      // TODO: Better error handling. The current impl swallows exceptions for jobs that were started by this method call.
+      // One potential way to improve the error handling is to make this error swallowing conifgurable
     } catch (Throwable t) {
       errorInJobLaunching = t;
     } finally {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.cluster;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,7 @@ import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
@@ -131,6 +133,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   private final Config jobConfig;
   private final long workFlowExpiryTimeSeconds;
   private final long helixJobStopTimeoutSeconds;
+  private final long helixWorkflowSubmissionTimeoutSeconds;
   private Map<String, TaskConfig> workUnitToHelixConfig;
   private Retryer<Boolean> taskRetryer;
 
@@ -162,6 +165,10 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     this.helixJobStopTimeoutSeconds =
         ConfigUtils.getLong(jobConfig, GobblinClusterConfigurationKeys.HELIX_JOB_STOP_TIMEOUT_SECONDS,
             GobblinClusterConfigurationKeys.DEFAULT_HELIX_JOB_STOP_TIMEOUT_SECONDS);
+
+    this.helixWorkflowSubmissionTimeoutSeconds = ConfigUtils.getLong(jobConfig,
+        GobblinClusterConfigurationKeys.HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS,
+        GobblinClusterConfigurationKeys.DEFAULT_HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS);
 
     Config stateStoreJobConfig = ConfigUtils.propertiesToConfig(jobProps)
         .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigValueFactory.fromAnyRef(
@@ -434,7 +441,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
    */
   private void submitJobToHelix(JobConfig.Builder jobConfigBuilder) throws Exception {
     HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixWorkFlowName, this.jobContext.getJobId(),
-        this.helixTaskDriver, this.helixManager, this.workFlowExpiryTimeSeconds);
+        this.helixTaskDriver, this.helixManager, this.workFlowExpiryTimeSeconds,
+        Duration.ofSeconds(this.helixWorkflowSubmissionTimeoutSeconds));
   }
 
   public void launchJob(@Nullable JobListener jobListener) throws JobException {
@@ -447,11 +455,11 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
       if (this.runningMap.replace(this.jobContext.getJobName(), false, true)) {
         LOGGER.info("Job {} will be executed, add into running map.", this.jobContext.getJobId());
         isLaunched = true;
-        super.launchJob(jobListener);
+        launchJobImpl(jobListener);
       } else {
         LOGGER.warn("Job {} will not be executed because other jobs are still running.", this.jobContext.getJobId());
       }
-      // TODO: Better error handling
+      // TODO: Better error handling. The current impl swallows exceptions for jobs that were started by this method call
     } catch (Throwable t) {
       errorInJobLaunching = t;
     } finally {
@@ -465,6 +473,29 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
         }
       }
     }
+  }
+
+
+  /**
+   * This method looks silly at first glance but exists for a reason.
+   *
+   * The method {@link GobblinHelixJobLauncher#launchJob(JobListener)} contains boiler plate for handling exceptions and
+   * mutating the runningMap to communicate state back to the {@link GobblinHelixJobScheduler}. The boiler plate swallows
+   * exceptions when launching the job because many use cases require that 1 job failure should not affect other jobs by causing the
+   * entire process to fail through an uncaught exception.
+   *
+   * This method is useful for unit testing edge cases where we expect {@link JobException}s during the underlying launch operation.
+   * It would be nice to not swallow exceptions, but the implications of doing that will require careful refactoring since
+   * the class {@link GobblinHelixJobLauncher} and {@link GobblinHelixJobScheduler} are shared for 2 quite different cases
+   * between GaaS and streaming. GaaS typically requiring many short lifetime workflows (where a failure is tolerated) and
+   * streaming requiring a small number of long running workflows (where failure to submit is unexpected and is not
+   * tolerated)
+   *
+   * @throws JobException
+   */
+  @VisibleForTesting
+  void launchJobImpl(@Nullable JobListener jobListener) throws JobException {
+    super.launchJob(jobListener);
   }
 
   private TaskConfig getTaskConfig(WorkUnit workUnit, ParallelRunner stateSerDeRunner) throws IOException {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -229,17 +229,17 @@ public class HelixUtils {
       String jobName,
       TaskDriver helixTaskDriver,
       HelixManager helixManager,
-      long workFlowExpiryTime,
-      Duration timeout) throws Exception {
+      Duration workFlowExpiryTime,
+      Duration submissionTimeout) throws Exception {
 
-    WorkflowConfig workFlowConfig = new WorkflowConfig.Builder().setExpiry(workFlowExpiryTime, TimeUnit.SECONDS).build();
+    WorkflowConfig workFlowConfig = new WorkflowConfig.Builder().setExpiry(workFlowExpiryTime.getSeconds(), TimeUnit.SECONDS).build();
     // Create a work flow for each job with the name being the queue name
     Workflow workFlow = new Workflow.Builder(workFlowName).setWorkflowConfig(workFlowConfig).addJob(jobName, jobConfigBuilder).build();
     // start the workflow
     helixTaskDriver.start(workFlow);
     log.info("Created a work flow {}", workFlowName);
 
-    waitJobInitialization(helixManager, workFlowName, jobName, timeout);
+    waitJobInitialization(helixManager, workFlowName, jobName, submissionTimeout);
   }
 
   static void waitJobCompletion(HelixManager helixManager, String workFlowName, String jobName,

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
@@ -286,6 +286,19 @@ public class GobblinHelixJobLauncherTest {
     Assert.assertEquals(testListener.getCompletes().get() == 1, true);
   }
 
+  public void testTimeout() throws Exception {
+    final ConcurrentHashMap<String, Boolean> runningMap = new ConcurrentHashMap<>();
+
+    final Properties props = generateJobProperties(this.baseConfig, "testTimeoutTest", "_12345");
+    props.setProperty(GobblinClusterConfigurationKeys.HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS, "0");
+    final GobblinHelixJobLauncher gobblinHelixJobLauncher = this.closer.register(
+        new GobblinHelixJobLauncher(props, this.helixManager, this.appWorkDir, ImmutableList.<Tag<?>>of(), runningMap,
+            java.util.Optional.empty()));
+
+    // using launchJobImpl because we do not want to swallow the exception
+    Assert.assertThrows(JobException.class, () -> gobblinHelixJobLauncher.launchJobImpl(null));
+  }
+
   @Test(enabled = false, dependsOnMethods = {"testLaunchJob", "testLaunchMultipleJobs"})
   public void testJobCleanup() throws Exception {
     final ConcurrentHashMap<String, Boolean> runningMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1813] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1813


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

#### Problem Statement:
 When Helix is under tremendous load, Helix workflows can easily exceed the 5 minute timeout. When the timeout is exceeded, our jobs clean up the Gobblin job state. Gobblin considers these workflows effectively dead. 

If Helix were to schedule these workflows, the workflows will spin up and the tasks assigned will immediately have a `FileNotFoundException`, causing an immediate termination of the container. This ironically puts a greater load on ZK / Helix and can further increase the delays in future workflow submissions.

#### Solution:
The workflow timeouts need to be not hardcoded so that users can adjust the timeout based on their workflow needs and helix / zk cluster size. 

This is just a single change as part of a series of changes for improving how Gobblin uses Helix. There are other issues that need to be addressed like:
- Offline helix instance purging should occur before workflow submission
- Helix lost node fencing should occur on each new ApplicationMaster, since Application masters do not hand over containers when an AM dies and is replaced
- Helix workflows should have a configurable safeguard for how often a workflow can be resubmitted / replaced in order to prevent multiple external systems from doing unsafe concurrent mutations to a running workflow. A replanner should not occur too frequently because the work is redundant and the time between workflows is not sufficient for anything to change. 

#### Caveats:
This code is shared between GaaS and Kafka ETL code. The default timeout remains unchanged, and is backwards compatible. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    3. Subject is limited to 50 characters
    4. Subject does not end with a period
    5. Subject uses the imperative mood ("add", not "adding")
    6. Body wraps at 72 characters
    7. Body explains "what" and "why", not "how"

