### PR TITLE
[GOBBLIN-1897] Fix the findBugsMain complaining redundant null check after adding annotation of EqualsAndHashCode

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/ligradle/findbugs/findbugsExclude.xml
+++ b/ligradle/findbugs/findbugsExclude.xml
@@ -53,4 +53,8 @@
     <Class name="org.apache.gobblin.compaction.verify.CompactionTimeRangeVerifier" />
     <Bug pattern="REC_CATCH_EXCEPTION" />
   </Match>
+  <Match>
+    <Class name="org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic" />
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1897


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Fix the findBugsMain complaining redundant null check after adding annotation of EqualsAndHashCode. More details can be found in  https://github.com/projectlombok/lombok/issues/891

Original error:
Code | Warning
RCN | Redundant nullcheck of this$partitions, which is known to be non-null in org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic.equals(Object)
RCN | Redundant nullcheck of $partitions, which is known to be non-null in org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic.hashCode()


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
local build pass the check

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

