### PR TITLE
[GOBBLIN-1971] Allow `IcebergCatalog` to specify the `DatasetDescriptor` name for the `IcebergTable`s it creates

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -42,11 +42,19 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
   @Override
   public IcebergTable openTable(String dbName, String tableName) {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
-    return new IcebergTable(tableId, createTableOperations(tableId), this.getCatalogUri());
+    return new IcebergTable(tableId, calcDatasetDescriptorName(tableId), createTableOperations(tableId), this.getCatalogUri());
   }
 
   protected Catalog createCompanionCatalog(Map<String, String> properties, Configuration configuration) {
     return CatalogUtil.loadCatalog(this.companionCatalogClass.getName(), this.catalogName, properties, configuration);
+  }
+
+  /**
+   * Enable catalog-specific qualification for charting lineage, etc.  This default impl is an identity pass-through that adds no qualification.
+   * @return the name to use for the table identified by {@link TableIdentifier}
+   */
+  protected String calcDatasetDescriptorName(TableIdentifier tableId) {
+    return tableId.toString(); // default to FQ ID with both table namespace and name
   }
 
   protected abstract TableOperations createTableOperations(TableIdentifier tableId);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergCatalog.java
@@ -28,8 +28,10 @@ import org.apache.iceberg.catalog.TableIdentifier;
  */
 public interface IcebergCatalog {
 
+  /** @return table identified by `dbName` and `tableName` */
   IcebergTable openTable(String dbName, String tableName);
 
+  /** @return table identified by `tableId` */
   default IcebergTable openTable(TableIdentifier tableId) {
     // CHALLENGE: clearly better to implement in the reverse direction - `openTable(String, String)` in terms of `openTable(TableIdentifier)` -
     // but challenging to do at this point, with multiple derived classes already "in the wild" that implement `openTable(String, String)`

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -70,8 +71,15 @@ public class IcebergTable {
 
   @Getter
   private final TableIdentifier tableId;
+  /** allow the {@link IcebergCatalog} creating this table to qualify its name when used for lineage, etc. */
+  private final String datasetDescriptorName;
   private final TableOperations tableOps;
   private final String catalogUri;
+
+  @VisibleForTesting
+  IcebergTable(TableIdentifier tableId, TableOperations tableOps, String catalogUri) {
+    this(tableId, tableId.toString(), tableOps, catalogUri);
+  }
 
   /** @return metadata info limited to the most recent (current) snapshot */
   public IcebergSnapshotInfo getCurrentSnapshotInfo() throws IOException {
@@ -188,7 +196,7 @@ public class IcebergTable {
     DatasetDescriptor descriptor = new DatasetDescriptor(
         DatasetConstants.PLATFORM_ICEBERG,
         URI.create(this.catalogUri),
-        this.tableId.toString() // use FQ ID, including table namespace
+        this.datasetDescriptorName
     );
     descriptor.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
     return descriptor;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -116,10 +116,11 @@ public class IcebergDatasetTest {
   @Test
   public void testGetDatasetDescriptor() throws URISyntaxException {
     TableIdentifier tableId = TableIdentifier.of(testDbName, testTblName);
-    IcebergTable table = new IcebergTable(tableId, Mockito.mock(TableOperations.class), SRC_CATALOG_URI);
+    String qualifiedTableName = "foo_prefix." + tableId.toString();
+    IcebergTable table = new IcebergTable(tableId, qualifiedTableName, Mockito.mock(TableOperations.class), SRC_CATALOG_URI);
     FileSystem mockFs = Mockito.mock(FileSystem.class);
     Mockito.when(mockFs.getUri()).thenReturn(SRC_FS_URI);
-    DatasetDescriptor expected = new DatasetDescriptor(DatasetConstants.PLATFORM_ICEBERG, URI.create(SRC_CATALOG_URI), tableId.toString());
+    DatasetDescriptor expected = new DatasetDescriptor(DatasetConstants.PLATFORM_ICEBERG, URI.create(SRC_CATALOG_URI), qualifiedTableName);
     expected.addMetadata(DatasetConstants.FS_URI, SRC_FS_URI.toString());
     Assert.assertEquals(table.getDatasetDescriptor(mockFs), expected);
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1971


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

For some dataset lineage schemes, metadata tracing must take into account not only the Iceberg `TableIdentifier`, but also the catalog where that table resides.  Allow therefore `IcebergCatalog`s to adjust the name of the tables they create, for metadata reporting purposes.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated existing test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

