### PR TITLE
[GOBBLIN-1957] GobblinOrcwriter improvements for large records

### DIFF
--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinBaseOrcWriter.java
@@ -91,7 +91,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   private int orcFileWriterRowsBetweenCheck;
   private long orcStripeSize;
   private int maxOrcBatchSize;
-  private int rowCheckFactor;
+  private int batchSizeRowCheckFactor;
   private boolean enableLimitBufferSizeOrcStripe;
 
   private int concurrentWriterTasks;
@@ -111,7 +111,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
     this.typeDescription = getOrcSchema();
     this.selfTuningWriter = properties.getPropAsBoolean(GobblinOrcWriterConfigs.ORC_WRITER_AUTO_SELFTUNE_ENABLED, false);
     this.validateORCAfterClose = properties.getPropAsBoolean(GobblinOrcWriterConfigs.ORC_WRITER_VALIDATE_FILE_AFTER_CLOSE, false);
-    this.rowCheckFactor = properties.getPropAsInt(GobblinOrcWriterConfigs.ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR, GobblinOrcWriterConfigs.DEFAULT_ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR);
+    this.batchSizeRowCheckFactor = properties.getPropAsInt(GobblinOrcWriterConfigs.ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR, GobblinOrcWriterConfigs.DEFAULT_ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR);
     this.maxOrcBatchSize = properties.getPropAsInt(GobblinOrcWriterConfigs.ORC_WRITER_AUTO_SELFTUNE_MAX_BATCH_SIZE,
         GobblinOrcWriterConfigs.DEFAULT_MAX_ORC_WRITER_BATCH_SIZE);
     this.batchSize = this.selfTuningWriter ?
@@ -348,7 +348,7 @@ public abstract class GobblinBaseOrcWriter<S, D> extends FsDataWriter<D> {
   void initializeOrcFileWriter() {
     try {
       this.orcFileWriterRowsBetweenCheck = Math.max(
-          Math.min(this.batchSize * this.rowCheckFactor, this.orcFileWriterMaxRowsBetweenCheck),
+          Math.min(this.batchSize * this.batchSizeRowCheckFactor, this.orcFileWriterMaxRowsBetweenCheck),
           this.orcFileWriterMinRowsBetweenCheck
       );
       this.writerConfig.set(OrcConf.ROWS_BETWEEN_CHECKS.getAttribute(), String.valueOf(this.orcFileWriterRowsBetweenCheck));

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
@@ -65,6 +65,12 @@ public class GobblinOrcWriterConfigs {
    */
   public static final String ORC_WRITER_MAX_ROWCHECK = ORC_WRITER_PREFIX + "max.rows.between.memory.checks";
 
+  /**
+   * Enable a maximum buffer size of both the native ORC writer and the Gobblin ORC writer by the size of a stripe divided by the estimated
+   * size of each record. This is to capture the case when records are extremely large and cause large buffer sizes to dominate the memory usage
+   */
+  public static final String ORC_WRITER_ENABLE_BUFFER_LIMIT_ORC_STRIPE = ORC_WRITER_PREFIX + "auto.selfTune.max.buffer.orc.stripe";
+
   public static final String ORC_WRITER_INSTRUMENTED = ORC_WRITER_PREFIX + "instrumented";
 
   public static final int DEFAULT_ORC_WRITER_BATCH_SIZE = 1000;
@@ -75,12 +81,6 @@ public class GobblinOrcWriterConfigs {
    */
   public static final int DEFAULT_CONCURRENT_WRITERS = 3;
   public static final double DEFAULT_ORC_WRITER_BATCHSIZE_MEMORY_USAGE_FACTOR = 0.3;
-  /**
-   * Factor when calculating a logical max buffer size for the Gobblin ORC Writer as the size of a buffer should not
-   * greatly exceed the size of a stripe, ideally. This is to capture the case when records are extremely large and cause
-   * large buffer sizes to dominate the memory usage
-   */
-  public static final double DEFAULT_RECORD_BUFFER_SIZE_MAX_FACTOR = 1.2;
 
   public static final int DEFAULT_ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR = 5;
 

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriterConfigs.java
@@ -40,6 +40,11 @@ public class GobblinOrcWriterConfigs {
    */
   public static final String ORC_WRITER_AUTO_SELFTUNE_MAX_BATCH_SIZE = ORC_WRITER_PREFIX + "auto.selfTune.max.batch.size";
   /**
+   * The ratio of native ORC Writer buffer size to Gobblin ORC Writer buffer size
+   */
+  public static final String ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR = "auto.selfTune.rowCheck.factor";
+
+  /**
    * How often should the Gobblin ORC Writer check for tuning
    */
   public static final String ORC_WRITER_AUTO_SELFTUNE_ROWS_BETWEEN_CHECK = ORC_WRITER_PREFIX + "auto.selfTune.rowsBetweenCheck";
@@ -71,9 +76,14 @@ public class GobblinOrcWriterConfigs {
   public static final int DEFAULT_CONCURRENT_WRITERS = 3;
   public static final double DEFAULT_ORC_WRITER_BATCHSIZE_MEMORY_USAGE_FACTOR = 0.3;
   /**
-   * The ratio of native ORC Writer buffer size to Gobblin ORC Writer buffer size
+   * Factor when calculating a logical max buffer size for the Gobblin ORC Writer as the size of a buffer should not
+   * greatly exceed the size of a stripe, ideally. This is to capture the case when records are extremely large and cause
+   * large buffer sizes to dominate the memory usage
    */
+  public static final double DEFAULT_RECORD_BUFFER_SIZE_MAX_FACTOR = 1.2;
+
   public static final int DEFAULT_ORC_WRITER_BATCHSIZE_ROWCHECK_FACTOR = 5;
+
   public static final int DEFAULT_MAX_ORC_WRITER_BATCH_SIZE = DEFAULT_ORC_WRITER_BATCH_SIZE;
   public static final int DEFAULT_ORC_AUTO_SELFTUNE_ROWS_BETWEEN_CHECK = 500;
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1957


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

GobblinORCWriter self tune uses a number of metrics to determine how large their buffers should be for both its own internal buffer used for conversion and the native ORC writer buffer. However when there are very large record sizes (100s of kb) the buffers default max size (e.g. 1000) can still hold a very large amount of data. Observed performance would be hundreds of megabytes to even a gigabyte depending on the configured batch size maximums.

We want a configuration to impose a maximum buffer max size so that large records in the buffer do not exceed the size of a stripe, so when it is added to the native ORC Writer, the native orc writer should be flushing its records and freeing the memory.

This PR adds the configuration `gobblin.orcWriter.auto.selfTune.max.buffer.orc.stripe` which when enabled to `true`, will restrict the max buffer size to be the value of the ORC stripe size divided by the estimated record size recorded. Since it can still tune the buffer sizes in between the min value (1) and this maximum, it will not overfill the buffers like previously recorded. 

Since this configuration may impact performance, hid it under a feature flag as it will lead to less OOM but more frequent memory checks may impact write speed. However since it should generally be checking as often as it has enough memory to fill one stripe, this should be acceptable.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Unit tests, tested on large topic, reduction in OOM observed

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

