### PR TITLE
[GOBBLIN-1875] Create Unique Trigger Keys 

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
@@ -273,7 +273,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
           ResultSet resultSet = getInfoStatement.executeQuery();
           try {
             if (!resultSet.next()) {
-              return Optional.absent();
+              return Optional.<GetEventInfoResult>absent();
             }
             return Optional.of(createGetInfoResult(resultSet));
           } finally {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -586,9 +587,13 @@ public class JobScheduler extends AbstractIdleService {
    * Get a {@link org.quartz.Trigger} from the given job configuration properties.
    */
   public static Trigger createTriggerForJob(JobKey jobKey, Properties jobProps) {
-    // Build a trigger for the job with the given cron-style schedule
+    Random random = new Random();
+    /*
+    Build a trigger for the job with the given cron-style schedule
+    Append a random integer to job name to be able to add multiple triggers associated with the same job.
+    */
     return TriggerBuilder.newTrigger()
-        .withIdentity(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY),
+        .withIdentity(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + random.nextInt(1000),
             Strings.nullToEmpty(jobProps.getProperty(ConfigurationKeys.JOB_GROUP_KEY)))
         .forJob(jobKey)
         .withSchedule(CronScheduleBuilder.cronSchedule(jobProps.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY)))

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
@@ -583,16 +583,13 @@ public class JobScheduler extends AbstractIdleService {
 
   /**
    * Get a {@link org.quartz.Trigger} from the given job configuration properties. If triggerSuffix is provided, appends
-   * it to the end of the flow name.
+   * it to the end of the flow name. The suffix is used to add multiple unique triggers associated with the same job
    */
   public static Trigger createTriggerForJob(JobKey jobKey, Properties jobProps, Optional<String> triggerSuffix) {
-    /*
-    Build a trigger for the job with the given cron-style schedule
-    Append a random integer to job name to be able to add multiple triggers associated with the same job.
-    */
+    // Build a trigger for the job with the given cron-style schedule
     return TriggerBuilder.newTrigger()
         .withIdentity(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY)
-                + (triggerSuffix.isPresent() ? "_" + triggerSuffix.get() : ""),
+            + triggerSuffix.transform(s -> "_" + s).or(""),
             Strings.nullToEmpty(jobProps.getProperty(ConfigurationKeys.JOB_GROUP_KEY)))
         .forJob(jobKey)
         .withSchedule(CronScheduleBuilder.cronSchedule(jobProps.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY)))

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 
 public class JobSchedulerTest {
+  // This test creates two triggers with the same job key and job props, then verifies the trigger keys are unique
   @Test
   public void testCreateUniqueTriggersForJob() {
     String jobName = "flow123";

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.scheduler;
 
+import com.google.common.base.Optional;
 import java.util.Properties;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.junit.Assert;
@@ -26,7 +27,8 @@ import org.testng.annotations.Test;
 
 
 public class JobSchedulerTest {
-  // This test creates two triggers with the same job key and job props, then verifies the trigger keys are unique
+  // This test creates two triggers with the same job key and job props, but one should have an extra value appended to
+  // it.
   @Test
   public void testCreateUniqueTriggersForJob() {
     String jobName = "flow123";
@@ -37,9 +39,10 @@ public class JobSchedulerTest {
     jobProps.put(ConfigurationKeys.JOB_GROUP_KEY, jobGroup);
     jobProps.put(ConfigurationKeys.JOB_SCHEDULE_KEY, "0/2 * * * * ?");
 
-    Trigger trigger1 = JobScheduler.createTriggerForJob(jobKey, jobProps);
-    Trigger trigger2 = JobScheduler.createTriggerForJob(jobKey, jobProps);
+    Trigger trigger1 = JobScheduler.createTriggerForJob(jobKey, jobProps, Optional.absent());
+    Trigger trigger2 = JobScheduler.createTriggerForJob(jobKey, jobProps, Optional.of("suffix"));
 
     Assert.assertTrue(trigger1.getKey() != trigger2.getKey());
+    Assert.assertTrue(trigger2.getKey().getName().endsWith("suffix"));
   }
 }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/scheduler/JobSchedulerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.scheduler;
+
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.junit.Assert;
+import org.quartz.JobKey;
+import org.quartz.Trigger;
+import org.testng.annotations.Test;
+
+
+public class JobSchedulerTest {
+  @Test
+  public void testCreateUniqueTriggersForJob() {
+    String jobName = "flow123";
+    String jobGroup = "groupA";
+    JobKey jobKey = new JobKey(jobName, jobGroup);
+    Properties jobProps = new Properties();
+    jobProps.put(ConfigurationKeys.JOB_NAME_KEY, jobName);
+    jobProps.put(ConfigurationKeys.JOB_GROUP_KEY, jobGroup);
+    jobProps.put(ConfigurationKeys.JOB_SCHEDULE_KEY, "0/2 * * * * ?");
+
+    Trigger trigger1 = JobScheduler.createTriggerForJob(jobKey, jobProps);
+    Trigger trigger2 = JobScheduler.createTriggerForJob(jobKey, jobProps);
+
+    Assert.assertTrue(trigger1.getKey() != trigger2.getKey());
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -201,7 +201,7 @@ public class FlowTriggerHandler {
    * @return
    */
   public static String createSuffixForJobTrigger(long eventToRevisitMillis) {
-    return "reminder_for_" + (eventToRevisitMillis);
+    return "reminder_for_" + eventToRevisitMillis;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -179,16 +179,29 @@ public class FlowTriggerHandler {
         String.valueOf(originalEventTimeMillis));
     JobKey key = new JobKey(flowAction.getFlowName(), flowAction.getFlowGroup());
     // Create a new trigger for the flow in job scheduler that is set to fire at the minimum reminder wait time calculated
-    Trigger trigger = JobScheduler.createTriggerForJob(key, jobProps);
+    Trigger trigger = JobScheduler.createTriggerForJob(key, jobProps,
+        Optional.of(createSuffixForJobTrigger(status.getEventTimeMillis())));
     try {
       log.info("Flow Trigger Handler - [{}, eventTimestamp: {}] -  attempting to schedule reminder for event {} in {} millis",
           flowAction, originalEventTimeMillis, status.getEventTimeMillis(), trigger.getNextFireTime());
       this.schedulerService.getScheduler().scheduleJob(trigger);
     } catch (SchedulerException e) {
-      log.warn("Failed to add job reminder due to SchedulerException for job {} trigger event {} ", key, status.getEventTimeMillis(), e);
+      log.warn("Failed to add job reminder due to SchedulerException for job {} trigger event {} ", key,
+          status.getEventTimeMillis(), e);
+      // TODO: emit a metric for failed job reminders
     }
     log.info(String.format("Flow Trigger Handler - [%s, eventTimestamp: %s] - SCHEDULED REMINDER for event %s in %s millis",
         flowAction, originalEventTimeMillis, status.getEventTimeMillis(), trigger.getNextFireTime()));
+  }
+
+  /**
+   * Create suffix to add to end of flow name to differentiate reminder triggers from the original job schedule trigger
+   * and ensure they are added to the scheduler.
+   * @param eventToRevisitMillis
+   * @return
+   */
+  public static String createSuffixForJobTrigger(long eventToRevisitMillis) {
+    return "reminder_for_" + (eventToRevisitMillis);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1875


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We are seeing the following errors when trying to schedule reminders for Multi-active scheduler after losing lease acquisition:
`Unable to store Trigger with name: '...' and group: '...' because one already exists with this identification`
The Quartz scheduler allows multiple unique triggers mapping to one job in a N:1 relation, but this requires the trigger having a unique identifier associated with it. When we create triggers, we were previously using only the job name and group to identify the trigger so we're unable to add additional triggers for the same job. The trigger key is only used internally by the Quartz scheduler, so it is safe to manipulate by adding a random number to identify the trigger. We also don't expect more than a handful of triggers associated with a job, so an int 0 to 1000 will be sufficient to uniquely identify the trigger.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`testCreateUniqueTriggersForJob` creates two triggers with the same job key and verifies the trigger key's are unique

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

