### PR TITLE
[GOBBLIN-1905] Fix bug where memory estimate occurs after writer flush, leading to a…

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -211,6 +211,10 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
         initializeOrcFileWriter();
       }
       orcFileWriter.addRowBatch(rowBatch);
+      // Depending on the orcFileWriter orc.rows.between.memory.check, this may be an underestimate depending on if it flushed right after
+      // adding the rows or not. However, since the rowBatch is reset and that buffer is cleared, this should still be safe to use as an estimate
+      // We can also explore checking to see if rowBatch size is greater than orc.rows.between.memory check, add just the maximum amount of rows
+      // such that the native file writer is saturated but not flushed, record that memory then flush after. But that may be overkill for the time being.
       if (this.selfTuningWriter) {
         this.currentOrcWriterMaxUnderlyingMemory = Math.max(this.currentOrcWriterMaxUnderlyingMemory, orcFileWriter.estimateMemory());
       }

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -253,7 +253,6 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   @Override
   public void commit()
       throws IOException {
-    // Capture memory in the writer before commit as a flush in closeInternal() will reset the internal buffer of the native ORC writer
     closeInternal();
     super.commit();
     if (this.selfTuningWriter) {


### PR DESCRIPTION
…n underestimate in memory

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1905


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Fixes a bug that causes the ORC Writer self tune to underestimate the native ORC writer memory, leading to potential OOM issues.

This occurs in the scenario where the writer would close before ever tuning itself and measuring the native ORC writer buffer. 

During close, the native ORC writer would flush itself - emptying its buffers and leading to the memory estimate to be extremely minimal, then record its memory estimate in the saved state if it has not recorded an estimate before. So for datasets that write a small number of records to file it would greatly underestimate the memory within the native ORC writer.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

