### PR TITLE
[GOBBLIN-1906] Add null-check to `JobConfigurationUtils.putStateIntoConfiguration` to avoid `IllegalArgumentException`

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.state.ConstructState;
+import org.apache.gobblin.util.JobConfigurationUtils;
 
 /**
  * A wrapper for ORC-core writer without dependency on Hive SerDe library.
@@ -117,9 +118,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     // Create file-writer
     this.writerConfig = new Configuration();
     // Populate job Configurations into Conf as well so that configurations related to ORC writer can be tuned easily.
-    for (Object key : properties.getProperties().keySet()) {
-      this.writerConfig.set((String) key, properties.getProp((String) key));
-    }
+    JobConfigurationUtils.putStateIntoConfiguration(properties, this.writerConfig);
     OrcFile.WriterOptions options = OrcFile.writerOptions(properties.getProperties(), this.writerConfig);
     options.setSchema(typeDescription);
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -316,7 +316,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
       prepareHadoopJob(workUnits);
       if (this.shouldPersistWorkUnitsThenCancel) {
-        LOG.info("Cancelling job after persisting workunits beneath: " + this.jobInputPath);
+        // NOTE: `warn` level is hack for including path among automatic troubleshooter 'issues'
+        LOG.warn("Cancelling job after persisting workunits beneath: " + this.jobInputPath);
         jobState.setState(JobState.RunningState.CANCELLED);
         return;
       }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/JobConfigurationUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/JobConfigurationUtils.java
@@ -92,7 +92,10 @@ public class JobConfigurationUtils {
    */
   public static void putStateIntoConfiguration(State state, Configuration configuration) {
     for (String key : state.getPropertyNames()) {
-      configuration.set(key, state.getProp(key));
+      String value = state.getProp(key);
+      if (value != null) { // ignore `null`, to prevent `IllegalArgumentException` from `Configuration::set`
+        configuration.set(key, value);
+      }
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1906


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
A customer reported seeing:
```
Error: java.io.IOException: Task failed: java.lang.IllegalArgumentException: The value of property <<redacted>> must not be null
  at com.google.common.base.Preconditions.checkArgument(Preconditions.java:146)
  at org.apache.hadoop.conf.Configuration.set(Configuration.java:1260)
  at org.apache.hadoop.conf.Configuration.set(Configuration.java:1241)
  at org.apache.gobblin.util.JobConfigurationUtils.putStateIntoConfiguration(JobConfigurationUtils.java:95)
...
```
the appears to arise from concurrent modification to the `State`'s underlying `Properties` (i.e. between the time the `keySet()` is first read and when each value is accessed from the same `Properties`).

although the customer's impl seems to warrant synchronization, given that a null-value is certain to be rejected by `o.a.hadoop.conf.Configuration`, defensively filter those out ahead of time.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
no current unit tests for this small utility method

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

