### PR TITLE
[GOBBLIN-1864] Catch exceptions if specific watermark calculation fails

### DIFF
--- a/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
+++ b/gobblin-completeness/src/main/java/org/apache/gobblin/completeness/verifier/KafkaAuditCountVerifier.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.completeness.verifier;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,10 +126,13 @@ public class KafkaAuditCountVerifier {
     countsByTier.forEach((x,y) -> log.info(String.format(" %s : %s ", x, y)));
 
     Map<CompletenessType, Boolean> result = new HashMap<>();
-    result.put(CompletenessType.ClassicCompleteness, calculateCompleteness(datasetName, beginInMillis, endInMillis,
-        CompletenessType.ClassicCompleteness, countsByTier) > threshold);
-    result.put(CompletenessType.TotalCountCompleteness, calculateCompleteness(datasetName, beginInMillis, endInMillis,
-        CompletenessType.TotalCountCompleteness, countsByTier) > threshold);
+    Arrays.stream(CompletenessType.values()).forEach(type -> {
+      try {
+        result.put(type, calculateCompleteness(datasetName, beginInMillis, endInMillis, type, countsByTier) > threshold);
+      } catch (IOException e) {
+        log.error("Failed to calculate completeness for type " + type, e);
+      }
+    });
     return result;
   }
 

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/CompletenessWatermarkUpdater.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/CompletenessWatermarkUpdater.java
@@ -230,7 +230,7 @@ public class CompletenessWatermarkUpdater {
     @Override
     protected void computeAndUpdateInternal(Map<KafkaAuditCountVerifier.CompletenessType, Boolean> results,
         ZonedDateTime timestampDT) {
-      if (!results.get(KafkaAuditCountVerifier.CompletenessType.ClassicCompleteness)) {
+      if (!results.getOrDefault(KafkaAuditCountVerifier.CompletenessType.ClassicCompleteness, false)) {
         return;
       }
 
@@ -261,7 +261,7 @@ public class CompletenessWatermarkUpdater {
     @Override
     protected void computeAndUpdateInternal(Map<KafkaAuditCountVerifier.CompletenessType, Boolean> results,
         ZonedDateTime timestampDT) {
-      if (!results.get(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness)) {
+      if (!results.getOrDefault(KafkaAuditCountVerifier.CompletenessType.TotalCountCompleteness, false)) {
         return;
       }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1864


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If one type of watermark calculation fails (e.g. due to missing tier, or count being 0) it causes all watermarks not to get updated. This PR allows watermarks to get updated individually to avoid blocking other ones if they are working correctly.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test which reproduces the issue

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

