### PR TITLE
[GOBBLIN-1892] replace setAcl with modifyEntries while preserving acls during distcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -29,10 +29,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AclEntry;
-import org.apache.hadoop.fs.permission.AclEntryScope;
-import org.apache.hadoop.fs.permission.AclEntryType;
 import org.apache.hadoop.fs.permission.AclStatus;
-import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.google.common.base.Optional;
@@ -444,33 +441,7 @@ public class CopyableFile extends CopyEntity implements File {
 
   private static List<AclEntry> getAclEntries(FileSystem srcFs, Path path) throws IOException {
     AclStatus aclStatus = srcFs.getAclStatus(path);
-    return addOthersEntryTypeToAclEntriesIfMissing(aclStatus.getEntries());
-  }
-  /*
-   * When we get AclEntry from org.apache.hadoop.fs.permission.AclStatus, it's missing AclEntryType.OTHER.
-   * This causes AclTransformation validation to fail on the list of AclEntries. As a result, adding this helper
-   * method to provide DEFAULT scope in cases where AclEntryType.OTHER is absent
-   */
-  private static List<AclEntry> addOthersEntryTypeToAclEntriesIfMissing(List<AclEntry> aclEntries) {
-    // Check if "others" entry is missing
-    boolean othersAclEntryTypeMissing = true;
-
-    for (AclEntry aclEntry : aclEntries) {
-      if (aclEntry.getType() == AclEntryType.OTHER) {
-        othersAclEntryTypeMissing = false;
-        break;
-      }
-    }
-    // If "others" entry is missing, add it
-    if (othersAclEntryTypeMissing) {
-      AclEntry othersEntry = new AclEntry.Builder().setType(AclEntryType.OTHER).setScope(AclEntryScope.DEFAULT)
-          .setPermission(FsAction.READ_EXECUTE).build();
-
-      // Modify the ACL entries to include the new "others" entry
-      aclEntries.add(othersEntry);
-    }
-    return aclEntries;
-
+    return aclStatus.getEntries();
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -361,8 +361,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       if (targetOwnerAndPermission.getFsPermission() != null) {
         fs.setPermission(path, targetOwnerAndPermission.getFsPermission());
       }
-      if (!ownerAndPermission.getAclEntries().isEmpty()) {
-        fs.setAcl(path, ownerAndPermission.getAclEntries());
+      if (!targetOwnerAndPermission.getAclEntries().isEmpty()) {
+        fs.setAcl(path, targetOwnerAndPermission.getAclEntries());
       }
     } catch (IOException ioe) {
       log.warn("Failed to set permission for directory " + path, ioe);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -362,7 +362,9 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
         fs.setPermission(path, targetOwnerAndPermission.getFsPermission());
       }
       if (!targetOwnerAndPermission.getAclEntries().isEmpty()) {
-        fs.setAcl(path, targetOwnerAndPermission.getAclEntries());
+        // use modify acls instead of setAcl since latter requires all three acl entry types: user, group and others
+        // while overwriting the acls for a given path. If anyone is absent it fails acl transformation validation.
+        fs.modifyAclEntries(path, targetOwnerAndPermission.getAclEntries());
       }
     } catch (IOException ioe) {
       log.warn("Failed to set permission for directory " + path, ioe);
@@ -519,7 +521,9 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
         log.warn("Failed to set owner and/or group for path " + path + " to " + owner + ":" + group, ioe);
       }
       if (!aclEntries.isEmpty()) {
-        fs.setAcl(path, aclEntries);
+        // use modify acls instead of setAcl since latter requires all three acl entry types: user, group and others
+        // while overwriting the acls for a given path. If anyone is absent it fails acl transformation validation.
+        fs.modifyAclEntries(path, aclEntries);
       }
     } else {
       fs.mkdirs(path);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
@@ -647,7 +647,7 @@ public class FileAwareInputStreamDataWriterTest {
   protected class TestLocalFileSystem extends LocalFileSystem {
     private final ConcurrentHashMap<Path, List<AclEntry>> pathToAclEntries = new ConcurrentHashMap<>();
     @Override
-    public void setAcl(Path path, List<AclEntry> aclEntries) {
+    public void modifyAclEntries(Path path, List<AclEntry> aclEntries) {
       pathToAclEntries.put(path, aclEntries);
     }
     public ImmutableMap<Path, List<AclEntry>> getPathToAclEntries() {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemDecorator.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemDecorator.java
@@ -110,6 +110,9 @@ class FileSystemDecorator extends FileSystem implements Decorator {
   public void setAcl(Path path, List<AclEntry> aclSpec) throws IOException {
     this.underlyingFs.setAcl(path, aclSpec);
   }
+  public void modifyAclEntries(Path path, List<AclEntry> aclSpec) throws IOException {
+    this.underlyingFs.modifyAclEntries(path, aclSpec);
+  }
 
   public FsStatus getStatus() throws java.io.IOException {
     return this.underlyingFs.getStatus();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1892


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
- We run into issues when we try to update acl entries for existing paths. Previously, used `setAcl`API provided by `hadoop.fs`, but it requires all 3 Acl entry types: `user, group and others` to be always present, which might not be case when fetching acl entries. Thus, `modifyEntries` should be used since it will either update existing Acls or set Acls if missing.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- modified unit tests


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

