### PR TITLE
[GOBBLIN-1930] Improve Multi-active related logs and metrics

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -43,10 +43,11 @@ public class ServiceMetricNames {
   public static final String FLOW_TRIGGER_HANDLER_JOB_DOES_NOT_EXIST_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".jobDoesNotExistInScheduler";
   public static final String FLOW_TRIGGER_HANDLER_FAILED_TO_SET_REMINDER_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".failedToSetReminderCount";
 
-  // Dag Action Handling Related Metrics
-  public static final String DAG_ACTION_HANDLING_PREFIX = "dagActionHandling";
+  // DagManager Related Metrics
+  public static final String DAG_MANAGER_HANDLING_PREFIX = GOBBLIN_SERVICE_PREFIX + ".dagManagerHandling";
   public static final String
-      DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT = DAG_ACTION_HANDLING_PREFIX + ".dagManagerFailedLaunchEventsOnStartupCount";
+      DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT = DAG_MANAGER_HANDLING_PREFIX + ".failedLaunchEventsOnStartupCount";
+  public static final String FLOW_FAILED_FORWARD_TO_DAG_MANAGER_COUNT = DAG_MANAGER_HANDLING_PREFIX + ".flowFailedForwardToDagManagerCount";
 
   //Job status poll timer
   public static final String JOB_STATUS_POLLED_TIMER = GOBBLIN_SERVICE_PREFIX + ".jobStatusPoll.time";

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -44,10 +44,10 @@ public class ServiceMetricNames {
   public static final String FLOW_TRIGGER_HANDLER_FAILED_TO_SET_REMINDER_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".failedToSetReminderCount";
 
   // DagManager Related Metrics
-  public static final String DAG_MANAGER_HANDLING_PREFIX = GOBBLIN_SERVICE_PREFIX + ".dagManagerHandling";
+  public static final String DAG_MANAGER_PREFIX = GOBBLIN_SERVICE_PREFIX + ".dagManager";
   public static final String
-      DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT = DAG_MANAGER_HANDLING_PREFIX + ".failedLaunchEventsOnStartupCount";
-  public static final String FLOW_FAILED_FORWARD_TO_DAG_MANAGER_COUNT = DAG_MANAGER_HANDLING_PREFIX + ".flowFailedForwardToDagManagerCount";
+      DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT = DAG_MANAGER_PREFIX + ".failedLaunchEventsOnStartupCount";
+  public static final String FLOW_FAILED_FORWARD_TO_DAG_MANAGER_COUNT = DAG_MANAGER_PREFIX + ".flowFailedForwardToDagManagerCount";
 
   //Job status poll timer
   public static final String JOB_STATUS_POLLED_TIMER = GOBBLIN_SERVICE_PREFIX + ".jobStatusPoll.time";

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -43,6 +43,11 @@ public class ServiceMetricNames {
   public static final String FLOW_TRIGGER_HANDLER_JOB_DOES_NOT_EXIST_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".jobDoesNotExistInScheduler";
   public static final String FLOW_TRIGGER_HANDLER_FAILED_TO_SET_REMINDER_COUNT = GOBBLIN_SERVICE_PREFIX + "." + FLOW_TRIGGER_HANDLER_PREFIX + ".failedToSetReminderCount";
 
+  // Dag Action Handling Related Metrics
+  public static final String DAG_ACTION_HANDLING_PREFIX = "dagActionHandling";
+  public static final String
+      DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT = DAG_ACTION_HANDLING_PREFIX + ".dagManagerFailedLaunchEventsOnStartupCount";
+
   //Job status poll timer
   public static final String JOB_STATUS_POLLED_TIMER = GOBBLIN_SERVICE_PREFIX + ".jobStatusPoll.time";
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/DagActionStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/DagActionStore.java
@@ -54,7 +54,6 @@ public interface DagActionStore {
       return new DagActionStore.DagAction(flowAction.getFlowGroup(), flowAction.getFlowName(),
           String.valueOf(eventTimeMillis), flowAction.getFlowActionType());
     }
-
   }
 
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/DagActionStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/DagActionStore.java
@@ -45,6 +45,16 @@ public interface DagActionStore {
     public FlowId getFlowId() {
       return new FlowId().setFlowGroup(this.flowGroup).setFlowName(this.flowName);
     }
+
+    /**
+     *   Replace flow execution id with agreed upon event time to easily track the flow
+     */
+    public static DagActionStore.DagAction updateFlowExecutionId(DagActionStore.DagAction flowAction,
+        long eventTimeMillis) {
+      return new DagActionStore.DagAction(flowAction.getFlowGroup(), flowAction.getFlowName(),
+          String.valueOf(eventTimeMillis), flowAction.getFlowActionType());
+    }
+
   }
 
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiActiveLeaseArbiter.java
@@ -89,8 +89,7 @@ public interface MultiActiveLeaseArbiter {
     private final long leaseAcquisitionTimestamp;
 
     /**
-     * Returns event time in millis since epoch for the event of this lease acquisition.
-     * @return
+     * @return event time in millis since epoch for the event of this lease acquisition
      */
     public long getEventTimeMillis() {
       return Long.parseLong(flowAction.getFlowExecutionId());
@@ -99,8 +98,8 @@ public interface MultiActiveLeaseArbiter {
 
   /*
   This flow action event already has a valid lease owned by another participant.
-  `Flow action`'s flow execution id is the timestamp the lease is associated with, which may be a different timestamp
-  for the same flow action corresponding to the same instance of the event or a distinct one.
+  `Flow action`'s flow execution id is the timestamp the lease is associated with, however the flow action event it
+  corresponds to may be a different and distinct occurrence of the same event.
   `minimumLingerDurationMillis` is the minimum amount of time to wait before this participant should return to check if
   the lease has completed or expired
    */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiActiveLeaseArbiter.java
@@ -79,28 +79,42 @@ public interface MultiActiveLeaseArbiter {
   class NoLongerLeasingStatus extends LeaseAttemptStatus {}
 
   /*
-  The participant calling this method acquired the lease for the event in question. The class contains the
-  `eventTimestamp` associated with the lease as well as the time the caller obtained the lease or
-  `leaseAcquisitionTimestamp`.
+  The participant calling this method acquired the lease for the event in question. `Flow action`'s flow execution id
+  is the timestamp associated with the lease and the time the caller obtained the lease is stored within the
+  `leaseAcquisitionTimestamp` field.
   */
   @Data
   class LeaseObtainedStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction flowAction;
-    private final long eventTimestamp;
     private final long leaseAcquisitionTimestamp;
+
+    /**
+     * Returns event time in millis since epoch for the event of this lease acquisition.
+     * @return
+     */
+    public long getEventTimeMillis() {
+      return Long.parseLong(flowAction.getFlowExecutionId());
+    }
   }
 
   /*
   This flow action event already has a valid lease owned by another participant.
-  `eventTimeMillis` is the timestamp the lease is associated with, which may be a different timestamp for the same flow
-  action corresponding to the same instance of the event or a distinct one.
+  `Flow action`'s flow execution id is the timestamp the lease is associated with, which may be a different timestamp
+  for the same flow action corresponding to the same instance of the event or a distinct one.
   `minimumLingerDurationMillis` is the minimum amount of time to wait before this participant should return to check if
   the lease has completed or expired
    */
   @Data
   class LeasedToAnotherStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction flowAction;
-    private final long eventTimeMillis;
     private final long minimumLingerDurationMillis;
+
+    /**
+     * Returns event time in millis since epoch for the event whose lease was obtained by another participant.
+     * @return
+     */
+    public long getEventTimeMillis() {
+      return Long.parseLong(flowAction.getFlowExecutionId());
+    }
 }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
@@ -242,7 +242,6 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
     Runnable retentionTask = () -> {
       try {
-        Thread.sleep(10000);
         withPreparedStatement(thisTableRetentionStatement,
             retentionStatement -> {
               retentionStatement.setLong(1, retentionPeriodMillis);
@@ -253,7 +252,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
               }
               return numRowsDeleted;
             }, true);
-      } catch (InterruptedException | IOException e) {
+      } catch (IOException e) {
         log.error("Failing to run retention on lease arbiter table. Unbounded growth can lead to database slowness and "
             + "affect our system performance. Examine exception: ", e);
       }
@@ -308,7 +307,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         if (eventTimeMillis == dbEventTimestamp.getTime()) {
           // TODO: change this to a debug after fixing issue
           log.info("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Reminder event time"
-                  + "is the same as db event.", flowAction, isReminderEvent ? "reminder" : "original",
+                  + " is the same as db event.", flowAction, isReminderEvent ? "reminder" : "original",
               eventTimeMillis, dbEventTimestamp);
         }
       }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MysqlMultiActiveLeaseArbiter.java
@@ -306,8 +306,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         }
         if (eventTimeMillis == dbEventTimestamp.getTime()) {
           // TODO: change this to a debug after fixing issue
-          log.info("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Reminder event time"
-                  + " is the same as db event.", flowAction, isReminderEvent ? "reminder" : "original",
+          log.info("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Reminder event time "
+                  + "is the same as db event.", flowAction, isReminderEvent ? "reminder" : "original",
               eventTimeMillis, dbEventTimestamp);
         }
       }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -43,17 +43,17 @@ public class RuntimeMetrics {
   public static final String GOBBLIN_SPEC_STORE_MESSAGE_PROCESSED= ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".specStoreMonitor.message.processed";
   public static final String GOBBLIN_SPEC_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS =
       ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".specstoreMonitor.produce.to.consume.delay";
-  public static final String DAG_ACTION_STORE_MONITOR_PREFIX = "dagActionStoreMonitor";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".kills.invoked";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGE_PROCESSED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".message.processed";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGES_FILTERED_OUT = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".messagesFilteredOut";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".resumes.invoked";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_FLOWS_LAUNCHED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".flows.launched";
+  public static final String DAG_ACTION_STORE_MONITOR_PREFIX = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED = DAG_ACTION_STORE_MONITOR_PREFIX + ".kills.invoked";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGE_PROCESSED = DAG_ACTION_STORE_MONITOR_PREFIX + ".message.processed";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGES_FILTERED_OUT = DAG_ACTION_STORE_MONITOR_PREFIX + ".messagesFilteredOut";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED = DAG_ACTION_STORE_MONITOR_PREFIX + ".resumes.invoked";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_FLOWS_LAUNCHED = DAG_ACTION_STORE_MONITOR_PREFIX + ".flows.launched";
 
-  public static final String GOBBLIN_DAG_ACTION_STORE_FAILED_FLOW_LAUNCHED_SUBMISSIONS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".failedFlowLaunchSubmissions";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_UNEXPECTED_ERRORS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".unexpected.errors";
+  public static final String GOBBLIN_DAG_ACTION_STORE_FAILED_FLOW_LAUNCHED_SUBMISSIONS = DAG_ACTION_STORE_MONITOR_PREFIX + ".failedFlowLaunchSubmissions";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_UNEXPECTED_ERRORS = DAG_ACTION_STORE_MONITOR_PREFIX + ".unexpected.errors";
   public static final String
-      GOBBLIN_DAG_ACTION_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".produce.to.consume.delay";
+      GOBBLIN_DAG_ACTION_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS = DAG_ACTION_STORE_MONITOR_PREFIX + ".produce.to.consume.delay";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_UNEXPECTED_ERRORS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.unexpected.errors";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_QUOTA_REQUESTS_EXCEEDED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.quotaRequests.exceeded";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_TIME_TO_CHECK_QUOTA = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.time.to.check.quota";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -43,14 +43,17 @@ public class RuntimeMetrics {
   public static final String GOBBLIN_SPEC_STORE_MESSAGE_PROCESSED= ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".specStoreMonitor.message.processed";
   public static final String GOBBLIN_SPEC_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS =
       ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".specstoreMonitor.produce.to.consume.delay";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.kills.invoked";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGE_PROCESSED= ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.message.processed";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.resumes.invoked";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_FLOWS_LAUNCHED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.flows.launched";
-  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_UNEXPECTED_ERRORS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.unexpected.errors";
-  public static final String
-      GOBBLIN_DAG_ACTION_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + ".dagActionStoreMonitor.produce.to.consume.delay";
+  public static final String DAG_ACTION_STORE_MONITOR_PREFIX = "dagActionStoreMonitor";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".kills.invoked";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGE_PROCESSED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".message.processed";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGES_FILTERED_OUT = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".messagesFilteredOut";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".resumes.invoked";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_FLOWS_LAUNCHED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".flows.launched";
 
+  public static final String GOBBLIN_DAG_ACTION_STORE_FAILED_FLOW_LAUNCHED_SUBMISSIONS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "." + DAG_ACTION_STORE_MONITOR_PREFIX + ".failedFlowLaunchSubmissions";
+  public static final String GOBBLIN_DAG_ACTION_STORE_MONITOR_UNEXPECTED_ERRORS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".unexpected.errors";
+  public static final String
+      GOBBLIN_DAG_ACTION_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "."  + DAG_ACTION_STORE_MONITOR_PREFIX + ".produce.to.consume.delay";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_UNEXPECTED_ERRORS = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.unexpected.errors";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_QUOTA_REQUESTS_EXCEEDED = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.quotaRequests.exceeded";
   public static final String GOBBLIN_MYSQL_QUOTA_MANAGER_TIME_TO_CHECK_QUOTA = ServiceMetricNames.GOBBLIN_SERVICE_PREFIX + "gobblin.mysql.quota.manager.time.to.check.quota";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -306,8 +306,8 @@ public class DagManager extends AbstractIdleService {
    * Note this should only be called from the {@link Orchestrator} or {@link org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor}
    */
   public synchronized void addDag(Dag<JobExecutionPlan> dag, boolean persist, boolean setStatus) throws IOException {
-    // TODO: Additional log added here to track missing dag issue, remove later as needed
-    log.info("Add dag called for dag: {} to be persisted: {} and status set: {}", dag, persist, setStatus);
+    // TODO: Used to track missing dag issue, remove later as needed
+    log.info("Add dag (persist: {}, setStatus: {}): {}", persist, setStatus, dag);
     if (!isActive) {
       log.warn("Skipping add dag because this instance of DagManager is not active for dag: {}", dag);
       return;
@@ -511,18 +511,18 @@ public class DagManager extends AbstractIdleService {
       // Upon handling the action, delete it so on leadership change this is not duplicated
       this.dagActionStore.get().deleteDagAction(launchAction);
     } catch (URISyntaxException e) {
-      log.warn(String.format("Could not create URI object for flowId %s due to exception", flowId), e.fillInStackTrace());
+      log.warn(String.format("Could not create URI object for flowId %s due to exception", flowId), e);
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (SpecNotFoundException e) {
-      log.warn(String.format("Spec not found for flowId %s due to exception", flowId), e.fillInStackTrace());
+      log.warn(String.format("Spec not found for flowId %s due to exception", flowId), e);
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (IOException e) {
       log.warn(String.format("Failed to add Job Execution Plan for flowId %s OR delete dag action from dagActionStore "
-          + "(check stacktrace) due to exception", flowId), e.fillInStackTrace());
+          + "(check stacktrace) due to exception", flowId), e);
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (InterruptedException e) {
       log.warn(String.format("SpecCompiler failed to reach healthy state before compilation of flowId %s due to "
-              + "exception", flowId), e.fillInStackTrace());
+              + "exception", flowId), e);
       this.dagManagerMetrics.incrementFailedLaunchCount();
     }
   }
@@ -628,7 +628,7 @@ public class DagManager extends AbstractIdleService {
             //Initialize dag.
             initialize(dag);
           } else {
-            log.warn("Null dag; ignoring the dag");
+            log.warn("Null dag despite non-empty queue; ignoring the dag");
           }
         }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -306,6 +306,8 @@ public class DagManager extends AbstractIdleService {
    * Note this should only be called from the {@link Orchestrator} or {@link org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor}
    */
   public synchronized void addDag(Dag<JobExecutionPlan> dag, boolean persist, boolean setStatus) throws IOException {
+    // TODO: Additional log added here to track missing dag issue, remove later as needed
+    log.info("Add dag called for dag: {} to be persisted: {} and status set: {}", dag, persist, setStatus);
     if (!isActive) {
       log.warn("Skipping add dag because this instance of DagManager is not active for dag: {}", dag);
       return;
@@ -509,18 +511,18 @@ public class DagManager extends AbstractIdleService {
       // Upon handling the action, delete it so on leadership change this is not duplicated
       this.dagActionStore.get().deleteDagAction(launchAction);
     } catch (URISyntaxException e) {
-      log.warn("Could not create URI object for flowId {} due to exception {}", flowId, e.getMessage());
+      log.warn(String.format("Could not create URI object for flowId %s due to exception", flowId), e.fillInStackTrace());
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (SpecNotFoundException e) {
-      log.warn("Spec not found for flowId {} due to exception {}", flowId, e.getMessage());
+      log.warn(String.format("Spec not found for flowId %s due to exception", flowId), e.fillInStackTrace());
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (IOException e) {
-      log.warn("Failed to add Job Execution Plan for flowId {} OR delete dag action from dagActionStore (check "
-          + "stacktrace) due to exception {}", flowId, e.getMessage());
+      log.warn(String.format("Failed to add Job Execution Plan for flowId %s OR delete dag action from dagActionStore "
+          + "(check stacktrace) due to exception", flowId), e.fillInStackTrace());
       this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (InterruptedException e) {
-      log.warn("SpecCompiler failed to reach healthy state before compilation of flowId {} due to exception {}", flowId,
-          e);
+      log.warn(String.format("SpecCompiler failed to reach healthy state before compilation of flowId %s due to "
+              + "exception", flowId), e.fillInStackTrace());
       this.dagManagerMetrics.incrementFailedLaunchCount();
     }
   }
@@ -625,6 +627,8 @@ public class DagManager extends AbstractIdleService {
             }
             //Initialize dag.
             initialize(dag);
+          } else {
+            log.warn("Null dag; ignoring the dag");
           }
         }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -510,13 +510,18 @@ public class DagManager extends AbstractIdleService {
       this.dagActionStore.get().deleteDagAction(launchAction);
     } catch (URISyntaxException e) {
       log.warn("Could not create URI object for flowId {} due to exception {}", flowId, e.getMessage());
+      this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (SpecNotFoundException e) {
       log.warn("Spec not found for flowId {} due to exception {}", flowId, e.getMessage());
+      this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (IOException e) {
       log.warn("Failed to add Job Execution Plan for flowId {} OR delete dag action from dagActionStore (check "
           + "stacktrace) due to exception {}", flowId, e.getMessage());
+      this.dagManagerMetrics.incrementFailedLaunchCount();
     } catch (InterruptedException e) {
-      log.warn("SpecCompiler failed to reach healthy state before compilation of flowId {}. Exception: ", flowId, e);
+      log.warn("SpecCompiler failed to reach healthy state before compilation of flowId {} due to exception {}", flowId,
+          e);
+      this.dagManagerMetrics.incrementFailedLaunchCount();
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerMetrics.java
@@ -75,6 +75,9 @@ public class DagManagerMetrics {
   private final Map<String, ContextAwareMeter> executorStartSlaExceededMeters = Maps.newConcurrentMap();
   private final Map<String, ContextAwareMeter> executorSlaExceededMeters = Maps.newConcurrentMap();
   private final Map<String, ContextAwareMeter> executorJobSentMeters = Maps.newConcurrentMap();
+
+  // Metrics for unexpected flow handling failures
+  private ContextAwareCounter failedLaunchEventsOnActivationCount;
   MetricContext metricContext;
 
   public DagManagerMetrics(MetricContext metricContext) {
@@ -100,6 +103,9 @@ public class DagManagerMetrics {
           ServiceMetricNames.SLA_EXCEEDED_FLOWS_METER));
       allRunningMeter = metricContext.contextAwareMeter(MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
           ServiceMetricNames.JOBS_SENT_TO_SPEC_EXECUTOR));
+      failedLaunchEventsOnActivationCount = metricContext.contextAwareCounter(
+          MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
+              ServiceMetricNames.DAG_MANAGER_FAILED_LAUNCH_EVENTS_ON_STARTUP_COUNT));
     }
   }
 
@@ -196,6 +202,13 @@ public class DagManagerMetrics {
       this.getGroupMeterForDag(flowGroup, ServiceMetricNames.START_SLA_EXCEEDED_FLOWS_METER, groupStartSlaExceededMeters);
       this.allStartSlaExceededMeter.mark();
       this.getExecutorMeterForDag(node, ServiceMetricNames.START_SLA_EXCEEDED_FLOWS_METER, executorStartSlaExceededMeters).mark();
+    }
+  }
+
+  // Increment the count for num of failed launches during leader activation
+  public void incrementFailedLaunchCount() {
+    if (this.metricContext != null) {
+      this.failedLaunchEventsOnActivationCount.inc();
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -150,8 +150,7 @@ public class FlowTriggerHandler {
     if (this.dagActionStore.isPresent() && this.multiActiveLeaseArbiter.isPresent()) {
       try {
         DagActionStore.DagAction flowAction = leaseStatus.getFlowAction();
-        // Replace flow execution id with trigger timestamp to easily track the flow
-        this.dagActionStore.get().addDagAction(flowAction.getFlowGroup(), flowAction.getFlowName(), String.valueOf(leaseStatus.getEventTimestamp()), flowAction.getFlowActionType());
+        this.dagActionStore.get().addDagAction(flowAction.getFlowGroup(), flowAction.getFlowName(), flowAction.getFlowExecutionId(), flowAction.getFlowActionType());
         // If the flow action has been persisted to the {@link DagActionStore} we can close the lease
         this.numFlowsSubmitted.mark();
         return this.multiActiveLeaseArbiter.get().recordLeaseSuccess(leaseStatus);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandler.java
@@ -150,7 +150,8 @@ public class FlowTriggerHandler {
     if (this.dagActionStore.isPresent() && this.multiActiveLeaseArbiter.isPresent()) {
       try {
         DagActionStore.DagAction flowAction = leaseStatus.getFlowAction();
-        this.dagActionStore.get().addDagAction(flowAction.getFlowGroup(), flowAction.getFlowName(), flowAction.getFlowExecutionId(), flowAction.getFlowActionType());
+        // Replace flow execution id with trigger timestamp to easily track the flow
+        this.dagActionStore.get().addDagAction(flowAction.getFlowGroup(), flowAction.getFlowName(), String.valueOf(leaseStatus.getEventTimestamp()), flowAction.getFlowActionType());
         // If the flow action has been persisted to the {@link DagActionStore} we can close the lease
         this.numFlowsSubmitted.mark();
         return this.multiActiveLeaseArbiter.get().recordLeaseSuccess(leaseStatus);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -353,7 +353,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       this.dagManager.get().addDag(jobExecutionPlanDag, true, true);
     } catch (Exception ex) {
       String failureMessage = "Failed to add Job Execution Plan due to: " + ex.getMessage();
-      _log.warn("Orchestrator call - " + failureMessage);
+      _log.warn("Orchestrator call - " + failureMessage, ex);
       if (this.flowFailedForwardToDagManagerCounter.isPresent()) {
         this.flowFailedForwardToDagManagerCounter.get().inc();
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -347,9 +347,10 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       //Send the dag to the DagManager.
       this.dagManager.get().addDag(jobExecutionPlanDag, true, true);
     } catch (Exception ex) {
+      String failureMessage = "Failed to add Job Execution Plan due to: " + ex.getMessage();
+      _log.warn("Orchestrator call - " + failureMessage);
       if (this.eventSubmitter.isPresent()) {
         // pronounce failed before stack unwinds, to ensure flow not marooned in `COMPILED` state; (failure likely attributable to DB connection/failover)
-        String failureMessage = "Failed to add Job Execution Plan due to: " + ex.getMessage();
         Map<String, String> flowMetadata = TimingEventUtils.getFlowMetadata(flowSpec);
         flowMetadata.put(TimingEvent.METADATA_MESSAGE, failureMessage);
         new TimingEvent(this.eventSubmitter.get(), TimingEvent.FlowTimings.FLOW_FAILED).stop(flowMetadata);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
@@ -93,6 +94,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
   private Optional<Meter> flowOrchestrationFailedMeter;
   @Getter
   private Optional<Timer> flowOrchestrationTimer;
+  private Optional<Counter> flowFailedForwardToDagManagerCounter;
   @Setter
   private FlowStatusGenerator flowStatusGenerator;
 
@@ -137,12 +139,14 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       this.flowOrchestrationSuccessFulMeter = Optional.of(this.metricContext.meter(ServiceMetricNames.FLOW_ORCHESTRATION_SUCCESSFUL_METER));
       this.flowOrchestrationFailedMeter = Optional.of(this.metricContext.meter(ServiceMetricNames.FLOW_ORCHESTRATION_FAILED_METER));
       this.flowOrchestrationTimer = Optional.of(this.metricContext.timer(ServiceMetricNames.FLOW_ORCHESTRATION_TIMER));
+      this.flowFailedForwardToDagManagerCounter = Optional.of(this.metricContext.counter(ServiceMetricNames.FLOW_FAILED_FORWARD_TO_DAG_MANAGER_COUNT));
       this.eventSubmitter = Optional.of(new EventSubmitter.Builder(this.metricContext, "org.apache.gobblin.service").build());
     } else {
       this.metricContext = null;
       this.flowOrchestrationSuccessFulMeter = Optional.absent();
       this.flowOrchestrationFailedMeter = Optional.absent();
       this.flowOrchestrationTimer = Optional.absent();
+      this.flowFailedForwardToDagManagerCounter = Optional.absent();
       this.eventSubmitter = Optional.absent();
     }
     this.isFlowConcurrencyEnabled = ConfigUtils.getBoolean(config, ServiceConfigKeys.FLOW_CONCURRENCY_ALLOWED,
@@ -337,6 +341,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     if (optionalJobExecutionPlanDag.isPresent()) {
       submitFlowToDagManager(flowSpec, optionalJobExecutionPlanDag.get());
     } else {
+      _log.warn("Flow: {} submitted to dagManager failed to compile and produce a job execution plan dag", flowSpec);
       Instrumented.markMeter(this.flowOrchestrationFailedMeter);
     }
   }
@@ -349,6 +354,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     } catch (Exception ex) {
       String failureMessage = "Failed to add Job Execution Plan due to: " + ex.getMessage();
       _log.warn("Orchestrator call - " + failureMessage);
+      if (this.flowFailedForwardToDagManagerCounter.isPresent()) {
+        this.flowFailedForwardToDagManagerCounter.get().inc();
+      }
       if (this.eventSubmitter.isPresent()) {
         // pronounce failed before stack unwinds, to ensure flow not marooned in `COMPILED` state; (failure likely attributable to DB connection/failover)
         Map<String, String> flowMetadata = TimingEventUtils.getFlowMetadata(flowSpec);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -144,12 +144,11 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
     // {@link DagActionStore.FlowActionType} flow requests that have to be processed. DELETEs require no action.
     try {
       if (operation.equals("INSERT")) {
+        log.info("DagAction change ({}) received for flow: {}", dagActionType, dagAction);
         if (dagActionType.equals(DagActionStore.FlowActionType.RESUME)) {
-          log.info("Received insert dag action and about to send resume flow request for: {}", dagAction);
           dagManager.handleResumeFlowRequest(flowGroup, flowName,Long.parseLong(flowExecutionId));
           this.resumesInvoked.mark();
         } else if (dagActionType.equals(DagActionStore.FlowActionType.KILL)) {
-          log.info("Received insert dag action and about to send kill flow request for: {}", dagAction);
           dagManager.handleKillFlowRequest(flowGroup, flowName, Long.parseLong(flowExecutionId));
           this.killsInvoked.mark();
         } else if (dagActionType.equals(DagActionStore.FlowActionType.LAUNCH)) {
@@ -159,7 +158,6 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
             throw new RuntimeException(String.format("Received LAUNCH dagAction while not in multi-active scheduler "
                 + "mode for flowAction: %s", dagAction));
           }
-          log.info("Received insert dag action and about to forward launch request to DagManager for: {}", dagAction);
           submitFlowToDagManagerHelper(flowGroup, flowName);
         } else {
           log.warn("Received unsupported dagAction {}. Expected to be a KILL, RESUME, or LAUNCH", dagActionType);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowTriggerHandlerTest.java
@@ -34,9 +34,9 @@ public class FlowTriggerHandlerTest {
   String cronExpressionSuffix = truncateFirstTwoFieldsOfCronExpression(cronExpression);
   int schedulerBackOffMillis = 10;
   DagActionStore.DagAction flowAction = new DagActionStore.DagAction("flowName", "flowGroup",
-      "999999", DagActionStore.FlowActionType.LAUNCH);
+      String.valueOf(eventToRevisit), DagActionStore.FlowActionType.LAUNCH);
   MultiActiveLeaseArbiter.LeasedToAnotherStatus leasedToAnotherStatus =
-      new MultiActiveLeaseArbiter.LeasedToAnotherStatus(flowAction, eventToRevisit, minimumLingerDurationMillis);
+      new MultiActiveLeaseArbiter.LeasedToAnotherStatus(flowAction, minimumLingerDurationMillis);
 
   /**
    * Remove first two fields from cron expression representing seconds and minutes to return truncated cron expression


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1930


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Improve logging and metrics around multi-active launch flow event handling to identify any missing events between the `MysqlMultiActiveLeaseArbiter` committing the launch event to the `dagActionStore` and the `DagActionMonitor` receiving events for processing. We want to be able to distinguish between the following cases of 

- events that are never received by the `DagActionMonitor`
- events incorrectly filtered out by the `DagActionMonitor`
- any failed submissions of dags to the `DagManager` either upon leader change or from the `DagActionChangeMonitor`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

