### PR TITLE
[GOBBLIN-1855] Metadata writer tests do not work in isolation after upgrading to Iceberg 1.2.0

### DIFF
--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/predicates/DatasetHiveSchemaContainsNonOptionalUnionTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -66,7 +67,10 @@ public class DatasetHiveSchemaContainsNonOptionalUnionTest extends HiveMetastore
   @BeforeSuite
   public void setup() throws Exception {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
-    startMetastore();
+    try {
+      startMetastore();
+    } catch (AlreadyExistsException ignored) { }
+
     tmpDir = Files.createTempDir();
     dbUri = String.format("%s/%s/%s", tmpDir.getAbsolutePath(),"metastore", dbName);
     try {

--- a/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
+++ b/gobblin-iceberg/src/test/java/org/apache/gobblin/iceberg/writer/HiveMetadataWriterTest.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.serde.serdeConstants;
@@ -128,6 +129,10 @@ public class HiveMetadataWriterTest extends HiveMetastoreTest {
   @BeforeSuite
   public void setUp() throws Exception {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
+    try {
+      startMetastore();
+    } catch (AlreadyExistsException ignored) { }
+
     State state = ConfigUtils.configToState(ConfigUtils.propertiesToConfig(hiveConf.getAllProperties()));
     Optional<String> metastoreUri = Optional.fromNullable(state.getProperties().getProperty(HiveRegister.HIVE_METASTORE_URI_KEY));
     hc = HiveMetastoreClientPool.get(state.getProperties(), metastoreUri);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX



### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
HiveMetaStoreTest from Iceberg had some minor changes to the class that affect the order of metastore creation. This did not break our CI because iceberg tests run as a group in ABC order, so one of the tests was properly starting the metastore. But going forward, we should call the method and have an empty catch in case another test already init the hive metastore. 

This would cause a NPE when the tests were run in isolation. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://github.com/apache/gobblin/assets/35702680/acd8c3d5-7601-47db-94a6-cf8390a08ad6)

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

