### PR TITLE
[GOBBLIN-1929]implement get dataset path for IcebergDataset and RecursiveCopyableDataset

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -237,4 +237,9 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
     return fileInTarget.getLen() == fileInSource.getLen() && fileInSource.getModificationTime() <= fileInTarget
         .getModificationTime();
   }
+  @Override
+  public String getDatasetPath() {
+    String datasetPath = Path.getPathWithoutSchemeAndAuthority(this.rootPath).toString();
+    log.info("Target dataset path: {}", datasetPath);
+    return datasetPath; }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -90,6 +90,19 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   /**
+   * Provides absolute path of an iceberg dataset at the destination
+   * @return string value of the iceberg dataset location
+   */
+  @Override
+  public String getDatasetPath() {
+    try {
+      return this.destIcebergTable.getTablePath();
+    } catch (IcebergTable.TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Finds all files read by the table and generates CopyableFiles.
    * For the specific semantics see {@link #createFileSets}.
    */

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -19,6 +19,8 @@ package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
@@ -201,5 +203,16 @@ public class IcebergTable {
       // use current destination metadata as 'base metadata' and source as 'updated metadata' while committing
       this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(dstMetadata.properties()));
     }
+  }
+
+  /**
+   * Provides absolute path of the iceberg table location
+   * @return string value of table location if present
+   * @throws TableNotFoundException
+   */
+  public String getTablePath() throws TableNotFoundException {
+    Path tablePath = Paths.get(accessTableMetadata().location());
+    log.info("Iceberg table location: {}", tablePath.toAbsolutePath());
+    return tablePath.toAbsolutePath().toString();
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1929


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
I want to implement the dataset path for `IcebergDataset` and `RecursiveCopyableDataset` which previously would resolve to empty `String`. Now, with this implementation, it would help enable `DestinationShardHandler` based on the dataset path for all distcp workflows

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

