### PR TITLE
[GOBBLIN-1845] Changes parallelstream to stream in DatasetsFinderFilt…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/dataset/DatasetsFinderFilteringDecorator.java
@@ -75,7 +75,7 @@ public class DatasetsFinderFilteringDecorator<T extends Dataset> implements Data
     log.info("Found {} datasets", datasets.size());
     List<T> allowedDatasets = Collections.emptyList();
     try {
-      allowedDatasets = datasets.parallelStream()
+      allowedDatasets = datasets.stream()
           .filter(dataset -> allowDatasetPredicates.stream()
               .map(CheckedExceptionPredicate::wrapToTunneled)
               .allMatch(p -> p.test(dataset)))


### PR DESCRIPTION
…eringDecorator  to avoid classloader issues in spark

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1845] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1845


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
DatasetsFinderFilteringDecorator uses parallel stream on datasets to filter them on predicates. When this code runs in spark, system class loader gets used to pickup hive jar instead of the current conext class loader which leads to ClassNotFound issues 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Small change that should already be covered in unit tests
Also, tested this on the hadoop cluster at linkedin

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

