### PR TITLE
[GOBBLIN-1826] Change isAssignableFrom() to isSuperTypeOf() per Guava 20 javadocs to…

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
@@ -33,6 +33,7 @@ import com.google.common.reflect.TypeToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.State;
@@ -125,14 +126,13 @@ public class HiveRegistrationUnit {
   protected static <T> Optional<T> populateField(State state, String key, TypeToken<T> token) {
     if (state.contains(key)) {
       Optional<T> fieldValue;
-
-      if (new TypeToken<Boolean>() {}.getRawType().isAssignableFrom(token.getClass())) {
+      if (new TypeToken<Boolean>(){}.isSupertypeOf(token)) {
         fieldValue = (Optional<T>) Optional.of(state.getPropAsBoolean(key));
-      } else if (new TypeToken<Integer>() {}.getRawType().isAssignableFrom(token.getClass())) {
+      } else if (new TypeToken<Integer>(){}.isSupertypeOf(token)) {
         fieldValue = (Optional<T>) Optional.of(state.getPropAsInt(key));
-      } else if (new TypeToken<Long>() {}.getRawType().isAssignableFrom(token.getClass())) {
+      } else if (new TypeToken<Long>(){}.isSupertypeOf(token)) {
         fieldValue = (Optional<T>) Optional.of(state.getPropAsLong(key));
-      } else if (new TypeToken<List<String>>() {}.getRawType().isAssignableFrom(token.getClass())) {
+      } else if (new TypeToken<List<String>>(){}.isSupertypeOf(token)) {
         fieldValue = (Optional<T>) Optional.of(state.getPropAsList(key));
       } else {
         fieldValue = (Optional<T>) Optional.of(state.getProp(key));

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
@@ -33,7 +33,6 @@ import com.google.common.reflect.TypeToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.State;

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveTableTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveTableTest.java
@@ -26,7 +26,6 @@ import junit.framework.Assert;
 
 import org.apache.gobblin.configuration.State;
 
-
 public class HiveTableTest {
 
   @Test
@@ -48,7 +47,6 @@ public class HiveTableTest {
     builder.withStorageProps(storageProps);
 
     HiveTable hiveTable = builder.build();
-
 
     Assert.assertEquals(hiveTable.getLastAccessTime().get().longValue(), lastAccessTime.longValue());
     Assert.assertEquals(hiveTable.getLocation().get(), "/tmp");

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveTableTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveTableTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import junit.framework.Assert;
+
+import org.apache.gobblin.configuration.State;
+
+
+public class HiveTableTest {
+
+  @Test
+  public void testPopulateFieldTypeCasting() throws Exception {
+    // Test one property of each type in HiveRegistrationUnit storageProps
+
+    State props = new State();
+    Long lastAccessTime = System.currentTimeMillis();
+    props.setProp(HiveConstants.LAST_ACCESS_TIME, String.valueOf(lastAccessTime));
+    State storageProps = new State();
+    storageProps.setProp(HiveConstants.LOCATION, "/tmp");
+    storageProps.setProp(HiveConstants.COMPRESSED, "false");
+    storageProps.setProp(HiveConstants.NUM_BUCKETS, "1");
+    storageProps.setProp(HiveConstants.BUCKET_COLUMNS, "col1, col2");
+    HiveTable.Builder builder = new HiveTable.Builder();
+    builder.withTableName("tableName");
+    builder.withDbName("dbName");
+    builder.withProps(props);
+    builder.withStorageProps(storageProps);
+
+    HiveTable hiveTable = builder.build();
+
+
+    Assert.assertEquals(hiveTable.getLastAccessTime().get().longValue(), lastAccessTime.longValue());
+    Assert.assertEquals(hiveTable.getLocation().get(), "/tmp");
+    Assert.assertEquals(hiveTable.isCompressed.get().booleanValue(), false);
+    Assert.assertEquals(hiveTable.getNumBuckets().get().intValue(), 1);
+    List<String> bucketColumns = new ArrayList<>();
+    bucketColumns.add("col1");
+    bucketColumns.add("col2");
+    Assert.assertEquals(hiveTable.getBucketColumns().get().get(0), bucketColumns.get(0));
+    Assert.assertEquals(hiveTable.getBucketColumns().get().get(1), bucketColumns.get(1));
+  }
+}


### PR DESCRIPTION
… fix bug in Hive registration where classes can escape type casts

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1826


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
After the Guava 20 upgrade, there is a bug in the Hive registration code.
When setting table properties, `HiveTable` calls this function in `HiveRegistrationUnit` to set Properties
```
  protected static <T> Optional<T> populateField(State state, String key, TypeToken<T> token) {
```
Since it returns a type generic Optional, it is possible to assign an incorrect class to a field. So an Optional<Long> can actually be holding a String value and causes a Class cast exception.

What was happening is that in Guava 20, `isAssignableFrom` is deprecated from the `TypeToken` class. Instead, the following code pattern was used:

```
      } else if (new TypeToken<Long>() {}.getRawType().isAssignableFrom(token.getClass())) {
```
However, in this case getRawType() would have returned java.Lang.Long, so it would not be assignable to the token class but rather the templated class. This would cause the code to fall through and make every property casted into an Optional<String>

To avoid all this headache, and to also properly validate the List<String> token type, we should be using `.isSupertypeOf()` in lieu of `isAssignableFrom()`.

This time also wrote a unit test to validate the runtime behavior of each type.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

