### PR TITLE
[GOBBLIN-1976] Allow an `IcebergCatalog` to override the `DatasetDescriptor` platform name for the `IcebergTable`s it creates

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/BaseIcebergCatalog.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.gobblin.dataset.DatasetConstants;
 
 /**
  * Base implementation of {@link IcebergCatalog} to access {@link IcebergTable} and the
@@ -42,7 +43,7 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
   @Override
   public IcebergTable openTable(String dbName, String tableName) {
     TableIdentifier tableId = TableIdentifier.of(dbName, tableName);
-    return new IcebergTable(tableId, calcDatasetDescriptorName(tableId), createTableOperations(tableId), this.getCatalogUri());
+    return new IcebergTable(tableId, calcDatasetDescriptorName(tableId), getDatasetDescriptorPlatform(), createTableOperations(tableId), this.getCatalogUri());
   }
 
   protected Catalog createCompanionCatalog(Map<String, String> properties, Configuration configuration) {
@@ -55,6 +56,14 @@ public abstract class BaseIcebergCatalog implements IcebergCatalog {
    */
   protected String calcDatasetDescriptorName(TableIdentifier tableId) {
     return tableId.toString(); // default to FQ ID with both table namespace and name
+  }
+
+  /**
+   * Enable catalog-specific naming for charting lineage, etc.  This default impl gives {@link DatasetConstants#PLATFORM_ICEBERG}
+   * @return the {@link org.apache.gobblin.dataset.DatasetDescriptor#getPlatform()} to use for tables from this catalog
+   */
+  protected String getDatasetDescriptorPlatform() {
+    return DatasetConstants.PLATFORM_ICEBERG;
   }
 
   protected abstract TableOperations createTableOperations(TableIdentifier tableId);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -71,7 +71,7 @@ public class IcebergTable {
 
   @Getter
   private final TableIdentifier tableId;
-  /** allow the {@link IcebergCatalog} creating this table to qualify its {@link DatasetDescriptor#getName()} when used for lineage, etc. */
+  /** allow the {@link IcebergCatalog} creating this table to qualify its {@link DatasetDescriptor#getName()} used for lineage, etc. */
   private final String datasetDescriptorName;
   /** allow the {@link IcebergCatalog} creating this table to specify the {@link DatasetDescriptor#getPlatform()} used for lineage, etc. */
   private final String datasetDescriptorPlatform;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -71,14 +71,16 @@ public class IcebergTable {
 
   @Getter
   private final TableIdentifier tableId;
-  /** allow the {@link IcebergCatalog} creating this table to qualify its name when used for lineage, etc. */
+  /** allow the {@link IcebergCatalog} creating this table to qualify its {@link DatasetDescriptor#getName()} when used for lineage, etc. */
   private final String datasetDescriptorName;
+  /** allow the {@link IcebergCatalog} creating this table to specify the {@link DatasetDescriptor#getPlatform()} used for lineage, etc. */
+  private final String datasetDescriptorPlatform;
   private final TableOperations tableOps;
   private final String catalogUri;
 
   @VisibleForTesting
   IcebergTable(TableIdentifier tableId, TableOperations tableOps, String catalogUri) {
-    this(tableId, tableId.toString(), tableOps, catalogUri);
+    this(tableId, tableId.toString(), DatasetConstants.PLATFORM_ICEBERG, tableOps, catalogUri);
   }
 
   /** @return metadata info limited to the most recent (current) snapshot */
@@ -194,7 +196,7 @@ public class IcebergTable {
 
   public DatasetDescriptor getDatasetDescriptor(FileSystem fs) {
     DatasetDescriptor descriptor = new DatasetDescriptor(
-        DatasetConstants.PLATFORM_ICEBERG,
+        datasetDescriptorPlatform,
         URI.create(this.catalogUri),
         this.datasetDescriptorName
     );

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -117,10 +117,11 @@ public class IcebergDatasetTest {
   public void testGetDatasetDescriptor() throws URISyntaxException {
     TableIdentifier tableId = TableIdentifier.of(testDbName, testTblName);
     String qualifiedTableName = "foo_prefix." + tableId.toString();
-    IcebergTable table = new IcebergTable(tableId, qualifiedTableName, Mockito.mock(TableOperations.class), SRC_CATALOG_URI);
+    String platformName = "Floe";
+    IcebergTable table = new IcebergTable(tableId, qualifiedTableName, platformName, Mockito.mock(TableOperations.class), SRC_CATALOG_URI);
     FileSystem mockFs = Mockito.mock(FileSystem.class);
     Mockito.when(mockFs.getUri()).thenReturn(SRC_FS_URI);
-    DatasetDescriptor expected = new DatasetDescriptor(DatasetConstants.PLATFORM_ICEBERG, URI.create(SRC_CATALOG_URI), qualifiedTableName);
+    DatasetDescriptor expected = new DatasetDescriptor(platformName, URI.create(SRC_CATALOG_URI), qualifiedTableName);
     expected.addMetadata(DatasetConstants.FS_URI, SRC_FS_URI.toString());
     Assert.assertEquals(table.getDatasetDescriptor(mockFs), expected);
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1976


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

For some dataset lineage schemes, metadata tracing would use a catalog-specific platform name.  Therefore allow IcebergCatalogs to choose the platform name for all tables they create.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

enhanced existing tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

