### PR TITLE
Enhance `ManifestBasedDatasetFinder` with config for specifying an alt. FS solely for reading manifests

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDatasetFinder.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,6 +37,7 @@ import com.google.common.base.Splitter;
 import org.apache.gobblin.dataset.IterableDatasetFinder;
 
 
+@Slf4j
 public class ManifestBasedDatasetFinder implements IterableDatasetFinder<ManifestBasedDataset> {
 
   public static final String CONFIG_PREFIX = CopyConfiguration.COPY_PREFIX + ".manifestBased";
@@ -54,6 +56,7 @@ public class ManifestBasedDatasetFinder implements IterableDatasetFinder<Manifes
       this.manifestReadFs = optManifestReadFsUriStr.isPresent()
           ? FileSystem.get(URI.create(optManifestReadFsUriStr.get()), new Configuration())
           : srcFs;
+      log.info("using file system to read manifest files: '{}'", this.manifestReadFs.getUri());
     } catch (final IOException | IllegalArgumentException e) {
       throw new RuntimeException("unable to create manifest-loading FS at URI '" + optManifestReadFsUriStr + "'", e);
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1877


### Description
Manifest-based copy (FS distcp) shouldn't presume the manifest files to be on the same FileSystem used as the I/O source to copy from.  Instead allow optional config to provide an alternative solely for reading manifest files (enumerating filepaths).

Proposed config: `gobblin.copy.manifestBased.read.fs.uri` (after `gobblin.copy.manifestBased.manifest.location`, and `source.filebased.fs.uri`)

### Tests
Improved `ManifestBasedDatasetFinderTest`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

