### PR TITLE
[GOBBLIN-1850] Emit warning for retention of Snapshot Hive Tables instead of failing job

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -76,7 +76,7 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
       if (hiveDataset.getTable().getTableType() == TableType.VIRTUAL_VIEW) {
         log.warn("Skipping processing a view type dataset: ", ((HiveDataset) dataset).getTable().getTableName());
       } else {
-        log.warn("Skipping processing a snapshot hive table: ", ((HiveDataset) dataset).getTable().getTableName());
+        log.warn("Skipping processing a snapshot hive table: ", ((HiveDataset) dataset).getTable().getTableName()); 
       }
       return Collections.emptyList();
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -58,8 +58,8 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
    * Calls {@link #getDatasetVersion(Partition)} for every {@link Partition} found.
    * <p>
    * Note: If an exception occurs while processing a partition, that partition will be ignored in the returned collection
-   * Also note that if the dataset passed is a view type, we will return an empty list even if the underlying table is
-   * partitioned.
+   * Also note that if the dataset passed is a view type or a snapshot of a hive table, we will return an empty list
+   * even if the underlying table is partitioned.
    * </p>
    *
    * @throws IllegalArgumentException if <code>dataset</code> is not a {@link HiveDataset}. Or if {@link HiveDataset#getTable()}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -76,7 +76,7 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
       if (hiveDataset.getTable().getTableType() == TableType.VIRTUAL_VIEW) {
         log.warn("Skipping processing a view type dataset: ", ((HiveDataset) dataset).getTable().getTableName());
       } else {
-        log.warn("Skipping processing a snapshot hive table: ", ((HiveDataset) dataset).getTable().getTableName()); 
+        log.warn("Skipping processing a snapshot hive table: ", ((HiveDataset) dataset).getTable().getTableName());
       }
       return Collections.emptyList();
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -75,11 +75,10 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
     if (!hiveDataset.getTable().isPartitioned()) {
       if (hiveDataset.getTable().getTableType() == TableType.VIRTUAL_VIEW) {
         log.warn("Skipping processing a view type dataset: ", ((HiveDataset) dataset).getTable().getTableName());
-        return Collections.emptyList();
       } else {
-        throw new IllegalArgumentException("HiveDatasetVersionFinder is only compatible with partitioned hive tables. "
-            + "This is a snapshot hive table.");
+        log.warn("Skipping processing a snapshot hive table: ", ((HiveDataset) dataset).getTable().getTableName());
       }
+      return Collections.emptyList();
     }
 
     try (AutoReturnableObject<IMetaStoreClient> client = hiveDataset.getClientPool().getClient()) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1850


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Currently, we are dynamically determining at runtime whether to skip retention on a dataset and we are not allowing hive retention on a view as it doesn't have access to delete underlying data (#3695). 

However, we also need to not allow hive retention on a snapshot as it is only a point-in-time copy of the filesystem/directory. Instead of failing the entire job due to this snapshot format, and we do not want to have a static allow/denylist, it should throw a warning message instead and continue the retention job onto the next possiblility.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested with a sample retention job and observed that no exceptions related to hive snapshot tables were encountered.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

