### PR TITLE
[GOBBLIN-1978] Initialize dag action store monitor metrics

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -99,7 +99,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
   protected Counter messagesRead;
   @Getter
   private final GobblinKafkaConsumerClient gobblinKafkaConsumerClient;
-  private final ScheduledExecutorService consumerExecutor;
+  protected final ScheduledExecutorService consumerExecutor;
   private final ExecutorService queueExecutor;
   private final BlockingQueue[] queues;
   private ContextAwareGauge[] queueSizeGauges;
@@ -253,7 +253,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
    * Note: All records from a KafkaPartition are added to the same queue.
    * A queue can contain records from multiple partitions if partitions > numThreads(queues)
    */
-  private void consume() {
+  protected void consume() {
     try {
       Iterator<KafkaConsumerRecord> itr = gobblinKafkaConsumerClient.consume();
       // TODO: we may be committing too early and only want to commit after process messages
@@ -275,7 +275,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
    * Assigns a queue to each thread of the {@link #queueExecutor}
    * Note: Assumption here is that {@link #numThreads} is same a number of queues
    */
-  private void processQueues() {
+  protected void processQueues() {
     for(BlockingQueue queue : queues) {
       queueExecutor.execute(new QueueProcessor(queue));
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -123,6 +123,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
    * Load all actions from the DagActionStore to process any missed actions during service startup
    */
   protected void initializeMonitor() {
+    // These metrics need to be created before handleDagAction() is called on any dagAction
     createDagActionMetrics();
     Collection<DagActionStore.DagAction> dagActions = null;
     try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -123,6 +123,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
    * Load all actions from the DagActionStore to process any missed actions during service startup
    */
   protected void initializeMonitor() {
+    createDagActionMetrics();
     Collection<DagActionStore.DagAction> dagActions = null;
     try {
       dagActions = dagActionStore.getDagActions();
@@ -286,6 +287,13 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
   @Override
   protected void createMetrics() {
     super.createMetrics();
+  }
+
+  /*
+  A separate function is needed to create these metrics when the monitor is initialized because they are used
+  immediately as dag actions are processed upon loading from the DagActionStore.
+  */
+  private void createDagActionMetrics() {
     // Dag Action specific metrics
     this.killsInvoked = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_KILLS_INVOKED);
     this.resumesInvoked = this.getMetricContext().contextAwareMeter(RuntimeMetrics.GOBBLIN_DAG_ACTION_STORE_MONITOR_RESUMES_INVOKED);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1978


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We encounter a `NullPointerException` when initializing the `DagActionStoreMonitor` after moving the loading of `DagActions` on startup from the `DagManager` to the `DagActionStoreMonitor`. Metrics for the `DagActionStoreMonitor` were initialized by its parent class the `HighLevelConsumer` only before starting to consume Kafka messages, however with the refactor these metrics are needed beforehand. In this PR I separate the creation of these metrics into a separate function and call it before loading dagActions. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

