### PR TITLE
[GOBBLIN-1842] Add timers to GobblinMCEWriter

### DIFF
--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/GobblinMCEWriter.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.commons.collections.CollectionUtils;
+
+import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.google.common.base.Joiner;
@@ -69,6 +71,7 @@ import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metadata.DataFile;
 import org.apache.gobblin.metadata.GobblinMetadataChangeEvent;
 import org.apache.gobblin.metadata.OperationType;
+import org.apache.gobblin.metrics.ContextAwareTimer;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.EventSubmitter;
@@ -131,6 +134,9 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   protected EventSubmitter eventSubmitter;
   private final Set<String> transientExceptionMessages;
   private final Set<String> nonTransientExceptionMessages;
+  private final Map<String, ContextAwareTimer> metadataWriterWriteTimers = new HashMap<>();
+  private final Map<String, ContextAwareTimer> metadataWriterFlushTimers = new HashMap<>();
+  private final ContextAwareTimer hiveSpecComputationTimer;
 
   @AllArgsConstructor
   static class TableStatus {
@@ -150,19 +156,22 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
     acceptedClusters = properties.getPropAsSet(ACCEPTED_CLUSTER_NAMES, ClustersNames.getInstance().getClusterName());
     state = properties;
     maxErrorDataset = state.getPropAsInt(GMCE_METADATA_WRITER_MAX_ERROR_DATASET, DEFUALT_GMCE_METADATA_WRITER_MAX_ERROR_DATASET);
-    for (String className : state.getPropAsList(GMCE_METADATA_WRITER_CLASSES, IcebergMetadataWriter.class.getName())) {
-      metadataWriters.add(closer.register(GobblinConstructorUtils.invokeConstructor(MetadataWriter.class, className, state)));
-    }
-    tableOperationTypeMap = new HashMap<>();
-    parallelRunner = closer.register(new ParallelRunner(state.getPropAsInt(METADATA_REGISTRATION_THREADS, 20),
-        FileSystem.get(HadoopUtils.getConfFromState(properties))));
-    parallelRunnerTimeoutMills =
-        state.getPropAsInt(METADATA_PARALLEL_RUNNER_TIMEOUT_MILLS, DEFAULT_ICEBERG_PARALLEL_TIMEOUT_MILLS);
     List<Tag<?>> tags = Lists.newArrayList();
     String clusterIdentifier = ClustersNames.getInstance().getClusterName();
     tags.add(new Tag<>(MetadataWriterKeys.CLUSTER_IDENTIFIER_KEY_NAME, clusterIdentifier));
     MetricContext metricContext = Instrumented.getMetricContext(state, this.getClass(), tags);
     eventSubmitter = new EventSubmitter.Builder(metricContext, GOBBLIN_MCE_WRITER_METRIC_NAMESPACE).build();
+    for (String className : state.getPropAsList(GMCE_METADATA_WRITER_CLASSES, IcebergMetadataWriter.class.getName())) {
+      metadataWriters.add(closer.register(GobblinConstructorUtils.invokeConstructor(MetadataWriter.class, className, state)));
+      metadataWriterWriteTimers.put(className, metricContext.contextAwareTimer(className + ".write", 1, TimeUnit.HOURS));
+      metadataWriterFlushTimers.put(className, metricContext.contextAwareTimer(className + ".flush", 1, TimeUnit.HOURS));
+    }
+    hiveSpecComputationTimer = metricContext.contextAwareTimer("hiveSpec.computation", 1, TimeUnit.HOURS);
+    tableOperationTypeMap = new HashMap<>();
+    parallelRunner = closer.register(new ParallelRunner(state.getPropAsInt(METADATA_REGISTRATION_THREADS, 20),
+        FileSystem.get(HadoopUtils.getConfFromState(properties))));
+    parallelRunnerTimeoutMills =
+        state.getPropAsInt(METADATA_PARALLEL_RUNNER_TIMEOUT_MILLS, DEFAULT_ICEBERG_PARALLEL_TIMEOUT_MILLS);
     transientExceptionMessages = new HashSet<>(properties.getPropAsList(TRANSIENT_EXCEPTION_MESSAGES_KEY, ""));
     nonTransientExceptionMessages = new HashSet<>(properties.getPropAsList(NON_TRANSIENT_EXCEPTION_MESSAGES_KEY, ""));
   }
@@ -187,26 +196,28 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
    */
   private void computeSpecMap(List<String> files, ConcurrentHashMap<String, Collection<HiveSpec>> specsMap,
       Cache<String, Collection<HiveSpec>> cache, State registerState, boolean isPrefix) throws IOException {
-    HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(registerState);
-    for (String file : files) {
-      parallelRunner.submitCallable(new Callable<Void>() {
-        @Override
-        public Void call() throws Exception {
-          try {
-            Path regPath = isPrefix ? new Path(file) : new Path(file).getParent();
-            //Use raw path to comply with HDFS federation setting.
-            Path rawPath = new Path(regPath.toUri().getRawPath());
-            specsMap.put(regPath.toString(), cache.get(regPath.toString(), () -> policy.getHiveSpecs(rawPath)));
-          } catch (Throwable e) {
-            //todo: Emit failed GMCE in the future to easily track the error gmce and investigate the reason for that.
-            log.warn("Cannot get Hive Spec for {} using policy {} due to:", file, policy.toString());
-            log.warn(e.getMessage());
+    try (Timer.Context context = hiveSpecComputationTimer.time()) {
+      HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(registerState);
+      for (String file : files) {
+        parallelRunner.submitCallable(new Callable<Void>() {
+          @Override
+          public Void call() throws Exception {
+            try {
+              Path regPath = isPrefix ? new Path(file) : new Path(file).getParent();
+              //Use raw path to comply with HDFS federation setting.
+              Path rawPath = new Path(regPath.toUri().getRawPath());
+              specsMap.put(regPath.toString(), cache.get(regPath.toString(), () -> policy.getHiveSpecs(rawPath)));
+            } catch (Throwable e) {
+              //todo: Emit failed GMCE in the future to easily track the error gmce and investigate the reason for that.
+              log.warn("Cannot get Hive Spec for {} using policy {} due to:", file, policy.toString());
+              log.warn(e.getMessage());
+            }
+            return null;
           }
-          return null;
-        }
-      }, file);
+        }, file);
+      }
+      parallelRunner.waitForTasks(parallelRunnerTimeoutMills);
     }
-    parallelRunner.waitForTasks(parallelRunnerTimeoutMills);
   }
 
   @Override
@@ -341,7 +352,10 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         writer.reset(dbName, tableName);
       } else {
         try {
-          writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
+          Timer timer = metadataWriterWriteTimers.get(writer.getClass().getName());
+          try (Timer.Context context = timer.time()) {
+            writer.writeEnvelope(recordEnvelope, newSpecsMap, oldSpecsMap, spec);
+          }
         } catch (Exception e) {
           if (exceptionMatches(e, transientExceptionMessages)) {
             throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
@@ -419,7 +433,10 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
         writer.reset(dbName, tableName);
       } else {
         try {
-          writer.flush(dbName, tableName);
+          Timer timer = metadataWriterFlushTimers.get(writer.getClass().getName());
+          try (Timer.Context context = timer.time()) {
+            writer.flush(dbName, tableName);
+          }
         } catch (IOException e) {
           if (exceptionMatches(e, transientExceptionMessages)) {
             throw new RuntimeException("Failing container due to transient exception for db: " + dbName + " table: " + tableName, e);
@@ -480,6 +497,7 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
       }
       entry.getValue().clear();
     }
+    logTimers();
   }
 
   @Override
@@ -564,5 +582,16 @@ public class GobblinMCEWriter implements DataWriter<GenericRecord> {
   private List<String> getFailedWriterList(MetadataWriter failedWriter) {
     List<MetadataWriter> failedWriters = metadataWriters.subList(metadataWriters.indexOf(failedWriter), metadataWriters.size());
     return failedWriters.stream().map(writer -> writer.getClass().getName()).collect(Collectors.toList());
+  }
+
+  private void logTimers() {
+    metadataWriterWriteTimers.values().forEach(this::logTimer);
+    metadataWriterFlushTimers.values().forEach(this::logTimer);
+    logTimer(hiveSpecComputationTimer);
+  }
+
+  private void logTimer(ContextAwareTimer timer) {
+    log.info("Timer {} 1 hour mean duration: {} ms", timer.getName(), TimeUnit.NANOSECONDS.toMillis((long) timer.getSnapshot().getMean()));
+    log.info("Timer {} 1 hour 99th percentile duration: {} ms", timer.getName(), TimeUnit.NANOSECONDS.toMillis((long) timer.getSnapshot().get99thPercentile()));
   }
 }

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriterTest.java
@@ -350,6 +350,10 @@ public class IcebergMetadataWriterTest extends HiveMetastoreTest {
     MetadataWriter mockWriter = Mockito.mock(MetadataWriter.class);
     Mockito.doThrow(new IOException("Test failure")).when(mockWriter).writeEnvelope(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     gobblinMCEWriter.metadataWriters.add(0, mockWriter);
+    gobblinMCEWriter.metadataWriterWriteTimers.put(mockWriter.getClass().getName(), gobblinMCEWriter.metricContext
+        .contextAwareTimer(mockWriter.getClass().getName() + ".write", 1, TimeUnit.HOURS));
+    gobblinMCEWriter.metadataWriterFlushTimers.put(mockWriter.getClass().getName(), gobblinMCEWriter.metricContext
+        .contextAwareTimer(mockWriter.getClass().getName() + ".flush", 1, TimeUnit.HOURS));
 
     GobblinMetadataChangeEvent gmceWithMockWriter = SpecificData.get().deepCopy(gmce.getSchema(), gmce);
     gmceWithMockWriter.setAllowedMetadataWriters(Arrays.asList(IcebergMetadataWriter.class.getName(), mockWriter.getClass().getName()));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1842


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add timers for:
- hivespec computation
- write for each metadata writer
- flush for each metadata writer

These timers are set up with a 1 hour sliding window, so the statistics will be for the last hour of execution. The timers are registered with metric context so they will send metrics through gobblin's metric framework. Also, added logging during every flush interval (every 1 min) which logs the current mean/99th percentile of every timer, so it is easier to see where time is being spent.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran test pipeline. Example timer logs:
```
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - begin flushing 0 records
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.iceberg.writer.IcebergMetadataWriter.write 1 hour mean duration: 10 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.iceberg.writer.IcebergMetadataWriter.write 1 hour 99th percentile duration: 104 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.hive.writer.HiveMetadataWriter.write 1 hour mean duration: 14 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.hive.writer.HiveMetadataWriter.write 1 hour 99th percentile duration: 213 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.iceberg.writer.IcebergMetadataWriter.flush 1 hour mean duration: 3756 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.iceberg.writer.IcebergMetadataWriter.flush 1 hour 99th percentile duration: 69138 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.hive.writer.HiveMetadataWriter.flush 1 hour mean duration: 0 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer org.apache.gobblin.hive.writer.HiveMetadataWriter.flush 1 hour 99th percentile duration: 1 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer hiveSpec.computation 1 hour mean duration: 10 ms
2023-06-13 11:16:58 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.iceberg.writer.GobblinMCEWriter  - Timer hiveSpec.computation 1 hour 99th percentile duration: 19 ms
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

