### PR TITLE
[GOBBLIN-1948] Use same flowExecutionId across participants

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -420,16 +420,6 @@ public class FlowSpec implements Configurable, Spec {
     return getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY);
   }
 
-  /**
-   * Create a new FlowSpec object with the added property defined by path and value parameters
-   * @param path key for new property
-   * @param value
-   */
-  public FlowSpec addProperty(String path, String value) {
-    Config updatedConfig = this.getConfig().withValue(path, ConfigValueFactory.fromAnyRef(value));
-    return new Builder(this.getUri()).withConfig(updatedConfig).build();
-  }
-
   @Slf4j
   public static class Utils {
     private final static String URI_SCHEME = "gobblin-flow";
@@ -528,5 +518,15 @@ public class FlowSpec implements Configurable, Spec {
       return URI_SCHEME.length() + ":".length() // URI separator
         + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_NAME_LENGTH + URI_PATH_SEPARATOR.length() + ServiceConfigKeys.MAX_FLOW_GROUP_LENGTH;
     }
+  }
+
+  /**
+   * Create a new FlowSpec object with the added property defined by path and value parameters
+   * @param path key for new property
+   * @param value
+   */
+  public static FlowSpec createFlowSpecWithProperty(FlowSpec flowSpec, String path, String value) {
+    Config updatedConfig = flowSpec.getConfig().withValue(path, ConfigValueFactory.fromAnyRef(value));
+    return new Builder(flowSpec.getUri()).withConfig(updatedConfig).build();
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -17,17 +17,6 @@
 
 package org.apache.gobblin.runtime.api;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -37,12 +26,20 @@ import com.google.common.collect.Sets;
 import com.linkedin.data.template.StringMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
+import com.typesafe.config.ConfigValueFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
-
+import org.apache.commons.lang.StringUtils;
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.service.FlowConfig;
@@ -429,10 +426,8 @@ public class FlowSpec implements Configurable, Spec {
    * @param value
    */
   public FlowSpec addProperty(String path, String value) {
-    Properties properties = this.getConfigAsProperties();
-    properties.setProperty(path, value);
-    Config config = ConfigFactory.parseProperties(properties);
-    return new Builder(this.getUri()).withConfigAsProperties(properties).withConfig(config).build();
+    Config updatedConfig = this.getConfig().withValue(path, ConfigValueFactory.fromAnyRef(value));
+    return new Builder(this.getUri()).withConfig(updatedConfig).build();
   }
 
   @Slf4j

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -423,6 +423,17 @@ public class FlowSpec implements Configurable, Spec {
     return getConfig().hasPath(ConfigurationKeys.JOB_SCHEDULE_KEY);
   }
 
+  /**
+   * Create a new FlowSpec object with the added property defined by path and value parameters
+   * @param path key for new property
+   * @param value
+   */
+  public FlowSpec addProperty(String path, String value) {
+    Properties properties = this.getConfigAsProperties();
+    properties.setProperty(path, value);
+    return new Builder(this.getUri()).withConfigAsProperties(properties).build();
+  }
+
   @Slf4j
   public static class Utils {
     private final static String URI_SCHEME = "gobblin-flow";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -431,7 +431,8 @@ public class FlowSpec implements Configurable, Spec {
   public FlowSpec addProperty(String path, String value) {
     Properties properties = this.getConfigAsProperties();
     properties.setProperty(path, value);
-    return new Builder(this.getUri()).withConfigAsProperties(properties).build();
+    Config config = ConfigFactory.parseProperties(properties);
+    return new Builder(this.getUri()).withConfigAsProperties(properties).withConfig(config).build();
   }
 
   @Slf4j

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
@@ -1,0 +1,42 @@
+package org.apache.gobblin.runtime.api;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.service.FlowId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FlowSpecTest {
+
+  /**
+   * Tests that the addProperty() function to ensure the new flowSpec returned has the original properties and updated
+   * ones
+   * @throws URISyntaxException
+   */
+  @Test
+  public void testAddProperty() throws URISyntaxException {
+    String flowGroup = "myGroup";
+    String flowName = "myName";
+    String flowExecutionId = "myId";
+    FlowId flowId = new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
+    URI flowUri = FlowSpec.Utils.createFlowSpecUri(flowId);
+
+    // Create properties to be used as config
+    Properties properties = new Properties();
+    properties.setProperty(ConfigurationKeys.FLOW_GROUP_KEY, flowGroup);
+    properties.setProperty(ConfigurationKeys.FLOW_NAME_KEY, flowName);
+    properties.setProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY, "true");
+
+    FlowSpec originalFlowSpec = FlowSpec.builder(flowUri).withConfigAsProperties(properties).build();
+    FlowSpec updatedFlowSpec = originalFlowSpec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
+
+    Properties updatedProperties = updatedFlowSpec.getConfigAsProperties();
+    Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY), flowExecutionId);
+    Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_GROUP_KEY), flowGroup);
+    Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_NAME_KEY), flowName);
+    Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY), "true");
+  }
+}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
@@ -1,5 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.runtime.api;
 
+import com.typesafe.config.Config;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
@@ -38,5 +56,11 @@ public class FlowSpecTest {
     Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_GROUP_KEY), flowGroup);
     Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_NAME_KEY), flowName);
     Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY), "true");
+
+    Config updatedConfig = updatedFlowSpec.getConfig();
+    Assert.assertEquals(updatedConfig.getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY), flowExecutionId);
+    Assert.assertEquals(updatedConfig.getString(ConfigurationKeys.FLOW_GROUP_KEY), flowGroup);
+    Assert.assertEquals(updatedConfig.getString(ConfigurationKeys.FLOW_NAME_KEY), flowName);
+    Assert.assertEquals(updatedConfig.getString(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY), "true");
   }
 }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FlowSpecTest.java
@@ -26,6 +26,8 @@ import org.apache.gobblin.service.FlowId;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.gobblin.runtime.api.FlowSpec.*;
+
 
 public class FlowSpecTest {
 
@@ -49,7 +51,7 @@ public class FlowSpecTest {
     properties.setProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY, "true");
 
     FlowSpec originalFlowSpec = FlowSpec.builder(flowUri).withConfigAsProperties(properties).build();
-    FlowSpec updatedFlowSpec = originalFlowSpec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
+    FlowSpec updatedFlowSpec = createFlowSpecWithProperty(originalFlowSpec, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
 
     Properties updatedProperties = updatedFlowSpec.getConfigAsProperties();
     Assert.assertEquals(updatedProperties.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY), flowExecutionId);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -42,6 +42,8 @@ import org.apache.gobblin.service.FlowId;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 
+import static org.apache.gobblin.runtime.api.FlowSpec.*;
+
 
 /**
  * A DagActionStore change monitor that uses {@link DagActionStoreChangeEvent} schema to process Kafka messages received
@@ -198,7 +200,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
       URI flowUri = FlowSpec.Utils.createFlowSpecUri(flowId);
       spec = (FlowSpec) flowCatalog.getSpecs(flowUri);
       // Adds flowExecutionId to config to ensure they are consistent across hosts
-      FlowSpec updatedSpec = spec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
+      FlowSpec updatedSpec = createFlowSpecWithProperty(spec, ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
       this.orchestrator.submitFlowToDagManager(updatedSpec);
     } catch (URISyntaxException e) {
       log.warn("Could not create URI object for flowId {}. Exception {}", flowId, e.getMessage());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1948


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
A consistent `flowExecutionId` is used during lease arbitration between hosts and that id is available to the `DagActionStoreChangeMonitor` but not used when passing `launch` events to the `Orchestrator` for recompilation and eventual execution. The unintended consequence of this is that a different `flowExecutionId` will be used across each participant when the flow is recompiled before passing to the `DagManager`. This messes up the job status of the most recent flow execution of each flow as it appears there are `N flow execution Ids`, 1 for each of the `N` hosts. Only one will be executed but the other `N-1` are stuck in `"compiling"` job status state.  

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests `addProperty` method added

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

