### PR TITLE
[GOBBLIN-1981] Renames writer.path.type config name as it has a type conflict with w…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -432,7 +432,11 @@ public class ConfigurationKeys {
   public static final String DEFAULT_WRITER_BUILDER_CLASS = "org.apache.gobblin.writer.AvroDataWriterBuilder";
   public static final String WRITER_FILE_NAME = WRITER_PREFIX + ".file.name";
   public static final String WRITER_FILE_PATH = WRITER_PREFIX + ".file.path";
-  public static final String WRITER_FILE_PATH_TYPE = WRITER_PREFIX + ".file.path.type";
+
+  @Deprecated // Use WRITER_FILE_PATH instead as configuration is not type safe with WRITER_FILE_PATH when stored in config
+  public static final String WRITER_FILE_PATH_TYPE_DEPRECATED = WRITER_PREFIX + ".file.path.type";
+
+  public static final String WRITER_FILE_PATH_TYPE = WRITER_PREFIX + ".file.pathType";
   public static final String WRITER_FILE_OWNER = WRITER_PREFIX + ".file.owner";
   public static final String WRITER_FILE_GROUP = WRITER_PREFIX + ".file.group";
   public static final String WRITER_FILE_REPLICATION_FACTOR = WRITER_PREFIX + ".file.replication.factor";

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.util;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,6 +29,7 @@ import java.util.function.BiConsumer;
 import lombok.SneakyThrows;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
+import org.apache.gobblin.util.deprecation.DeprecationUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -175,6 +177,8 @@ public class WriterUtils {
   }
 
   private static WriterFilePathType getWriterFilePathType(State state) {
+    DeprecationUtils.renameDeprecatedKeys(state, ConfigurationKeys.WRITER_FILE_PATH_TYPE,
+        Arrays.asList(ConfigurationKeys.WRITER_FILE_PATH_TYPE_DEPRECATED));
     String pathTypeStr =
         state.getProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, ConfigurationKeys.DEFAULT_WRITER_FILE_PATH_TYPE);
     return WriterFilePathType.valueOf(pathTypeStr.toUpperCase());


### PR DESCRIPTION
…riter.path

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1981


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

There are some properties in Gobblin that are not typesafe when put in a Config class object, this causes issues with GaaS passing those properties to Gobblin cluster.
To resolve this, we should fix the property names so that there are no conflicts.

The property in particular we want to change is `writer.file.path.type` that conflicts with `writer.file.path` due to sharing the same prefix but expanding the key when there's a value mapped to it (making it not type safe as it can't transform a string value to a map). We can rename this property to writer.file.pathType.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Backwards compatible

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

