### PR TITLE
replace job props upon setting reminder scheduler event

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -34,10 +34,14 @@ public class ServiceMetricNames {
   public static final String FLOW_ORCHESTRATION_TIMER = GOBBLIN_SERVICE_PREFIX + ".flowOrchestration.time";
   public static final String FLOW_ORCHESTRATION_DELAY = GOBBLIN_SERVICE_PREFIX + ".flowOrchestration.delay";
 
-  // Flow Trigger Handler Lease Status Counts
-  public static final String FLOW_TRIGGER_HANDLER_LEASE_OBTAINED_COUNT = GOBBLIN_SERVICE_PREFIX + ".flowTriggerHandler.leaseObtained";
-  public static final String FLOW_TRIGGER_HANDLER_LEASED_TO_ANOTHER_COUNT = GOBBLIN_SERVICE_PREFIX + ".flowTriggerHandler.leasedToAnother";
-  public static final String FLOW_TRIGGER_HANDLER_NO_LONGER_LEASING_COUNT = GOBBLIN_SERVICE_PREFIX + ".flowTriggerHandler.noLongerLeasing";
+  // Flow Trigger Handler
+  public static final String FLOW_TRIGGER_HANDLER_PREFIX = "flowTriggerHandler";
+  public static final String GOBBLIN_FLOW_TRIGGER_HANDLER_NUM_FLOWS_SUBMITTED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".numFlowsSubmitted";
+  public static final String FLOW_TRIGGER_HANDLER_LEASE_OBTAINED_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".leaseObtained";
+  public static final String FLOW_TRIGGER_HANDLER_LEASED_TO_ANOTHER_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".leasedToAnother";
+  public static final String FLOW_TRIGGER_HANDLER_NO_LONGER_LEASING_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".noLongerLeasing";
+  public static final String FLOW_TRIGGER_HANDLER_JOB_DOES_NOT_EXIST_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".jobDoesNotExistInScheduler";
+  public static final String FLOW_TRIGGER_HANDLER_FAILED_TO_SET_REMINDER_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".failedToSetReminderCount";
 
   //Job status poll timer
   public static final String JOB_STATUS_POLLED_TIMER = GOBBLIN_SERVICE_PREFIX + ".jobStatusPoll.time";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -73,8 +73,7 @@ public class RuntimeMetrics {
   public static final String GOBBLIN_JOB_SCHEDULER_TOTAL_GET_SPEC_TIME_NANOS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".jobScheduler.totalGetSpecTimeNanos";
   public static final String GOBBLIN_JOB_SCHEDULER_TOTAL_ADD_SPEC_TIME_NANOS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".jobScheduler.totalAddSpecTimeNanos";
   public static final String GOBBLIN_JOB_SCHEDULER_NUM_JOBS_SCHEDULED_DURING_STARTUP = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".jobScheduler.numJobsScheduledDuringStartup";
-  // Metrics Used to Track flowTriggerHandlerProgress
-  public static final String GOBBLIN_FLOW_TRIGGER_HANDLER_NUM_FLOWS_SUBMITTED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".flowTriggerHandler.numFlowsSubmitted";
+
   // Metadata keys
   public static final String TOPIC = "topic";
   public static final String GROUP_ID = "groupId";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -497,6 +497,7 @@ public class DagManager extends AbstractIdleService {
     FlowId flowId = action.getFlowId();
     FlowSpec spec;
     try {
+      log.info("Handle launch flow event for action: {}", action);
       URI flowUri = FlowSpec.Utils.createFlowSpecUri(flowId);
       spec = (FlowSpec) flowCatalog.getSpecs(flowUri);
       Optional<Dag<JobExecutionPlan>> optionalJobExecutionPlanDag =

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -24,8 +24,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Random;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -175,7 +175,8 @@ public class FlowTriggerHandler {
     JobKey key = new JobKey(flowAction.getFlowName(), flowAction.getFlowGroup());
     try {
       if (!this.schedulerService.getScheduler().checkExists(key)) {
-        log.warn("Attempting to set a reminder for a job that does not exist in the scheduler. Key: {}", key);
+        log.warn("Attempting to set a reminder for a job that does not exist in the scheduler that may result in a "
+            + "duplicate job added to scheduler. Key: {}", key);
         this.jobDoesNotExistInSchedulerCount.inc();
       }
       JobDetailImpl prevJobDetail = (JobDetailImpl) this.schedulerService.getScheduler().getJobDetail(key);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration;
+
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
+import org.junit.Assert;
+import org.quartz.JobDataMap;
+import org.testng.annotations.Test;
+
+
+public class FlowTriggerHandlerTest {
+  String newCronExpression = "0 0 0 ? * * 2024";
+  long newEventToRevisit = 123L;
+  long newEventToTrigger = 456L;
+
+  /**
+   * Provides an input with all three values (cronExpression, reminderTimestamp, originalEventTime) set in the map
+   * Properties and checks that they are updated properly
+   */
+  @Test
+  public void testUpdatePropsInJobDataMap() {
+    JobDataMap oldJobDataMap = new JobDataMap();
+    Properties originalProperties = new Properties();
+    originalProperties.setProperty(ConfigurationKeys.JOB_SCHEDULE_KEY, "0 0 0 ? * * 2050");
+    originalProperties.setProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY, "0");
+    originalProperties.setProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY, "1");
+    oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+
+    JobDataMap newJobDataMap = FlowTriggerHandler.updatePropsInJobDataMap(oldJobDataMap, newCronExpression,
+        newEventToRevisit, newEventToTrigger);
+    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertEquals(newCronExpression, newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));
+    Assert.assertEquals(String.valueOf(newEventToRevisit),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY));
+    Assert.assertEquals(String.valueOf(newEventToTrigger),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY));
+  }
+
+  /**
+   * Provides input with an empty Properties object and checks that the three values in question are set.
+   */
+  @Test
+  public void testSetPropsInJobDataMap() {
+    JobDataMap oldJobDataMap = new JobDataMap();
+    Properties originalProperties = new Properties();
+    oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+    
+    JobDataMap newJobDataMap = FlowTriggerHandler.updatePropsInJobDataMap(oldJobDataMap, newCronExpression,
+        newEventToRevisit, newEventToTrigger);
+    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertEquals(newCronExpression, newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));
+    Assert.assertEquals(String.valueOf(newEventToRevisit),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY));
+    Assert.assertEquals(String.valueOf(newEventToTrigger),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY));
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1881 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The following error is thrown when attempting to schedule reminder events. 
```
{{The job ... referenced by the trigger does not exist.","stackTrace":[
{"index":0,"call":"storeTrigger","columnNumber":null,"fileName":"RAMJobStore.java","lineNumber":422,"nativeMethod":"0","source":"org.quartz.simpl.RAMJobStore"}
,
{"index":1,"call":"scheduleJob","columnNumber":null,"fileName":"QuartzScheduler.java","lineNumber":932,"nativeMethod":"0","source":"org.quartz.core.QuartzScheduler"}
,
{"index":2,"call":"scheduleJob","columnNumber":null,"fileName":"StdScheduler.java","lineNumber":258,"nativeMethod":"0","source":"org.quartz.impl.StdScheduler"}
,
{"index":3,"call":"scheduleReminderForEvent","columnNumber":null,"fileName":"FlowTriggerHandler.java","lineNumber":187,"nativeMethod":"0","source":"org.apache.gobblin.service.modules.orchestration.FlowTriggerHandler"}
,
{"index":4,"call":"handleTriggerEvent","columnNumber":null,"fileName":"FlowTriggerHandler.java","lineNumber":124,"nativeMethod":"0","source":"org.apache.gobblin.service.modules.orchestration.FlowTriggerHandler"}
,
{"index":5,"call":"orchestrate","columnNumber":null,"fileName":"Orchestrator.java","lineNumber":267,"nativeMethod":"0","source":"org.apache.gobblin.service.modules.orchestration.Orchestrator"}
,{"index":6,"call":"runJob","columnNumber":null,"fileName":"GobblinServiceJobScheduler.java","lineNumber":47}}
```
 
The issue above from FlowTriggerHandler reveals two problems

- The job referenced is not found by scheduler -> The job key is constructed with flow name/group instead of job name/group, which is probably causing this issue. We add a check for if this happens by searching for the jobKey within the scheduler and emit a metric in case we encounter it in the future. 
- Upon looking closely at the code, we also need to update the job props of the job in the scheduler to keep track of the event to set reminder for. The job props we set [here](https://github.com/apache/gobblin/blob/69d7e0fa4df2499934462854514ddc9ddbfe7dc7/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java#L176) are never used in [createTriggerForJob](https://github.com/apache/gobblin/blob/69d7e0fa4df2499934462854514ddc9ddbfe7dc7/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java#L588) We want to use `StdScheduler.scheduleJob(JobDetail jobDetail, Set<? extends Trigger> triggersForJob, boolean replace)` to replace the `jobDetail` we construct when making a reminder event.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests static helper function to update job properties in JobDataMap with two types of input
- testUpdatePropsInJobDataMap
- testSetPropsInJobDataMap

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

