### PR TITLE
[GOBBLIN-1884] Delete Dag Action After Loading from Store Upon Startup

### DIFF
--- a/FlowTriggerHandlerTest.java
+++ b/FlowTriggerHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration;
+
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
+import org.junit.Assert;
+import org.quartz.JobDataMap;
+import org.testng.annotations.Test;
+
+
+public class FlowTriggerHandlerTest {
+  String newCronExpression = "0 0 0 ? * * 2024";
+  long newEventToRevisit = 123L;
+  long newEventToTrigger = 456L;
+
+  /**
+   * Provides an input with all three values (cronExpression, reminderTimestamp, originalEventTime) set in the map
+   * Properties and checks that they are updated properly
+   */
+  @Test
+  public void testUpdatePropsInJobDataMap() {
+    JobDataMap oldJobDataMap = new JobDataMap();
+    Properties originalProperties = new Properties();
+    originalProperties.setProperty(ConfigurationKeys.JOB_SCHEDULE_KEY, "0 0 0 ? * * 2050");
+    originalProperties.setProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY, "0");
+    originalProperties.setProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY, "1");
+    oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+
+    JobDataMap newJobDataMap = FlowTriggerHandler.updatePropsInJobDataMap(oldJobDataMap, newCronExpression,
+        newEventToRevisit, newEventToTrigger);
+    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertEquals(newCronExpression, newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));
+    Assert.assertEquals(String.valueOf(newEventToRevisit),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY));
+    Assert.assertEquals(String.valueOf(newEventToTrigger),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY));
+  }
+
+  /**
+   * Provides input with an empty Properties object and checks that the three values in question are set.
+   */
+  @Test
+  public void testSetPropsInJobDataMap() {
+    JobDataMap oldJobDataMap = new JobDataMap();
+    Properties originalProperties = new Properties();
+    oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+    
+    JobDataMap newJobDataMap = FlowTriggerHandler.updatePropsInJobDataMap(oldJobDataMap, newCronExpression,
+        newEventToRevisit, newEventToTrigger);
+    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertEquals(newCronExpression, newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));
+    Assert.assertEquals(String.valueOf(newEventToRevisit),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_REVISIT_TIMESTAMP_MILLIS_KEY));
+    Assert.assertEquals(String.valueOf(newEventToTrigger),
+        newProperties.getProperty(ConfigurationKeys.SCHEDULER_EVENT_TO_TRIGGER_TIMESTAMP_MILLIS_KEY));
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -494,6 +494,7 @@ public class DagManager extends AbstractIdleService {
    * the process.
    */
   public void handleLaunchFlowEvent(DagActionStore.DagAction action) {
+    log.info("Handle launch flow event for action {}", action);
     FlowId flowId = action.getFlowId();
     FlowSpec spec;
     try {
@@ -505,12 +506,15 @@ public class DagManager extends AbstractIdleService {
       if (optionalJobExecutionPlanDag.isPresent()) {
         addDag(optionalJobExecutionPlanDag.get(), true, true);
       }
+      // Upon handling the action, delete it so on leadership change this is not duplicated
+      this.dagActionStore.get().deleteDagAction(action);
     } catch (URISyntaxException e) {
       log.warn("Could not create URI object for flowId {} due to exception {}", flowId, e.getMessage());
     } catch (SpecNotFoundException e) {
       log.warn("Spec not found for flowId {} due to exception {}", flowId, e.getMessage());
     } catch (IOException e) {
-      log.warn("Failed to add Job Execution Plan for flowId {} due to exception {}", flowId, e.getMessage());
+      log.warn("Failed to add Job Execution Plan for flowId {} OR delete dag action from dagActionStore due to "
+          + "exception {}", flowId, e.getMessage());
     } catch (InterruptedException e) {
       log.warn("SpecCompiler failed to reach healthy state before compilation of flowId {}. Exception: ", flowId, e);
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1884


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
There is a bug in which launch actions get accumulated and "stuck" in the dag action store, so every time a leader is changed or the service is re-deployed we will keep redoing old launch actions again and again. 
*Also includes a few refactoring improvements to the `FlowTriggerHandler` to make it more readable and ensure the right `JobKey` when adding trigger reminders to the `Scheduler`.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

