### PR TITLE
[GOBBLIN-1820] Add null default value to observability events that are additionally …

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSObservabilityEventExperimental.avsc
@@ -136,6 +136,7 @@
         "null",
         "string"
       ],
+      "default": null,
       "doc": "The instance of GaaS that is sending the event (if multiple GaaS instances are running)"
     },
     {
@@ -144,6 +145,7 @@
         "null",
         "string"
       ],
+      "default": null,
       "doc": "The job properties GaaS sends to the job executor. This is a JSON string of the job properties"
     },
     {
@@ -239,7 +241,8 @@
             ]
           }
         }
-      ]
+      ],
+      "default": null
     }
   ]
 }


### PR DESCRIPTION
…added

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1820


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Additional fields to GaaSObservabilityEventExperimental should default to null so that kafka producers can properly register the schema.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

