### PR TITLE
GOBBLIN-1879: Add a new unit count field in CopyManifest

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/TestCopyManifest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/TestCopyManifest.java
@@ -43,8 +43,8 @@ public class TestCopyManifest {
         getClass().getClassLoader().getResource("manifestBasedDistcpTest/sampleManifest.json").getPath();
 
     CopyManifest manifest = CopyManifest.read(localFs, new Path(manifestPath));
-    Assert.assertEquals(manifest._copyableUnits.size(), 2);
-    CopyManifest.CopyableUnit cu = manifest._copyableUnits.get(0);
+    Assert.assertEquals(manifest.copyableUnits.size(), 2);
+    CopyManifest.CopyableUnit cu = manifest.copyableUnits.get(0);
     Assert.assertEquals(cu.fileName, "/tmp/dataset/test1.txt");
   }
 
@@ -53,12 +53,15 @@ public class TestCopyManifest {
     File tmpDir = Files.createTempDir();
     Path output = new Path(tmpDir.getAbsolutePath(), "test");
     CopyManifest manifest = new CopyManifest();
-    manifest.add(new CopyManifest.CopyableUnit("testfilename", null, null, null));
+    manifest.add(new CopyManifest.CopyableUnit("testfilename1", null, null, null));
+    manifest.add(new CopyManifest.CopyableUnit("testfilename2", null, null, null));
     manifest.write(localFs, output);
 
     CopyManifest readManifest = CopyManifest.read(localFs, output);
-    Assert.assertEquals(readManifest._copyableUnits.size(), 1);
-    Assert.assertEquals(readManifest._copyableUnits.get(0).fileName, "testfilename");
+    Assert.assertEquals(readManifest.unitCount.intValue(), readManifest.copyableUnits.size());
+    Assert.assertEquals(readManifest.copyableUnits.size(), 2);
+    Assert.assertEquals(readManifest.copyableUnits.get(0).fileName, "testfilename1");
+    Assert.assertEquals(readManifest.copyableUnits.get(1).fileName, "testfilename2");
   }
 
   @Test
@@ -73,12 +76,12 @@ public class TestCopyManifest {
     int count = 0;
     while (manifestIterator.hasNext()) {
       CopyManifest.CopyableUnit cu = manifestIterator.next();
-      Assert.assertEquals(cu.fileName, manifest._copyableUnits.get(count).fileName);
-      Assert.assertEquals(cu.fileGroup, manifest._copyableUnits.get(count).fileGroup);
+      Assert.assertEquals(cu.fileName, manifest.copyableUnits.get(count).fileName);
+      Assert.assertEquals(cu.fileGroup, manifest.copyableUnits.get(count).fileGroup);
       count++;
     }
     Assert.assertEquals(count, 2);
-    Assert.assertEquals(count, manifest._copyableUnits.size());
+    Assert.assertEquals(count, manifest.copyableUnits.size());
     manifestIterator.close();
   }
 

--- a/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/missingFileNameManifest.json
+++ b/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/missingFileNameManifest.json
@@ -1,7 +1,10 @@
-[
-  {
-    "id":"1",
-    "fileGroup":"/tmp/dataset",
-    "fileSizeInBytes":"1024"
-  }
-]
+{
+  "unitCount": 1,
+  "copyableUnits": [
+    {
+      "id":"1",
+      "fileGroup":"/tmp/dataset",
+      "fileSizeInBytes":"1024"
+    }
+  ]
+}

--- a/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/sampleManifest.json
+++ b/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/sampleManifest.json
@@ -1,14 +1,17 @@
-[
-  {
-    "id":"1",
-    "fileName":"/tmp/dataset/test1.txt",
-    "fileGroup":"/tmp/dataset",
-    "fileSizeInBytes":"1024"
-  },
-  {
-    "id":"2",
-    "fileName":"/tmp/dataset/test2.txt",
-    "fileGroup":"/tmp/dataset1",
-    "fileSizeInBytes":"1028"
-  }
-]
+{
+  "unitCount": 2,
+  "copyableUnits": [
+    {
+      "id": "1",
+      "fileName": "/tmp/dataset/test1.txt",
+      "fileGroup": "/tmp/dataset",
+      "fileSizeInBytes": "1024"
+    },
+    {
+      "id": "2",
+      "fileName": "/tmp/dataset/test2.txt",
+      "fileGroup": "/tmp/dataset1",
+      "fileSizeInBytes": "1028"
+    }
+  ]
+}


### PR DESCRIPTION
We need to know how many files within a manifest, add a new field and changed the json schema.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

