### PR TITLE
[GOBBLIN-1836] Ensuring Task Reliability: Handling Job Cancellation and Graceful Exits for Error-Free Completion

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -520,6 +520,8 @@ public class IcebergMetadataWriter implements MetadataWriter {
     try (Timer.Context context = metricContext.timer(CREATE_TABLE_TIME).time()) {
       icebergTable =
           catalog.createTable(tid, tableSchema, partitionSpec, tableLocation, IcebergUtils.getTableProperties(table));
+      // We should set the avro schema literal when creating the table.
+      icebergTable.updateProperties().set(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), schema).commit();
       log.info("Created table {}, schema: {} partition spec: {}", tid, tableSchema, partitionSpec);
     } catch (AlreadyExistsException e) {
       log.warn("table {} already exist, there may be some other process try to create table concurrently", tid);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1836


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In our system, when a helix disconnection occurs, we take the necessary step to cancel the ongoing job. Furthermore, when we opt for a graceful exit, we ensure that no exception is thew and we mark the task as complete. However, it is important to note that due to this graceful exit, the task cannot be retried accurately. 

So we need to introduce a cancel flag to make sure we return the correct task status

Also, a small fix to add schema.literal when creating a new iceberg table. (Ideally, iceberg should work without schema.literal property, but some downstream query engine need the original avro schema to do processing, so this property is added to support that use case)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added new unit test for cancellation logic

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

