### PR TITLE
[GOBBLIN-1862] Allow reference count to be 0 but no less

### DIFF
--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -217,7 +217,7 @@ public class KafkaAuditCountVerifier {
         throw new IOException(String.format("Reference tier %s audit count cannot be retrieved for dataset %s between %s and %s", refTier, datasetName, beginInMillis, endInMillis));
       }
       long refCount = countsByTier.get(refTier);
-      if(refCount < 0) {
+      if (refCount < 0) {
         throw new IOException(String.format("Reference tier %s count cannot be less than or equal to zero", refTier));
       }
     }

--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -217,8 +217,10 @@ public class KafkaAuditCountVerifier {
         throw new IOException(String.format("Reference tier %s audit count cannot be retrieved for dataset %s between %s and %s", refTier, datasetName, beginInMillis, endInMillis));
       }
       long refCount = countsByTier.get(refTier);
-      if (refCount < 0) {
-        throw new IOException(String.format("Reference tier %s count cannot be less than or equal to zero", refTier));
+      if (refCount == 0) {
+        log.warn(String.format("Reference tier %s audit count is reported to be zero", refCount));
+      } else if (refCount < 0) {
+        throw new IOException(String.format("Reference tier %s count cannot be less than zero", refTier));
       }
     }
   }

--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -218,6 +218,7 @@ public class KafkaAuditCountVerifier {
       }
       long refCount = countsByTier.get(refTier);
       if (refCount == 0) {
+        // If count in refTier is 0, it will be assumed that the data for that hour is completed and move the watermark forward.
         log.warn(String.format("Reference tier %s audit count is reported to be zero", refCount));
       } else if (refCount < 0) {
         throw new IOException(String.format("Reference tier %s count cannot be less than zero", refTier));

--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -217,7 +217,7 @@ public class KafkaAuditCountVerifier {
         throw new IOException(String.format("Reference tier %s audit count cannot be retrieved for dataset %s between %s and %s", refTier, datasetName, beginInMillis, endInMillis));
       }
       long refCount = countsByTier.get(refTier);
-      if(refCount <= 0) {
+      if(refCount < 0) {
         throw new IOException(String.format("Reference tier %s count cannot be less than or equal to zero", refTier));
       }
     }

--- a/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
+++ b/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
@@ -113,20 +113,6 @@ public class KafkaAuditCountVerifierTest {
     ));
     Assert.assertFalse(verifier.calculateCompleteness(topic, 0L, 0L)
         .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
-
-    // Check validation tiers for exceptions
-    client.setTierCounts(ImmutableMap.of(
-        SOURCE_TIER, 990L,
-        REFERENCE_TIERS, 0L,
-        TOTAL_COUNT_REF_TIER_0, 0L,
-        TOTAL_COUNT_REF_TIER_1, 0L
-    ));
-    try {
-      verifier.calculateCompleteness(topic, 0L, 0L)
-          .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness);
-    } catch (IOException e){
-      Assert.fail("Completeness calculation failure.");
-    }
   }
 
   public void testEmptyAuditCount() throws IOException {
@@ -148,5 +134,16 @@ public class KafkaAuditCountVerifierTest {
         .get(KafkaAuditCountVerifier.CompletenessType.ClassicCompleteness));
     Assert.assertTrue(verifier.calculateCompleteness(topic, 0L, 0L)
         .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
+
+    // Check validation tiers for exceptions
+    client.setTierCounts(
+        ImmutableMap.of(
+            SOURCE_TIER, 990L,
+            REFERENCE_TIERS, 0L,
+            TOTAL_COUNT_REF_TIER_0, 0L,
+            TOTAL_COUNT_REF_TIER_1, 0L
+        ));
+    Assert.assertTrue(verifier.calculateCompleteness(topic, 0L, 0L).get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
+    Assert.assertTrue(verifier.calculateCompleteness(topic, 0L, 0L).get(KafkaAuditCountVerifier.CompletenessType.ClassicCompleteness));
   }
 }

--- a/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
+++ b/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
@@ -26,8 +26,6 @@ import com.google.common.collect.ImmutableMap;
 
 import org.apache.gobblin.completeness.audit.TestAuditClient;
 import org.apache.gobblin.configuration.State;
-import org.testng.asserts.Assertion;
-
 
 @Test
 public class KafkaAuditCountVerifierTest {

--- a/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
+++ b/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
@@ -135,4 +135,12 @@ public class KafkaAuditCountVerifierTest {
     Assert.assertTrue(verifier.calculateCompleteness(topic, 0L, 0L)
         .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
   }
+
+  public void testDivideByDoubleZero() throws IOException {
+    double anyNumerator = 5;
+    double arithmeticDivide = anyNumerator/(double) 0;
+    double readDoubleValue = Double.POSITIVE_INFINITY;
+    Assert.assertEquals(arithmeticDivide, readDoubleValue);
+    Assert.assertTrue(arithmeticDivide > 0);
+  }
 }

--- a/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
+++ b/gobblin-completeness/src/test/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifierTest.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableMap;
 
 import org.apache.gobblin.completeness.audit.TestAuditClient;
 import org.apache.gobblin.configuration.State;
+import org.testng.asserts.Assertion;
+
 
 @Test
 public class KafkaAuditCountVerifierTest {
@@ -113,6 +115,20 @@ public class KafkaAuditCountVerifierTest {
     ));
     Assert.assertFalse(verifier.calculateCompleteness(topic, 0L, 0L)
         .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
+
+    // Check validation tiers for exceptions
+    client.setTierCounts(ImmutableMap.of(
+        SOURCE_TIER, 990L,
+        REFERENCE_TIERS, 0L,
+        TOTAL_COUNT_REF_TIER_0, 0L,
+        TOTAL_COUNT_REF_TIER_1, 0L
+    ));
+    try {
+      verifier.calculateCompleteness(topic, 0L, 0L)
+          .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness);
+    } catch (IOException e){
+      Assert.fail("Completeness calculation failure.");
+    }
   }
 
   public void testEmptyAuditCount() throws IOException {
@@ -134,13 +150,5 @@ public class KafkaAuditCountVerifierTest {
         .get(KafkaAuditCountVerifier.CompletenessType.ClassicCompleteness));
     Assert.assertTrue(verifier.calculateCompleteness(topic, 0L, 0L)
         .get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness));
-  }
-
-  public void testDivideByDoubleZero() throws IOException {
-    double anyNumerator = 5;
-    double arithmeticDivide = anyNumerator/(double) 0;
-    double readDoubleValue = Double.POSITIVE_INFINITY;
-    Assert.assertEquals(arithmeticDivide, readDoubleValue);
-    Assert.assertTrue(arithmeticDivide > 0);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1862] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1862


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Due to possible issues upstream reporting incorrect reference counts for number of records, there could be times when the reference count reported to be 0.
In the current case, if reference tier counter is reported to be 0 but there are counts in other PCM tiers, an exception is thrown, however is silently swallowed, thus, causing the watermark to not move forward in this case.
This PR fixes said issue, allowing reference count to be 0 but no less. For completeness percentage calculations in such cases, the completeness will be reported as positive infinity as any number divided by double 0 is positive infinity.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test added to check that no exceptions are encountered when reference count is 0

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

