### PR TITLE
[GOBBLIN-1909] Disable zk state store test as it tends to timeout on github runners

### DIFF
--- a/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/StateStoreWatermarkStorageTest.java
+++ b/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/StateStoreWatermarkStorageTest.java
@@ -61,7 +61,6 @@ public class StateStoreWatermarkStorageTest {
     taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_TYPE_KEY, "zk");
     taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_CONFIG_PREFIX +
       ZkStateStoreConfigurationKeys.STATE_STORE_ZK_CONNECT_STRING_KEY, testingServer.getConnectString());
-    taskState.setProp()
     StateStoreBasedWatermarkStorage watermarkStorage = new StateStoreBasedWatermarkStorage(taskState);
 
     watermarkStorage.commitWatermarks(ImmutableList.of(watermark));

--- a/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/StateStoreWatermarkStorageTest.java
+++ b/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/StateStoreWatermarkStorageTest.java
@@ -50,7 +50,7 @@ public class StateStoreWatermarkStorageTest {
     testingServer = new TestingServer(-1);
   }
 
-  @Test
+  @Test( groups = {"disabledOnCI"} )
   public void testPersistWatermarkStateToZk() throws IOException {
     CheckpointableWatermark watermark = new DefaultCheckpointableWatermark("source", new LongWatermark(startTime));
 
@@ -61,7 +61,7 @@ public class StateStoreWatermarkStorageTest {
     taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_TYPE_KEY, "zk");
     taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_CONFIG_PREFIX +
       ZkStateStoreConfigurationKeys.STATE_STORE_ZK_CONNECT_STRING_KEY, testingServer.getConnectString());
-
+    taskState.setProp()
     StateStoreBasedWatermarkStorage watermarkStorage = new StateStoreBasedWatermarkStorage(taskState);
 
     watermarkStorage.commitWatermarks(ImmutableList.of(watermark));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1909


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Github Actions CI fails consistently with this error:
```
Gradle suite > Gradle test > org.apache.gobblin.runtime.StateStoreWatermarkStorageTest > testPersistWatermarkStateToZk FAILED
    java.lang.RuntimeException: Failed to create ZkStateStore with factory
        at org.apache.gobblin.metastore.ZkStateStoreFactory.createStateStore(ZkStateStoreFactory.java:39)
        at org.apache.gobblin.runtime.StateStoreBasedWatermarkStorage.<init>(StateStoreBasedWatermarkStorage.java:107)
        at org.apache.gobblin.runtime.StateStoreWatermarkStorageTest.testPersistWatermarkStateToZk(StateStoreWatermarkStorageTest.java:65)

        Caused by:
        org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException: Unable to connect to zookeeper server within timeout: 60000 
```
Given that this test seems to be an infra issue on the test runners, will be disabling this test on CI for now. The long term solution is to find a container for the GA runner to load up on start time, similar to how it handles mysql.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

