### PR TITLE
[GOBBLIN-1876] Kafka source / extractor utility to get a simple name for kafka brokers

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -916,6 +916,7 @@ public class ConfigurationKeys {
    * Kafka job configurations.
    */
   public static final String KAFKA_BROKERS = "kafka.brokers";
+  public static final String KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY = ConfigurationKeys.KAFKA_BROKERS + ".simpleNameMap";
   public static final String KAFKA_SOURCE_WORK_UNITS_CREATION_THREADS = "kafka.source.work.units.creation.threads";
   public static final int KAFKA_SOURCE_WORK_UNITS_CREATION_DEFAULT_THREAD_COUNT = 30;
   public static final String KAFKA_SOURCE_SHARE_CONSUMER_CLIENT = "kafka.source.shareConsumerClient";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -916,7 +916,7 @@ public class ConfigurationKeys {
    * Kafka job configurations.
    */
   public static final String KAFKA_BROKERS = "kafka.brokers";
-  public static final String KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY = ConfigurationKeys.KAFKA_BROKERS + ".simpleNameMap";
+  public static final String KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY = ConfigurationKeys.KAFKA_BROKERS + "ToSimpleNameMap";
   public static final String KAFKA_SOURCE_WORK_UNITS_CREATION_THREADS = "kafka.source.work.units.creation.threads";
   public static final int KAFKA_SOURCE_WORK_UNITS_CREATION_DEFAULT_THREAD_COUNT = 30;
   public static final String KAFKA_SOURCE_SHARE_CONSUMER_CLIENT = "kafka.source.shareConsumerClient";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -916,7 +916,7 @@ public class ConfigurationKeys {
    * Kafka job configurations.
    */
   public static final String KAFKA_BROKERS = "kafka.brokers";
-  public static final String KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY = ConfigurationKeys.KAFKA_BROKERS + "ToSimpleNameMap";
+  public static final String KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY = "kafka.brokersToSimpleNameMap";
   public static final String KAFKA_SOURCE_WORK_UNITS_CREATION_THREADS = "kafka.source.work.units.creation.threads";
   public static final int KAFKA_SOURCE_WORK_UNITS_CREATION_DEFAULT_THREAD_COUNT = 30;
   public static final String KAFKA_SOURCE_SHARE_CONSUMER_CLIENT = "kafka.source.shareConsumerClient";

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
@@ -32,7 +32,7 @@ import com.google.common.base.Splitter;
 
 import org.apache.gobblin.configuration.State;
 
-import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY;
+import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY;
 
 
 public class KafkaCommonUtil {
@@ -72,9 +72,9 @@ public class KafkaCommonUtil {
   }
 
   public static Map<String, String> getKafkaBrokerToSimpleNameMap(State state) {
-    Preconditions.checkArgument(state.contains(KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY),
-        String.format("Configuration must contain value for %s", KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY));
-    String mapStr = state.getProp(KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY);
+    Preconditions.checkArgument(state.contains(KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY),
+        String.format("Configuration must contain value for %s", KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY));
+    String mapStr = state.getProp(KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY);
     Map<String, String> kafkaBrokerUriToSimpleName = new HashMap<>();
     for (String entry : LIST_SPLITTER.splitToList(mapStr)) {
       String[] items = entry.trim().split(MAP_KEY_VALUE_DELIMITER_KEY);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
@@ -30,14 +30,11 @@ import java.util.concurrent.TimeoutException;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.configuration.State;
 
 import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY;
 
 
-@Slf4j
 public class KafkaCommonUtil {
   public static final long KAFKA_FLUSH_TIMEOUT_SECONDS = 15L;
   public static final String MAP_KEY_VALUE_DELIMITER_KEY = "->";

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/KafkaCommonUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.gobblin;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -25,9 +27,21 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.State;
+
+import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY;
+
+
+@Slf4j
 public class KafkaCommonUtil {
   public static final long KAFKA_FLUSH_TIMEOUT_SECONDS = 15L;
+  public static final String MAP_KEY_VALUE_DELIMITER_KEY = "->";
+  public static final Splitter LIST_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings();
 
   public static void runWithTimeout(final Runnable runnable, long timeout, TimeUnit timeUnit) throws Exception {
     runWithTimeout(() -> {
@@ -58,5 +72,18 @@ public class KafkaCommonUtil {
         throw new IllegalStateException(t);
       }
     }
+  }
+
+  public static Map<String, String> getKafkaBrokerToSimpleNameMap(State state) {
+    Preconditions.checkArgument(state.contains(KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY),
+        String.format("Configuration must contain value for %s", KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY));
+    String mapStr = state.getProp(KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY);
+    Map<String, String> kafkaBrokerUriToSimpleName = new HashMap<>();
+    for (String entry : LIST_SPLITTER.splitToList(mapStr)) {
+      String[] items = entry.trim().split(MAP_KEY_VALUE_DELIMITER_KEY);
+      kafkaBrokerUriToSimpleName.put(items[0], items[1]);
+    }
+
+    return kafkaBrokerUriToSimpleName;
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -50,7 +50,7 @@ import org.apache.gobblin.source.extractor.extract.EventBasedExtractor;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY;
+import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY;
 
 
 /**
@@ -356,7 +356,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
 
     Preconditions.checkArgument(brokerToSimpleName.get(brokerUri) != null,
         String.format("Unable to find simple name for the kafka cluster broker uri in the config. Please check the map "
-            + "value of %s. brokerUri=%s, configMapValue=%s", KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, brokerUri, brokerToSimpleName));
+            + "value of %s. brokerUri=%s, configMapValue=%s", KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY, brokerUri, brokerToSimpleName));
 
     return brokerToSimpleName.get(brokerUri);
   }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Maps;
 
 import lombok.Getter;
 
+import org.apache.gobblin.KafkaCommonUtil;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -48,6 +49,8 @@ import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.extractor.extract.EventBasedExtractor;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
+
+import static org.apache.gobblin.configuration.ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY;
 
 
 /**
@@ -336,5 +339,25 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   @Override
   public long getHighWatermark() {
     return 0;
+  }
+
+  public static String getKafkaBrokerSimpleName(State state) {
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.KAFKA_BROKERS), String.format("%s is not defined in"
+            + " the configuration.", ConfigurationKeys.KAFKA_BROKERS));
+    List<String> kafkaBrokerUriList = state.getPropAsList(ConfigurationKeys.KAFKA_BROKERS);
+    Preconditions.checkArgument(kafkaBrokerUriList.size() == 1,
+        String.format("The %s only supports having exactly one kafka broker defined for %s. "
+                + "This is partially because the watermark implementation (e.g. %s class) does not have a schema that supports writing watermarks that contains offsets "
+                + "from multiple brokers in a single job", KafkaExtractor.class.getSimpleName(),
+            ConfigurationKeys.KAFKA_BROKERS, KafkaStreamingExtractor.KafkaWatermark.class.getName()));
+
+    String brokerUri = kafkaBrokerUriList.get(0);
+    Map<String, String> brokerToSimpleName = KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state);
+
+    Preconditions.checkArgument(brokerToSimpleName.get(brokerUri) != null,
+        String.format("Unable to find simple name for the kafka cluster broker uri in the config. Please check the map "
+            + "value of %s. brokerUri=%s, configMapValue=%s", KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, brokerUri, brokerToSimpleName));
+
+    return brokerToSimpleName.get(brokerUri);
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/KafkaCommonUtilTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/KafkaCommonUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+
+
+public class KafkaCommonUtilTest {
+
+  @Test
+  public void testGetKafkaBrokerToSimpleNameMap() {
+    String brokerUri =  "kafka.some-identifier.kafka.coloc-123.com:12345";
+    String simpleName = "some-identifier";
+
+    State state = new State();
+    Assert.assertThrows(IllegalArgumentException.class, () -> KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state));
+
+    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s", brokerUri, simpleName));
+    Assert.assertEquals(KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state),
+        ImmutableMap.of(brokerUri, simpleName));
+
+    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY,
+        String.format("foobar.com:12345->foobar,%s->%s", brokerUri, simpleName));
+    Assert.assertEquals(KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state),
+        ImmutableMap.of(brokerUri, simpleName, "foobar.com:12345", "foobar"));
+  }
+}

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/KafkaCommonUtilTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/KafkaCommonUtilTest.java
@@ -36,11 +36,11 @@ public class KafkaCommonUtilTest {
     State state = new State();
     Assert.assertThrows(IllegalArgumentException.class, () -> KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state));
 
-    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s", brokerUri, simpleName));
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s", brokerUri, simpleName));
     Assert.assertEquals(KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state),
         ImmutableMap.of(brokerUri, simpleName));
 
-    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY,
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY,
         String.format("foobar.com:12345->foobar,%s->%s", brokerUri, simpleName));
     Assert.assertEquals(KafkaCommonUtil.getKafkaBrokerToSimpleNameMap(state),
         ImmutableMap.of(brokerUri, simpleName, "foobar.com:12345", "foobar"));

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
@@ -42,10 +42,10 @@ public class KafkaExtractorTest {
     state.setProp(ConfigurationKeys.KAFKA_BROKERS, kafkaBrokerUri);
     Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
 
-    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY, String.format("foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
     Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
 
-    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s,foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s,foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
     Assert.assertEquals(KafkaExtractor.getKafkaBrokerSimpleName(state), kafkaBrokerSimpleName);
   }
 
@@ -53,10 +53,10 @@ public class KafkaExtractorTest {
   public void testSimpleMapKeyIsBackwardCompatible() {
     Config cfg = ConfigFactory.empty()
         .withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("kafkaBrokerUri"))
-        .withValue(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY,
+        .withValue(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY,
             ConfigValueFactory.fromAnyRef("kafkaBrokerUri->simpleName"));
 
     Assert.assertEquals(cfg.getString(ConfigurationKeys.KAFKA_BROKERS), "kafkaBrokerUri");
-    Assert.assertEquals(cfg.getString(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY), "kafkaBrokerUri->simpleName");
+    Assert.assertEquals(cfg.getString(ConfigurationKeys.KAFKA_BROKERS_TO_SIMPLE_NAME_MAP_KEY), "kafkaBrokerUri->simpleName");
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.source.extractor.extract.kafka;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+
+
+public class KafkaExtractorTest {
+
+  @Test
+  public void testGetKafkaBrokerSimpleName() {
+    State state = new State();
+    Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS, "");
+    Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
+
+    final String kafkaBrokerUri = "kafka.broker.uri.com:12345";
+    final String kafkaBrokerSimpleName = "simple.kafka.name";
+    state.setProp(ConfigurationKeys.KAFKA_BROKERS, kafkaBrokerUri);
+    Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
+
+    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
+    Assert.assertThrows(IllegalArgumentException.class, () -> KafkaExtractor.getKafkaBrokerSimpleName(state));
+
+    state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s,foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
+    Assert.assertEquals(KafkaExtractor.getKafkaBrokerSimpleName(state), kafkaBrokerSimpleName);
+
+  }
+}

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java
@@ -20,6 +20,10 @@ package org.apache.gobblin.source.extractor.extract.kafka;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 
@@ -43,6 +47,16 @@ public class KafkaExtractorTest {
 
     state.setProp(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY, String.format("%s->%s,foobar->foobarId", kafkaBrokerUri, kafkaBrokerSimpleName));
     Assert.assertEquals(KafkaExtractor.getKafkaBrokerSimpleName(state), kafkaBrokerSimpleName);
+  }
 
+  @Test
+  public void testSimpleMapKeyIsBackwardCompatible() {
+    Config cfg = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.KAFKA_BROKERS, ConfigValueFactory.fromAnyRef("kafkaBrokerUri"))
+        .withValue(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY,
+            ConfigValueFactory.fromAnyRef("kafkaBrokerUri->simpleName"));
+
+    Assert.assertEquals(cfg.getString(ConfigurationKeys.KAFKA_BROKERS), "kafkaBrokerUri");
+    Assert.assertEquals(cfg.getString(ConfigurationKeys.KAFKA_BROKER_TO_SIMPLE_NAME_MAP_KEY), "kafkaBrokerUri->simpleName");
   }
 }


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX



### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Gobblin has the ability to process records from multiple kafka brokers, across multiple *.conf files and *.job files. But the tracking metadata / observability does a poor job of specifying which broker the events correspond to.

This is because Gobblin was written with the assumption that it would consume from a single aggregate kafka broker (e.g. brooklin). But going forward, we want to add support for multiple *.conf files each with their own kafka broker. This change adds a utility for mapping the different Kafka broker URI's to a simple human readable name that can be used within `GobblinTrackingEvent` and `GobblinMetadataChangeEvent`s for Iceberg data loss tracking.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/KafkaCommonUtilTest.java`
- tests that the map parsing works correctly
`gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorTest.java`
- Tests the assumptions error codes for having exactly one `kafka.brokers` specified, and that the simple name map is defined with the kafka broker specified in `kafka.brokers` is also defined in the map. 


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

