### PR TITLE
[GOBBLIN-1951] Emit GTE when deleting corrupted ORC files

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -38,6 +38,7 @@ import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
@@ -387,6 +388,9 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   }
 
   @VisibleForTesting
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE",
+    justification = "Find bugs believes the eventBuilder is always null and that there is a null check, "
+        + "but both are not true.")
   static void assertOrcFileIsValid(FileSystem fs, Path filePath, OrcFile.ReaderOptions readerOptions, MetricContext metricContext) throws IOException {
     try (Reader ignored = OrcFile.createReader(filePath, readerOptions)) {
     } catch (Exception e) {

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -24,8 +24,9 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.gobblin.util.HadoopUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile;
@@ -40,15 +41,24 @@ import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 import org.apache.gobblin.state.ConstructState;
+import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.JobConfigurationUtils;
+
 
 /**
  * A wrapper for ORC-core writer without dependency on Hive SerDe library.
  */
 @Slf4j
 public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
+  public static final String ORC_WRITER_NAMESPACE = "gobblin.orc.writer";
+  public static final String CORRUPTED_ORC_FILE_DELETION_EVENT = "CorruptedOrcFileDeletion";
 
+  protected final MetricContext metricContext;
   protected final OrcValueWriter<D> valueWriter;
   @VisibleForTesting
   VectorizedRowBatch rowBatch;
@@ -113,6 +123,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     this.orcWriterStripeSizeBytes = properties.getPropAsLong(OrcConf.STRIPE_SIZE.getAttribute(), (long) OrcConf.STRIPE_SIZE.getDefaultValue());
     this.converterMemoryManager = new OrcConverterMemoryManager(this.rowBatch, properties);
     this.valueWriter = getOrcValueWriter(typeDescription, this.inputSchema, properties);
+    this.metricContext = getMetricContext();
 
     // Track the number of other writer tasks from different datasets ingesting on the same container
     this.concurrentWriterTasks = properties.getPropAsInt(GobblinOrcWriterConfigs.RuntimeStateConfigs.ORC_WRITER_CONCURRENT_TASKS, 1);
@@ -262,16 +273,11 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   public void commit()
       throws IOException {
     closeInternal();
-    // Validate the ORC file after writer close. Default is false as it introduce more load to FS and decrease the performance
+    // Validate the ORC file after writer close. Default is false as it introduce more load to FS from an extra read call
     if(this.validateORCAfterClose) {
-      try (Reader reader = OrcFile.createReader(this.stagingFile, new OrcFile.ReaderOptions(conf))) {
-      } catch (Exception e) {
-        log.error("Found error when validating staging ORC file {} during commit phase. "
-            + "Will delete the malformed file and terminate the commit", this.stagingFile, e);
-        HadoopUtils.deletePath(this.fs, this.stagingFile, false);
-        throw e;
-      }
+      assertOrcFileIsValid(this.fs, this.stagingFile, new OrcFile.ReaderOptions(conf), this.metricContext);
     }
+
     super.commit();
 
     if (this.selfTuningWriter) {
@@ -373,6 +379,25 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     }
     if (rowBatch.size == this.batchSize) {
       this.flush();
+    }
+  }
+
+  protected MetricContext getMetricContext() {
+    return Instrumented.getMetricContext(new State(properties), this.getClass());
+  }
+
+  @VisibleForTesting
+  static void assertOrcFileIsValid(FileSystem fs, Path filePath, OrcFile.ReaderOptions readerOptions, MetricContext metricContext) throws IOException {
+    try (Reader ignored = OrcFile.createReader(filePath, readerOptions)) {
+    } catch (Exception e) {
+      log.error("Found error when validating staging ORC file {} during the commit phase. "
+          + "Will delete the malformed file and abort the commit by throwing an exception", filePath, e);
+      HadoopUtils.deletePath(fs, filePath, false);
+      GobblinEventBuilder eventBuilder = new GobblinEventBuilder(CORRUPTED_ORC_FILE_DELETION_EVENT, GobblinBaseOrcWriter.ORC_WRITER_NAMESPACE);
+      eventBuilder.addMetadata("filePath", filePath.toString());
+      EventSubmitter.submit(metricContext, eventBuilder);
+
+      throw e;
     }
   }
 }

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/InstrumentedGobblinOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/InstrumentedGobblinOrcWriter.java
@@ -28,8 +28,6 @@ import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 
@@ -39,18 +37,16 @@ import org.apache.gobblin.metrics.event.GobblinEventBuilder;
  */
 @Slf4j
 public class InstrumentedGobblinOrcWriter extends GobblinOrcWriter {
-  MetricContext metricContext;
+
   public static final String METRICS_SCHEMA_NAME = "schemaName";
   public static final String METRICS_BYTES_WRITTEN = "bytesWritten";
   public static final String METRICS_RECORDS_WRITTEN = "recordsWritten";
   public static final String METRICS_BUFFER_RESIZES = "bufferResizes";
   public static final String METRICS_BUFFER_SIZE = "bufferSize";
   public static final String ORC_WRITER_METRICS_NAME = "OrcWriterMetrics";
-  private static final String ORC_WRITER_NAMESPACE = "gobblin.orc.writer";
 
   public InstrumentedGobblinOrcWriter(FsDataWriterBuilder<Schema, GenericRecord> builder, State properties) throws IOException {
     super(builder, properties);
-    metricContext = Instrumented.getMetricContext(new State(properties), this.getClass());
   }
 
   @Override

--- a/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
+++ b/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
@@ -1,0 +1,50 @@
+package org.apache.gobblin.writer;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.FileFormatException;
+import org.apache.orc.OrcFile;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.io.Files;
+
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.event.GobblinEventBuilder;
+
+import static org.apache.gobblin.writer.GobblinBaseOrcWriter.CORRUPTED_ORC_FILE_DELETION_EVENT;
+
+
+public class GobblinBaseOrcWriterTest {
+
+  @Test
+  public void testOrcValidation()
+      throws IOException {
+    Configuration conf = new Configuration();
+    FileSystem fs = FileSystem.getLocal(conf);
+    File tmpDir = Files.createTempDir();
+    File corruptedOrcFile = new File(tmpDir, "test.orc");
+    try (FileWriter writer = new FileWriter(corruptedOrcFile)) {
+      // write a corrupted ORC file that only contains the header but without content
+      writer.write(OrcFile.MAGIC);
+    }
+
+    OrcFile.ReaderOptions readerOptions = new OrcFile.ReaderOptions(conf);
+
+    MetricContext mockContext = Mockito.mock(MetricContext.class);
+    Path p = new Path(corruptedOrcFile.getAbsolutePath());
+    Assert.assertThrows(FileFormatException.class,
+        () -> GobblinBaseOrcWriter.assertOrcFileIsValid(fs, p, readerOptions, mockContext));
+
+    GobblinEventBuilder eventBuilder = new GobblinEventBuilder(CORRUPTED_ORC_FILE_DELETION_EVENT, GobblinBaseOrcWriter.ORC_WRITER_NAMESPACE);
+    eventBuilder.addMetadata("filePath", p.toString());
+    Mockito.verify(mockContext, Mockito.times(1))
+        .submitEvent(eventBuilder.build());
+  }
+}

--- a/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
+++ b/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.writer;
 
 import java.io.File;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1951] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1951


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

This commit modifies ORC file validation during the commit phase and deletes corrupted files to also emit a GTE. It also includes a test for ORC file validation.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
![image](https://github.com/apache/gobblin/assets/35702680/f2482cb9-3cea-48c4-ba5f-9f0e4a7cc350)


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

