### PR TITLE
[GOBBLIN-1827] Add check that if nested field is optional and has a non-null default…

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroFlattener.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroFlattener.java
@@ -23,13 +23,13 @@ import java.util.List;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
 /***
  * This class provides methods to flatten an Avro Schema to make it more optimal for ORC
@@ -402,6 +402,10 @@ public class AvroFlattener {
           }
           // Wrap the Union, since parent Union is an option
           else {
+            // If the field within the parent Union has a non-null default value, then null should not be the first member
+            if (f.hasDefaultValue() && f.defaultVal() != null) {
+              isNullFirstMember = false;
+            }
             if (isNullFirstMember) {
               flattenedFieldSchema =
                   Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), flattenedFieldSchema));

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
@@ -188,4 +188,26 @@ public class AvroFlattenerTest {
   }
 
 
+  /**
+   * Test flattening for non-null default within an Option within another Record
+   * Record R1 {
+   *  fields: {
+   *    Union [ null,
+   *            Record 2 {
+   *              field: type
+   *              default: type
+   *            }
+   *          ]
+   *    }
+   * }
+   */
+  @Test
+  public void testNonNullDefaultWithinOptionWithinRecord () throws IOException {
+
+    Schema originalSchema = readSchemaFromJsonFile("nonNullDefaultWithinOptionWithinRecord_original.json");
+    Schema expectedSchema = readSchemaFromJsonFile("nonNullDefaultWithinOptionWithinRecord_flattened.json");
+    Assert.assertEquals(new AvroFlattener().flatten(originalSchema, false).toString(), expectedSchema.toString());
+  }
+
+
 }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroFlattenerTest.java
@@ -22,6 +22,8 @@ import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
 
 public class AvroFlattenerTest {
 
@@ -206,7 +208,11 @@ public class AvroFlattenerTest {
 
     Schema originalSchema = readSchemaFromJsonFile("nonNullDefaultWithinOptionWithinRecord_original.json");
     Schema expectedSchema = readSchemaFromJsonFile("nonNullDefaultWithinOptionWithinRecord_flattened.json");
-    Assert.assertEquals(new AvroFlattener().flatten(originalSchema, false).toString(), expectedSchema.toString());
+    Schema flattenedSchema = new AvroFlattener().flatten(originalSchema, false);
+    Assert.assertEquals(AvroCompatibilityHelper.getSpecificDefaultValue(
+        flattenedSchema.getField("parentFieldUnion__unionRecordMemberFieldUnion__superNestedFieldString1")).toString(),
+        "defaultString1");
+    Assert.assertEquals(flattenedSchema.toString(), expectedSchema.toString());
   }
 
 

--- a/gobblin-utility/src/test/resources/flattenAvro/nonNullDefaultWithinOptionWithinRecord_flattened.json
+++ b/gobblin-utility/src/test/resources/flattenAvro/nonNullDefaultWithinOptionWithinRecord_flattened.json
@@ -1,0 +1,37 @@
+{
+  "type":"record",
+  "name":"parentRecordName",
+  "fields":[
+    {
+      "name":"parentFieldUnion__unionRecordMemberFieldUnion__superNestedFieldString1",
+      "type":[
+        "string",
+        "null"
+      ],
+      "default":"defaultString1",
+      "flatten_source":"parentFieldUnion.unionRecordMemberFieldUnion.superNestedFieldString1"
+    },
+    {
+      "name":"parentFieldUnion__unionRecordMemberFieldUnion__superNestedFieldString2",
+      "type":[
+        "string",
+        "null"
+      ],
+      "default":"defaultString2",
+      "flatten_source":"parentFieldUnion.unionRecordMemberFieldUnion.superNestedFieldString2"
+    },
+    {
+      "name":"parentFieldUnion__unionRecordMemberFieldString",
+      "type":[
+        "null",
+        "string"
+      ],
+      "default":null,
+      "flatten_source":"parentFieldUnion.unionRecordMemberFieldString"
+    },
+    {
+      "name":"parentFieldInt",
+      "type":"int"
+    }
+  ]
+}

--- a/gobblin-utility/src/test/resources/flattenAvro/nonNullDefaultWithinOptionWithinRecord_original.json
+++ b/gobblin-utility/src/test/resources/flattenAvro/nonNullDefaultWithinOptionWithinRecord_original.json
@@ -1,0 +1,33 @@
+{
+  "type" : "record",
+  "name" : "parentRecordName",
+  "fields" : [ {
+    "name" : "parentFieldUnion",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "unionRecordMember",
+      "fields" : [ {
+        "name" : "unionRecordMemberFieldUnion",
+        "type" : [ "null", {
+          "type" : "record",
+          "name" : "superNestedRecord",
+          "fields" : [ {
+            "name" : "superNestedFieldString1",
+            "type" : "string",
+            "default": "defaultString1"
+          }, {
+            "name" : "superNestedFieldString2",
+            "type" : "string",
+            "default": "defaultString2"
+          } ]
+        } ]
+      }, {
+        "name" : "unionRecordMemberFieldString",
+        "type" : "string"
+      } ]
+    } ]
+  }, {
+    "name" : "parentFieldInt",
+    "type" : "int"
+  } ]
+}


### PR DESCRIPTION
…, then it should order the types with its default type first instead of null

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1827


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Consider the following description:
```
 * Record R1 {
 *   fields : {[
 *      {
 *        Union : [
 *          null,
 *          Record R2 {
 *            fields : {[
 *                {
 *                  String S1
 *.                  default: String S3
 *                }, {
 *                  String S2
 *                }
 *            ]}
 *          }
 *      }
 *   ]}
 * }
 * will be flattened to:
 * Record R1 {
 *   fields : {[
 *      {
 *        Union : [ null, String S1]
 *.       default: String S3
 *      }, {
 *        Union : [ null, String S2]
 *      }
 *   ]}
 * }
 ```
Due to the addition of the AvroCompatibilityHelper, Avro flattening can run into an issue in the above scenario due to the nested non-null default S3 since the default type needs to be the first type in the field order. So R1 should have field S1 as Union [String S1, null]

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

