### PR TITLE
[GOBBLIN-1890] Offset ranges allow multiple formats GMIP

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -267,14 +267,15 @@ public class HiveMetadataWriter implements MetadataWriter {
   }
 
   @Nullable
-  private String getTopicName(GobblinMetadataChangeEvent gmce) {
+  protected String getTopicName(GobblinMetadataChangeEvent gmce) {
     //Calculate the topic name from gmce, fall back to topic.name in hive spec which can also be null
     //todo: make topicName fall back to topic.name in hive spec so that we can also get schema for re-write operation
     String topicName = null;
     if (gmce.getTopicPartitionOffsetsRange() != null && !gmce.getTopicPartitionOffsetsRange().isEmpty()) {
       String topicPartitionString = gmce.getTopicPartitionOffsetsRange().keySet().iterator().next();
       //In case the topic name is not the table name or the topic name contains '-'
-      topicName = topicPartitionString.substring(0, topicPartitionString.lastIndexOf('-'));
+      int startOfTopicName = topicPartitionString.lastIndexOf('.') + 1;
+      topicName = topicPartitionString.substring(startOfTopicName, topicPartitionString.lastIndexOf('-'));
     }
     return topicName;
   }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/writer/HiveMetadataWriter.java
@@ -272,12 +272,16 @@ public class HiveMetadataWriter implements MetadataWriter {
     //todo: make topicName fall back to topic.name in hive spec so that we can also get schema for re-write operation
     String topicName = null;
     if (gmce.getTopicPartitionOffsetsRange() != null && !gmce.getTopicPartitionOffsetsRange().isEmpty()) {
+      // In case the topic name is not the table name or the topic name contains '-'
       String topicPartitionString = gmce.getTopicPartitionOffsetsRange().keySet().iterator().next();
-      //In case the topic name is not the table name or the topic name contains '-'
-      int startOfTopicName = topicPartitionString.lastIndexOf('.') + 1;
-      topicName = topicPartitionString.substring(startOfTopicName, topicPartitionString.lastIndexOf('-'));
+      topicName = parseTopicNameFromOffsetRangeKey(topicPartitionString);
     }
     return topicName;
+  }
+
+  public static String parseTopicNameFromOffsetRangeKey(String offsetRangeKey) {
+    int startOfTopicName = offsetRangeKey.lastIndexOf('.') + 1;
+    return offsetRangeKey.substring(startOfTopicName, offsetRangeKey.lastIndexOf('-'));
   }
 
   /**

--- a/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
+++ b/gobblin-iceberg/src/main/java/org/apache/gobblin/iceberg/writer/IcebergMetadataWriter.java
@@ -107,6 +107,7 @@ import org.apache.gobblin.hive.HiveLock;
 import org.apache.gobblin.hive.HivePartition;
 import org.apache.gobblin.hive.metastore.HiveMetaStoreUtils;
 import org.apache.gobblin.hive.spec.HiveSpec;
+import org.apache.gobblin.hive.writer.HiveMetadataWriter;
 import org.apache.gobblin.hive.writer.MetadataWriter;
 import org.apache.gobblin.hive.writer.MetadataWriterKeys;
 import org.apache.gobblin.iceberg.Utils.IcebergUtils;
@@ -813,7 +814,7 @@ public class IcebergMetadataWriter implements MetadataWriter {
     if (tableMetadata.dataOffsetRange.isPresent() && tableMetadata.dataOffsetRange.get().size() != 0) {
       String topicPartitionString = tableMetadata.dataOffsetRange.get().keySet().iterator().next();
       //In case the topic name is not the table name or the topic name contains '-'
-      return topicPartitionString.substring(0, topicPartitionString.lastIndexOf('-'));
+      return HiveMetadataWriter.parseTopicNameFromOffsetRangeKey(topicPartitionString);
     }
     return tableMetadata.newProperties.or(
         Maps.newHashMap(tableMetadata.lastProperties.or(getIcebergTable(tid).properties()))).get(TOPIC_NAME_KEY);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1890] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1890


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
It's possible for GMIP to support processing GMCEs that correspond to records from different kafka brokers. This can be done by passing in extra information as a prefix to the offset range map. However, we must also update the algorithm for fetching the topic name to allow for a prefix.

For example, the following offset range keys should be valid and all parse to the `topicname`
- `topicname-0`
- `kafkaBroker1.topicname-0`
- `colocation-kafkabroker1.topicname-0`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://github.com/apache/gobblin/assets/35702680/253c5cef-fe52-42d4-bd72-20c962b462aa)


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

