### PR TITLE
Add `MRJobLauncher` option to persist WorkUnits, then cancel before running the job

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -715,11 +715,13 @@ public class ConfigurationKeys {
   public static final String MR_JARS_BASE_DIR = "mr.jars.base.dir";
   public static final String MR_JOB_MAX_MAPPERS_KEY = "mr.job.max.mappers";
   public static final String MR_JOB_MAPPER_FAILURE_IS_FATAL_KEY = "mr.job.map.failure.is.fatal";
+  public static final String MR_PERSIST_WORK_UNITS_THEN_CANCEL_KEY = "mr.persist.workunits.then.cancel";
   public static final String MR_TARGET_MAPPER_SIZE = "mr.target.mapper.size";
   public static final String MR_REPORT_METRICS_AS_COUNTERS_KEY = "mr.report.metrics.as.counters";
   public static final boolean DEFAULT_MR_REPORT_METRICS_AS_COUNTERS = false;
   public static final int DEFAULT_MR_JOB_MAX_MAPPERS = 100;
   public static final boolean DEFAULT_MR_JOB_MAPPER_FAILURE_IS_FATAL = false;
+  public static final boolean DEFAULT_MR_PERSIST_WORK_UNITS_THEN_CANCEL = false;
   public static final String DEFAULT_ENABLE_MR_SPECULATIVE_EXECUTION = "false";
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -316,7 +316,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
       prepareHadoopJob(workUnits);
       if (this.shouldPersistWorkUnitsThenCancel) {
-        LOG.info("Cancelling job after persisting WorkUnits beneath: " + this.jobInputPath);
+        LOG.info("Cancelling job after persisting workunits beneath: " + this.jobInputPath);
         jobState.setState(JobState.RunningState.CANCELLED);
         return;
       }
@@ -714,7 +714,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
     try {
       if (this.fs.exists(this.mrJobDir)) {
         if (this.shouldPersistWorkUnitsThenCancel) {
-          LOG.info("Preserving persisted WorkUnits beneath: " + this.jobInputPath);
+          LOG.info("Preserving persisted workunits beneath: " + this.jobInputPath);
         } else {
           this.fs.delete(this.mrJobDir, true);
           LOG.info("Deleted working directory " + this.mrJobDir);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -173,6 +173,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   private final Path unsharedJarsDir;
   private final Path jobInputPath;
   private final Path jobOutputPath;
+  private final boolean shouldPersistWorkUnitsThenCancel;
 
   private final int parallelRunnerThreads;
 
@@ -248,6 +249,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
     this.jobInputPath = new Path(this.mrJobDir, INPUT_DIR_NAME);
     this.jobOutputPath = new Path(this.mrJobDir, OUTPUT_DIR_NAME);
     Path outputTaskStateDir = new Path(this.jobOutputPath, this.jobContext.getJobId());
+    this.shouldPersistWorkUnitsThenCancel = isPersistWorkUnitsThenCancelEnabled(this.jobProps);
 
     // Finally create the Hadoop job after all updates to conf are already made (including
     // adding dependent jars/files to the DistributedCache that also updates the conf)
@@ -313,6 +315,11 @@ public class MRJobLauncher extends AbstractJobLauncher {
       LOG.info("Emitting WorkUnitsCreated Count: " + countEventBuilder.getCount());
 
       prepareHadoopJob(workUnits);
+      if (this.shouldPersistWorkUnitsThenCancel) {
+        LOG.info("Cancelling job after persisting WorkUnits beneath: " + this.jobInputPath);
+        jobState.setState(JobState.RunningState.CANCELLED);
+        return;
+      }
 
       // Start the output TaskState collector service
       this.taskStateCollectorService.startAsync().awaitRunning();
@@ -525,11 +532,19 @@ public class MRJobLauncher extends AbstractJobLauncher {
         && Boolean.parseBoolean(properties.getProperty(ENABLED_CUSTOMIZED_PROGRESS));
   }
 
-  static boolean isMapperFailureFatalEnabled(Properties properties) {
-    return (
-        properties.containsKey(ConfigurationKeys.MR_JOB_MAPPER_FAILURE_IS_FATAL_KEY)
-        && Boolean.parseBoolean(properties.getProperty(ConfigurationKeys.MR_JOB_MAPPER_FAILURE_IS_FATAL_KEY)))
-        || ConfigurationKeys.DEFAULT_MR_JOB_MAPPER_FAILURE_IS_FATAL;
+  static boolean isBooleanPropEnabled(Properties props, String propKey, Optional<Boolean> optDefault) {
+    return (props.containsKey(propKey) && Boolean.parseBoolean(props.getProperty(propKey)))
+        || (optDefault.isPresent() && optDefault.get());
+  }
+
+  static boolean isMapperFailureFatalEnabled(Properties props) {
+    return isBooleanPropEnabled(props, ConfigurationKeys.MR_JOB_MAPPER_FAILURE_IS_FATAL_KEY,
+        Optional.of(ConfigurationKeys.DEFAULT_MR_JOB_MAPPER_FAILURE_IS_FATAL));
+  }
+
+  static boolean isPersistWorkUnitsThenCancelEnabled(Properties props) {
+    return isBooleanPropEnabled(props, ConfigurationKeys.MR_PERSIST_WORK_UNITS_THEN_CANCEL_KEY,
+        Optional.of(ConfigurationKeys.DEFAULT_MR_PERSIST_WORK_UNITS_THEN_CANCEL));
   }
 
   @VisibleForTesting
@@ -698,8 +713,12 @@ public class MRJobLauncher extends AbstractJobLauncher {
   private void cleanUpWorkingDirectory() {
     try {
       if (this.fs.exists(this.mrJobDir)) {
-        this.fs.delete(this.mrJobDir, true);
-        LOG.info("Deleted working directory " + this.mrJobDir);
+        if (this.shouldPersistWorkUnitsThenCancel) {
+          LOG.info("Preserving persisted WorkUnits beneath: " + this.jobInputPath);
+        } else {
+          this.fs.delete(this.mrJobDir, true);
+          LOG.info("Deleted working directory " + this.mrJobDir);
+        }
       }
     } catch (IOException ioe) {
       LOG.error("Failed to delete working directory " + this.mrJobDir);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1900


### Description
MapReduce is an aging legacy technology, so it's worth exploring additional execution frameworks.  To simplify experimentation and evaluation, add the ability to "borrow" MR's WorkUnit preparation, so such forays may at first jump ahead to investigate WU execution.

The option `mr.persist.workunits.then.cancel` works as advertised.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
successful manual testing

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

