### PR TITLE
[GOBBLIN-1972] Fix `CopyDataPublisher` to avoid committing post-publish WUs before they've actually run

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -305,7 +305,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     Map<String, String> additionalMetadata = Maps.newHashMap();
 
     Preconditions.checkArgument(!datasetWorkUnitStates.isEmpty(),
-        String.format("[%s] publishFileSet got empty work unit states. This is an error in code."), datasetAndPartition.identifier());
+        String.format("[%s] publishFileSet got empty work unit states. This is an error in code.", datasetAndPartition.identifier()));
 
     WorkUnitStatesHelper statesHelper = new WorkUnitStatesHelper(datasetWorkUnitStates);
     WorkUnitState sampledWorkUnitState =  statesHelper.getAny();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1972


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

A regression in Iceberg-Distcp began erroneously showing the job finishing as "SUCCESSFUL", despite the commit step failing with an exception.  The same Iceberg-Distcp `CommitStep` fails (`org.apache.gobblin.data.management.copy.iceberg.IcebergRegisterStep`), but with apache gobblin build `0.18.0-dev-493` it correctly shows "FAILED" yet with `0.18.0-dev-515` it claims "SUCCEEDED".  (see the ticket for more details)

It turned out to be due to changes made here:
https://github.com/apache/gobblin/pull/3804/files#diff-65bb0891b2d30ff3515db8eae2c7986872fd410c898241ee2bb962a28721d0c7

specifically the reordering of:
```
executeCommitSequence(postPublish);
```
As mentioned in code comments, this MUST NOT run before the WU is actually executed:
```
      // ensure every successful state is committed
      if (wus.getWorkingState() == WorkingState.SUCCESSFUL) {
        wus.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
      }
```
that's because `WorkUnitState::getWorkingState()` returns `WorkingState.SUCCESSFUL` merely when the overall job succeeded--even for WUs yet to execute!

thus it must wait to run for post-publish steps until after:
```
executeCommitSequence(postPublishSteps);
```

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
manual testing

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

