### PR TITLE
Make KafkaTopicGroupingWorkUnitPacker pack with desired num of container

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/MultiWorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/MultiWorkUnit.java
@@ -155,4 +155,15 @@ public class MultiWorkUnit extends WorkUnit {
   public static MultiWorkUnit createEmpty() {
     return new MultiWorkUnit();
   }
+
+  /**
+   * Create a new {@link MultiWorkUnit} instance based on provided collection of {@link WorkUnit}s.
+   *
+   * @return a the {@link MultiWorkUnit} instance with the provided collection of {@link WorkUnit}s.
+   */
+  public static MultiWorkUnit createMultiWorkUnit(Collection<WorkUnit> workUnits) {
+    MultiWorkUnit multiWorkUnit = new MultiWorkUnit();
+    multiWorkUnit.addWorkUnits(workUnits);
+    return multiWorkUnit;
+  }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
@@ -393,9 +393,9 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
   }
 
   /**
-   * A method that split a list of {@link MultiWorkUnit} to the size of desiredWUSize if possible. The split approach is to
-   * try split the {@link WorkUnit} within each MWU into two, in order of size WU within. Stop when each {@link MultiWorkUnit}
-   * only contains single {@link WorkUnit} as further split is no possible.
+   * A method that split a list of {@link MultiWorkUnit} to the size of desiredWUSize if possible. The approach is to try
+   * to evenly split the {@link WorkUnit} within MWU into two, and always try to split MWU with more partitions first.
+   * Stop when each {@link MultiWorkUnit} only contains single {@link WorkUnit} as further split is no possible.
    * @param multiWorkUnits the list of {@link MultiWorkUnit} to be split
    * @param desiredWUSize desired number of {@link MultiWorkUnit}
    * @return splitted MultiWorkUnit


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1936] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1936


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Make KafkaTopicGroupingWorkUnitPacker pick up the variable numContainers so that be able to pack with desired num of container. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test cases.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

