### PR TITLE
[GOBBLIN-1819] Log helix workflow information and timeout information during submission wait / polling

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.yarn;
 
-import com.google.common.base.Strings;
 import java.util.ArrayDeque;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -31,7 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -47,12 +45,14 @@ import org.apache.helix.task.WorkflowContext;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.typesafe.config.Config;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.ExecutorsUtils;
 
@@ -220,8 +220,6 @@ public class YarnAutoScalingManager extends AbstractIdleService {
           int numPartitions = 0;
           String jobTag = defaultHelixInstanceTags;
           if (jobContext != null) {
-            log.debug("JobContext {} num partitions {}", jobContext, jobContext.getPartitionSet().size());
-
             inUseInstances.addAll(jobContext.getPartitionSet().stream().map(jobContext::getAssignedParticipant)
                 .filter(Objects::nonNull).collect(Collectors.toSet()));
 
@@ -244,6 +242,8 @@ public class YarnAutoScalingManager extends AbstractIdleService {
           // per partition. Scale the result by a constant overprovision factor.
           int containerCount = (int) Math.ceil(((double)numPartitions / this.partitionsPerContainer) * this.overProvisionFactor);
           yarnContainerRequestBundle.add(jobTag, containerCount, resource);
+          log.info("jobName={}, jobTag={}, numPartitions={}, targetNumContainers={}",
+              jobName, jobTag, numPartitions, containerCount);
         }
       }
       // Find all participants appearing in this cluster. Note that Helix instances can contain cluster-manager

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -1109,5 +1109,11 @@ public class YarnService extends AbstractIdleService {
       this.helixTag = helixTag;
       this.startupCommand = YarnService.this.buildContainerCommand(container, helixParticipantId, helixTag);
     }
+
+    @Override
+    public String toString() {
+      return String.format("ContainerInfo{ container=%s, helixParticipantId=%s, helixTag=%s, startupCommand=%s }",
+          container.getId(), helixParticipantId, helixTag, startupCommand);
+    }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1819] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1819


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

Logging during helix workflow submission are currently pretty unhelpful. I Here are some examples of what has changed.
```
Before:
Waiting for work flow initialization.

After:
Waiting for workflow initialization. workflowName=job_GobblinHelixJobLauncherTest1_1504201348470, jobName=job_GobblinHelixJobLauncherTest1_1504201348470, timeSubmittedEpoch=1681873657577, timeoutSeconds=300
```

```
Before:
Work flow job_KafkaHdfsStreamingTrackingOrcMedVol0_1680885392649 initialized

After:
Workflow job_GobblinHelixJobLauncherTest1_1504201348470 initialized. timeToInitMs=2003
```



```
 ContainerInfo{ container=container_1_0000_00_000000, helixParticipantId=helixInstance1, helixTag=helixTag, startupCommand=$JAVA_HOME/bin/java -Xmx1628M -Duser.timezone=America/Los_Angeles -Dgobblin.yarn.app.container.log.dir=<LOG_DIR> -Dgobblin.yarn.app.container.log.file=GobblinYarnTaskRunner.stdout  org.apache.gobblin.yarn.GobblinYarnTaskRunner --app_name testApp2 --app_id appId2 --helix_instance_name helixInstance1 --helix_instance_tags helixTag 1><LOG_DIR>/GobblinYarnTaskRunner.stdout 2><LOG_DIR>/GobblinYarnTaskRunner.stderr }


```

```
org.apache.gobblin.runtime.JobException: Job cannot be initialized within 0 milliseconds, considered as an error. workflowName=job_GobblinHelixJobLauncherTesttestTimeoutTest_12345, jobName=job_GobblinHelixJobLauncherTesttestTimeoutTest_12345, timeSubmittedEpoch=1681875162106
	at org.apache.gobblin.cluster.HelixUtils.waitJobInitialization(HelixUtils.java:138)
```

```
2023-04-20 16:35:24 PDT INFO  [main] org.apache.gobblin.yarn.YarnAutoScalingManager$YarnAutoScalingRunnable 245 - jobName=job1, jobTag=DefaultHelixTag, numPartitions=2, targetNumContainers=2
2023-04-20 16:35:24 PDT INFO  [main] org.apache.gobblin.yarn.YarnAutoScalingManager$YarnAutoScalingRunnable 245 - jobName=job2, jobTag=DefaultHelixTag, numPartitions=1, targetNumContainers=1
```


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

