### PR TITLE
[GOBBLIN-1857] Add override flag to force generate a job execution id based on gobbl…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -181,7 +181,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
 
   // Job Execution ID for Helix jobs is inferred from Flow Execution IDs, but there are scenarios in earlyStop jobs where
-  // this behavior needs to be avoided due to concurrent planning and acutal jobs sharing the same execution ID
+  // this behavior needs to be avoided due to concurrent planning and actual jobs sharing the same execution ID
   public static final String USE_GENERATED_JOBEXECUTION_IDS = GOBBLIN_CLUSTER_PREFIX + "job.useGeneratedJobExecutionIds";
 
   // By default we cancel job by calling helix stop API. In some cases, jobs just hang in STOPPING state and preventing

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -180,6 +180,10 @@ public class GobblinClusterConfigurationKeys {
   public static final String CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelRunningJobOnDelete";
   public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
 
+  // Job Execution ID for Helix jobs is inferred from Flow Execution IDs, but there are scenarios in earlyStop jobs where
+  // this behavior needs to be avoided due to concurrent planning and acutal jobs sharing the same execution ID
+  public static final String USE_GENERATED_JOBEXECUTION_IDS = GOBBLIN_CLUSTER_PREFIX + "job.useGeneratedJobExecutionIds";
+
   // By default we cancel job by calling helix stop API. In some cases, jobs just hang in STOPPING state and preventing
   // new job being launched. We provide this config to give an option to cancel jobs by calling Delete API. Directly delete
   // a Helix workflow should be safe in Gobblin world, as Gobblin job is stateless for Helix since we implement our own state store

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -96,15 +96,17 @@ public class HelixJobsMapping {
   }
 
   public static String createPlanningJobId (Properties jobPlanningProps) {
+    long planningJobId = PropertiesUtils.getPropAsBoolean(jobPlanningProps, GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "false") ?
+        System.currentTimeMillis() : PropertiesUtils.getPropAsLong(jobPlanningProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis());
     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.PLANNING_JOB_NAME_PREFIX
-            + JobState.getJobNameFromProps(jobPlanningProps),
-        PropertiesUtils.getPropAsLong(jobPlanningProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis()));
+            + JobState.getJobNameFromProps(jobPlanningProps), planningJobId);
   }
 
   public static String createActualJobId (Properties jobProps) {
-     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX
-             + JobState.getJobNameFromProps(jobProps),
-          PropertiesUtils.getPropAsLong(jobProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis()));
+    long actualJobId = PropertiesUtils.getPropAsBoolean(jobProps, GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "false") ?
+        System.currentTimeMillis() : PropertiesUtils.getPropAsLong(jobProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis());
+    return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX
+        + JobState.getJobNameFromProps(jobProps), actualJobId);
   }
 
   @Nullable

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobMappingTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobMappingTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+
+
+public class GobblinHelixJobMappingTest {
+
+  @Test
+  void testMapJobNameWithFlowExecutionId() {
+    Properties props = new Properties();
+    props.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, "1234");
+    props.setProperty(ConfigurationKeys.JOB_NAME_KEY, "job1");
+    String planningJobId = HelixJobsMapping.createPlanningJobId(props);
+    String actualJobId = HelixJobsMapping.createActualJobId(props);
+    Assert.assertEquals(planningJobId, "job_PlanningJobjob1_1234");
+    Assert.assertEquals(actualJobId, "job_ActualJobjob1_1234");
+  }
+
+  @Test
+  void testMapJobNameWithOverride() {
+    Properties props = new Properties();
+    props.setProperty(GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "true");
+    props.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, "1234");
+    props.setProperty(ConfigurationKeys.JOB_NAME_KEY, "job1");
+    String planningJobId = HelixJobsMapping.createPlanningJobId(props);
+    String actualJobId = HelixJobsMapping.createActualJobId(props);
+    // The jobID will be the system timestamp instead of the flow execution ID
+    Assert.assertNotEquals(planningJobId, "job_PlanningJobjob1_1234");
+    Assert.assertNotEquals(actualJobId, "job_ActualJobjob1_1234");
+  }
+}


### PR DESCRIPTION
…in cluster system time

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1857

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Job Execution ID is automatically inferred from the flow execution ID if the job was orchestrated by Gobblin-as-a-Service. However, this can lead to bugs in conjunction with other job keys such as earlyStop, since it would create multiple planningJobs and job IDs sent to Helix. These jobs would then have the same execution ID which is rejected by Helix.

When the user sets a configuration `gobblin.cluster.job.useGeneratedJobExecutionIds` are set, we want to force the Gobblin cluster to default to creating the job execution ID from its timestamp. This may make the job harder to track but earlyStop jobs are already difficult to track due to having multiple submitted Helix jobs

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

