### PR TITLE
[Hotfix][GOBBLIN-1949] add option to detect malformed orc during commit

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -265,7 +265,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
       try {
         OrcFile.createReader(this.outputFile, new OrcFile.ReaderOptions(conf));
       } catch (IOException ioException) {
-        log.error("Found error when validating ORC file during commit phase", ioException);
+        log.error("Found error when validating ORC file {} during commit phase", this.outputFile, ioException);
         log.error("Delete the malformed ORC file is successful: {}", this.fs.delete(this.outputFile, false));
         throw ioException;
       }

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -266,9 +266,9 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     if(this.validateORCAfterClose) {
       try (Reader reader = OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
       } catch (Exception e) {
-        log.error("Found error when validating ORC file during commit phase", e);
+        log.error("Found error when validating staging ORC file {} during commit phase. "
+            + "Will delete the malformed file and terminate the commit", this.stagingFile, e);
         HadoopUtils.deletePath(this.fs, this.stagingFile, false);
-        log.error("Delete the malformed ORC file after close the writer: {}", this.stagingFile);
         throw e;
       }
     }

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -264,11 +264,11 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     if(this.validateORCDuringCommit) {
       try {
         OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf));
-      } catch (IOException ioException) {
-        log.error("Found error when validating ORC file during commit phase", ioException);
+      } catch (Exception e) {
+        log.error("Found error when validating ORC file during commit phase", e);
         HadoopUtils.deletePath(this.fs, this.stagingFile, false);
         log.error("Delete the malformed ORC file after close the writer: {}", this.stagingFile);
-        throw ioException;
+        throw e;
       }
     }
     super.commit();

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -245,16 +245,6 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
         throw new CloseBeforeFlushException(this.inputSchema.toString());
       }
     }
-    // Validate the ORC file after writer close. Default is false as it introduce more load to FS and decrease the performance
-    if(this.validateORCAfterClose) {
-      try(Reader reader =OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
-      } catch (Exception e) {
-        log.error("Found error when validating ORC file during commit phase", e);
-        HadoopUtils.deletePath(this.fs, this.stagingFile, false);
-        log.error("Delete the malformed ORC file after close the writer: {}", this.stagingFile);
-        throw e;
-      }
-    }
   }
 
   @Override
@@ -272,6 +262,16 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   public void commit()
       throws IOException {
     closeInternal();
+    // Validate the ORC file after writer close. Default is false as it introduce more load to FS and decrease the performance
+    if(this.validateORCAfterClose) {
+      try(Reader reader =OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
+      } catch (Exception e) {
+        log.error("Found error when validating ORC file during commit phase", e);
+        HadoopUtils.deletePath(this.fs, this.stagingFile, false);
+        log.error("Delete the malformed ORC file after close the writer: {}", this.stagingFile);
+        throw e;
+      }
+    }
     super.commit();
 
     if (this.selfTuningWriter) {

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -264,7 +264,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     closeInternal();
     // Validate the ORC file after writer close. Default is false as it introduce more load to FS and decrease the performance
     if(this.validateORCAfterClose) {
-      try(Reader reader =OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
+      try (Reader reader =OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
       } catch (Exception e) {
         log.error("Found error when validating ORC file during commit phase", e);
         HadoopUtils.deletePath(this.fs, this.stagingFile, false);

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -264,7 +264,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     closeInternal();
     // Validate the ORC file after writer close. Default is false as it introduce more load to FS and decrease the performance
     if(this.validateORCAfterClose) {
-      try (Reader reader =OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
+      try (Reader reader = OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
       } catch (Exception e) {
         log.error("Found error when validating ORC file during commit phase", e);
         HadoopUtils.deletePath(this.fs, this.stagingFile, false);

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
@@ -26,7 +26,7 @@ public class GobblinOrcWriterConfigs {
    * Configuration for enabling validation of ORC file to detect malformation. If enabled, will throw exception and
    * delete malformed ORC file during commit
    */
-  public static final String ORC_WRITER_VALIDATE_FILE_DURING_COMMIT = ORC_WRITER_PREFIX + "validate.commit.file";
+  public static final String ORC_WRITER_VALIDATE_FILE_AFTER_CLOSE = ORC_WRITER_PREFIX + "validate.file.after.close";
   /**
    * Default buffer size in the ORC Writer before sending the records to the native ORC Writer
    */

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
@@ -23,6 +23,11 @@ package org.apache.gobblin.writer;
 public class GobblinOrcWriterConfigs {
   public static final String ORC_WRITER_PREFIX = "orcWriter.";
   /**
+   * Configuration for enabling validation of ORC file to detect malformation. If enabled, will throw exception and
+   * delete malformed ORC file during commit
+   */
+  public static final String ORC_WRITER_VALIDATE_FILE_DURING_COMMIT = ORC_WRITER_PREFIX + "validate.commit.file";
+  /**
    * Default buffer size in the ORC Writer before sending the records to the native ORC Writer
    */
   public static final String ORC_WRITER_BATCH_SIZE = ORC_WRITER_PREFIX + "batchSize";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1949] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1949


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Added an option to validate of ORC file to detect malformation. If enabled, will throw exception and delete malformed ORC file during commit

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

