### PR TITLE
Prevent NPE in `FlowCompilationValidationHelper.validateAndHandleConcurrentExecution`

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -202,10 +202,10 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
   }
 
   /**
-   * j
    * @param spec an instance of {@link FlowSpec}.
    * @return A DAG of {@link JobExecutionPlan}s, which encapsulates the compiled {@link org.apache.gobblin.runtime.api.JobSpec}s
-   * together with the {@link SpecExecutor} where the job can be executed.
+   * together with the {@link SpecExecutor} where the job can be executed; when compilation fails, return `null`, and also add a
+   * {@link org.apache.gobblin.runtime.api.FlowSpec.CompilationError} to `spec` (after casting to a {@link FlowSpec})
    */
   @Override
   public Dag<JobExecutionPlan> compileFlow(Spec spec) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -115,7 +115,7 @@ public final class FlowCompilationValidationHelper {
     Dag<JobExecutionPlan> jobExecutionPlanDag = specCompiler.compileFlow(spec);
 
     if (isExecutionPermitted(flowStatusGenerator, flowName, flowGroup, allowConcurrentExecution)) {
-      return Optional.of(jobExecutionPlanDag);
+      return Optional.fromNullable(jobExecutionPlanDag);
     } else {
       log.warn("Another instance of flowGroup: {}, flowName: {} running; Skipping flow execution since "
           + "concurrent executions are disabled for this flow.", flowGroup, flowName);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Flow compilation failures currently result in an NPE:
```
java.lang.NullPointerException: null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:770) ~[guava-21.0.jar:?]
        at com.google.common.base.Optional.of(Optional.java:105) ~[guava-21.0.jar:?]
        at org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper.validateAndHandleConcurrentExecution(FlowCompilationValidationHelper.java:114) ~[gobblin-service-0.18.0-dev-483.jar:?]
        at org.apache.gobblin.service.modules.orchestration.Orchestrator.orchestrate(Orchestrator.java:240) ~[gobblin-service-0.18.0-dev-483.jar:?]

...
```

Prevent this by using (guava) `Optional.fromNullable` rather than `Optional.of`, which does not permit nulls
### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

existing unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

