### PR TITLE
[GOBBLIN-1952] Make jobname shortening in GaaS more aggressive

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -61,7 +61,8 @@ import static org.apache.gobblin.runtime.AbstractJobLauncher.GOBBLIN_JOB_TEMPLAT
 public class JobExecutionPlan {
   public static final String JOB_MAX_ATTEMPTS = "job.maxAttempts";
   public static final String JOB_PROPS_KEY = "job.props";
-  private static final int MAX_JOB_NAME_LENGTH = 255;
+  private static final int MAX_JOB_NAME_LENGTH = 128;
+  private static final String DEFAULT_LONG_JOBNAME_PREFIX = "GaaS_job";
 
   private final JobSpec jobSpec;
   private final SpecExecutor specExecutor;
@@ -112,10 +113,10 @@ public class JobExecutionPlan {
       // job names are assumed to be unique within a dag.
       int hash = flowInputPath.hashCode();
       jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, edgeId, hash);
-      // jobNames are commonly used as a directory name, which is limited to 255 characters
+      // jobNames are commonly used as a directory name, which is limited to 255 characters (account for potential prefixes added/file name lengths)
       if (jobName.length() >= MAX_JOB_NAME_LENGTH) {
-        // shorten job length to be 128 characters (flowGroup) + (hashed) flowName, hashCode length
-        jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName.hashCode(), hash);
+        // shorten job length but make it uniquely identifiable in multihop flows or concurrent jobs
+        jobName = DEFAULT_LONG_JOBNAME_PREFIX + jobName.hashCode();
       }
       JobSpec.Builder jobSpecBuilder = JobSpec.builder(jobSpecURIGenerator(flowGroup, jobName, flowSpec)).withConfig(jobConfig)
           .withDescription(flowSpec.getDescription()).withVersion(flowSpec.getVersion());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -62,7 +62,6 @@ public class JobExecutionPlan {
   public static final String JOB_MAX_ATTEMPTS = "job.maxAttempts";
   public static final String JOB_PROPS_KEY = "job.props";
   private static final int MAX_JOB_NAME_LENGTH = 128;
-  private static final String DEFAULT_LONG_JOBNAME_PREFIX = "GaaS_job";
 
   private final JobSpec jobSpec;
   private final SpecExecutor specExecutor;
@@ -115,8 +114,8 @@ public class JobExecutionPlan {
       jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, edgeId, hash);
       // jobNames are commonly used as a directory name, which is limited to 255 characters (account for potential prefixes added/file name lengths)
       if (jobName.length() >= MAX_JOB_NAME_LENGTH) {
-        // shorten job length but make it uniquely identifiable in multihop flows or concurrent jobs
-        jobName = DEFAULT_LONG_JOBNAME_PREFIX + jobName.hashCode();
+        // shorten job length but make it uniquely identifiable in multihop flows or concurrent jobs, max length 139 characters (128 flow group  + hash)
+        jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, jobName.hashCode());
       }
       JobSpec.Builder jobSpecBuilder = JobSpec.builder(jobSpecURIGenerator(flowGroup, jobName, flowSpec)).withConfig(jobConfig)
           .withDescription(flowSpec.getDescription()).withVersion(flowSpec.getVersion());

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
@@ -232,7 +232,9 @@ public class JobExecutionPlanDagFactoryTest {
 
     Dag<JobExecutionPlan> dag1 = new JobExecutionPlanDagFactory().createDag(Arrays.asList(jobExecutionPlan));
 
-    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY).length(), 142);
+    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY).length(), 18);
+    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "GaaS_job-120225869");
+
   }
 
   @Test

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanDagFactoryTest.java
@@ -232,8 +232,7 @@ public class JobExecutionPlanDagFactoryTest {
 
     Dag<JobExecutionPlan> dag1 = new JobExecutionPlanDagFactory().createDag(Arrays.asList(jobExecutionPlan));
 
-    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY).length(), 18);
-    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "GaaS_job-120225869");
+    Assert.assertEquals(dag1.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY).length(), 139);
 
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1952


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Gobblin-as-a-Service creates jobnames using flowgroups flownames, edges, and jobnames from the template. However, this tends to create a very long string which then causes issues in Gobblin job when creating files that use the jobname to create working directories or state stores. 

Although there has been previous code that shortens job name lengths, we want to further increase this by being more aggressive with the maximum length of the jobname to reduce the odds of exceeding 255 chars (max length of HDFS component)

The PR reduces the max job name length to 128 characters (1/2 of previous max) as well as forcing jobnames to then be shortened to `flowGroup_<job_hash>` which will be a UUID at a per-job level for each dag.

The reason why it uses flowGroup still as a prefix before the jobname hash is to reduce the odds that a shared job working directory will run into hash collisions, which can lead to complications on concurrent jobs

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

