### PR TITLE
[GOBBLIN-1872] Enable scheduler for non-leader in multi-active scheduler configuration

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -330,8 +330,9 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
         LOGGER.info("Leader lost notification for {} HM.isLeader {}", this.helixManager.get().getInstanceName(),
             this.helixManager.get().isLeader());
 
-        if (configuration.isSchedulerEnabled()) {
-          LOGGER.info("Gobblin Service is now running in slave instance mode, disabling Scheduler.");
+        if (configuration.isSchedulerEnabled() && !configuration.isMultiActiveSchedulerEnabled()) {
+          LOGGER.info("Gobblin Service is now running in non-leader mode without multi-active scheduler enabled, "
+              + "disabling Scheduler.");
           this.scheduler.setActive(false);
         }
 
@@ -473,7 +474,12 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
       } else {
         if (configuration.isSchedulerEnabled()) {
-          LOGGER.info("[Init] Gobblin Service is running in slave instance mode, not enabling Scheduler.");
+          if (configuration.isMultiActiveSchedulerEnabled()) {
+          LOGGER.info("[Init] Gobblin Service enabling scheduler for non-leader since multi-active scheduler enabled");
+          this.scheduler.setActive(true);
+          } else {
+          LOGGER.info("[Init] Gobblin Service is running in non-leader instance mode, not enabling Scheduler.");
+          }
         }
         if (helixLeaderGauges.isPresent()) {
           helixLeaderGauges.get().setState(LeaderState.SLAVE);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1872


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Set scheduler to active for all hosts when multi-active scheduler is enabled to allow hosts to use multi-active lease arbiter to handle flow triggers and ensure no missed flows and zero downtime.  

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

