### PR TITLE
[GOBBLIN-1843] Utility for detecting non optional unions should convert dataset urn to hive compatible format

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/hive/HiveTable.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/hive/HiveTable.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Splitter;
 
+import org.apache.gobblin.hive.metastore.HiveMetaStoreUtils;
 import org.apache.gobblin.util.HiveJdbcConnector;
 
 
@@ -42,7 +43,7 @@ public abstract class HiveTable {
   protected List<HiveAttribute> attributes;
 
   public static class Builder<T extends Builder<?>> {
-    protected String name = UUID.randomUUID().toString().replaceAll("-", "_");
+    protected String name = HiveMetaStoreUtils.getHiveTableName(UUID.randomUUID().toString());
     protected List<String> primaryKeys = new ArrayList<>();
     protected List<HiveAttribute> attributes = new ArrayList<>();
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.fs.Path;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.dataset.Dataset;
 import org.apache.gobblin.dataset.DatasetsFinder;
 import org.apache.gobblin.util.PropertiesUtils;
@@ -39,6 +41,7 @@ import org.apache.gobblin.util.function.CheckedExceptionPredicate;
 /**
  * A decorator for filtering datasets after a {@link DatasetsFinder} finds a {@link List} of {@link Dataset}s
  */
+@Slf4j
 public class DatasetsFinderFilteringDecorator<T extends Dataset> implements DatasetsFinder<T> {
   private static final String PREFIX = "filtering.datasets.finder.";
   public static final String DATASET_CLASS = PREFIX + "class";
@@ -69,6 +72,7 @@ public class DatasetsFinderFilteringDecorator<T extends Dataset> implements Data
   @Override
   public List<T> findDatasets() throws IOException {
     List<T> datasets = datasetFinder.findDatasets();
+    log.info("Found {} datasets", datasets.size());
     List<T> allowedDatasets = Collections.emptyList();
     try {
       allowedDatasets = datasets.parallelStream()
@@ -83,6 +87,7 @@ public class DatasetsFinderFilteringDecorator<T extends Dataset> implements Data
       wrappedIOException.rethrowWrapped();
     }
 
+    log.info("Allowed {}/{} datasets", allowedDatasets.size() ,datasets.size());
     return allowedDatasets;
   }
 

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -29,8 +29,6 @@ import java.util.stream.Stream;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.commons.lang.reflect.MethodUtils;
-import org.apache.gobblin.hive.avro.HiveAvroSerDeManager;
-import org.apache.gobblin.hive.spec.HiveSpec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -73,6 +71,8 @@ import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveRegistrationUnit.Column;
 import org.apache.gobblin.hive.HiveTable;
 import org.apache.gobblin.hive.SharedHiveConfKey;
+import org.apache.gobblin.hive.avro.HiveAvroSerDeManager;
+import org.apache.gobblin.hive.spec.HiveSpec;
 
 
 /**
@@ -289,7 +289,8 @@ public class HiveMetaStoreUtils {
           .anyMatch(type -> isNonOptionalUnion(type));
     }
 
-    throw new RuntimeException("Avro based Hive tables without \"" + HiveAvroSerDeManager.SCHEMA_LITERAL +"\" are not supported");
+    throw new RuntimeException("Avro based Hive tables without \"" + HiveAvroSerDeManager.SCHEMA_LITERAL +"\" are not supported. "
+        + "hiveTable=" + hiveTable.getDbName() + "." + hiveTable.getTableName());
   }
 
   /**

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -152,6 +152,15 @@ public class HiveMetaStoreUtils {
   }
 
   /**
+   * Hive does not use '-' or '.' in the table name, so they are replaced with '_'
+   * @param topic
+   * @return
+   */
+  public static String getHiveTableName(String topic) {
+    return topic.replaceAll("[-.]", "_");
+  }
+
+  /**
    * Convert a {@link HivePartition} into a {@link Partition}.
    */
   public static Partition getPartition(HivePartition hivePartition) {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
@@ -77,9 +77,7 @@ public class DatasetHiveSchemaContainsNonOptionalUnion<T extends Dataset> implem
       "Expected pattern = %s", dataset.getUrn(), pattern.pattern()));
     }
 
-    // hive does not use '-' in the table name, so they are replaced with '_'
-    String hiveTableName = m.group(2).replaceAll("-", "_");
-    return new DbAndTable(m.group(1), hiveTableName);
+    return new DbAndTable(m.group(1), HiveMetaStoreUtils.getHiveTableName(m.group(2)));
   }
 
   boolean containsNonOptionalUnion(HiveTable table) {

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnion.java
@@ -76,7 +76,10 @@ public class DatasetHiveSchemaContainsNonOptionalUnion<T extends Dataset> implem
       throw new IllegalStateException(String.format("Dataset urn [%s] doesn't follow expected pattern. " +
       "Expected pattern = %s", dataset.getUrn(), pattern.pattern()));
     }
-    return new DbAndTable(m.group(1), m.group(2));
+
+    // hive does not use '-' in the table name, so they are replaced with '_'
+    String hiveTableName = m.group(2).replaceAll("-", "_");
+    return new DbAndTable(m.group(1), hiveTableName);
   }
 
   boolean containsNonOptionalUnion(HiveTable table) {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
@@ -48,7 +48,7 @@ import org.apache.gobblin.util.ConfigUtils;
 @Slf4j
 // depends on icebergMetadataWriterTest to avoid concurrency between other HiveMetastoreTest(s) in CI.
 // You can uncomment the dependsOnGroups if you want to test this class in isolation
-@Test (dependsOnGroups = "icebergMetadataWriterTest")
+@Test(dependsOnGroups = "icebergMetadataWriterTest")
 public class DatasetHiveSchemaContainsNonOptionalUnionTest extends HiveMetastoreTest {
 
   private static String dbName = "dbName";
@@ -84,7 +84,7 @@ public class DatasetHiveSchemaContainsNonOptionalUnionTest extends HiveMetastore
     metastoreClient.createTable(HiveMetaStoreUtils.getTable(testTable));
 
     state = ConfigUtils.configToState(ConfigUtils.propertiesToConfig(hiveConf.getAllProperties()));
-    state.setProp(DatasetHiveSchemaContainsNonOptionalUnion.PATTERN, "/data/(\\w+)/.*/([\\w\\d_-]+)/[hourly].*");
+    state.setProp(DatasetHiveSchemaContainsNonOptionalUnion.PATTERN, "/data/(\\w+)/.*/([\\w\\d_-]+)/hourly.*");
     Assert.assertNotNull(metastoreClient.getTable(dbName, DatasetHiveSchemaContainsNonOptionalUnionTest.testTable));
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1843] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1843


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Datasets with URN that have a `-` will be represented in Hive with an `_`.  Failing to do so will mean the code will fail to pull up the correct hive table

This code will replace all '-' with '_' before querying hive. We do not need to consider lower / uppercase because hive is case insensitive

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
<img width="464" alt="image" src="https://github.com/apache/gobblin/assets/35702680/a30b9ef5-4d9f-4b7d-a5d6-a5d7ce9ad18a">


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

