### PR TITLE
[GOBBLIN-1922]Add function in Kafka Source to recompute workUnits for filtered partitions

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -157,4 +157,17 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
     return processedName;
   }
 
+  /**
+   * Get a list of all kafka topics
+   */
+  public abstract List<KafkaTopic> getTopics();
+
+  /**
+   * Get a list of {@link KafkaTopic} with the provided topic names.
+   * The default implementation lists all the topics.
+   * Implementations of this class can improve this method.
+   */
+  public Collection<KafkaTopic> getTopics(Collection<String> topics) {
+    return getTopics();
+  }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -157,18 +157,4 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
     return processedName;
   }
 
-
-  /**
-   * Get a list of all kafka topics
-   */
-  public abstract List<KafkaTopic> getTopics();
-
-  /**
-   * Get a list of {@link KafkaTopic} with the provided topic names.
-   * The default implementation lists all the topics.
-   * Implementations of this class can improve this method.
-   */
-  public Collection<KafkaTopic> getTopics(Collection<String> topics) {
-    return getTopics();
-  }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -28,7 +28,6 @@ import com.codahale.metrics.Metric;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 
-import java.util.stream.Collectors;
 import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaOffsetRetrievalFailureException;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaPartition;
@@ -169,22 +168,6 @@ public interface GobblinKafkaConsumerClient extends Closeable {
   }
 
   public default void assignAndSeek(List<KafkaPartition> topicPartitions, Map<KafkaPartition, LongWatermark> topicWatermarksMap) { return; }
-
-  /**
-   * Get a list of all kafka topics
-   */
-  public default List<KafkaTopic> getTopics() {return Collections.emptyList();};
-
-  /**
-   * Get a list of {@link KafkaTopic} with the provided topic names.
-   * The default implementation firstly retrieve all the topics, then filter by the provided list.
-   * Implementations of this class can improve this method.
-   */
-  public default Collection<KafkaTopic> getTopics(Collection<String> topics) {
-    return getTopics().stream()
-        .filter(list-> topics.contains(list))
-        .collect(Collectors.toList());
-  }
 
   /**
    * A factory to create {@link GobblinKafkaConsumerClient}s

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -28,6 +28,7 @@ import com.codahale.metrics.Metric;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 
+import java.util.stream.Collectors;
 import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaOffsetRetrievalFailureException;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaPartition;
@@ -168,6 +169,22 @@ public interface GobblinKafkaConsumerClient extends Closeable {
   }
 
   public default void assignAndSeek(List<KafkaPartition> topicPartitions, Map<KafkaPartition, LongWatermark> topicWatermarksMap) { return; }
+
+  /**
+   * Get a list of all kafka topics
+   */
+  public default List<KafkaTopic> getTopics() {return Collections.emptyList();};
+
+  /**
+   * Get a list of {@link KafkaTopic} with the provided topic names.
+   * The default implementation firstly retrieve all the topics, then filter by the provided list.
+   * Implementations of this class can improve this method.
+   */
+  public default Collection<KafkaTopic> getTopics(Collection<String> topics) {
+    return getTopics().stream()
+        .filter(list-> topics.contains(list))
+        .collect(Collectors.toList());
+  }
 
   /**
    * A factory to create {@link GobblinKafkaConsumerClient}s

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.source.extractor.extract.kafka;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +62,7 @@ import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient.GobblinKafkaCo
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.source.extractor.extract.EventBasedSource;
+import org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaTopicGroupingWorkUnitPacker;
 import org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker;
 import org.apache.gobblin.source.extractor.extract.kafka.validator.TopicValidators;
 import org.apache.gobblin.source.extractor.limiter.LimiterConfigurationKeys;
@@ -269,20 +272,104 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
       // but aren't processed).
       createEmptyWorkUnitsForSkippedPartitions(workUnits, topicSpecificStateMap, state);
-      //determine the number of mappers
-      int maxMapperNum =
-          state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
+
       KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
-      int numOfMultiWorkunits = maxMapperNum;
-      if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
-        double totalEstDataSize = kafkaWorkUnitPacker.setWorkUnitEstSizes(workUnits);
-        LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
-        double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
-        numOfMultiWorkunits = (int) (totalEstDataSize / targetMapperSize) + 1;
-        numOfMultiWorkunits = Math.min(numOfMultiWorkunits, maxMapperNum);
+      int numOfMultiWorkunits= 0;
+      if(!(kafkaWorkUnitPacker instanceof KafkaTopicGroupingWorkUnitPacker)) {
+        numOfMultiWorkunits = calculateNumMappersForPacker(state, kafkaWorkUnitPacker, workUnits);
       }
       addTopicSpecificPropsToWorkUnits(workUnits, topicSpecificStateMap);
       List<WorkUnit> workUnitList = kafkaWorkUnitPacker.pack(workUnits, numOfMultiWorkunits);
+      setLimiterReportKeyListToWorkUnits(workUnitList, getLimiterExtractorReportKeys());
+      return workUnitList;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new RuntimeException("Checked exception caught", e);
+    } catch (Throwable t) {
+      throw new RuntimeException("Unexpected throwable caught, ", t);
+    } finally {
+      try {
+        GobblinKafkaConsumerClient consumerClient = this.kafkaConsumerClient.get();
+        if (consumerClient != null) {
+          consumerClient.close();
+        }
+        // cleanup clients from pool
+        for (GobblinKafkaConsumerClient client: kafkaConsumerClientPool) {
+          client.close();
+        }
+      } catch (Throwable t) {
+        //Swallow any exceptions in the finally{..} block to allow potential exceptions from the main try{..} block to be
+        //propagated
+        LOG.error("Exception {} encountered closing GobblinKafkaConsumerClient ", t);
+      }
+    }
+  }
+
+  public List<WorkUnit> getWorkunitsForFilteredPartitions(SourceState state, Map<String, List<String>> filteredTopicPartitionMap, int minContainer) {
+    Map<String, List<WorkUnit>> kafkaTopicWorkunitMap = Maps.newConcurrentMap();
+    Collection<KafkaTopic> topics;
+    try {
+      Config config = ConfigUtils.propertiesToConfig(state.getProperties());
+      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory = kafkaConsumerClientResolver
+          .resolveClass(
+              state.getProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
+                  DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
+
+      this.kafkaConsumerClient.set(kafkaConsumerClientFactory.create(config));
+      topics = this.kafkaConsumerClient.get().getTopics(filteredTopicPartitionMap.keySet());
+
+      Map<String, State> topicSpecificStateMap =
+          DatasetUtils.getDatasetSpecificProps(Iterables.transform(topics, new Function<KafkaTopic, String>() {
+
+            @Override
+            public String apply(KafkaTopic topic) {
+              return topic.getName();
+            }
+          }), state);
+
+      int numOfThreads = Math.min(topics.size(), state.getPropAsInt(ConfigurationKeys.KAFKA_SOURCE_WORK_UNITS_CREATION_THREADS,
+          ConfigurationKeys.KAFKA_SOURCE_WORK_UNITS_CREATION_DEFAULT_THREAD_COUNT));
+      ExecutorService threadPool =
+          Executors.newFixedThreadPool(numOfThreads, ExecutorsUtils.newThreadFactory(Optional.of(LOG)));
+
+      if (state.getPropAsBoolean(ConfigurationKeys.KAFKA_SOURCE_SHARE_CONSUMER_CLIENT,
+          ConfigurationKeys.DEFAULT_KAFKA_SOURCE_SHARE_CONSUMER_CLIENT)) {
+        this.sharedKafkaConsumerClient = this.kafkaConsumerClient.get();
+      } else {
+        // preallocate one client per thread
+        populateClientPool(3, kafkaConsumerClientFactory, config);
+      }
+
+      Stopwatch createWorkUnitStopwatch = Stopwatch.createStarted();
+      for (KafkaTopic topic : topics) {
+        LOG.info("Trying to re-compute the workunit for topic {} with filtered partitions: {}",
+            topic.getName(), filteredTopicPartitionMap.get(topic.getName()));
+        if (topic.getTopicSpecificState().isPresent()) {
+          topicSpecificStateMap.computeIfAbsent(topic.getName(), k -> new State())
+              .addAllIfNotExist(topic.getTopicSpecificState().get());
+        }
+        Set<Integer> partitionIDSet = filteredTopicPartitionMap.get(topic.getName())
+            .stream().map(Integer::parseInt).collect(Collectors.toSet());
+        threadPool.submit(
+            new WorkUnitCreator(topic, state, Optional.fromNullable(topicSpecificStateMap.get(topic.getName())),
+                kafkaTopicWorkunitMap, partitionIDSet));
+      }
+      ExecutorsUtils.shutdownExecutorService(threadPool, Optional.of(LOG), 1L, TimeUnit.HOURS);
+      LOG.info("Created workunits for {} topics in {} seconds", kafkaTopicWorkunitMap.size(),
+          createWorkUnitStopwatch.elapsed(TimeUnit.SECONDS));
+
+      // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
+      // but aren't processed).
+      createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
+      KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
+      int numOfMultiWorkunits = minContainer;
+      if(state.contains(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {
+        numOfMultiWorkunits = Math.max(numOfMultiWorkunits,
+            calculateNumMappersForPacker(state, kafkaWorkUnitPacker, kafkaTopicWorkunitMap));
+      }
+      addTopicSpecificPropsToWorkUnits(kafkaTopicWorkunitMap, topicSpecificStateMap);
+      // TODO: numOfMultiWorkunits is currently not used in the #KafkaTopicGroupingWorkUnitPacker.pack() method.
+      //  Next step is utilize this number to determine the container count
+      List<WorkUnit> workUnitList = kafkaWorkUnitPacker.pack(kafkaTopicWorkunitMap, numOfMultiWorkunits);
       setLimiterReportKeyListToWorkUnits(workUnitList, getLimiterExtractorReportKeys());
       return workUnitList;
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
@@ -377,10 +464,31 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     }
   }
 
+  //determine the number of mappers/containers for workunit packer
+  private int calculateNumMappersForPacker(SourceState state,
+      KafkaWorkUnitPacker kafkaWorkUnitPacker, Map<String, List<WorkUnit>> workUnits) {
+    int maxMapperNum =
+        state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
+    int numContainers = maxMapperNum;
+    if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
+      double totalEstDataSize = kafkaWorkUnitPacker.setWorkUnitEstSizes(workUnits);
+      LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
+      double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
+      numContainers = (int) (totalEstDataSize / targetMapperSize) + 1;
+      numContainers = Math.min(numContainers, maxMapperNum);
+    }
+    return numContainers;
+  }
+
   /*
    * This function need to be thread safe since it is called in the Runnable
    */
   private List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state, Optional<State> topicSpecificState) {
+    return this.getWorkUnitsForTopic(topic, state, topicSpecificState, Optional.absent());
+  }
+
+  private List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state,
+      Optional<State> topicSpecificState, Optional<Set<Integer>> filteredPartitions) {
     Timer.Context context = this.metricContext.timer("isTopicQualifiedTimer").time();
     boolean topicQualified = isTopicQualified(topic);
     context.close();
@@ -388,6 +496,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     List<WorkUnit> workUnits = Lists.newArrayList();
     List<KafkaPartition> topicPartitions = topic.getPartitions();
     for (KafkaPartition partition : topicPartitions) {
+      if(filteredPartitions.isPresent() && !filteredPartitions.get().contains(partition.getId())) {
+        continue;
+      }
       WorkUnit workUnit = getWorkUnitForTopicPartition(partition, state, topicSpecificState);
       if (workUnit != null) {
         // For disqualified topics, for each of its workunits set the high watermark to be the same
@@ -895,6 +1006,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     private final SourceState state;
     private final Optional<State> topicSpecificState;
     private final Map<String, List<WorkUnit>> allTopicWorkUnits;
+    private final Optional<Set<Integer>> filteredPartitionsId;
 
     WorkUnitCreator(KafkaTopic topic, SourceState state, Optional<State> topicSpecificState,
         Map<String, List<WorkUnit>> workUnits) {
@@ -902,6 +1014,16 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       this.state = state;
       this.topicSpecificState = topicSpecificState;
       this.allTopicWorkUnits = workUnits;
+      this.filteredPartitionsId = Optional.absent();
+    }
+
+    WorkUnitCreator(KafkaTopic topic, SourceState state, Optional<State> topicSpecificState,
+        Map<String, List<WorkUnit>> workUnits, Set<Integer> filteredPartitionsId) {
+      this.topic = topic;
+      this.state = state;
+      this.topicSpecificState = topicSpecificState;
+      this.allTopicWorkUnits = workUnits;
+      this.filteredPartitionsId = Optional.of(filteredPartitionsId);
     }
 
     @Override
@@ -917,7 +1039,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         }
 
         this.allTopicWorkUnits.put(this.topic.getName(),
-            KafkaSource.this.getWorkUnitsForTopic(this.topic, this.state, this.topicSpecificState));
+            KafkaSource.this.getWorkUnitsForTopic(this.topic, this.state, this.topicSpecificState, this.filteredPartitionsId));
       } catch (Throwable t) {
         LOG.error("Caught error in creating work unit for " + this.topic.getName(), t);
         throw new RuntimeException(t);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -302,7 +302,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
       // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
       // but aren't processed). When filteredTopicPartition present, only filtered topic-partitions are needed so skip this call
-      if(filteredTopicPartition.isPresent()) {
+      if(!filteredTopicPartition.isPresent()) {
         createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
       }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -301,8 +301,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           createWorkUnitStopwatch.elapsed(TimeUnit.SECONDS)));
 
       // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
-      // but aren't processed).
-      createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
+      // but aren't processed). When filteredTopicPartition present, only filtered topic-partitions are needed so skip this call
+      if(filteredTopicPartition.isPresent()) {
+        createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
+      }
 
       KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
       int numOfMultiWorkunits = minContainer.or(1);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -305,7 +305,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
 
       KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
-      int numOfMultiWorkunits = minContainer.or(0);
+      int numOfMultiWorkunits = minContainer.or(1);
       if(state.contains(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {
         numOfMultiWorkunits = Math.max(numOfMultiWorkunits,
             calculateNumMappersForPacker(state, kafkaWorkUnitPacker, kafkaTopicWorkunitMap));

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
@@ -17,17 +17,27 @@
 
 package org.apache.gobblin.source.extractor.extract.kafka;
 
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.gobblin.annotation.Alias;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.source.extractor.extract.kafka.validator.TopicNameValidator;
 import org.apache.gobblin.source.extractor.extract.kafka.validator.TopicValidators;
+import org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker;
+import org.apache.gobblin.source.workunit.MultiWorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnit;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -38,8 +48,54 @@ import org.apache.gobblin.kafka.client.KafkaConsumerRecord;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.util.DatasetFilterUtils;
 
+import static org.apache.gobblin.source.extractor.extract.kafka.KafkaSource.*;
+
 
 public class KafkaSourceTest {
+  private static List<String> testTopics =Arrays.asList(
+      "topic1", "topic2", "topic3");
+
+  @Test
+  public void testGetWorkunits() {
+    TestKafkaClient testKafkaClient = new TestKafkaClient();
+    testKafkaClient.testTopics = testTopics;
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, "TestPath");
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_TYPE, KafkaWorkUnitPacker.PackerType.CUSTOM);
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE, "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaTopicGroupingWorkUnitPacker");
+    state.setProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS, "MockTestKafkaConsumerClientFactory");
+    TestKafkaSource testKafkaSource = new TestKafkaSource(testKafkaClient);
+    List<WorkUnit> workUnits = testKafkaSource.getWorkunits(state);
+
+    validatePartitionNumWithinWorkUnits(workUnits, 48);
+
+  }
+
+  @Test
+  public void testGetWorkunitsForFilteredPartitions() {
+    TestKafkaClient testKafkaClient = new TestKafkaClient();
+    List<String> allTopics = testTopics;
+    Map<String, List<Integer>> filteredTopicPartitionMap = new HashMap<>();
+    filteredTopicPartitionMap.put(allTopics.get(0), new LinkedList<>());
+    filteredTopicPartitionMap.put(allTopics.get(1), new LinkedList<>());
+    filteredTopicPartitionMap.put(allTopics.get(2), new LinkedList<>());
+    filteredTopicPartitionMap.get(allTopics.get(0)).addAll(Arrays.asList(0, 11));
+    filteredTopicPartitionMap.get(allTopics.get(1)).addAll(Arrays.asList(2, 8, 10));
+    filteredTopicPartitionMap.get(allTopics.get(2)).addAll(Arrays.asList(1, 3, 5, 7));
+
+    testKafkaClient.testTopics = allTopics;
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, "TestPath");
+    state.setProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS, "MockTestKafkaConsumerClientFactory");
+    TestKafkaSource testKafkaSource = new TestKafkaSource(testKafkaClient);
+    List<WorkUnit> workUnits = testKafkaSource.getWorkunitsForFilteredPartitions(state, Optional.of(filteredTopicPartitionMap), Optional.of(3));
+    validatePartitionNumWithinWorkUnits(workUnits, 9);
+
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_TYPE, KafkaWorkUnitPacker.PackerType.CUSTOM);
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE, "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaTopicGroupingWorkUnitPacker");
+    workUnits = testKafkaSource.getWorkunitsForFilteredPartitions(state, Optional.of(filteredTopicPartitionMap), Optional.of(1));
+    validatePartitionNumWithinWorkUnits(workUnits, 9);
+  }
 
   @Test
   public void testGetFilteredTopics() {
@@ -89,12 +145,60 @@ public class KafkaSourceTest {
         toKafkaTopicList(allTopics.subList(0, 3))));
   }
 
-  public List<KafkaTopic> toKafkaTopicList(List<String> topicNames) {
-    return topicNames.stream().map(topicName -> new KafkaTopic(topicName, Collections.emptyList())).collect(Collectors.toList());
+  public static List<KafkaPartition> creatPartitions(String topicName, int partitionNum) {
+    List<KafkaPartition> partitions = new ArrayList<>(partitionNum);
+    for(int i = 0; i < partitionNum; i++ ) {
+      partitions.add(new KafkaPartition.Builder().withTopicName(topicName).withId(i).withLeaderHostAndPort("test").withLeaderId(1).build());
+    }
+    return partitions;
   }
 
-  private class TestKafkaClient implements GobblinKafkaConsumerClient {
-    List<String> testTopics;
+  public static List<KafkaPartition> getPartitionFromWorkUnit(WorkUnit workUnit) {
+    List<KafkaPartition> topicPartitions = new ArrayList<>();
+    if(workUnit instanceof MultiWorkUnit) {
+      for(WorkUnit wu : ((MultiWorkUnit) workUnit).getWorkUnits()) {
+        topicPartitions.addAll(getPartitionFromWorkUnit(wu));
+      }
+    }else {
+      int i = 0;
+      String partitionIdProp = KafkaSource.PARTITION_ID + "." + i;
+      while (workUnit.getProp(partitionIdProp) != null) {
+        int partitionId = workUnit.getPropAsInt(partitionIdProp);
+        KafkaPartition topicPartition =
+            new KafkaPartition.Builder().withTopicName(workUnit.getProp(KafkaSource.TOPIC_NAME)).withId(partitionId).build();
+        topicPartitions.add(topicPartition);
+        i++;
+        partitionIdProp = KafkaSource.PARTITION_ID + "." + i;
+      }
+    }
+    return topicPartitions;
+  }
+
+
+  public static List<KafkaTopic> toKafkaTopicList(List<String> topicNames) {
+    return topicNames.stream().map(topicName -> new KafkaTopic(topicName, creatPartitions(topicName, 16))).collect(Collectors.toList());
+  }
+
+  private void validatePartitionNumWithinWorkUnits(List<WorkUnit> workUnits, int expectPartitionNum) {
+    List<KafkaPartition> partitionList = new ArrayList<>();
+    for(WorkUnit workUnit : workUnits) {
+      partitionList.addAll(getPartitionFromWorkUnit(workUnit));
+    }
+    Assert.assertEquals(partitionList.size(), expectPartitionNum);
+  }
+
+  @Alias("MockTestKafkaConsumerClientFactory")
+  public static class MockTestKafkaConsumerClientFactory
+      implements GobblinKafkaConsumerClient.GobblinKafkaConsumerClientFactory {
+
+    @Override
+    public GobblinKafkaConsumerClient create(Config config) {
+      return new TestKafkaClient();
+    }
+  }
+
+  public static class TestKafkaClient implements GobblinKafkaConsumerClient {
+    List<String> testTopics = KafkaSourceTest.testTopics;
 
     @Override
     public List<KafkaTopic> getFilteredTopics(List<Pattern> blacklist, List<Pattern> whitelist) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1922] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1922


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Add a new feature in Kafka source to create workUnit for selected topics partitions. This feature can provide functionality for:
1. Recompute and split tasks(workUnit) during runtime for selected topics partitions, instead of recompute for all Kafka topics
2. Make topic level replan feasible
3. One step closer to dynamic work unit allocation 

Need to have a followup to make work unit packer able to pack the recomputed workunits into a desired number of containers 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

