### PR TITLE
[GOBBLIN-1901] Define MultiActiveLeaseArbiter Decorator to Model Failed Lease Completion

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -103,6 +103,9 @@ public class ConfigurationKeys {
   public static final String DEFAULT_SCHEDULER_LEASE_DETERMINATION_STORE_DB_TABLE = "gobblin_scheduler_lease_determination_store";
   // Refers to the event we originally tried to acquire a lease which achieved `consensus` among participants through
   // the database
+  public static final String MULTI_ACTIVE_LEASE_ARBITER_HOST_TO_BIT_MASK_MAP = MYSQL_LEASE_ARBITER_PREFIX + ".hostToBitMaskMap";
+  public static final String MULTI_ACTIVE_LEASE_ARBITER_BIT_MASK_LENGTH = MYSQL_LEASE_ARBITER_PREFIX + ".bitMaskLength";
+  public static final int DEFAULT_MULTI_ACTIVE_LEASE_ARBITER_BIT_MASK_LENGTH = 4;
   public static final String SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY = "preservedConsensusEventTimeMillis";
   // Time the reminder event Trigger is supposed to fire from the scheduler
   public static final String SCHEDULER_EXPECTED_REMINDER_TIME_MILLIS_KEY = "expectedReminderTimeMillis";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiterTestingDecorator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiterTestingDecorator.java
@@ -1,0 +1,201 @@
+package org.apache.gobblin.runtime.api;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.HostUtils;
+
+
+/**
+ * This class is a decorator for {@link MysqlMultiActiveLeaseArbiter} used to model scenarios where a lease owner fails
+ * to complete a lease successfully intermittently (representing a variety of slowness or failure cases that can result
+ * on the participant side, network connectivity, or database).
+ *
+ * It will fail on calls to {@link MysqlMultiActiveLeaseArbiter.recordLeaseSuccess()} where a function of the lease
+ * obtained timestamp matches a bitmask of the host. Ideally, each participant should fail on different calls (with
+ * limited overlap if we want to test that). We use a deterministic method of failing some calls to complete a lease
+ * success with the following methodology. We take the binary representation of the lease obtained timestamp, scatter
+ * its bits through bit interleaving of the first and second halves of the binary representation to differentiate
+ * behavior of consecutive timestamps, and compare the last N digits (determined through config) to the bit mask of the
+ * host. If the bitwise AND comparison to the host bit mask equals the bitmask we fail the call.
+ */
+@Slf4j
+public class MysqlMultiActiveLeaseArbiterTestingDecorator extends MysqlMultiActiveLeaseArbiter {
+  private final int bitMaskLength;
+  private final HashMap<Integer, Integer> hostIdToBitMask = new HashMap();
+
+  @Inject
+  public MysqlMultiActiveLeaseArbiterTestingDecorator(Config config) throws IOException {
+    super(config);
+    bitMaskLength = ConfigUtils.getInt(config, ConfigurationKeys.MULTI_ACTIVE_LEASE_ARBITER_BIT_MASK_LENGTH,
+        ConfigurationKeys.DEFAULT_MULTI_ACTIVE_LEASE_ARBITER_BIT_MASK_LENGTH);
+    initializeHostToBitMaskMap(config);
+  }
+
+  /**
+   * Extract bit mask from input config if one is present. Otherwise set the default bitmask for each host id which
+   * does not have overlapping bits between two hosts so that a given status will not fail on multiple hosts.
+   * @param config expected to contain a mapping of host address to bitmap in format
+   *              "host1:bitMask1,host2:bitMask2,...,hostN:bitMaskN"
+   * Note: that if the mapping format is incorrect or there are fewer than 4 mappings provide we utilize the default to
+   *       prevent unintended consequences of overlapping bit masks.
+   */
+  protected void initializeHostToBitMaskMap(Config config) {
+    // Set default bit masks for each hosts (assumes 4 hosts)
+    hostIdToBitMask.put(1, 0b0001);
+    hostIdToBitMask.put(2, 0b0010);
+    hostIdToBitMask.put(3, 0b0100);
+    hostIdToBitMask.put(4, 0b1000);
+
+    // If a valid mapping is provided in config, then we overwrite all the default values.
+    if (config.hasPath(ConfigurationKeys.MULTI_ACTIVE_LEASE_ARBITER_HOST_TO_BIT_MASK_MAP)) {
+      String stringMap = config.getString(ConfigurationKeys.MULTI_ACTIVE_LEASE_ARBITER_HOST_TO_BIT_MASK_MAP);
+      Optional<HashMap<InetAddress,Integer>> addressToBitMapOptional = validateStringMap(stringMap);
+      if (addressToBitMapOptional.isPresent()) {
+        for (InetAddress inetAddress : addressToBitMapOptional.get().keySet()) {
+          hostIdToBitMask.put(getHostIdFromAddress(inetAddress), addressToBitMapOptional.get().get(inetAddress));
+        }
+      }
+    }
+  }
+
+  protected static Optional<HashMap<InetAddress,Integer>> validateStringMap(String stringMap, int bitMaskLength) {
+    // TODO: Refactor to increase abstraction
+    String[] hostAddressToMap = stringMap.split(",");
+    if (hostAddressToMap.length < bitMaskLength) {
+      log.warn("Host address to bit mask map expected to be in format "
+          + "`host1:bitMask1,host2:bitMask2,...,hostN:bitMaskN` with at least 4 hosts necessary. Using default.");
+      return Optional.absent();
+    }
+    HashMap<InetAddress,Integer> addressToBitmap = new HashMap<>();
+    for (String mapping : hostAddressToMap) {
+      String[] keyAndValue = mapping.split(":");
+      if (keyAndValue.length != 2) {
+        log.warn("Host address to bit mask map should be separated by `:`. Expected format "
+            + "`host1:bitMask1,host2:bitMask2,...,hostN:bitMaskN`. Using default.");
+      }
+      Optional<InetAddress> addressOptional = HostUtils.getAddressForHostName(keyAndValue[0]);
+      if (!addressOptional.isPresent()) {
+        log.warn("Invalid hostname format in configuration. Using default.");
+        return Optional.absent();
+      }
+      if (!isValidBitMask(keyAndValue[1], bitMaskLength)) {
+        log.warn("Invalid bit mask format in configuration, expected to be " + bitMaskLength + " digit binary number "
+            + "ie: `1010`. Using default.");
+        return Optional.absent();
+      }
+      addressToBitmap.put(addressOptional.get(), Integer.valueOf(keyAndValue[1], 2));
+    }
+    return Optional.of(addressToBitmap);
+  }
+
+  protected static boolean isValidBitMask(String input, int bitMaskLength) {
+    // Check if the string contains only 0s and 1s
+    if (!input.matches("[01]+")) {
+      return false;
+    }
+    // Check if the string is exactly `bitMaskLength` characters long
+    if (input.length() != bitMaskLength) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Retrieve the host id as a number between 1 through 4 by using the host address's hashcode.
+   * @return
+   */
+  protected int getHostIdFromAddress(InetAddress address) {
+      return (address.hashCode() % 4) + 1;
+  }
+
+  /**
+   * Returns bit mask for given host
+   * @param hostId
+   * @return
+   */
+  protected int getBitMaskForHostId(int hostId) {
+    return this.hostIdToBitMask.get(hostId);
+  }
+
+  /**
+   * Return bit mask for the current host
+   */
+  protected int getBitMaskForHost() throws UnknownHostException {
+    return getBitMaskForHostId(getHostIdFromAddress(Inet6Address.getLocalHost()));
+  }
+
+  /**
+   * Apply a deterministic function to the input status to evaluate whether this host should fail to complete a lease
+   * for testing purposes.
+   */
+  @Override
+  public boolean recordLeaseSuccess(LeaseObtainedStatus status) throws IOException {
+    // Get host bit mask
+    int bitMask = getBitMaskForHost();
+    if (shouldFailLeaseCompletionAttempt(status, bitMask)) {
+      log.info("Multi-active lease arbiter lease attempt: [{}, eventTimestamp: {}] - FAILED to complete in testing "
+          + "scenario");
+      return false;
+    } else {
+      return super.recordLeaseSuccess(status);
+    }
+  }
+
+  /**
+   * Applies bitmask to lease acquisition timestamp of a status parameter provided to evaluate if the lease attempt to
+   * this host should fail
+   * @param status {@link org.apache.gobblin.runtime.api.MultiActiveLeaseArbiter.LeaseObtainedStatus}
+   * @param bitmask 4-bit binary integer used to compare against modified lease acquisition timestamp
+   * @return true if the host should fail the lease completion attempt
+   */
+  protected static boolean shouldFailLeaseCompletionAttempt(LeaseObtainedStatus status, int bitmask,
+      int bitMaskLength) {
+    // Convert event timestamp to binary
+    Long.toString(status.getLeaseAcquisitionTimestamp()).getBytes();
+    String binaryString = Long.toBinaryString(status.getLeaseAcquisitionTimestamp());
+    // Scatter binary bits
+    String scatteredBinaryString = scatterBinaryStringBits(binaryString);
+    // Take last `bitMaskLength`` bits of the string
+    int length = scatteredBinaryString.length();
+    String shortenedBinaryString = scatteredBinaryString.substring(length-bitMaskLength, length);
+    // Apply bitmask
+    int binaryInt = Integer.valueOf(shortenedBinaryString, 2);
+    return (binaryInt & bitmask) == bitmask;
+  }
+
+  /**
+   * Given an input string in binary format, scatter the bits to arrange data in a non-contiguous, deterministic way.
+   * @param inputBinaryString 64-bit binary string
+   * @return a binary format String
+   */
+  protected static String scatterBinaryStringBits(String inputBinaryString) {
+    String firstHalf = inputBinaryString.substring(0, inputBinaryString.length()/2);
+    String secondHalf = inputBinaryString.substring(inputBinaryString.length()/2);
+    return String.valueOf(interleaveBits(firstHalf, secondHalf));
+  }
+
+  /**
+   * Interleave bits of two binary strings of the same length to return a binary format long with interleaved bits
+   * @param binaryString1 32-bit binary string
+   * @param binaryString2 32-bit binary string
+   * @return 64-bit binary format long
+   */
+  protected static long interleaveBits(String binaryString1, String binaryString2) {
+    long binaryLong1 = Long.parseLong(binaryString1, 2);
+    long binaryLong2 = Long.parseLong(binaryString2, 2);
+    long result = 0;
+    for (int i=0; i < binaryString1.length(); i++) {
+      result |= ((binaryLong1 & (1 << i)) << i) | ((binaryLong2 & (1 << i)) << (i + 1));
+    }
+    return result;
+  }
+}

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HostUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HostUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.util;
 
+import com.google.common.base.Optional;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -31,5 +32,17 @@ public class HostUtils {
 
   public static String getPrincipalUsingHostname(String name, String realm) {
     return name + "/" + getHostName() + "@" + realm;
+  }
+
+  /**
+   * Given a host name return an optional containing the InetAddress object if one can be constructed for the input
+   * // TODO: provide details about expected hostName format
+   */
+  public static Optional<InetAddress> getAddressForHostName(String hostName) {
+    try {
+      return Optional.of(InetAddress.getByName(hostName));
+    } catch (UnknownHostException e) {
+      return Optional.absent();
+    }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1901 


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Creates MysqlMultiActiveLeaseAribterTestingDecorator class used to model scenarios where a lease owner fails to complete a lease successfully intermittently (representing a variety of slowness or failure cases that can result on the participant side, network connectivity, or database).
It will fail on calls to {@link MysqlMultiActiveLeaseArbiter.recordLeaseSuccess()} where a deterministic function of the lease obtained timestamp matches a bitmask of the host. Ideally, each participant should fail on different calls (with limited overlap if we want to test that). See java doc for more details. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
WIP (will add in second iteration once methodology is agreed upon)

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

