### PR TITLE
[GOBBLIN-1847] Exceptions in the JobLauncher should try to delete the existing workflow if it is launched

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -167,6 +167,12 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowListingTimeoutSeconds";
   public static final long DEFAULT_HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = 60;
 
+  /**
+   * When a Gobblin job exits (success or failure), it will attempt to cancel the underlying Helix workflow
+   */
+  public static final String HELIX_WORKFLOW_CANCEL_ON_EXIT = GOBBLIN_CLUSTER_PREFIX + "cancelWorkflowOnExit";
+  public static final boolean DEFAULT_HELIX_WORKFLOW_CANCEL_ON_EXIT = false;
+
   public static final String CLEAN_ALL_DIST_JOBS = GOBBLIN_CLUSTER_PREFIX + "bootup.clean.dist.jobs";
   public static final boolean DEFAULT_CLEAN_ALL_DIST_JOBS = false;
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -167,12 +167,6 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowListingTimeoutSeconds";
   public static final long DEFAULT_HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = 60;
 
-  /**
-   * When a Gobblin job exits (success or failure), it will attempt to cancel the underlying Helix workflow
-   */
-  public static final String HELIX_WORKFLOW_CANCEL_ON_EXIT = GOBBLIN_CLUSTER_PREFIX + "cancelWorkflowOnExit";
-  public static final boolean DEFAULT_HELIX_WORKFLOW_CANCEL_ON_EXIT = false;
-
   public static final String CLEAN_ALL_DIST_JOBS = GOBBLIN_CLUSTER_PREFIX + "bootup.clean.dist.jobs";
   public static final boolean DEFAULT_CLEAN_ALL_DIST_JOBS = false;
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
@@ -38,6 +38,7 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -63,6 +64,7 @@ import org.apache.gobblin.runtime.JobContext;
 import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.runtime.listeners.AbstractJobListener;
+import org.apache.gobblin.runtime.listeners.JobListener;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -298,6 +300,25 @@ public class GobblinHelixJobLauncherTest {
     // using launchJobImpl because we do not want to swallow the exception
     Assert.assertThrows(JobException.class, () -> gobblinHelixJobLauncher.launchJobImpl(null));
   }
+
+  public void testCancelJobOnExit() throws Exception {
+    final ConcurrentHashMap<String, Boolean> runningMap = new ConcurrentHashMap<>();
+
+    final Properties props = generateJobProperties(this.baseConfig, "testCancelOnExit", "_12345");
+    props.setProperty(GobblinClusterConfigurationKeys.HELIX_WORKFLOW_SUBMISSION_TIMEOUT_SECONDS, "0");
+    props.setProperty(GobblinClusterConfigurationKeys.HELIX_WORKFLOW_CANCEL_ON_EXIT, "true");
+
+    final GobblinHelixJobLauncher gobblinHelixJobLauncher = this.closer.register(
+        new GobblinHelixJobLauncher(props, this.helixManager, this.appWorkDir, ImmutableList.<Tag<?>>of(), runningMap,
+            java.util.Optional.empty()));
+
+    // The launchJob will throw an exception (see testTimeout test) and we expect the launcher to swallow the exception,
+    // then call still properly call cancel. We use the listener to confirm the cancel hook was correctly called once
+    JobListener mockListener = Mockito.mock(JobListener.class);
+    gobblinHelixJobLauncher.launchJob(mockListener);
+    Mockito.verify(mockListener).onJobCancellation(Mockito.any(JobContext.class));
+  }
+
 
   @Test(enabled = false, dependsOnMethods = {"testLaunchJob", "testLaunchMultipleJobs"})
   public void testJobCleanup() throws Exception {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1847] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1847


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
If the JobLauncher encounters any errors, Gobblin code cleans up the working directory that contains Gobblin state. But we do not clean up the helix workflows. This can cause us to spin up helix workflows that do not have valid Gobblin State on HDFS / S3. 

When this occurs, it causes rapid container recycling, which puts tremendous load on Zookeeper due to Helix API calls, causing a peak in ZK callbacks

![image](https://github.com/apache/gobblin/assets/35702680/cafba644-bc69-4603-a5c8-3f2ba5ed9e77)

The cancellation logic is obnoxious, so here is the high level of what happens.
1. Calling `AbstractJobLauncher#cancelJob(JobListener)` sets `AbstractJobLauncher#cancellationRequested` to `true`
2. This causes the `AbstractJobLauncher#cancellationExecutor` created by the `AbstractJobLauncher#startCancellationExecutor()` method to call the abstract method `AbstractJobLauncher#executeCancellation()`
3. That method implemented in `GobblinHelixJobLauncher#executeCancellation()`, which eventually calls `HelixUtils.cancelWorkflow(...)`


#### Considerations
- I considered modifying the `runWorkunits` itself since that is where the cleanup directory is called. But I wanted to leverage the existing the cancellation request logic (which is admittedly super overkill and has a ton of concurrency). We also collect a ton of metrics during the cancellation process, so it's important that I call the cancel method that is part of the `AbstractJobLauncher`. Since we need access to the job listener, it makes most sense to have it be part of the `launchJob` method
  
- The reason I clean up even when there is a successful finish, is because there isn't really a reason not to cancel a workflow to run after the job is finished for Fast Ingest. The cancel call is safe to call multiple times and there are clearly still edge cases where we don't call cancel properly
- I am not a fan of adding a new flag, but I want to maintain backward compatibility since this job launcher is used beyond Fast Ingest

### Testing
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://github.com/apache/gobblin/assets/35702680/48db7f5e-38b4-4789-88d5-7163f0b7068b)


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    3. Subject is limited to 50 characters
    5. Subject does not end with a period
    6. Subject uses the imperative mood ("add", not "adding")
    7. Body wraps at 72 characters
    8. Body explains "what" and "why", not "how"

