### PR TITLE
[GOBBLIN-1899] More unit tests for ClustersNames

### DIFF
--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/ClustersNamesTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/ClustersNamesTest.java
@@ -33,6 +33,10 @@ public class ClustersNamesTest {
                 "cluster1");
         Assert.assertEquals(clustersNames.getClusterName("http://cluster2-rm.some.company.com:12345"),
                 "cluster2");
+        Assert.assertEquals(clustersNames.getClusterName("http://coloc1-some-identifier.some.company.com:8032"),
+            "cluster-no-scheme-with-port");
+        Assert.assertEquals(clustersNames.getClusterName("https://coloc1-some-identifier.some.company.com:8032"),
+            "cluster-no-scheme-with-port");
     }
 
     @Test
@@ -41,6 +45,8 @@ public class ClustersNamesTest {
                 "cluster1-rm.some.company.com");
         Assert.assertEquals(clustersNames.getClusterName("cluster-host-name-4.some.company.com"),
                 "cluster4");
+        Assert.assertEquals(clustersNames.getClusterName("coloc1-some-identifier.some.company.com:8032"),
+            "cluster-no-scheme-with-port");
     }
 
     @Test

--- a/gobblin-utility/src/test/resources/GobblinClustersNames.properties
+++ b/gobblin-utility/src/test/resources/GobblinClustersNames.properties
@@ -20,4 +20,5 @@
 http\://cluster1-rm.some.company.com=cluster1
 http\://cluster2-rm.some.company.com\:12345=cluster2
 cluster-host-name-4.some.company.com=cluster4
+coloc1-some-identifier.some.company.com\:8032=cluster-no-scheme-with-port
 http\://cluster-host-name-4.some.company.com\:789=cluster4-custom-port


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1899] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1899


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Nothing crazy here. I had concerns about the current behavior of the clusters names properties that is used to add the `clusterIdentifier` for GMCE and GTE. 

Internally we use non scheme in the properties with a port and it wasn't clear whether or not this code was working as expected. I've added these unit tests to both check this behavior and maintain this behavior going forward.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://github.com/apache/gobblin/assets/35702680/bd385b1e-fc6c-46db-bde3-850bd0f2d5a2)


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

