### PR TITLE
[GOBBLIN-1865] Fix for job id tracking where configuration is unnecessary

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -36,7 +36,6 @@ import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.JobLauncherUtils;
-import org.apache.gobblin.util.PropertiesUtils;
 
 
 /**
@@ -96,17 +95,17 @@ public class HelixJobsMapping {
   }
 
   public static String createPlanningJobId (Properties jobPlanningProps) {
-    long planningJobId = PropertiesUtils.getPropAsBoolean(jobPlanningProps, GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "false") ?
-        System.currentTimeMillis() : PropertiesUtils.getPropAsLong(jobPlanningProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis());
+    String flowExecIdSuffix = jobPlanningProps.containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY) ?
+        "_" + jobPlanningProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY) : "";
     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.PLANNING_JOB_NAME_PREFIX
-            + JobState.getJobNameFromProps(jobPlanningProps), planningJobId);
+            + JobState.getJobNameFromProps(jobPlanningProps) + flowExecIdSuffix);
   }
 
   public static String createActualJobId (Properties jobProps) {
-    long actualJobId = PropertiesUtils.getPropAsBoolean(jobProps, GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "false") ?
-        System.currentTimeMillis() : PropertiesUtils.getPropAsLong(jobProps, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis());
+    String flowExecIdSuffix = jobProps.containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY) ?
+        "_" + jobProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY) : "";
     return JobLauncherUtils.newJobId(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX
-        + JobState.getJobNameFromProps(jobProps), actualJobId);
+        + JobState.getJobNameFromProps(jobProps) + flowExecIdSuffix);
   }
 
   @Nullable

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobMappingTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobMappingTest.java
@@ -34,20 +34,19 @@ public class GobblinHelixJobMappingTest {
     props.setProperty(ConfigurationKeys.JOB_NAME_KEY, "job1");
     String planningJobId = HelixJobsMapping.createPlanningJobId(props);
     String actualJobId = HelixJobsMapping.createActualJobId(props);
-    Assert.assertEquals(planningJobId, "job_PlanningJobjob1_1234");
-    Assert.assertEquals(actualJobId, "job_ActualJobjob1_1234");
+    // The jobID contains the system timestamp that we need to parse out
+    Assert.assertEquals(planningJobId.substring(0, planningJobId.lastIndexOf("_")), "job_PlanningJobjob1_1234");
+    Assert.assertEquals(actualJobId.substring(0, actualJobId.lastIndexOf("_")), "job_ActualJobjob1_1234");
   }
 
   @Test
-  void testMapJobNameWithOverride() {
+  void testMapJobNameWithoutFlowExecutionId() {
     Properties props = new Properties();
-    props.setProperty(GobblinClusterConfigurationKeys.USE_GENERATED_JOBEXECUTION_IDS, "true");
-    props.setProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, "1234");
     props.setProperty(ConfigurationKeys.JOB_NAME_KEY, "job1");
     String planningJobId = HelixJobsMapping.createPlanningJobId(props);
     String actualJobId = HelixJobsMapping.createActualJobId(props);
-    // The jobID will be the system timestamp instead of the flow execution ID
-    Assert.assertNotEquals(planningJobId, "job_PlanningJobjob1_1234");
-    Assert.assertNotEquals(actualJobId, "job_ActualJobjob1_1234");
+    // The jobID contains the system timestamp that we need to parse out
+    Assert.assertEquals(planningJobId.substring(0, planningJobId.lastIndexOf("_")), "job_PlanningJobjob1");
+    Assert.assertEquals(actualJobId.substring(0, actualJobId.lastIndexOf("_")), "job_ActualJobjob1");
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1865

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
With "gobblin.cluster.job.useGeneratedJobIds" configuration, jobs with that prefix should be using the system timestamp of Gobblin cluster instead of a provided flow execution ID.

Instead of this, it is more consistent to append flowExecutionId to a jobName then append a timestamp on top of that, so that all earlystop jobs relating to a flow execution can be tracked.

Now jobNames should have the following structure:
job_ActualJob<jobName><flowExecutionId><timestamp>

The timestamp is needed so that Helix can run concurrent jobs given a job ID.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

