### PR TITLE
[GOBBLIN-1911] Fixing NPE in Salesforce high watermark fetch

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
@@ -282,12 +282,19 @@ public class SalesforceExtractor extends RestApiExtractor {
     long highTs;
     try {
       JsonObject jsonObject = element.getAsJsonObject();
+      log.info("High watermark json object: {}", jsonObject.toString());
+
       JsonArray jsonArray = jsonObject.getAsJsonArray("records");
-      if (jsonArray.size() == 0) {
+      if (jsonArray == null || jsonArray.size() == 0) {
         return -1;
       }
 
-      String value = jsonObject.getAsJsonArray("records").get(0).getAsJsonObject().get(watermarkColumn).getAsString();
+      JsonElement hwmJsonElement = jsonArray.get(0).getAsJsonObject().get(watermarkColumn);
+      if (hwmJsonElement == null) {
+        return -1;
+      }
+
+      String value = hwmJsonElement.getAsString();
       if (format != null) {
         SimpleDateFormat inFormat = new SimpleDateFormat(format);
         Date date = null;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1911


### Description
- We updated the Salesforce high watermark query to use MAX aggregate function instead of order by with limit 1 as part of https://github.com/apache/gobblin/pull/3750.
- When there are no modified records, this query returns an empty row, compared to no rows with the previous query.
- This is resulting in NPE while trying to parse the high watermark value.
- Adding checks on the objects to prevent the NPE as part of this change.


### Tests
- Added UTs to cover for the potential cases where empty response is returned for the high watermark query


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

