### PR TITLE
[GOBBLIN-1940] Expose functions to fetch record partitionColumn value and customize default record timestamp

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
@@ -85,7 +85,7 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
   /**
    *  Check if the partition column value is present and is a Long object. Otherwise, use current system time.
    */
-  private long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
+  protected long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
 
     if (writerPartitionColumnValue.isPresent()) {
       Object val = writerPartitionColumnValue.get();
@@ -103,7 +103,7 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
   /**
    * Retrieve the value of the partition column field specified by this.partitionColumns
    */
-  private Optional<Object> getWriterPartitionColumnValue(GenericRecord record) {
+  protected Optional<Object> getWriterPartitionColumnValue(GenericRecord record) {
     if (!this.partitionColumns.isPresent()) {
       return Optional.absent();
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1940


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
This PR expose functions in TimeBasedAvroWriterPartitioner in order to allow extended classes to be able to operate independently based on the writerPartitionColumnValue and calculate the timestamp of the record separately with different defaults.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

