### PR TITLE
[GOBBLIN-1973] Change Manifest distcp logic to compare permissions of source and dest files even when source is older

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -176,10 +176,11 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
 
   private static boolean shouldCopy(FileSystem targetFs, FileStatus fileInSource, FileStatus fileInTarget, OwnerAndPermission replicatedPermission)
       throws IOException {
-    if (fileInSource.isDirectory() || fileInSource.getModificationTime() == fileInTarget.getModificationTime()) {
-      // if source is dir or source and dst has same version, we compare the permission to determine whether it needs another sync
+    if (fileInSource.isDirectory() || fileInSource.getModificationTime() <= fileInTarget.getModificationTime()) {
+      // even if destination has a newer version than the source, we still copy the file if the owner or permission is different
       return !replicatedPermission.hasSameOwnerAndPermission(targetFs, fileInTarget);
     }
-    return fileInSource.getModificationTime() > fileInTarget.getModificationTime();
+    // Source is newer than the target, must copy
+    return true;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.data.management.copy;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -176,11 +177,7 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
 
   private static boolean shouldCopy(FileSystem targetFs, FileStatus fileInSource, FileStatus fileInTarget, OwnerAndPermission replicatedPermission)
       throws IOException {
-    if (fileInSource.isDirectory() || fileInSource.getModificationTime() <= fileInTarget.getModificationTime()) {
-      // even if destination has a newer version than the source, we still copy the file if the owner or permission is different
-      return !replicatedPermission.hasSameOwnerAndPermission(targetFs, fileInTarget);
-    }
-    // Source is newer than the target, must copy
-    return true;
+    // Copy only if source is newer than target or if the owner or permission is different
+    return fileInSource.getModificationTime() > fileInTarget.getModificationTime() || !replicatedPermission.hasSameOwnerAndPermission(targetFs, fileInTarget);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.data.management.copy;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -34,12 +34,10 @@ import org.apache.gobblin.data.management.partition.FileSet;
 import org.apache.gobblin.util.commit.SetPermissionCommitStep;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -34,8 +34,12 @@ import org.apache.gobblin.data.management.partition.FileSet;
 import org.apache.gobblin.util.commit.SetPermissionCommitStep;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -79,39 +83,113 @@ public class ManifestBasedDatasetFinderTest {
     Properties props = new Properties();
     props.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/");
 
-    try (
-        FileSystem sourceFs = Mockito.mock(FileSystem.class);
+    try (FileSystem sourceFs = Mockito.mock(FileSystem.class);
         FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
-        FileSystem destFs = Mockito.mock(FileSystem.class);
-    ) {
-      URI SRC_FS_URI = new URI("source", "the.source.org", "/", null);
-      URI MANIFEST_READ_FS_URI = new URI("manifest-read", "the.manifest-source.org", "/", null);
-      URI DEST_FS_URI = new URI("dest", "the.dest.org", "/", null);
-      Mockito.when(sourceFs.getUri()).thenReturn(SRC_FS_URI);
-      Mockito.when(manifestReadFs.getUri()).thenReturn(MANIFEST_READ_FS_URI);
-      Mockito.when(destFs.getUri()).thenReturn(DEST_FS_URI);
-      Mockito.when(sourceFs.getFileStatus(any(Path.class))).thenReturn(localFs.getFileStatus(new Path(tmpDir.toString())));
-      Mockito.when(sourceFs.exists(any(Path.class))).thenReturn(true);
-      Mockito.when(manifestReadFs.exists(any(Path.class))).thenReturn(true);
-      Mockito.when(manifestReadFs.getFileStatus(manifestPath)).thenReturn(localFs.getFileStatus(manifestPath));
-      Mockito.when(manifestReadFs.open(manifestPath)).thenReturn(localFs.open(manifestPath));
-      Mockito.when(destFs.exists(any(Path.class))).thenReturn(false);
-      Mockito.doAnswer(invocation -> {
-        Object[] args = invocation.getArguments();
-        Path path = (Path)args[0];
-        return localFs.makeQualified(path);
-      }).when(sourceFs).makeQualified(any(Path.class));
+        FileSystem destFs = Mockito.mock(FileSystem.class);) {
+      setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
+
       Iterator<FileSet<CopyEntity>> fileSets =
-          new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs, CopyConfiguration.builder(destFs, props).build());
+          new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs,
+              CopyConfiguration.builder(destFs, props).build());
       Assert.assertTrue(fileSets.hasNext());
       FileSet<CopyEntity> fileSet = fileSets.next();
       Assert.assertEquals(fileSet.getFiles().size(), 3);  // 2 files to copy + 1 post publish step
-      Assert.assertTrue(((PostPublishStep)fileSet.getFiles().get(2)).getStep() instanceof SetPermissionCommitStep);
+      Assert.assertTrue(((PostPublishStep) fileSet.getFiles().get(2)).getStep() instanceof SetPermissionCommitStep);
       Mockito.verify(manifestReadFs, Mockito.times(1)).exists(manifestPath);
       Mockito.verify(manifestReadFs, Mockito.times(1)).getFileStatus(manifestPath);
       Mockito.verify(manifestReadFs, Mockito.times(1)).open(manifestPath);
       Mockito.verifyNoMoreInteractions(manifestReadFs);
       Mockito.verify(sourceFs, Mockito.times(2)).exists(any(Path.class));
     }
+  }
+
+  @Test
+  public void testFindFilesWithDifferentPermissions() throws IOException, URISyntaxException {
+
+    //Get manifest Path
+    Path manifestPath = new Path(getClass().getClassLoader().getResource("manifestBasedDistcpTest/sampleManifest.json").getPath());
+    // Test manifestDatasetFinder
+    Properties props = new Properties();
+    props.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/");
+    props.setProperty("gobblin.copy.preserved.attributes", "rbugpvta");
+    try (
+        FileSystem sourceFs = Mockito.mock(FileSystem.class);
+        FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
+        FileSystem destFs = Mockito.mock(FileSystem.class)
+    ) {
+      setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
+      Mockito.when(destFs.exists(new Path("/tmp/dataset/test1.txt"))).thenReturn(true);
+      Mockito.when(destFs.exists(new Path("/tmp/dataset/test2.txt"))).thenReturn(false);
+      Mockito.when(destFs.getFileStatus(any(Path.class))).thenReturn(localFs.getFileStatus(new Path(tmpDir.toString())));
+
+      List<AclEntry> aclEntrySource = AclEntry.parseAclSpec("user::rwx,group::rwx,other::rwx", true);
+      AclStatus aclStatusSource = new AclStatus.Builder().group("group").owner("owner").addEntries(aclEntrySource).build();
+      Mockito.when(sourceFs.getAclStatus(any(Path.class))).thenReturn(aclStatusSource);
+      // Specify a different acl for the destination file so that it is recopied even though the modification time is the same
+      List<AclEntry> aclEntryDest = AclEntry.parseAclSpec("user::rwx,group::rw-,other::r--", true);
+      AclStatus aclStatusDest = new AclStatus.Builder().group("groupDest").owner("owner").addEntries(aclEntryDest).build();
+      Mockito.when(destFs.getAclStatus(any(Path.class))).thenReturn(aclStatusDest);
+
+      Iterator<FileSet<CopyEntity>> fileSets =
+          new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs, CopyConfiguration.builder(destFs, props).build());
+      Assert.assertTrue(fileSets.hasNext());
+      FileSet<CopyEntity> fileSet = fileSets.next();
+      Assert.assertEquals(fileSet.getFiles().size(), 3);  // 2 files to copy + 1 post publish step
+      Assert.assertTrue(((PostPublishStep)fileSet.getFiles().get(2)).getStep() instanceof SetPermissionCommitStep);
+
+    }
+  }
+
+  @Test
+  public void testIgnoreFilesWithSamePermissions() throws IOException, URISyntaxException {
+    //Get manifest Path
+    Path manifestPath = new Path(getClass().getClassLoader().getResource("manifestBasedDistcpTest/sampleManifest.json").getPath());
+    // Test manifestDatasetFinder
+    Properties props = new Properties();
+    props.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/");
+    props.setProperty("gobblin.copy.preserved.attributes", "rbugpvta");
+    try (
+        FileSystem sourceFs = Mockito.mock(FileSystem.class);
+        FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
+        FileSystem destFs = Mockito.mock(FileSystem.class)
+    ) {
+      setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
+      Mockito.when(destFs.exists(new Path("/tmp/dataset/test1.txt"))).thenReturn(true);
+      Mockito.when(destFs.exists(new Path("/tmp/dataset/test2.txt"))).thenReturn(true);
+      Mockito.when(destFs.getFileStatus(any(Path.class))).thenReturn(localFs.getFileStatus(new Path(tmpDir.toString())));
+
+      List<AclEntry> aclEntrySource = AclEntry.parseAclSpec("user::rwx,group::rwx,other::rwx", true);
+      AclStatus aclStatusSource = new AclStatus.Builder().group("group").owner("owner").addEntries(aclEntrySource).build();
+      Mockito.when(sourceFs.getAclStatus(any(Path.class))).thenReturn(aclStatusSource);
+      // Same as source acls, files should not be copied
+      AclStatus aclStatusDest = new AclStatus.Builder().group("groupDest").owner("owner").addEntries(aclEntrySource).build();
+      Mockito.when(destFs.getAclStatus(any(Path.class))).thenReturn(aclStatusDest);
+
+      Iterator<FileSet<CopyEntity>> fileSets =
+          new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs, CopyConfiguration.builder(destFs, props).build());
+      Assert.assertTrue(fileSets.hasNext());
+      FileSet<CopyEntity> fileSet = fileSets.next();
+      Assert.assertEquals(fileSet.getFiles().size(), 1); // Post publish step
+    }
+  }
+
+  private void setSourceAndDestFsMocks(FileSystem sourceFs, FileSystem destFs, Path manifestPath, FileSystem manifestReadFs) throws IOException, URISyntaxException {
+    URI SRC_FS_URI = new URI("source", "the.source.org", "/", null);
+    URI MANIFEST_READ_FS_URI = new URI("manifest-read", "the.manifest-source.org", "/", null);
+    URI DEST_FS_URI = new URI("dest", "the.dest.org", "/", null);
+    Mockito.when(sourceFs.getUri()).thenReturn(SRC_FS_URI);
+    Mockito.when(manifestReadFs.getUri()).thenReturn(MANIFEST_READ_FS_URI);
+    Mockito.when(destFs.getUri()).thenReturn(DEST_FS_URI);
+    Mockito.when(sourceFs.getFileStatus(any(Path.class))).thenReturn(localFs.getFileStatus(new Path(tmpDir.toString())));
+    Mockito.when(sourceFs.exists(any(Path.class))).thenReturn(true);
+    Mockito.when(manifestReadFs.exists(any(Path.class))).thenReturn(true);
+    Mockito.when(manifestReadFs.getFileStatus(manifestPath)).thenReturn(localFs.getFileStatus(manifestPath));
+    Mockito.when(manifestReadFs.open(manifestPath)).thenReturn(localFs.open(manifestPath));
+
+    Mockito.doAnswer(invocation -> {
+      Object[] args = invocation.getArguments();
+      Path path = (Path)args[0];
+      return localFs.makeQualified(path);
+    }).when(sourceFs).makeQualified(any(Path.class));
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1973


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

When Manifest distcp fails to set permissions for any reason, we would expect a retry of the copy to allow the datasets to reach eventual consistency. However, the current logic of checking if a file is eligible for copy is to check if the source file is newer, if so copy, and if the source file is exactly the same modification time as the destination file, also copy if the permissions are different. However, in most cases the destination will have a newer modification time once it is written and set permissions, so the source file will generally be older but we still want the permissions to match.

This PR changes the check so that if the source file is older, we still want to check permissions between source and destination to ensure if the file is eligible for copy.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

