### PR TITLE
[GOBBLIN-1927] Add topic validation support in KafkaSource, and add TopicNameValidator

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicNameValidator.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicNameValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.source.extractor.extract.kafka.validator;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
+
+/**
+ * A topic validator that validates the topic name
+ */
+public class TopicNameValidator extends TopicValidatorBase {
+  private static final String DOT = ".";
+
+  public TopicNameValidator(SourceState sourceState) {
+    super(sourceState);
+  }
+
+  /**
+   * Check if a topic name is valid, current rules are:
+   *  1. must not contain "."
+   * @param topic the topic to be validated
+   * @return true if the topic name is valid (aka. doesn't contain ".")
+   */
+  @Override
+  public boolean validate(KafkaTopic topic) {
+    return !topic.getName().contains(DOT);
+  }
+}

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicNameValidator.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicNameValidator.java
@@ -16,7 +16,7 @@
  */
 package org.apache.gobblin.source.extractor.extract.kafka.validator;
 
-import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 
 /**
@@ -25,8 +25,8 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 public class TopicNameValidator extends TopicValidatorBase {
   private static final String DOT = ".";
 
-  public TopicNameValidator(SourceState sourceState) {
-    super(sourceState);
+  public TopicNameValidator(State state) {
+    super(state);
   }
 
   /**
@@ -36,7 +36,7 @@ public class TopicNameValidator extends TopicValidatorBase {
    * @return true if the topic name is valid (aka. doesn't contain ".")
    */
   @Override
-  public boolean validate(KafkaTopic topic) {
+  public boolean validate(KafkaTopic topic) throws Exception {
     return !topic.getName().contains(DOT);
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorBase.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorBase.java
@@ -16,18 +16,18 @@
  */
 package org.apache.gobblin.source.extractor.extract.kafka.validator;
 
-import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 
 /**
  * The base class of a topic validator
  */
 public abstract class TopicValidatorBase {
-  protected SourceState sourceState;
+  protected State state;
 
-  public TopicValidatorBase(SourceState sourceState) {
-    this.sourceState = sourceState;
+  public TopicValidatorBase(State sourceState) {
+    this.state = sourceState;
   }
 
-  public abstract boolean validate(KafkaTopic topic);
+  public abstract boolean validate(KafkaTopic topic) throws Exception;
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorBase.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorBase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.source.extractor.extract.kafka.validator;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
+
+/**
+ * The base class of a topic validator
+ */
+public abstract class TopicValidatorBase {
+  protected SourceState sourceState;
+
+  public TopicValidatorBase(SourceState sourceState) {
+    this.sourceState = sourceState;
+  }
+
+  public abstract boolean validate(KafkaTopic topic);
+}

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidators.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidators.java
@@ -16,12 +16,11 @@
  */
 package org.apache.gobblin.source.extractor.extract.kafka.validator;
 
-import com.google.common.base.Strings;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
@@ -40,19 +39,14 @@ public class TopicValidators {
   private final List<TopicValidatorBase> validators = new ArrayList<>();
 
   public TopicValidators(SourceState state) {
-    String validatorClasses = state.getProp(VALIDATOR_CLASSES_KEY);
-    if (Strings.isNullOrEmpty(validatorClasses)) {
-      return;
-    }
-
-    String[] validatorClassNames = validatorClasses.split(VALIDATOR_CLASS_DELIMITER);
-    Arrays.stream(validatorClassNames).forEach(validator -> {
+    for (String validatorClassName : state.getPropAsList(VALIDATOR_CLASSES_KEY, StringUtils.EMPTY)) {
       try {
-        this.validators.add(GobblinConstructorUtils.invokeConstructor(TopicValidatorBase.class, validator, state));
+        this.validators.add(GobblinConstructorUtils.invokeConstructor(TopicValidatorBase.class, validatorClassName,
+            state));
       } catch (Exception e) {
-        log.error("Failed to create topic validator: {}, due to {}", validator, e);
+        log.error("Failed to create topic validator: {}, due to {}", validatorClassName, e);
       }
-    });
+    }
   }
 
   /**

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidators.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidators.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.source.extractor.extract.kafka.validator;
+
+import com.google.common.base.Strings;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+
+/**
+ * The TopicValidators contains a list of {@link TopicValidatorBase} that validate topics.
+ * To enable it, add below settings in the config:
+ *   gobblin.kafka.topicValidators=validator1_class_name,validator2_class_name...
+ */
+@Slf4j
+public class TopicValidators {
+  public static final String VALIDATOR_CLASSES_KEY = "gobblin.kafka.topicValidators";
+
+  public static final String VALIDATOR_CLASS_DELIMITER = ",";
+
+  private final List<TopicValidatorBase> validators = new ArrayList<>();
+
+  public TopicValidators(SourceState state) {
+    String validatorClasses = state.getProp(VALIDATOR_CLASSES_KEY);
+    if (Strings.isNullOrEmpty(validatorClasses)) {
+      return;
+    }
+
+    String[] validatorClassNames = validatorClasses.split(VALIDATOR_CLASS_DELIMITER);
+    Arrays.stream(validatorClassNames).forEach(validator -> {
+      try {
+        this.validators.add(GobblinConstructorUtils.invokeConstructor(TopicValidatorBase.class, validator, state));
+      } catch (Exception e) {
+        log.error("Failed to create topic validator: {}, due to {}", validator, e);
+      }
+    });
+  }
+
+  /**
+   * Validate topics with all the internal validators.
+   * Note: the validations for every topic run in parallel.
+   * @param topics the topics to be validated
+   * @return the topics that pass all the validators
+   */
+  public List<KafkaTopic> validate(List<KafkaTopic> topics) {
+    // Validate the topics in parallel
+    return topics.parallelStream()
+        .filter(this::validate)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Validates a single topic with all the internal validators
+   */
+  private boolean validate(KafkaTopic topic) {
+    log.debug("Validating topic {} in thread: {}", topic, Thread.currentThread().getName());
+    for (TopicValidatorBase validator : this.validators) {
+      if (!validator.validate(topic)) {
+        log.info("Skip KafkaTopic: {}, by validator: {}", topic, validator.getClass().getName());
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/validator/TopicValidatorsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.source.extractor.extract.kafka.validator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TopicValidatorsTest {
+  @Test
+  public void testTopicNameValidator() {
+    List<String> allTopics = Arrays.asList(
+        "topic1", "topic2", // allowed
+        "topic-with.period-in_middle", ".topic-with-period-at-start", "topicWithPeriodAtEnd.", // bad topics
+        "topic3", "topic4"); // in deny list
+    List<KafkaTopic> topics = allTopics.stream()
+        .map(topicName -> new KafkaTopic(topicName, Collections.emptyList())).collect(Collectors.toList());
+
+    String validatorsToUse = String.join(TopicValidators.VALIDATOR_CLASS_DELIMITER,
+        ImmutableList.of(TopicNameValidator.class.getName(), DenyListValidator.class.getName()));
+
+    SourceState state = new SourceState();
+    state.setProp(TopicValidators.VALIDATOR_CLASSES_KEY, validatorsToUse);
+    List<KafkaTopic> validTopics = new TopicValidators(state).validate(topics);
+
+    Assert.assertEquals(validTopics.size(), 2);
+    Assert.assertTrue(validTopics.stream().anyMatch(topic -> topic.getName().equals("topic1")));
+    Assert.assertTrue(validTopics.stream().anyMatch(topic -> topic.getName().equals("topic2")));
+  }
+
+  // A TopicValidator class to mimic a deny list
+  public static class DenyListValidator extends TopicValidatorBase {
+    Set<String> denyList = ImmutableSet.of("topic3", "topic4");
+
+    public DenyListValidator(SourceState sourceState) {
+      super(sourceState);
+    }
+
+    @Override
+    public boolean validate(KafkaTopic topic) {
+      return !this.denyList.contains(topic.getName());
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ExecutorsUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ExecutorsUtils.java
@@ -103,6 +103,21 @@ public class ExecutorsUtils {
     return newThreadFactory(new ThreadFactoryBuilder().setDaemon(true), logger, nameFormat);
   }
 
+  /**
+   * Get a new {@link ThreadFactory} that uses a {@link LoggingUncaughtExceptionHandler}
+   * to handle uncaught exceptions.
+   * Tasks running within such threads will have the same access control and class loader settings as the
+   * thread that invokes this method.
+   *
+   * @param logger an {@link Optional} wrapping the {@link Logger} that the
+   *               {@link LoggingUncaughtExceptionHandler} uses to log uncaught exceptions thrown in threads
+   * @return a new {@link ThreadFactory}
+   */
+  public static ThreadFactory newPrivilegedThreadFactory(Optional<Logger> logger) {
+    return newThreadFactory(new ThreadFactoryBuilder().setThreadFactory(Executors.privilegedThreadFactory()), logger,
+        Optional.<String>absent());
+  }
+
   private static ThreadFactory newThreadFactory(ThreadFactoryBuilder builder, Optional<Logger> logger,
       Optional<String> nameFormat) {
     if (nameFormat.isPresent()) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1927


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
* Topic validation is used for validating topic and skipping the bad ones during work unite creation. This PR introduces a generic validation layer to support plugging in topic validator, to validate topic names, bad schema evolution, etc.
* More details in this PR:
  * Add the topic validation support in `KafkaSource`
  * Add the first validator `TopicNameValidator` into the validator chain, as a refactor of existing codes.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Added `TopicValidatorsTest`
- Enhanced `KafkaSourceTest`


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

