### PR TITLE
Correct num of failures

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -608,6 +608,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         String errMsg = "Failed to launch and run job " + jobId + " due to " + t.getMessage();
         LOG.error(errMsg + ": " + t, t);
         this.jobContext.getJobState().setJobFailureException(t);
+        jobState.setProp(ConfigurationKeys.JOB_FAILURES_KEY,
+            Integer.parseInt(jobState.getProp(ConfigurationKeys.JOB_FAILURES_KEY, "0")) + 1);
       } finally {
         try {
           troubleshooter.refineIssues();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
@@ -48,7 +48,10 @@ public class EmailNotificationJobListener extends AbstractJobListener {
 
     // Send out alert email if the maximum number of consecutive failures is reached
     if (jobState.getState() == JobState.RunningState.FAILED) {
-      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0) + jobContext.getDatasetStateFailures();
+      // Number of fail attempts are increased during the commit phase by changing JOB_FAILURES_KEY.
+      // But if the job fails before commit, e.g. during workunit creation, this config is not set,
+      // so it makes sense to set the default value to 1 when the job state is FAILED
+      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 1) + jobContext.getDatasetStateFailures();
       int maxFailures =
           jobState.getPropAsInt(ConfigurationKeys.JOB_MAX_FAILURES_KEY, ConfigurationKeys.DEFAULT_JOB_MAX_FAILURES);
       if (alertEmailEnabled && failures >= maxFailures) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/listeners/EmailNotificationJobListener.java
@@ -48,10 +48,7 @@ public class EmailNotificationJobListener extends AbstractJobListener {
 
     // Send out alert email if the maximum number of consecutive failures is reached
     if (jobState.getState() == JobState.RunningState.FAILED) {
-      // Number of fail attempts are increased during the commit phase by changing JOB_FAILURES_KEY.
-      // But if the job fails before commit, e.g. during workunit creation, this config is not set,
-      // so it makes sense to set the default value to 1 when the job state is FAILED
-      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 1) + jobContext.getDatasetStateFailures();
+      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0) + jobContext.getDatasetStateFailures();
       int maxFailures =
           jobState.getPropAsInt(ConfigurationKeys.JOB_MAX_FAILURES_KEY, ConfigurationKeys.DEFAULT_JOB_MAX_FAILURES);
       if (alertEmailEnabled && failures >= maxFailures) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1860


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When job fails during workunit creation, it sets the job state as FAILED, but does not set JOB_FAILURES_KEY.
It also does not have datasets created if it fails at such an early stage and the current code relies on dataset state's properties to find the failure count.
This PR will set the config JOB_FAILURES_KEY when the job fails.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

