### PR TITLE
[GOBBLIN-1979] Pare down `TaskStateCollectorService` failure logging, to avoid flooding logs during widespread failure, e.g. O(1k)+

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskStateCollectorService.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskStateCollectorService.java
@@ -27,6 +27,7 @@ import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
@@ -42,6 +43,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.exception.RuntimeExceptionWithoutStackTrace;
 import org.apache.gobblin.metastore.FsStateStore;
 import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.runtime.troubleshooter.Issue;
@@ -50,6 +52,7 @@ import org.apache.gobblin.runtime.troubleshooter.TroubleshooterException;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.service.ServiceConfigKeys;
+import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ParallelRunner;
@@ -252,6 +255,8 @@ public class TaskStateCollectorService extends AbstractScheduledService {
     }
 
     final Queue<TaskState> taskStateQueue = Queues.newConcurrentLinkedQueue();
+    AtomicLong numStateStoreMissing = new AtomicLong(0L);
+    GrowthMilestoneTracker growthTracker = new GrowthMilestoneTracker();
     try (ParallelRunner stateSerDeRunner = new ParallelRunner(numDeserializerThreads, null)) {
       for (final String taskStateName : taskStateNames) {
         log.debug("Found output task state file " + taskStateName);
@@ -259,8 +264,16 @@ public class TaskStateCollectorService extends AbstractScheduledService {
         stateSerDeRunner.submitCallable(new Callable<Void>() {
           @Override
           public Void call() throws Exception {
-            TaskState taskState = taskStateStore.getAll(taskStateTableName, taskStateName).get(0);
-            taskStateQueue.add(taskState);
+            List<TaskState> matchingTaskStates = taskStateStore.getAll(taskStateTableName, taskStateName);
+            if (matchingTaskStates.isEmpty()) {
+              long currNumMissing = numStateStoreMissing.incrementAndGet();
+              // only log selective milestones to avoid flooding log w/ O(100k) stacktraces
+              if (growthTracker.isAnotherMilestone(currNumMissing)) {
+                throw new RuntimeExceptionWithoutStackTrace("missing task state [running total: " + currNumMissing + "] - " + taskStateName);
+              }
+              return null; // otherwise, when not a milestone, silently skip
+            }
+            taskStateQueue.add(matchingTaskStates.get(0));
             taskStateStore.delete(taskStateTableName, taskStateName);
             return null;
           }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskStateCollectorService.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskStateCollectorService.java
@@ -280,7 +280,7 @@ public class TaskStateCollectorService extends AbstractScheduledService {
         }, "Deserialize state for " + taskStateName);
       }
     } catch (IOException ioe) {
-      log.error("Could not read all task state files due to", ioe);
+      log.error("Could not read all task state files [missing final total: " + numStateStoreMissing.get() + "] - ", ioe);
     }
     log.info(String.format("Collected task state of %d completed tasks in %s", taskStateQueue.size(), taskStateTableName));
     return Optional.of(taskStateQueue);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/exception/RuntimeExceptionWithoutStackTrace.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/exception/RuntimeExceptionWithoutStackTrace.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.exception;
+
+
+/** {@link RuntimeException} that omits the stack trace to streamline both instantiation cost and log volume */
+public class RuntimeExceptionWithoutStackTrace extends RuntimeException {
+  public RuntimeExceptionWithoutStackTrace(String message) {
+    super(message);
+  }
+
+  public RuntimeExceptionWithoutStackTrace(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /** Secret sauce: no-op */
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1979


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Logging Task state collector failure at the granularity of every task is impractical, when tasks number in the 100k's.  Moreover the stacktrace from retrieval failure provides no meaningful info--even more so when faced w/ thousands of repetitive logs like (pre-change):
```
2023/12/20 22:08:17.894 +0000 WARN [ParallelRunner] [Azkaban] Task failed: Deserialize state for task_name_of_job_task_goes_here_0_1703105111101_51.tst
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at org.apache.gobblin.runtime.TaskStateCollectorService$2.call(TaskStateCollectorService.java:216)
	at org.apache.gobblin.runtime.TaskStateCollectorService$2.call(TaskStateCollectorService.java:213)
	at org.apache.gobblin.util.executors.MDCPropagatingCallable.call(MDCPropagatingCallable.java:42)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:111)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:58)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:75)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
Therefore only log sparsely (but present a running total) and omit the stack trace.

### Details
This arose because the dest-side volume enforced the namespace quota, which left over 100k+ WUs failing.  so while not every day, this is a normal occurrence and therefore deserves graceful handling.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
existing unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

