### PR TITLE
[GOBBLIN-1934] Monitor High Level Consumer queue size

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -129,7 +129,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     this.consumerExecutor = Executors.newSingleThreadScheduledExecutor(ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("HighLevelConsumerThread")));
     this.queueExecutor = Executors.newFixedThreadPool(this.numThreads, ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("QueueProcessor-%d")));
     this.queues = new LinkedBlockingQueue[numThreads];
-    for(int i = 0; i<queues.length; i++) {
+    for(int i = 0; i < queues.length; i++) {
       this.queues[i] = new LinkedBlockingQueue();
     }
     this.recordsProcessed = new AtomicInteger(0);
@@ -198,15 +198,24 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
    * this method to instantiate their own metrics.
    */
   protected void createMetrics() {
-    this.messagesRead = this.metricContext.counter(RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
+    String prefix = getMetricsPrefix();
+    this.messagesRead = this.metricContext.counter(prefix +
+        RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
     this.queueSizeGauges = new ContextAwareGauge[numThreads];
     for (int i=0; i < numThreads; i++) {
       // An 'effectively' final variable is needed inside the lambda expression below
       int finalI = i;
-      this.queueSizeGauges[i] = this.metricContext.newContextAwareGauge(
+      this.queueSizeGauges[i] = this.metricContext.newContextAwareGauge(prefix +
           RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX + "-" + i,
           () -> queues[finalI].size());
     }
+  }
+
+  /**
+   * Used by child classes to distinguish prefixes from one another
+   */
+  protected String getMetricsPrefix() {
+    return "";
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -88,7 +88,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
   @Getter
   protected final String topic;
   protected final Config config;
-  protected final int numThreads;
+  private final int numThreads;
 
   /**
    * {@link MetricContext} for the consumer. Note this is instantiated when {@link #startUp()} is called, so
@@ -101,8 +101,8 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
   private final GobblinKafkaConsumerClient gobblinKafkaConsumerClient;
   private final ScheduledExecutorService consumerExecutor;
   private final ExecutorService queueExecutor;
-  protected final BlockingQueue[] queues;
-  protected ContextAwareGauge[] queueSizeGauges;
+  private final BlockingQueue[] queues;
+  private ContextAwareGauge[] queueSizeGauges;
   private final AtomicInteger recordsProcessed;
   private final Map<KafkaPartition, Long> partitionOffsetsToCommit;
   private final boolean enableAutoCommit;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 
 import com.codahale.metrics.Counter;
@@ -130,7 +129,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     this.consumerExecutor = Executors.newSingleThreadScheduledExecutor(ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("HighLevelConsumerThread")));
     this.queueExecutor = Executors.newFixedThreadPool(this.numThreads, ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("QueueProcessor-%d")));
     this.queues = new LinkedBlockingQueue[numThreads];
-    for(int i=0; i<queues.length; i++) {
+    for(int i = 0; i<queues.length; i++) {
       this.queues[i] = new LinkedBlockingQueue();
     }
     this.recordsProcessed = new AtomicInteger(0);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -202,7 +202,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     this.messagesRead = this.metricContext.counter(prefix +
         RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
     this.queueSizeGauges = new ContextAwareGauge[numThreads];
-    for (int i=0; i < numThreads; i++) {
+    for (int i = 0; i < numThreads; i++) {
       // An 'effectively' final variable is needed inside the lambda expression below
       int finalI = i;
       this.queueSizeGauges[i] = this.metricContext.newContextAwareGauge(prefix +

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -28,6 +28,7 @@ public class RuntimeMetrics {
   // Metric names
   public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ =
       "gobblin.kafka.highLevelConsumer.messagesRead";
+  public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE = "gobblin.kafka.highLevelConsumer.queueSize";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_TOTAL_SPECS = "gobblin.jobMonitor.kafka.totalSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_NEW_SPECS = "gobblin.jobMonitor.kafka.newSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_UPDATED_SPECS = "gobblin.jobMonitor.kafka.updatedSpecs";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -28,7 +28,7 @@ public class RuntimeMetrics {
   // Metric names
   public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ =
       "gobblin.kafka.highLevelConsumer.messagesRead";
-  public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE = "gobblin.kafka.highLevelConsumer.queueSize";
+  public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX = "gobblin.kafka.highLevelConsumer.queueSize";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_TOTAL_SPECS = "gobblin.jobMonitor.kafka.totalSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_NEW_SPECS = "gobblin.jobMonitor.kafka.newSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_UPDATED_SPECS = "gobblin.jobMonitor.kafka.updatedSpecs";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -29,7 +29,6 @@ import com.google.common.cache.LoadingCache;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 
-import java.util.concurrent.atomic.AtomicIntegerArray;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
@@ -219,10 +218,11 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
   protected void createMetrics() {
     super.messagesRead = this.getMetricContext().counter(RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." + RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
     super.queueSizeGauges = new ContextAwareGauge[super.numThreads];
-    for (int i=0; i < numThreads; i++) {
+    for (int i = 0; i < numThreads; i++) {
       // An 'effectively' final variable is needed inside the lambda expression below
       int finalI = i;
       this.queueSizeGauges[i] = this.getMetricContext().newContextAwareGauge(
+          RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." +
           RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX + "-" + i,
           () -> super.queues[finalI].size());
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.ContextAwareMeter;
-import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.runtime.api.DagActionStore;
 import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
@@ -220,12 +219,12 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
   protected void createMetrics() {
     super.messagesRead = this.getMetricContext().counter(RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." + RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
     super.queueSizeGauges = new ContextAwareGauge[super.numThreads];
-    super.queueSizeGaugeValues = new AtomicIntegerArray(numThreads);
     for (int i=0; i < numThreads; i++) {
+      // An 'effectively' final variable is needed inside the lambda expression below
       int finalI = i;
       this.queueSizeGauges[i] = this.getMetricContext().newContextAwareGauge(
-          RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." + RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE + "-" + i,
-          () -> queueSizeGaugeValues.get(finalI));
+          RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX + "-" + i,
+          () -> super.queues[finalI].size());
     }
     // Dag Action specific metrics
     this.killsInvoked = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -216,16 +216,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
 
   @Override
   protected void createMetrics() {
-    super.messagesRead = this.getMetricContext().counter(RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." + RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
-    super.queueSizeGauges = new ContextAwareGauge[super.numThreads];
-    for (int i = 0; i < numThreads; i++) {
-      // An 'effectively' final variable is needed inside the lambda expression below
-      int finalI = i;
-      this.queueSizeGauges[i] = this.getMetricContext().newContextAwareGauge(
-          RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + "." +
-          RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX + "-" + i,
-          () -> super.queues[finalI].size());
-    }
+    super.createMetrics();
     // Dag Action specific metrics
     this.killsInvoked = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED);
     this.resumesInvoked = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED);
@@ -236,5 +227,10 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
     this.messageFilteredOutMeter = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_MESSAGES_FILTERED_OUT);
     this.produceToConsumeDelayMillis = this.getMetricContext().newContextAwareGauge(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_PRODUCE_TO_CONSUME_DELAY_MILLIS, () -> produceToConsumeDelayValue);
     this.getMetricContext().register(this.produceToConsumeDelayMillis);
+  }
+
+  @Override
+  protected String getMetricsPrefix() {
+    return RuntimeMetrics.DAG_ACTION_STORE_MONITOR_PREFIX + ".";
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1934


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We suspect that the HighLevelConsumer class may be dropping Kafka messages if the thread for a particular consumption queue is interrupted or stalled. Before changing how these queues are handled, we want to verify that blocked or dropped queues is the reason for missed messages by emitting metrics about each queue's size. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Metrics added to be verified by monitoring 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

