### PR TITLE
[GOBBLIN-1929] add dataset root in some common type of datasets

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -237,4 +237,9 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
     return fileInTarget.getLen() == fileInSource.getLen() && fileInSource.getModificationTime() <= fileInTarget
         .getModificationTime();
   }
+
+  @Override
+  public String getDatasetPath() {
+    return Path.getPathWithoutSchemeAndAuthority(this.rootPath).toString();
+  }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -89,6 +89,15 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     return this.getFileSetId();
   }
 
+  @Override
+  public String getDatasetPath() {
+    try {
+      return this.destIcebergTable.accessTableMetadata().location();
+    } catch (IcebergTable.TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Finds all files read by the table and generates CopyableFiles.
    * For the specific semantics see {@link #createFileSets}.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -178,11 +178,8 @@ public class IcebergTable {
   }
 
   protected static List<String> discoverDataFilePaths(ManifestFile manifest, FileIO io) throws IOException {
-    CloseableIterable<String> manifestPathsIterable = ManifestFiles.readPaths(manifest, io);
-    try {
+    try (CloseableIterable<String> manifestPathsIterable = ManifestFiles.readPaths(manifest, io)) {
       return Lists.newArrayList(manifestPathsIterable);
-    } finally {
-      manifestPathsIterable.close();
     }
   }
   protected DatasetDescriptor getDatasetDescriptor(FileSystem fs) {
@@ -194,6 +191,7 @@ public class IcebergTable {
     descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
     return descriptor;
   }
+
   /** Registers {@link IcebergTable} after publishing data.
    * @param dstMetadata is null if destination {@link IcebergTable} is absent, in which case registration is skipped */
   protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {


### PR DESCRIPTION
Dear Gobblin maintainers,
Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

This PR adds dataset path in IcebergDataset and RecursiveCopyableDataset , which is one of the most commonly used dataset type in distcp jobs. dataset path is needed by datasethandler to find the shard path.

### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1929


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
This PR completes the work of https://github.com/apache/gobblin/pull/3799/files 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes, tested manually

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

