### PR TITLE
[GOBBLIN-1894] Add ability to filter topics with a period in kafka source

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -115,6 +115,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   public static final String PREVIOUS_LATEST_OFFSET = "previousLatestOffset";
   public static final String OFFSET_FETCH_EPOCH_TIME = "offsetFetchEpochTime";
   public static final String PREVIOUS_OFFSET_FETCH_EPOCH_TIME = "previousOffsetFetchEpochTime";
+  public static final String ALLOW_PERIOD_IN_TOPIC_NAME = "gobblin.kafka.allowPeriodInTopicName";
   public static final String GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS = "gobblin.kafka.consumerClient.class";
   public static final String GOBBLIN_KAFKA_EXTRACT_ALLOW_TABLE_TYPE_NAMESPACE_CUSTOMIZATION =
       "gobblin.kafka.extract.allowTableTypeAndNamspaceCustomization";
@@ -801,7 +802,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   protected List<KafkaTopic> getFilteredTopics(SourceState state) {
     List<Pattern> blacklist = DatasetFilterUtils.getPatternList(state, TOPIC_BLACKLIST);
     List<Pattern> whitelist = DatasetFilterUtils.getPatternList(state, TOPIC_WHITELIST);
-    return this.kafkaConsumerClient.get().getFilteredTopics(blacklist, whitelist);
+    if (!state.getPropAsBoolean(KafkaSource.ALLOW_PERIOD_IN_TOPIC_NAME, true)) {
+      blacklist.add(Pattern.compile(".*\\..*"));
+    }
+    return kafkaConsumerClient.get().getFilteredTopics(blacklist, whitelist);
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaTopic.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaTopic.java
@@ -23,6 +23,9 @@ import java.util.List;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import org.apache.gobblin.configuration.State;
 
 
@@ -32,6 +35,8 @@ import org.apache.gobblin.configuration.State;
  * @author Ziyang Liu
  *
  */
+@EqualsAndHashCode
+@ToString
 public final class KafkaTopic {
   private final String name;
   private final List<KafkaPartition> partitions;

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.source.extractor.extract.kafka;
 
 import java.io.IOException;

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
@@ -1,0 +1,90 @@
+package org.apache.gobblin.source.extractor.extract.kafka;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
+import org.apache.gobblin.kafka.client.KafkaConsumerRecord;
+import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.util.DatasetFilterUtils;
+
+
+public class KafkaSourceTest {
+
+  @Test
+  public void testGetFilteredTopics() {
+    TestKafkaClient testKafkaClient = new TestKafkaClient();
+    List<String> allTopics = Arrays.asList(
+        "Topic1", "topic-v2", "topic3", // allowed
+        "topic-with.period-in_middle", ".topic-with-period-at-start", "topicWithPeriodAtEnd.", //period topics
+        "not-allowed-topic");
+    testKafkaClient.testTopics = allTopics;
+
+    SourceState state = new SourceState();
+    state.setProp(KafkaSource.TOPIC_WHITELIST, ".*[Tt]opic.*");
+    state.setProp(KafkaSource.TOPIC_BLACKLIST, "not-allowed.*");
+    Assert.assertEquals(new TestKafkaSource(testKafkaClient).getFilteredTopics(state), toKafkaTopicList(allTopics.subList(0, 6)));
+
+    state.setProp(KafkaSource.ALLOW_PERIOD_IN_TOPIC_NAME, false);
+    Assert.assertEquals(new TestKafkaSource(testKafkaClient).getFilteredTopics(state), toKafkaTopicList(allTopics.subList(0, 3)));
+  }
+
+  public List<KafkaTopic> toKafkaTopicList(List<String> topicNames) {
+    return topicNames.stream().map(topicName -> new KafkaTopic(topicName, Collections.emptyList())).collect(Collectors.toList());
+  }
+
+  private class TestKafkaClient implements GobblinKafkaConsumerClient {
+    List<String> testTopics;
+
+    @Override
+    public List<KafkaTopic> getFilteredTopics(List<Pattern> blacklist, List<Pattern> whitelist) {
+      return toKafkaTopicList(DatasetFilterUtils.filter(testTopics, blacklist, whitelist));
+    }
+
+    @Override
+    public long getEarliestOffset(KafkaPartition partition)
+        throws KafkaOffsetRetrievalFailureException {
+      return 0;
+    }
+
+    @Override
+    public long getLatestOffset(KafkaPartition partition)
+        throws KafkaOffsetRetrievalFailureException {
+      return 0;
+    }
+
+    @Override
+    public Iterator<KafkaConsumerRecord> consume(KafkaPartition partition, long nextOffset, long maxOffset) {
+      return null;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+
+    }
+  }
+
+  private class TestKafkaSource<S,D> extends KafkaSource<S,D> {
+
+    public TestKafkaSource(GobblinKafkaConsumerClient client) {
+      kafkaConsumerClient.set(client);
+    }
+
+    @Override
+    public Extractor getExtractor(WorkUnitState state)
+        throws IOException {
+      throw new RuntimeException("Not implemented");
+    }
+  }
+}


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Kafka source is commonly used to ETL from Kafka to HDFS as part of Fast Ingest. This data is later exposed via Hive / Iceberg to be queried via Spark / Trino. Hive does not support `.` to be part of the table name. This means that in order to keep consistency between Hive and Kafka names, it requires some conversion. 

This is a high toil and low reward process. It would be great to have a flag to just outright ignore these topics altogether. Especially if the Gobblin operator does not control who creates Kafka topics. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
<img width="394" alt="image" src="https://github.com/apache/gobblin/assets/35702680/8d2c95ad-d6da-426d-ba35-ee1f0eca1a45">


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

