### PR TITLE
[GOBBLIN-1835]Upgrade Iceberg Version from 0.11.1 to 1.2.0

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   compile externalDependency.junit
   compile externalDependency.jacksonMapperAsl
 
-  testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '1.2.0', classifier: 'tests') {
+  testCompile(externalDependency.icebergHiveMetastoreTest) {
     transitive = false
   }
   testCompile('org.apache.hadoop:hadoop-common:2.6.0')

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   compile externalDependency.junit
   compile externalDependency.jacksonMapperAsl
 
-  testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '0.11.1', classifier: 'tests') {
+  testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '1.2.0', classifier: 'tests') {
     transitive = false
   }
   testCompile('org.apache.hadoop:hadoop-common:2.6.0')

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -161,7 +161,7 @@ public class IcebergTable {
         metadataFileLocation,
         snapshot.manifestListLocation(),
         // NOTE: unable to `.stream().map(m -> calcManifestFileInfo(m, tableOps.io()))` due to checked exception
-        skipManifestFileInfo ? Lists.newArrayList() : calcAllManifestFileInfos(snapshot.allManifests(), tableOps.io())
+        skipManifestFileInfo ? Lists.newArrayList() : calcAllManifestFileInfos(snapshot.allManifests(tableOps.io()), tableOps.io())
       );
   }
 

--- a/gobblin-iceberg/build.gradle
+++ b/gobblin-iceberg/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile externalDependency.findBugsAnnotations
     compile externalDependency.avroMapredH2
 
-    testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '1.2.0', classifier: 'tests') {
+    testCompile(externalDependency.icebergHiveMetastoreTest) {
         transitive = false
     }
     testCompile('org.apache.hadoop:hadoop-common:2.6.0')

--- a/gobblin-iceberg/build.gradle
+++ b/gobblin-iceberg/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile externalDependency.findBugsAnnotations
     compile externalDependency.avroMapredH2
 
-    testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '0.11.1', classifier: 'tests') {
+    testCompile(group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: '1.2.0', classifier: 'tests') {
         transitive = false
     }
     testCompile('org.apache.hadoop:hadoop-common:2.6.0')

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/Utils/IcebergUtils.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/Utils/IcebergUtils.java
@@ -248,6 +248,7 @@ public class IcebergUtils {
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getColumnSizes(), schemaIdMap),
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getValueCounts(), schemaIdMap),
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getNullValueCounts(), schemaIdMap),
+        // TODO: If required, handle NaN value count File metric conversion in ORC metrics with iceberg upgrade
         IcebergUtils.getMapFromIntegerLongPairs(Lists.newArrayList(), schemaIdMap), // metric value will be null since Nan values are supported from avro version 1.10.*
         IcebergUtils.getMapFromIntegerBytesPairs(file.getFileMetrics().getLowerBounds(), schemaIdMap),
         IcebergUtils.getMapFromIntegerBytesPairs(file.getFileMetrics().getUpperBounds(), schemaIdMap));

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/Utils/IcebergUtils.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/Utils/IcebergUtils.java
@@ -248,6 +248,7 @@ public class IcebergUtils {
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getColumnSizes(), schemaIdMap),
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getValueCounts(), schemaIdMap),
         IcebergUtils.getMapFromIntegerLongPairs(file.getFileMetrics().getNullValueCounts(), schemaIdMap),
+        IcebergUtils.getMapFromIntegerLongPairs(Lists.newArrayList(), schemaIdMap), // metric value will be null since Nan values are supported from avro version 1.10.*
         IcebergUtils.getMapFromIntegerBytesPairs(file.getFileMetrics().getLowerBounds(), schemaIdMap),
         IcebergUtils.getMapFromIntegerBytesPairs(file.getFileMetrics().getUpperBounds(), schemaIdMap));
     return dataFileBuilder.withMetrics(metrics).build();

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/publisher/GobblinMCEPublisher.java
@@ -219,7 +219,7 @@ public class GobblinMCEPublisher extends DataPublisher {
       }
       case AVRO: {
         try {
-          return new Metrics(100000000L, null, null, null);
+          return new Metrics(100000000L, null, null, null, null);
         } catch (Exception e) {
           throw new RuntimeException("Cannot get file information for file " + path.toString(), e);
         }

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.ExpireSnapshots;
@@ -77,7 +78,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.hive.HiveCatalogs;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.types.Types;
 import org.joda.time.DateTime;
 import org.joda.time.format.PeriodFormatter;
@@ -253,7 +254,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
   }
 
   protected void initializeCatalog() {
-    catalog = HiveCatalogs.loadCatalog(conf);
+    catalog = CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "HiveCatalog", new HashMap<>(), conf);
   }
 
   private org.apache.iceberg.Table getIcebergTable(TableIdentifier tid) throws NoSuchTableException {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -128,7 +128,6 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
   @BeforeSuite
   public void setUp() throws Exception {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
-    startMetastore();
     State state = ConfigUtils.configToState(ConfigUtils.propertiesToConfig(hiveConf.getAllProperties()));
     Optional<String> metastoreUri = Optional.fromNullable(state.getProperties().getProperty(HiveRegister.HIVE_METASTORE_URI_KEY));
     hc = HiveMetastoreClientPool.get(state.getProperties(), metastoreUri);

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -559,7 +559,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     protected List<HiveTable> getTables(Path path) throws IOException {
       List<HiveTable> tables = super.getTables(path);
       for (HiveTable table : tables) {
-        if(table.getTableName().equals("testTopicCompleteness")) {
+        if (table.getTableName().equals("testTopicCompleteness")) {
           table.setPartitionKeys(ImmutableList.<HiveRegistrationUnit.Column>of(
               new HiveRegistrationUnit.Column("datepartition", serdeConstants.STRING_TYPE_NAME, StringUtils.EMPTY)
               , new HiveRegistrationUnit.Column("late", serdeConstants.INT_TYPE_NAME, StringUtils.EMPTY)));

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -124,7 +124,6 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
   @BeforeClass
   public void setUp() throws Exception {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
-
     tmpDir = Files.createTempDir();
     hourlyDataFile_1 = new File(tmpDir, "testDB/testTopic/hourly/2020/03/17/08/data.avro");
     Files.createParentDirs(hourlyDataFile_1);
@@ -364,7 +363,9 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
             new LongWatermark(52L))));
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap().size(), 1);
     Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap().values().iterator().next().size(), 1);
-
+    Assert.assertEquals(gobblinMCEWriter.getDatasetErrorMap()
+        .get(new File(tmpDir, "testDB/testTopic").getAbsolutePath())
+        .get("hivedb.testTopicCompleteness").get(0).getMessage(), "failed to flush table hivedb, testTopicCompleteness");
     // No events sent yet since the topic has not been flushed
     Assert.assertEquals(eventsSent.size(), 0);
 

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -236,7 +236,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     gobblinMCEWriter.flush();
     table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     Assert.assertEquals(table.properties().get("offset.range.testTopic-1"), "0-2000");
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 1);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 1);
     // Assert low watermark and high watermark set properly
     Assert.assertEquals(table.properties().get("gmce.low.watermark.GobblinMetadataChangeEvent_test-1"), "9");
     Assert.assertEquals(table.properties().get("gmce.high.watermark.GobblinMetadataChangeEvent_test-1"), "20");
@@ -256,7 +256,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     gobblinMCEWriter.flush();
     table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     Assert.assertEquals(table.properties().get("offset.range.testTopic-1"), "0-3000");
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 2);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 2);
     Assert.assertEquals(table.properties().get("gmce.low.watermark.GobblinMetadataChangeEvent_test-1"), "20");
     Assert.assertEquals(table.properties().get("gmce.high.watermark.GobblinMetadataChangeEvent_test-1"), "30");
 
@@ -269,7 +269,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     gobblinMCEWriter.flush();
     table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     Assert.assertEquals(table.properties().get("offset.range.testTopic-1"), "0-3000");
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 2);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 2);
   }
 
   //Make sure hive test execute later and close the metastore
@@ -290,7 +290,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     Table table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     Iterator<org.apache.iceberg.DataFile>
         result = FindFiles.in(table).withMetadataMatching(Expressions.startsWith("file_path", filePath_1)).collect().iterator();
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 2);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 2);
     Assert.assertTrue(result.hasNext());
     GenericRecord genericGmce = GenericData.get().deepCopy(gmce.getSchema(), gmce);
     gobblinMCEWriter.writeEnvelope(new RecordEnvelope<>(genericGmce,
@@ -313,7 +313,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
   public void testChangeProperty() throws IOException {
     Table table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     Assert.assertEquals(table.properties().get("offset.range.testTopic-1"), "0-3000");
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 3);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 3);
     Assert.assertEquals(table.properties().get("gmce.low.watermark.GobblinMetadataChangeEvent_test-1"), "30");
     Assert.assertEquals(table.properties().get("gmce.high.watermark.GobblinMetadataChangeEvent_test-1"), "40");
 
@@ -335,7 +335,7 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     table = catalog.loadTable(catalog.listTables(Namespace.of(dbName)).get(0));
     // Assert the offset has been updated
     Assert.assertEquals(table.properties().get("offset.range.testTopic-1"), "0-4000");
-    Assert.assertEquals(table.currentSnapshot().allManifests().size(), 3);
+    Assert.assertEquals(table.currentSnapshot().allManifests(table.io()).size(), 3);
     // Assert low watermark and high watermark set properly
     Assert.assertEquals(table.properties().get("gmce.low.watermark.GobblinMetadataChangeEvent_test-1"), "40");
     Assert.assertEquals(table.properties().get("gmce.high.watermark.GobblinMetadataChangeEvent_test-1"), "45");

--- a/gradle/scripts/defaultBuildProperties.gradle
+++ b/gradle/scripts/defaultBuildProperties.gradle
@@ -31,7 +31,7 @@ def BuildProperties BUILD_PROPERTIES = new BuildProperties(project)
     .register(new BuildProperty("gobblinFlavor", "standard", "Build flavor (see http://gobblin.readthedocs.io/en/latest/developer-guide/GobblinModules/)"))
     .register(new BuildProperty("hadoopVersion", "2.10.0", "Hadoop dependencies version"))
     .register(new BuildProperty("hiveVersion", "1.0.1-avro", "Hive dependencies version"))
-    .register(new BuildProperty("icebergVersion", "0.11.1", "Iceberg dependencies version"))
+    .register(new BuildProperty("icebergVersion", "1.2.0", "Iceberg dependencies version"))
     .register(new BuildProperty("jdkVersion", JavaVersion.VERSION_1_8.toString(),
     "Java languange compatibility; supported versions: " + JavaVersion.VERSION_1_8))
     .register(new BuildProperty("kafka08Version", "0.8.2.2", "Kafka 0.8 dependencies version"))

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -82,6 +82,7 @@ ext.externalDependency = [
     "httpcore": "org.apache.httpcomponents:httpcore:4.4.11",
     "httpasyncclient": "org.apache.httpcomponents:httpasyncclient:4.1.3",
     "icebergHive": "org.apache.iceberg:iceberg-hive-runtime:" + icebergVersion,
+    "icebergHiveMetastoreTest": "org.apache.iceberg:iceberg-hive-metastore:" + icebergVersion + ":tests",
     "jgit": "org.eclipse.jgit:org.eclipse.jgit:5.1.1.201809181055-r",
     "jmh": "org.openjdk.jmh:jmh-core:1.17.3",
     "jmhAnnotations": "org.openjdk.jmh:jmh-generator-annprocess:1.17.3",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1835


### Description
I want to upgrade our iceberg version to 1.2.0 to leverage performance improvements such as optimized metadata caching, reduced memory consumption, and faster metadata commits, enhanced APIs, schema evolution. Most importantly it natively provides support for Apache Spark 3.x, allowing seamless integration and improved performance when using Iceberg with Spark. As part of this upgrade, below are the major changes:
- Update method signatures for `CatalogUtil.loadCatalog()` and `Snapshots.allManifests`
- Initialize and load `HiveCatalog` via `CatalogUtil` inside `IcebergMetadataWriter` 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Updated unit tests
- Successful Build

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

