### PR TITLE
[GOBBLIN-1831] Use flowexecutionid in kafka monitor and jobnames

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -36,6 +36,7 @@ import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.JobLauncherUtils;
+import org.apache.gobblin.util.PropertiesUtils;
 
 
 /**
@@ -96,12 +97,14 @@ public class HelixJobsMapping {
 
   public static String createPlanningJobId (Properties jobPlanningProps) {
     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.PLANNING_JOB_NAME_PREFIX
-        + JobState.getJobNameFromProps(jobPlanningProps));
+            + JobState.getJobNameFromProps(jobPlanningProps),
+        PropertiesUtils.getPropAsLong(jobPlanningProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis()));
   }
 
   public static String createActualJobId (Properties jobProps) {
-    return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX
-        + JobState.getJobNameFromProps(jobProps));
+     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX
+             + JobState.getJobNameFromProps(jobProps),
+          PropertiesUtils.getPropAsLong(jobProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis()));
   }
 
   @Nullable

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
@@ -157,7 +157,8 @@ public abstract class KafkaJobMonitor extends HighLevelConsumer<byte[], byte[]> 
                   this.cancelledSpecs.mark();
                   this.jobCatalog.remove(specUri, true);
                 } else {
-                  log.warn("Could not find job spec {} with flow execution ID {} to cancel", specUri, flowIdToCancel);
+                  log.warn("Job spec {} that has flow execution ID {} could not be cancelled, incoming request expects to cancel flow execution ID {}", specUri,
+                      spec.getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY), flowIdToCancel);
                 }
               }
             } catch (JobSpecNotFoundException e) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1831


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
This PR handles the scenario where concurrent jobs can run on Gobblin cluster from GaaS and handles the cancellation logic properly.

When executing jobs from GaaS to Gobblin cluster, there can be a mismatch of flowexecution ids to jobs running on Gobblin cluster. The old behavior was that the current job will be deleted regardless of the execution ID, but this could mean that a state mismatch could lead to current jobs being deleted when they should still continue to run.

To address this, we tried adding the FlowExecutionId to the jobSpec, but that meant that jobs could run concurrently on Gobblin cluster when they should have been deduped.

So instead, during cancellation, we want to check if the incoming spec has a flow execution ID. If so, then it will cancel the existing job only if the flow execution IDs match. Otherwise, it will know that the current job does not match the incoming request and should not be deleted.

This PR also uses flow execution ID if applicable as the planningjob ID and job_actualJob ID, as there should only be one of these per flow.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

