### PR TITLE
[GOBBLIN-1908] Fix Date to Milliseconds Conversion to Use UTC 

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -311,6 +311,6 @@ public class FlowTriggerHandler {
   protected static long getUTCTimeFromDelayPeriod(long delayPeriodMillis) {
     LocalDateTime localDateTime = getLocalDateTimeFromDelayPeriod(delayPeriodMillis);
     Date date = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
-    return GobblinServiceJobScheduler.asUTCEpochMillis(date);
+    return GobblinServiceJobScheduler.utcDateAsUTCEpochMillis(date);
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -466,7 +466,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
   @Override
   protected void logNewlyScheduledJob(JobDetail job, Trigger trigger) {
     Properties jobProps = (Properties) job.getJobDataMap().get(PROPERTIES_KEY);
-    log.info(jobSchedulerTracePrefixBuilder(jobProps) + "nextTriggerTime: {} localConversionTriggerTime:{} - Job newly "
+    log.info(jobSchedulerTracePrefixBuilder(jobProps) + "nextTriggerTime: {} localTZNextTriggerTime:{} - Job newly "
             + "scheduled", utcDateAsUTCEpochMillis(trigger.getNextFireTime()),
         systemDefaultZoneDateAsUTCEpochMillis(trigger.getNextFireTime()));
   }
@@ -754,7 +754,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         Trigger trigger = context.getTrigger();
         // THIS current event has already fired if this method is called, so it now exists in <previousFireTime>
         long triggerTimeMillis = utcDateAsUTCEpochMillis(trigger.getPreviousFireTime());
-        long localConversionTriggerTimeMillis = systemDefaultZoneDateAsUTCEpochMillis(trigger.getPreviousFireTime());
+        long localTZTriggerTimeMillis = systemDefaultZoneDateAsUTCEpochMillis(trigger.getPreviousFireTime());
         // If the trigger is a reminder type event then utilize the trigger time saved in job properties rather than the
         // actual firing time
         if (jobDetail.getKey().getName().contains("reminder")) {
@@ -770,9 +770,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
           jobProps.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY,
               String.valueOf(triggerTimeMillis));
           _log.info(jobSchedulerTracePrefixBuilder(jobProps) + "triggerTime: {} nextTriggerTime: {} "
-              + "localConversionTriggerTime: {} localConversionNextTriggerTime: {}- Job triggered by "
-              + "scheduler", triggerTimeMillis, utcDateAsUTCEpochMillis(trigger.getNextFireTime()),
-              localConversionTriggerTimeMillis, systemDefaultZoneDateAsUTCEpochMillis(trigger.getNextFireTime()));
+              + "localTZTriggerTime: {} localTZNextTriggerTime: {}- Job triggered by scheduler", triggerTimeMillis,
+              utcDateAsUTCEpochMillis(trigger.getNextFireTime()), localTZTriggerTimeMillis,
+              systemDefaultZoneDateAsUTCEpochMillis(trigger.getNextFireTime()));
         }
         jobScheduler.runJob(jobProps, jobListener);
       } catch (Throwable t) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -466,8 +466,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
   @Override
   protected void logNewlyScheduledJob(JobDetail job, Trigger trigger) {
     Properties jobProps = (Properties) job.getJobDataMap().get(PROPERTIES_KEY);
-    log.info(jobSchedulerTracePrefixBuilder(jobProps) + "nextTriggerTime: {} - Job newly scheduled",
-         asUTCEpochMillis(trigger.getNextFireTime()));
+    log.info(jobSchedulerTracePrefixBuilder(jobProps) + "nextTriggerTime: {} localConversionTriggerTime:{} - Job newly "
+            + "scheduled", utcDateAsUTCEpochMillis(trigger.getNextFireTime()),
+        systemDefaultZoneDateAsUTCEpochMillis(trigger.getNextFireTime()));
   }
 
   protected static String jobSchedulerTracePrefixBuilder(Properties jobProps) {
@@ -477,13 +478,22 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
   }
 
   /**
-   * Takes a given Date object and converts the timezone to UTC before returning the number of millseconds since epoch
+   * Takes a Date object in system default time zone, converts it to UTC before returning the number of milliseconds
+   * since epoch
    * @param date
    */
-  public static long asUTCEpochMillis(Date date) {
+  public static long systemDefaultZoneDateAsUTCEpochMillis(Date date) {
     return ZonedDateTime.of(
         LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()),
         ZoneOffset.UTC).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Takes a Date object in UTC and returns the number of milliseconds since epoch
+   * @param date
+   */
+  public static long utcDateAsUTCEpochMillis(Date date) {
+    return date.toInstant().toEpochMilli();
   }
 
   @Override
@@ -743,7 +753,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         // Obtain trigger timestamp from trigger to pass to jobProps
         Trigger trigger = context.getTrigger();
         // THIS current event has already fired if this method is called, so it now exists in <previousFireTime>
-        long triggerTimeMillis = asUTCEpochMillis(trigger.getPreviousFireTime());
+        long triggerTimeMillis = utcDateAsUTCEpochMillis(trigger.getPreviousFireTime());
+        long localConversionTriggerTimeMillis = systemDefaultZoneDateAsUTCEpochMillis(trigger.getPreviousFireTime());
         // If the trigger is a reminder type event then utilize the trigger time saved in job properties rather than the
         // actual firing time
         if (jobDetail.getKey().getName().contains("reminder")) {
@@ -758,8 +769,10 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         } else {
           jobProps.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY,
               String.valueOf(triggerTimeMillis));
-          _log.info(jobSchedulerTracePrefixBuilder(jobProps) + "triggerTime: {} nextTriggerTime: {} - Job triggered by "
-              + "scheduler", triggerTimeMillis, asUTCEpochMillis(trigger.getNextFireTime()));
+          _log.info(jobSchedulerTracePrefixBuilder(jobProps) + "triggerTime: {} nextTriggerTime: {} "
+              + "localConversionTriggerTime: {} localConversionNextTriggerTime: {}- Job triggered by "
+              + "scheduler", triggerTimeMillis, utcDateAsUTCEpochMillis(trigger.getNextFireTime()),
+              localConversionTriggerTimeMillis, systemDefaultZoneDateAsUTCEpochMillis(trigger.getNextFireTime()));
         }
         jobScheduler.runJob(jobProps, jobListener);
       } catch (Throwable t) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1908


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We had previously assumed the `Date` object returned from a `Trigger` uses the system default timezone, but taking a look at the javadoc and runtime values have shown it is already in UTC so we update our conversion function. To prevent further confusion about timezones, we also log the conversion that assumes the `Date` object is in system default timezone to make it easier to debug. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

