### PR TITLE
[GOBBLIN-1829] Fixes bug where the wrong workunit event was being tracked for keepin…

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -689,7 +689,7 @@ public class KafkaAvroJobStatusMonitorTest {
     Map<String, String> metadata = Maps.newHashMap();
     metadata.put(TimingEvent.METADATA_START_TIME, "2");
     metadata.put(TimingEvent.METADATA_END_TIME, "3");
-    return createGTE(TimingEvent.RunJobTimings.WORK_UNITS_PREPARATION, metadata);
+    return createGTE(TimingEvent.LauncherTimings.WORK_UNITS_CREATION, metadata);
   }
 
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -127,13 +127,14 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
       case TimingEvent.FlowTimings.FLOW_COMPILED:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPILED.name());
         break;
-      case TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION:
+      case TimingEvent.LauncherTimings.WORK_UNITS_CREATION:
         properties.put(TimingEvent.WORKUNIT_PLAN_START_TIME, properties.getProperty(TimingEvent.METADATA_START_TIME));
         properties.put(TimingEvent.WORKUNIT_PLAN_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
       case TimingEvent.LauncherTimings.JOB_START:
       case TimingEvent.FlowTimings.FLOW_RUNNING:
       case TimingEvent.LauncherTimings.JOB_SUMMARY:
+      case TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());
         break;
       case TimingEvent.LauncherTimings.JOB_PENDING:


### PR DESCRIPTION
…g track of work discovery time

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1829


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

In Gobblin framework, there are 2 events that look similar but do very different functions:
1. WorkUnitPreparationTimer - which serializes workunits and compacts them into MultiWorkUnits
2. WorkUnitCreationTimer - which tracks the time taken to discover the work needed for Gobblin to launch a job.

We want to track the latter in GaaS

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

