### PR TITLE
[GOBBLIN-1859] Multi-active Unit Test for Multi-Participant state 

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
@@ -18,6 +18,9 @@
 package org.apache.gobblin.runtime.api;
 
 import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.typesafe.config.Config;
+import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -25,15 +28,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Timestamp;
-
-import com.google.inject.Inject;
-import com.typesafe.config.Config;
-import com.zaxxer.hikari.HikariDataSource;
-
 import javax.sql.DataSource;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.MysqlDataSourceFactory;
@@ -90,6 +87,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   private final int linger;
   private String thisTableGetInfoStatement;
   private String thisTableSelectAfterInsertStatement;
+  private String thisTableAcquireLeaseIfMatchingAllStatement;
+  private String thisTableAcquireLeaseIfFinishedStatement;
 
   // TODO: define retention on this table
   private static final String CREATE_LEASE_ARBITER_TABLE_STATEMENT = "CREATE TABLE IF NOT EXISTS %s ("
@@ -102,8 +101,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   private static final String CREATE_CONSTANTS_TABLE_STATEMENT = "CREATE TABLE IF NOT EXISTS %s "
       + "(primary_key INT, epsilon INT, linger INT, PRIMARY KEY (primary_key))";
   // Only insert epsilon and linger values from config if this table does not contain a pre-existing values already.
-  private static final String INSERT_CONSTANTS_TABLE_STATEMENT = "INSERT INTO %s (primary_key, epsilon, linger) "
-      + "VALUES(1, ?, ?)";
+  private static final String UPSERT_CONSTANTS_TABLE_STATEMENT = "INSERT INTO %s (primary_key, epsilon, linger) "
+      + "VALUES(1, ?, ?) ON DUPLICATE KEY UPDATE epsilon=VALUES(epsilon), linger=VALUES(linger)";
   protected static final String WHERE_CLAUSE_TO_MATCH_KEY = "WHERE flow_group=? AND flow_name=? AND flow_execution_id=?"
       + " AND flow_action=?";
   protected static final String WHERE_CLAUSE_TO_MATCH_ROW = WHERE_CLAUSE_TO_MATCH_KEY
@@ -121,9 +120,9 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
       + "ELSE 3 END as lease_validity_status, linger, CURRENT_TIMESTAMP FROM %s, %s " + WHERE_CLAUSE_TO_MATCH_KEY;
   // Insert or update row to acquire lease if values have not changed since the previous read
   // Need to define three separate statements to handle cases where row does not exist or has null values to check
-  protected static final String CONDITIONALLY_ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT = "INSERT INTO %s (flow_group, "
-      + "flow_name, flow_execution_id, flow_action, event_timestamp, lease_acquisition_timestamp) "
-      + "VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
+  protected static final String ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT = "INSERT INTO %s (flow_group, flow_name, "
+      + "flow_execution_id, flow_action, event_timestamp, lease_acquisition_timestamp) VALUES(?, ?, ?, ?, "
+      + "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
   protected static final String CONDITIONALLY_ACQUIRE_LEASE_IF_FINISHED_LEASING_STATEMENT = "UPDATE %s "
       + "SET event_timestamp=CURRENT_TIMESTAMP, lease_acquisition_timestamp=CURRENT_TIMESTAMP "
       + WHERE_CLAUSE_TO_MATCH_KEY + " AND event_timestamp=? AND lease_acquisition_timestamp is NULL";
@@ -155,6 +154,10 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         this.constantsTableName);
     this.thisTableSelectAfterInsertStatement = String.format(SELECT_AFTER_INSERT_STATEMENT, this.leaseArbiterTableName,
         this.constantsTableName);
+    this.thisTableAcquireLeaseIfMatchingAllStatement =
+        String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_MATCHING_ALL_COLS_STATEMENT, this.leaseArbiterTableName);
+    this.thisTableAcquireLeaseIfFinishedStatement =
+        String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_FINISHED_LEASING_STATEMENT, this.leaseArbiterTableName);
     this.dataSource = MysqlDataSourceFactory.get(config, SharedResourcesBrokerFactory.getImplicitBroker());
     String createArbiterStatement = String.format(
         CREATE_LEASE_ARBITER_TABLE_STATEMENT, leaseArbiterTableName);
@@ -175,65 +178,26 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     String createConstantsStatement = String.format(CREATE_CONSTANTS_TABLE_STATEMENT, this.constantsTableName);
     withPreparedStatement(createConstantsStatement, createStatement -> createStatement.executeUpdate(), true);
 
-    String insertConstantsStatement = String.format(INSERT_CONSTANTS_TABLE_STATEMENT, this.constantsTableName);
+    String insertConstantsStatement = String.format(UPSERT_CONSTANTS_TABLE_STATEMENT, this.constantsTableName);
     withPreparedStatement(insertConstantsStatement, insertStatement -> {
       int i = 0;
       insertStatement.setInt(++i, epsilon);
       insertStatement.setInt(++i, linger);
-      try {
-        return insertStatement.executeUpdate();
-      } catch (SQLIntegrityConstraintViolationException e) {
-        if (!e.getMessage().contains("Duplicate entry '1' for key 'PRIMARY")) {
-          throw e;
-        }
-      }
-      return null;
+      return insertStatement.executeUpdate();
     }, true);
   }
 
   @Override
   public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction flowAction, long eventTimeMillis)
       throws IOException {
-    // Check table for an existing entry for this flow action and event time
-    Optional<GetEventInfoResult> getResult = withPreparedStatement(thisTableGetInfoStatement,
-        getInfoStatement -> {
-          int i = 0;
-          getInfoStatement.setString(++i, flowAction.getFlowGroup());
-          getInfoStatement.setString(++i, flowAction.getFlowName());
-          getInfoStatement.setString(++i, flowAction.getFlowExecutionId());
-          getInfoStatement.setString(++i, flowAction.getFlowActionType().toString());
-          ResultSet resultSet = getInfoStatement.executeQuery();
-          try {
-            if (!resultSet.next()) {
-              return Optional.absent();
-            }
-            return Optional.of(createGetInfoResult(resultSet));
-          } finally {
-            if (resultSet !=  null) {
-              resultSet.close();
-            }
-          }
-        }, true);
+    // Query lease arbiter table about this flow action
+    Optional<GetEventInfoResult> getResult = getExistingEventInfo(flowAction);
 
     try {
       if (!getResult.isPresent()) {
         log.debug("tryAcquireLease for [{}, eventTimestamp: {}] - CASE 1: no existing row for this flow action, then go"
                 + " ahead and insert", flowAction, eventTimeMillis);
-        String formattedAcquireLeaseNewRowStatement =
-            String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT, this.leaseArbiterTableName,
-                this.leaseArbiterTableName);
-        int numRowsUpdated = withPreparedStatement(formattedAcquireLeaseNewRowStatement,
-            insertStatement -> {
-              completeInsertPreparedStatement(insertStatement, flowAction);
-              try {
-                return insertStatement.executeUpdate();
-              } catch (SQLIntegrityConstraintViolationException e) {
-                if (!e.getMessage().contains("Duplicate entry")) {
-                  throw e;
-                }
-              }
-              return 0;
-            }, true);
+        int numRowsUpdated = attemptLeaseIfNewRow(flowAction);
        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, flowAction, Optional.absent());
       }
 
@@ -273,14 +237,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
               dbEventTimestamp, dbLeaseAcquisitionTimestamp, dbLinger);
         }
         // Use our event to acquire lease, check for previous db eventTimestamp and leaseAcquisitionTimestamp
-        String formattedAcquireLeaseIfMatchingAllStatement =
-            String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_MATCHING_ALL_COLS_STATEMENT, this.leaseArbiterTableName);
-        int numRowsUpdated = withPreparedStatement(formattedAcquireLeaseIfMatchingAllStatement,
-            insertStatement -> {
-              completeUpdatePreparedStatement(insertStatement, flowAction, true,
-                  true, dbEventTimestamp, dbLeaseAcquisitionTimestamp);
-              return insertStatement.executeUpdate();
-            }, true);
+        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfMatchingAllStatement, flowAction,
+            true,true, dbEventTimestamp, dbLeaseAcquisitionTimestamp);
         return evaluateStatusAfterLeaseAttempt(numRowsUpdated, flowAction, Optional.of(dbCurrentTimestamp));
       } // No longer leasing this event
         if (isWithinEpsilon) {
@@ -291,18 +249,37 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         log.debug("tryAcquireLease for [{}, eventTimestamp: {}] - CASE 6: Distinct event, no longer leasing event in "
             + "db", flowAction, dbCurrentTimestamp.getTime());
         // Use our event to acquire lease, check for previous db eventTimestamp and NULL leaseAcquisitionTimestamp
-        String formattedAcquireLeaseIfFinishedStatement =
-            String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_FINISHED_LEASING_STATEMENT, this.leaseArbiterTableName);
-        int numRowsUpdated = withPreparedStatement(formattedAcquireLeaseIfFinishedStatement,
-            insertStatement -> {
-              completeUpdatePreparedStatement(insertStatement, flowAction, true,
-                  false, dbEventTimestamp, null);
-              return insertStatement.executeUpdate();
-            }, true);
+        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfFinishedStatement, flowAction,
+            true, false, dbEventTimestamp, null);
         return evaluateStatusAfterLeaseAttempt(numRowsUpdated, flowAction, Optional.of(dbCurrentTimestamp));
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Checks leaseArbiterTable for an existing entry for this flow action and event time
+   */
+  protected Optional<GetEventInfoResult> getExistingEventInfo(DagActionStore.DagAction flowAction) throws IOException {
+    return withPreparedStatement(thisTableGetInfoStatement,
+        getInfoStatement -> {
+          int i = 0;
+          getInfoStatement.setString(++i, flowAction.getFlowGroup());
+          getInfoStatement.setString(++i, flowAction.getFlowName());
+          getInfoStatement.setString(++i, flowAction.getFlowExecutionId());
+          getInfoStatement.setString(++i, flowAction.getFlowActionType().toString());
+          ResultSet resultSet = getInfoStatement.executeQuery();
+          try {
+            if (!resultSet.next()) {
+              return Optional.absent();
+            }
+            return Optional.of(createGetInfoResult(resultSet));
+          } finally {
+            if (resultSet !=  null) {
+              resultSet.close();
+            }
+          }
+        }, true);
   }
 
   protected GetEventInfoResult createGetInfoResult(ResultSet resultSet) throws IOException {
@@ -329,6 +306,62 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     }
   }
 
+  /**
+   * Called by participant to try to acquire lease for a flow action that does not have an attempt in progress or in
+   * near past for it.
+   * @return int corresponding to number of rows updated by INSERT statement to acquire lease
+   */
+  protected int attemptLeaseIfNewRow(DagActionStore.DagAction flowAction) throws IOException {
+    String formattedAcquireLeaseNewRowStatement =
+        String.format(ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT, this.leaseArbiterTableName);
+    return withPreparedStatement(formattedAcquireLeaseNewRowStatement,
+        insertStatement -> {
+          completeInsertPreparedStatement(insertStatement, flowAction);
+          try {
+            return insertStatement.executeUpdate();
+          } catch (SQLIntegrityConstraintViolationException e) {
+            if (!e.getMessage().contains("Duplicate entry")) {
+              throw e;
+            }
+            return 0;
+          }
+        }, true);
+  }
+
+  /**
+   * Called by participant to try to acquire lease for a flow action that has an existing, completed, or expired lease
+   * attempt for the flow action in the table.
+   * @return int corresponding to number of rows updated by INSERT statement to acquire lease
+   */
+  protected int attemptLeaseIfExistingRow(String acquireLeaseStatement, DagActionStore.DagAction flowAction,
+      boolean needEventTimeCheck, boolean needLeaseAcquisition, Timestamp dbEventTimestamp,
+      Timestamp dbLeaseAcquisitionTimestamp) throws IOException {
+    return withPreparedStatement(acquireLeaseStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, flowAction, needEventTimeCheck,
+              needLeaseAcquisition, dbEventTimestamp, dbLeaseAcquisitionTimestamp);
+          return insertStatement.executeUpdate();
+        }, true);
+  }
+
+  /**
+   * Checks leaseArbiter table for a row corresponding to this flow action to determine if the lease acquisition attempt
+   * was successful or not.
+   */
+  protected SelectInfoResult getRowInfo(DagActionStore.DagAction flowAction) throws IOException {
+    return withPreparedStatement(thisTableSelectAfterInsertStatement,
+        selectStatement -> {
+          completeWhereClauseMatchingKeyPreparedStatement(selectStatement, flowAction);
+          ResultSet resultSet = selectStatement.executeQuery();
+          try {
+            return createSelectInfoResult(resultSet);
+          } finally {
+            if (resultSet !=  null) {
+              resultSet.close();
+            }
+          }
+        }, true);
+  }
   protected static SelectInfoResult createSelectInfoResult(ResultSet resultSet) throws IOException {
       try {
         if (!resultSet.next()) {
@@ -363,25 +396,15 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
       DagActionStore.DagAction flowAction, Optional<Timestamp> dbCurrentTimestamp)
       throws SQLException, IOException {
     // Fetch values in row after attempted insert
-    SelectInfoResult selectInfoResult = withPreparedStatement(thisTableSelectAfterInsertStatement,
-        selectStatement -> {
-          completeWhereClauseMatchingKeyPreparedStatement(selectStatement, flowAction);
-          ResultSet resultSet = selectStatement.executeQuery();
-          try {
-            return createSelectInfoResult(resultSet);
-          } finally {
-            if (resultSet !=  null) {
-              resultSet.close();
-            }
-          }
-        }, true);
+    SelectInfoResult selectInfoResult = getRowInfo(flowAction);
     if (numRowsUpdated == 1) {
       log.debug("Obtained lease for [{}, eventTimestamp: {}] successfully!", flowAction,
           selectInfoResult.eventTimeMillis);
       return new LeaseObtainedStatus(flowAction, selectInfoResult.eventTimeMillis,
           selectInfoResult.getLeaseAcquisitionTimeMillis());
     }
-    log.debug("Another participant acquired lease in between for [{}, eventTimestamp: {}] - num rows updated: ", flowAction, selectInfoResult.eventTimeMillis, numRowsUpdated);
+    log.debug("Another participant acquired lease in between for [{}, eventTimestamp: {}] - num rows updated: ",
+        flowAction, selectInfoResult.eventTimeMillis, numRowsUpdated);
     // Another participant acquired lease in between
     return new LeasedToAnotherStatus(flowAction, selectInfoResult.getEventTimeMillis(),
         selectInfoResult.getLeaseAcquisitionTimeMillis() + selectInfoResult.getDbLinger()

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiterTest.java
@@ -18,6 +18,8 @@
 package org.apache.gobblin.runtime.api;
 
 import com.typesafe.config.Config;
+import java.io.IOException;
+import java.sql.Timestamp;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -26,6 +28,10 @@ import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.apache.gobblin.runtime.api.MysqlMultiActiveLeaseArbiter.*;
+
+
 
 @Slf4j
 public class MysqlMultiActiveLeaseArbiterTest {
@@ -37,11 +43,22 @@ public class MysqlMultiActiveLeaseArbiterTest {
   private static final String flowGroup = "testFlowGroup";
   private static final String flowName = "testFlowName";
   private static final String flowExecutionId = "12345677";
+  // The following are considered unique because they correspond to different flow action types
   private static DagActionStore.DagAction launchDagAction =
       new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, DagActionStore.FlowActionType.LAUNCH);
-
+  private static DagActionStore.DagAction resumeDagAction =
+      new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, DagActionStore.FlowActionType.RESUME);
   private static final long eventTimeMillis = System.currentTimeMillis();
   private MysqlMultiActiveLeaseArbiter mysqlMultiActiveLeaseArbiter;
+  private String formattedAcquireLeaseNewRowStatement =
+      String.format(MysqlMultiActiveLeaseArbiter.CONDITIONALLY_ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT,
+          TABLE, TABLE);
+  private String formattedAcquireLeaseIfMatchingAllStatement =
+      String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_MATCHING_ALL_COLS_STATEMENT, TABLE);
+  private String formattedAcquireLeaseIfFinishedStatement =
+      String.format(CONDITIONALLY_ACQUIRE_LEASE_IF_FINISHED_LEASING_STATEMENT, TABLE);
+  private String formattedSelectAfterInsertStatement = String.format(SELECT_AFTER_INSERT_STATEMENT, TABLE,
+          ConfigurationKeys.DEFAULT_MULTI_ACTIVE_SCHEDULER_CONSTANTS_DB_TABLE);
 
   // The setup functionality verifies that the initialization of the tables is done correctly and verifies any SQL
   // syntax errors.
@@ -50,12 +67,12 @@ public class MysqlMultiActiveLeaseArbiterTest {
     ITestMetastoreDatabase testDb = TestMetastoreDatabaseFactory.get();
 
     Config config = ConfigBuilder.create()
-        .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.SCHEDULER_EVENT_EPSILON_MILLIS_KEY, EPSILON)
-        .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.SCHEDULER_EVENT_LINGER_MILLIS_KEY, LINGER)
+        .addPrimitive(ConfigurationKeys.SCHEDULER_EVENT_EPSILON_MILLIS_KEY, EPSILON)
+        .addPrimitive(ConfigurationKeys.SCHEDULER_EVENT_LINGER_MILLIS_KEY, LINGER)
         .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
         .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
         .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
-        .addPrimitive(ConfigurationKeys.MYSQL_LEASE_ARBITER_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
+        .addPrimitive(ConfigurationKeys.SCHEDULER_LEASE_DETERMINATION_STORE_DB_TABLE_KEY, TABLE)
         .build();
 
     this.mysqlMultiActiveLeaseArbiter = new MysqlMultiActiveLeaseArbiter(config);
@@ -142,5 +159,118 @@ public class MysqlMultiActiveLeaseArbiterTest {
         (MultiActiveLeaseArbiter.LeaseObtainedStatus) sixthLaunchStatus;
     Assert.assertTrue(sixthObtainedStatus.getEventTimestamp()
         <= sixthObtainedStatus.getLeaseAcquisitionTimestamp());
+  }
+
+  /*
+     Tests CONDITIONALLY_ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT to ensure an insertion is not attempted unless the table
+     state remains the same as the prior read, which expects no row matching the primary key in the table
+     Note: this isolates and tests CASE 1 in which another participant could have acquired the lease between the time
+     the read was done and subsequent write was carried out
+  */
+  @Test //(dependsOnMethods = "testAcquireLeaseSingleParticipant")
+  public void testConditionallyAcquireLeaseIfNewRow() throws IOException {
+    // Inserting the first time should update 1 row
+    int numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(formattedAcquireLeaseNewRowStatement,
+        insertStatement -> {
+          completeInsertPreparedStatement(insertStatement, resumeDagAction);
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 1);
+    // Inserting the second time should update 0 rows but not throw any error
+    numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(formattedAcquireLeaseNewRowStatement,
+        insertStatement -> {
+          completeInsertPreparedStatement(insertStatement, resumeDagAction);
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 0);
+  }
+
+    /*
+  CASE 4; lease out of date and try to acquire lease if matching all -> update in btwn so not matching one or more of
+  the timestamps
+  - will end up returning LeasedToAnother
+   */
+  @Test (dependsOnMethods = "testConditionallyAcquireLeaseIfNewRow")
+  public void testConditionallyAcquireLeaseIfFMatchingAllColsStatement() throws IOException {
+    MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult =
+        this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(formattedSelectAfterInsertStatement,
+        selectStatement -> {
+          completeWhereClauseMatchingKeyPreparedStatement(selectStatement, resumeDagAction);
+          return MysqlMultiActiveLeaseArbiter.createSelectInfoResult(selectStatement.executeQuery());
+        }, true);
+    // This insert should work since the values match all the columns
+    int numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(
+        formattedAcquireLeaseIfMatchingAllStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, resumeDagAction, true,
+              true, new Timestamp(selectInfoResult.getEventTimeMillis()),
+              new Timestamp(selectInfoResult.getLeaseAcquisitionTimeMillis()));
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 1);
+
+    // The following insert will fail since the eventTimestamp does not match
+    numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(
+        formattedAcquireLeaseIfMatchingAllStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, resumeDagAction, true,
+              true, new Timestamp(99999),
+              new Timestamp(selectInfoResult.getLeaseAcquisitionTimeMillis()));
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 0);
+
+    // The following insert will fail since the leaseAcquisitionTimestamp does not match
+    numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(
+        formattedAcquireLeaseIfMatchingAllStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, resumeDagAction, true,
+              true, new Timestamp(selectInfoResult.getEventTimeMillis()),
+              new Timestamp(99999));
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 0);
+  }
+
+  /*
+  CASE 6: distinct event, no longer leasing in db will try to acquire lease if event time remains same
+  - in btwn update the event time and keep others same
+  - expected behavior also get LEASED to another instead of LeaseObtainedStatus
+   */
+  @Test (dependsOnMethods = "testConditionallyAcquireLeaseIfFMatchingAllColsStatement")
+  public void testConditionallyAcquireLeaseIfFinishedLeasingStatement() throws IOException, InterruptedException {
+    // Mark the resume action lease from above as completed by fabricating a LeaseObtainedStatus
+    MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult =
+        this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(formattedSelectAfterInsertStatement,
+            selectStatement -> {
+              completeWhereClauseMatchingKeyPreparedStatement(selectStatement, resumeDagAction);
+              return MysqlMultiActiveLeaseArbiter.createSelectInfoResult(selectStatement.executeQuery());
+            }, true);
+    boolean markedSuccess = this.mysqlMultiActiveLeaseArbiter.recordLeaseSuccess(new LeaseObtainedStatus(
+        resumeDagAction, selectInfoResult.getEventTimeMillis(), selectInfoResult.getLeaseAcquisitionTimeMillis()));
+    Assert.assertTrue(markedSuccess);
+
+    // Sleep enough time for event to be considered distinct
+    Thread.sleep(LINGER);
+
+    // The following insert will fail since eventTimestamp does not match the expected
+    int numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(
+        formattedAcquireLeaseIfFinishedStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, resumeDagAction, true,
+              false, new Timestamp(99999), null);
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 0);
+
+    // This insert does match since we utilize the right eventTimestamp
+    numRowsUpdated = this.mysqlMultiActiveLeaseArbiter.withPreparedStatement(
+        formattedAcquireLeaseIfFinishedStatement,
+        insertStatement -> {
+          completeUpdatePreparedStatement(insertStatement, resumeDagAction, true,
+              false, new Timestamp(selectInfoResult.getEventTimeMillis()), null);
+          return insertStatement.executeUpdate();
+        }, true);
+    Assert.assertEquals(numRowsUpdated, 1);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1859 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
In multi-active mode, multiple participants will be reading/writing to MySQL table. We want to make sure each participant acts on the table in a manner that takes into account that the state may have changed while the MultiActiveLeaseArbiter is processing the result of a READ. This PR adds unit tests that validate SQL Insertion statements are conditional upon the state of the particular row corresponding to the flow action event being unchanged from the read made by this participant. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The PR adds 3 unit tests to test each of the cases of acquiring a lease to ensure the following insertions do not complete if the state has changed from our initial read. 
- insert when there is no matching primary key in the table
- insert if a lease has expired
- insert if a lease has completed 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

