### PR TITLE
[GOBBLIN-1961] Allow `IcebergDatasetFinder` to use separate names for source vs. destination-side DB and table

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -20,14 +20,25 @@ package org.apache.gobblin.data.management.copy.iceberg;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 
 /**
  * Any catalog from which to access {@link IcebergTable}s.
  */
 public interface IcebergCatalog {
+
   IcebergTable openTable(String dbName, String tableName);
+
+  default IcebergTable openTable(TableIdentifier tableId) {
+    // CHALLENGE: clearly better to implement in the reverse direction - `openTable(String, String)` in terms of `openTable(TableIdentifier)` -
+    // but challenging to do at this point, with multiple derived classes already "in the wild" that implement `openTable(String, String)`
+    return openTable(tableId.namespace().toString(), tableId.name());
+  }
+
   String getCatalogUri();
+
   void initialize(Map<String, String> properties, Configuration configuration);
+
   boolean tableAlreadyExists(IcebergTable icebergTable);
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -55,22 +55,28 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   public static final String DEFAULT_ICEBERG_CATALOG_CLASS = "org.apache.gobblin.data.management.copy.iceberg.IcebergHiveCatalog";
   public static final String ICEBERG_CATALOG_KEY = "catalog";
   /**
-   * This is used with a prefix: "{@link IcebergDatasetFinder#ICEBERG_DATASET_PREFIX}" + "." + "(source or destination)" + "." + "{@link IcebergDatasetFinder#ICEBERG_CATALOG_KEY}" + "..."
-   * It is an open-ended pattern used to pass arbitrary catalog specific properties
+   * This is used with a prefix: "{@link IcebergDatasetFinder#ICEBERG_DATASET_PREFIX}" + "." + "( source | destination )" + "." + "{@link IcebergDatasetFinder#ICEBERG_CATALOG_KEY}" + "..."
+   * It is an open-ended pattern used to pass arbitrary catalog-scoped properties
    */
   public static final String ICEBERG_CATALOG_CLASS_KEY = "class";
-  public static final String ICEBERG_DB_NAME = ICEBERG_DATASET_PREFIX + ".database.name";
-  public static final String ICEBERG_TABLE_NAME = ICEBERG_DATASET_PREFIX + ".table.name";
+  public static final String ICEBERG_DB_NAME_KEY = "database.name";
+  public static final String ICEBERG_TABLE_NAME_KEY = "table.name";
+  /** please use source/dest-scoped properties */
+  @Deprecated
+  public static final String ICEBERG_DB_NAME_LEGACY = ICEBERG_DATASET_PREFIX + "." + ICEBERG_DB_NAME_KEY;
+  /** please use source/dest-scoped properties */
+  @Deprecated
+  public static final String ICEBERG_TABLE_NAME_LEGACY = ICEBERG_DATASET_PREFIX + "." + ICEBERG_TABLE_NAME_KEY;
 
   public enum CatalogLocation {
     SOURCE,
     DESTINATION;
 
     /**
-     * Provides prefix for configs based on the catalog location to filter catalog specific properties
+     * Provides prefix for configs based on the catalog orientation (source or destination) for catalog-targeted properties
      */
     public String getConfigPrefix() {
-      return ICEBERG_DATASET_PREFIX + "." + this.toString().toLowerCase() + "." + ICEBERG_CATALOG_KEY + ".";
+      return ICEBERG_DATASET_PREFIX + "." + this.toString().toLowerCase() + ".";
     }
   }
 
@@ -86,20 +92,38 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
    */
   @Override
   public List<IcebergDataset> findDatasets() throws IOException {
-    List<IcebergDataset> matchingDatasets = new ArrayList<>();
-    if (StringUtils.isBlank(properties.getProperty(ICEBERG_DB_NAME)) || StringUtils.isBlank(properties.getProperty(ICEBERG_TABLE_NAME))) {
-      throw new IllegalArgumentException(String.format("Iceberg database name: {%s} or Iceberg table name: {%s} is missing",
-          ICEBERG_DB_NAME, ICEBERG_TABLE_NAME));
+    String srcDbName = getLocationQualifiedProperty(properties, CatalogLocation.SOURCE, ICEBERG_DB_NAME_KEY);
+    String destDbName = getLocationQualifiedProperty(properties, CatalogLocation.DESTINATION, ICEBERG_DB_NAME_KEY);
+    // TODO: eventually remove support for combo (src+dest) iceberg props, in favor of separate source/dest-scoped props; for now, maintain support
+    if (StringUtils.isBlank(srcDbName) || StringUtils.isBlank(destDbName)) {
+      srcDbName = destDbName = properties.getProperty(ICEBERG_DB_NAME_LEGACY);
     }
-    String dbName = properties.getProperty(ICEBERG_DB_NAME);
-    String tblName = properties.getProperty(ICEBERG_TABLE_NAME);
+    String srcTableName = getLocationQualifiedProperty(properties, CatalogLocation.SOURCE, ICEBERG_TABLE_NAME_KEY);
+    String destTableName = getLocationQualifiedProperty(properties, CatalogLocation.DESTINATION, ICEBERG_TABLE_NAME_KEY);
+    // TODO: eventually remove support for combo (src+dest) iceberg props, in favor of separate source/dest-scoped props; for now, maintain support
+    if (StringUtils.isBlank(srcTableName) || StringUtils.isBlank(destTableName)) {
+      srcTableName = destTableName = properties.getProperty(ICEBERG_TABLE_NAME_LEGACY);
+    }
+    if (StringUtils.isBlank(srcDbName) || StringUtils.isBlank(srcTableName)) {
+      throw new IllegalArgumentException(
+          String.format("Missing (at least some) IcebergDataset properties - source: ('%s' and '%s') and destination: ('%s' and '%s') "
+                  + "or [deprecated!] common/combo: ('%s' and '%s')",
+              calcLocationQualifiedPropName(CatalogLocation.SOURCE, ICEBERG_DB_NAME_KEY),
+              calcLocationQualifiedPropName(CatalogLocation.SOURCE, ICEBERG_TABLE_NAME_KEY),
+              calcLocationQualifiedPropName(CatalogLocation.DESTINATION, ICEBERG_DB_NAME_KEY),
+              calcLocationQualifiedPropName(CatalogLocation.DESTINATION, ICEBERG_TABLE_NAME_KEY),
+              ICEBERG_DB_NAME_LEGACY,
+              ICEBERG_TABLE_NAME_LEGACY));
+    }
 
-    IcebergCatalog sourceIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.SOURCE);
-    IcebergCatalog destinationIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.DESTINATION);
+    IcebergCatalog srcIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.SOURCE);
+    IcebergCatalog destIcebergCatalog = createIcebergCatalog(this.properties, CatalogLocation.DESTINATION);
+
     /* Each Iceberg dataset maps to an Iceberg table */
-    matchingDatasets.add(createIcebergDataset(dbName, tblName, sourceIcebergCatalog, destinationIcebergCatalog, this.properties, this.sourceFs));
-    log.info("Found {} matching datasets: {} for the database name: {} and table name: {}", matchingDatasets.size(),
-        matchingDatasets, dbName, tblName); // until future support added to specify multiple icebergs, count expected always to be one
+    List<IcebergDataset> matchingDatasets = new ArrayList<>();
+    matchingDatasets.add(createIcebergDataset(srcIcebergCatalog, srcDbName, srcTableName, destIcebergCatalog, destDbName, destTableName, this.properties, this.sourceFs));
+    log.info("Found {} matching datasets: {} for the (source) '{}.{}' / (dest) '{}.{}'", matchingDatasets.size(),
+        matchingDatasets, srcDbName, srcTableName, destDbName, destTableName); // until future support added to specify multiple icebergs, count expected always to be one
     return matchingDatasets;
   }
 
@@ -114,26 +138,37 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
   }
 
   /**
-   * Requires both source and destination catalogs to connect to their respective {@link IcebergTable}
+   * Uses each source and destination {@link IcebergCatalog} to load and verify existence of the respective {@link IcebergTable}
    * Note: the destination side {@link IcebergTable} should be present before initiating replication
+   *
    * @return {@link IcebergDataset} with its corresponding source and destination {@link IcebergTable}
    */
-  protected IcebergDataset createIcebergDataset(String dbName, String tblName, IcebergCatalog sourceIcebergCatalog, IcebergCatalog destinationIcebergCatalog, Properties properties, FileSystem fs) throws IOException {
-    IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(dbName, tblName);
-    Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Missing Source Iceberg Table: {%s}.{%s}", dbName, tblName));
-    IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(dbName, tblName);
+  protected IcebergDataset createIcebergDataset(IcebergCatalog sourceIcebergCatalog, String srcDbName, String srcTableName, IcebergCatalog destinationIcebergCatalog, String destDbName, String destTableName, Properties properties, FileSystem fs) throws IOException {
+    IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(srcDbName, srcTableName);
+    Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Missing Source Iceberg Table: {%s}.{%s}", srcDbName, srcTableName));
+    IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(destDbName, destTableName);
     // TODO: Rethink strategy to enforce dest iceberg table
-    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", dbName, tblName));
-    return new IcebergDataset(dbName, tblName, srcIcebergTable, destIcebergTable, properties, fs);
+    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", destDbName, destTableName));
+    return new IcebergDataset(srcIcebergTable, destIcebergTable, properties, fs);
   }
 
   protected static IcebergCatalog createIcebergCatalog(Properties properties, CatalogLocation location) throws IOException {
-    String prefix = location.getConfigPrefix();
-    Map<String, String> catalogProperties = buildMapFromPrefixChildren(properties, prefix);
+    String catalogPrefix = calcLocationQualifiedPropName(location, ICEBERG_CATALOG_KEY + ".");
+    Map<String, String> catalogProperties = buildMapFromPrefixChildren(properties, catalogPrefix);
     // TODO: Filter properties specific to Hadoop
     Configuration configuration = HadoopUtils.getConfFromProperties(properties);
     String icebergCatalogClassName = catalogProperties.getOrDefault(ICEBERG_CATALOG_CLASS_KEY, DEFAULT_ICEBERG_CATALOG_CLASS);
     return IcebergCatalogFactory.create(icebergCatalogClassName, catalogProperties, configuration);
+  }
+
+  /** @return property value or `null` */
+  protected static String getLocationQualifiedProperty(Properties properties, CatalogLocation location, String relativePropName) {
+    return properties.getProperty(calcLocationQualifiedPropName(location, relativePropName));
+  }
+
+  /** @return absolute (`location`-qualified) property name for `relativePropName` */
+  protected static String calcLocationQualifiedPropName(CatalogLocation location, String relativePropName) {
+    return location.getConfigPrefix() + relativePropName;
   }
 
   /**

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -193,6 +193,7 @@ public class IcebergDatasetTest {
         validateGetFilePathsGivenDestState(icebergSnapshots, existingDestPaths, expectedResultPaths);
     // ensure short-circuiting was able to avert iceberg manifests scan
     Mockito.verify(mockTable, Mockito.times(1)).getCurrentSnapshotInfoOverviewOnly();
+    Mockito.verify(mockTable, Mockito.times(1)).getTableId();
     Mockito.verifyNoMoreInteractions(mockTable);
   }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -199,11 +199,11 @@ public class IcebergDatasetTest {
   /** Exception wrapping is used internally--ensure that doesn't lapse into silently swallowing errors */
   @Test(expectedExceptions = IOException.class)
   public void testGetFilePathsDoesNotSwallowDestFileSystemException() throws IOException {
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(Lists.newArrayList(SNAPSHOT_PATHS_0));
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(TableIdentifier.of(testDbName, testTblName), Lists.newArrayList(SNAPSHOT_PATHS_0));
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI);
     FileSystem sourceFs = sourceFsBuilder.build();
-    IcebergDataset icebergDataset = new IcebergDataset(testDbName, testTblName, icebergTable, null, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new IcebergDataset(srcIcebergTable, null, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destFsBuilder.build();
@@ -241,10 +241,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset =
-        new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
+    TableIdentifier tableIdInCommon = TableIdentifier.of(testDbName, testTblName);
+    IcebergTable srcIcebergTbl = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTbl = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(srcIcebergTbl, destIcebergTbl, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -267,10 +267,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
-    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset =
-        new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
+    TableIdentifier tableIdInCommon = TableIdentifier.of(testDbName, testTblName);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_1, SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -298,9 +298,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPathsAndFileStatuses(expectedPathsAndFileStatuses);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
+    TableIdentifier tableIdInCommon = TableIdentifier.of(testDbName, testTblName);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -326,9 +327,10 @@ public class IcebergDatasetTest {
     sourceBuilder.addPaths(expectedPaths);
     FileSystem sourceFs = sourceBuilder.build();
 
-    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_0));
-    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(Arrays.asList(SNAPSHOT_PATHS_1));
-    IcebergDataset icebergDataset = new TrickIcebergDataset(testDbName, testTblName, srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
+    TableIdentifier tableIdInCommon = TableIdentifier.of(testDbName, testTblName);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_0));
+    IcebergTable destIcebergTable = MockIcebergTable.withSnapshots(tableIdInCommon, Arrays.asList(SNAPSHOT_PATHS_1));
+    IcebergDataset icebergDataset = new TrickIcebergDataset(srcIcebergTable, destIcebergTable, new Properties(), sourceFs);
 
     MockFileSystemBuilder destBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     FileSystem destFs = destBuilder.build();
@@ -358,13 +360,12 @@ public class IcebergDatasetTest {
    */
   protected IcebergTable validateGetFilePathsGivenDestState(List<MockIcebergTable.SnapshotPaths> sourceSnapshotPathSets,
       Optional<List<String>> optExistingSourcePaths, List<String> existingDestPaths, Set<Path> expectedResultPaths) throws IOException {
-    IcebergTable icebergTable = MockIcebergTable.withSnapshots(sourceSnapshotPathSets);
+    IcebergTable srcIcebergTable = MockIcebergTable.withSnapshots(TableIdentifier.of(testDbName, testTblName), sourceSnapshotPathSets);
 
     MockFileSystemBuilder sourceFsBuilder = new MockFileSystemBuilder(SRC_FS_URI, !optExistingSourcePaths.isPresent());
     optExistingSourcePaths.ifPresent(sourceFsBuilder::addPaths);
     FileSystem sourceFs = sourceFsBuilder.build();
-    IcebergDataset icebergDataset =
-        new IcebergDataset(testDbName, testTblName, icebergTable, null, new Properties(), sourceFs);
+    IcebergDataset icebergDataset = new IcebergDataset(srcIcebergTable, null, new Properties(), sourceFs);
 
     MockFileSystemBuilder destFsBuilder = new MockFileSystemBuilder(DEST_FS_URI);
     destFsBuilder.addPaths(existingDestPaths);
@@ -377,7 +378,7 @@ public class IcebergDatasetTest {
     Assert.assertEquals(
         filePathsToFileStatus.values().stream().map(FileStatus::getPath).collect(Collectors.toSet()),
         expectedResultPaths);
-    return icebergTable;
+    return srcIcebergTable;
   }
 
   /** @return `paths` after adding to it all paths of every one of `snapshotDefs` */
@@ -464,9 +465,9 @@ public class IcebergDatasetTest {
    *  Without this, so to lose the mock, we'd be unable to set up any source paths as existing.
    */
   protected static class TrickIcebergDataset extends IcebergDataset {
-    public TrickIcebergDataset(String db, String table, IcebergTable srcIcebergTbl, IcebergTable destIcebergTbl, Properties properties,
+    public TrickIcebergDataset(IcebergTable srcIcebergTable, IcebergTable destIcebergTable, Properties properties,
         FileSystem sourceFs) {
-      super(db, table, srcIcebergTbl, destIcebergTbl, properties, sourceFs);
+      super(srcIcebergTable, destIcebergTable, properties, sourceFs);
     }
 
     @Override // as the `static` is not mock-able
@@ -581,8 +582,9 @@ public class IcebergDatasetTest {
       }
     }
 
-    public static IcebergTable withSnapshots(List<SnapshotPaths> snapshotPathSets) throws IOException {
+    public static IcebergTable withSnapshots(TableIdentifier tableId, List<SnapshotPaths> snapshotPathSets) throws IOException {
       IcebergTable table = Mockito.mock(IcebergTable.class);
+      Mockito.when(table.getTableId()).thenReturn(tableId);
       int lastIndex = snapshotPathSets.size() - 1;
       Mockito.when(table.getCurrentSnapshotInfoOverviewOnly())
           .thenReturn(snapshotPathSets.get(lastIndex).asSnapshotInfo(lastIndex));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1961
  
"Qualify IcebergTable DatasetDescriptors (used by Iceberg-Distcp)"


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

The same DB name and table name are currently used in common for both the source-side table and the dest-side table.  Instead, these should be allowed to be different, so facilitate separately specifying source names and dest names.  Nonetheless, continue, for the sake of backwards compatibility, to support the legacy properties that specify the current combo props (shared by both source AND destination).

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

enhanced existing tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

