### PR TITLE
[GOBBLIN-1953] Add an exception message to orc writer validation GTE

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -399,6 +399,8 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
       HadoopUtils.deletePath(fs, filePath, false);
       GobblinEventBuilder eventBuilder = new GobblinEventBuilder(CORRUPTED_ORC_FILE_DELETION_EVENT, GobblinBaseOrcWriter.ORC_WRITER_NAMESPACE);
       eventBuilder.addMetadata("filePath", filePath.toString());
+      eventBuilder.addMetadata("exceptionType", e.getClass().getCanonicalName());
+      eventBuilder.addMetadata("exceptionMessage", e.getMessage());
       EventSubmitter.submit(metricContext, eventBuilder);
 
       throw e;

--- a/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
+++ b/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinBaseOrcWriterTest.java
@@ -26,8 +26,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.FileFormatException;
 import org.apache.orc.OrcFile;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.common.io.Files;
@@ -36,31 +39,70 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 
 import static org.apache.gobblin.writer.GobblinBaseOrcWriter.CORRUPTED_ORC_FILE_DELETION_EVENT;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 
 public class GobblinBaseOrcWriterTest {
+  Configuration conf;
+  FileSystem fs;
+  File tmpDir;
+  File orcFile;
+  Path orcFilePath;
+
+  @Mock
+  MetricContext mockContext;
+
+  AutoCloseable closeable;
+
+  @BeforeTest
+  public void setup() throws IOException {
+    this.closeable = openMocks(this);
+    this.conf = new Configuration();
+    this.fs = FileSystem.getLocal(conf);
+    this.tmpDir = Files.createTempDir();
+    this.orcFile = new File(tmpDir, "test.orc");
+    this.orcFilePath = new Path(orcFile.getAbsolutePath());
+  }
+
+  @AfterTest
+  public void tearDown()
+      throws Exception {
+    this.closeable.close();
+  }
 
   @Test
-  public void testOrcValidation()
+  public void testOrcValidationOnlyHeader()
       throws IOException {
-    Configuration conf = new Configuration();
-    FileSystem fs = FileSystem.getLocal(conf);
-    File tmpDir = Files.createTempDir();
-    File corruptedOrcFile = new File(tmpDir, "test.orc");
-    try (FileWriter writer = new FileWriter(corruptedOrcFile)) {
-      // write a corrupted ORC file that only contains the header but without content
+    try (FileWriter writer = new FileWriter(orcFile)) {
+      // writer a corrupted ORC file that only contains thethe header
       writer.write(OrcFile.MAGIC);
     }
 
-    OrcFile.ReaderOptions readerOptions = new OrcFile.ReaderOptions(conf);
-
-    MetricContext mockContext = Mockito.mock(MetricContext.class);
-    Path p = new Path(corruptedOrcFile.getAbsolutePath());
-    Assert.assertThrows(FileFormatException.class,
-        () -> GobblinBaseOrcWriter.assertOrcFileIsValid(fs, p, readerOptions, mockContext));
+    Assert.assertThrows(FileFormatException.class, () -> GobblinBaseOrcWriter.assertOrcFileIsValid(
+        fs, orcFilePath, new OrcFile.ReaderOptions(conf), mockContext));
 
     GobblinEventBuilder eventBuilder = new GobblinEventBuilder(CORRUPTED_ORC_FILE_DELETION_EVENT, GobblinBaseOrcWriter.ORC_WRITER_NAMESPACE);
-    eventBuilder.addMetadata("filePath", p.toString());
+    eventBuilder.addMetadata("filePath", orcFilePath.toString());
+    eventBuilder.addMetadata("exceptionType", "org.apache.orc.FileFormatException");
+    eventBuilder.addMetadata("exceptionMessage", String.format("Not a valid ORC file %s (maxFileLength= 9223372036854775807)", orcFilePath));
+    Mockito.verify(mockContext, Mockito.times(1)).submitEvent(eventBuilder.build());
+  }
+
+  @Test
+  public void testOrcValidationWithContent() throws IOException {
+    try (FileWriter writer = new FileWriter(orcFile)) {
+      // write a corrupted ORC file that only contains the header and invalid protobuf content
+      writer.write(OrcFile.MAGIC);
+      writer.write("\n");
+    }
+
+    Assert.assertThrows(com.google.protobuf25.InvalidProtocolBufferException.class,
+        () -> GobblinBaseOrcWriter.assertOrcFileIsValid(fs, orcFilePath, new OrcFile.ReaderOptions(conf), mockContext));
+
+    GobblinEventBuilder eventBuilder = new GobblinEventBuilder(CORRUPTED_ORC_FILE_DELETION_EVENT, GobblinBaseOrcWriter.ORC_WRITER_NAMESPACE);
+    eventBuilder.addMetadata("filePath", orcFilePath.toString());
+    eventBuilder.addMetadata("exceptionType", "com.google.protobuf25.InvalidProtocolBufferException");
+    eventBuilder.addMetadata("exceptionMessage", "Protocol message tag had invalid wire type.");
     Mockito.verify(mockContext, Mockito.times(1))
         .submitEvent(eventBuilder.build());
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

The current metrics are not descriptive in what sorts of exceptions are occurring. The current try catch block is catching all exceptions, which could include errors other than malformed ORC file exceptions. 

I am adding this feature as a stop-gap for better insight while I am in parallel working on a change for removing orphan files on startup at the publisher level.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

