### PR TITLE
[GOBBLIN-1828] Implement Timeout for Creating Writer Functionality

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/test/TestPartitionAwareWriterBuilder.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/test/TestPartitionAwareWriterBuilder.java
@@ -37,9 +37,16 @@ import lombok.Data;
 public class TestPartitionAwareWriterBuilder extends PartitionAwareDataWriterBuilder<String, String> {
 
   public final Queue<Action> actions = Queues.newArrayDeque();
+  private boolean testTimeout;
 
   public enum Actions {
     BUILD, WRITE, COMMIT, CLEANUP, CLOSE
+  }
+  public TestPartitionAwareWriterBuilder() {
+    this(false);
+  }
+  public TestPartitionAwareWriterBuilder(boolean testTimeout) {
+    this.testTimeout = testTimeout;
   }
 
   @Override
@@ -50,6 +57,13 @@ public class TestPartitionAwareWriterBuilder extends PartitionAwareDataWriterBui
   @Override
   public DataWriter build()
       throws IOException {
+    if (testTimeout) {
+      try {
+        Thread.sleep(10*1000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
     String partition = this.partition.get().get(TestPartitioner.PARTITION).toString();
     this.actions.add(new Action(Actions.BUILD, partition, null));
     if (partition.matches(".*\\d+.*")) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1828


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

When HDFS slowness happens, we can get stuck in creating writer phase and never proceed further. So we want to add a timeout guarantee there to make sure to fail earlier and retry in this case. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Add new unit test and run job to make sure timeout can cause the task to retry

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

