### PR TITLE
[GOBBLIN-1866] Preserve sticky bit across distcp copies

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -417,7 +417,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
 
   static FsPermission addExecutePermissionToOwner(FsPermission fsPermission) {
     FsAction newOwnerAction = fsPermission.getUserAction().or(FsAction.EXECUTE);
-    return new FsPermission(newOwnerAction, fsPermission.getGroupAction(), fsPermission.getOtherAction());
+    return new FsPermission(newOwnerAction, fsPermission.getGroupAction(), fsPermission.getOtherAction(), fsPermission.getStickyBit());
   }
 
   @Override

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
@@ -574,22 +574,15 @@ public class FileAwareInputStreamDataWriterTest {
 
   @Test
   public void testAddExecutePermission() {
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("000")),
-        new FsPermission("100"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("100")),
-        new FsPermission("100"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("200")),
-        new FsPermission("300"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("400")),
-        new FsPermission("500"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("600")),
-        new FsPermission("700"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("700")),
-        new FsPermission("700"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("211")),
-        new FsPermission("311"));
-    Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission("250")),
-        new FsPermission("350"));
+    String[] setPermissions = {"000", "100", "200", "400", "600", "700", "211", "250"};
+    String[] expectPermissions = {"100", "100", "300", "500", "700", "700", "311", "350"};
+    String[] stickyBit = {"" ,"1"};
+    for (String bit : stickyBit) {
+      for (int index = 0; index < setPermissions.length; ++index) {
+        Assert.assertEquals(FileAwareInputStreamDataWriter.addExecutePermissionToOwner(new FsPermission(bit + setPermissions[index])),
+                new FsPermission(bit + expectPermissions[index]));
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following JIRA (https://issues.apache.org/jira/browse/GOBBLIN-1866) issues and references them in the PR title. 


### Description
Gobblin distcp copies the file permissions but not the sticky bit. As the expectation is that the destination files have preserved permissions from the source, we want to maintain the sticky bit across copies.


### Tests
-- Unit test to compare the input and output FsPermission with and without sticky bits with different permission modes
-- A workflow on HDFS where a  directory is copied from one location to another.

### Commits
☑︎ My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
   1. Subject is separated from body by a blank line
   2. Subject is limited to 50 characters
   3. Subject does not end with a period
   4. Subject uses the imperative mood ("add", not "adding")
   5. Body wraps at 72 characters
   6. Body explains "what" and "why", not "how"
