### PR TITLE
[GOBBLIN-1987] Allow run-immediately flows to execute in multi-active scheduler mode

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -114,7 +114,7 @@ public class ConfigurationKeys {
   public static final String SCHEDULER_EXPECTED_REMINDER_TIME_MILLIS_KEY = "expectedReminderTimeMillis";
   // Event time of flow action to orchestrate using the multi-active lease arbiter
   public static final String ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY = "orchestratorTriggerEventTimeMillis";
-  public static final String ORCHESTRATOR_TRIGGER_EVENT_TIME_NEVER_SET_VAL = "-1";
+  public static final String ORCHESTRATOR_TRIGGER_EVENT_TIME_DEFAULT_VAL = "0";
   public static final String FLOW_IS_REMINDER_EVENT_KEY = "isReminderEvent";
   public static final String SCHEDULER_EVENT_EPSILON_MILLIS_KEY = MYSQL_LEASE_ARBITER_PREFIX + ".epsilonMillis";
   public static final int DEFAULT_SCHEDULER_EVENT_EPSILON_MILLIS = 2000;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -237,15 +237,6 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       // If multi-active scheduler is enabled do not pass onto DagManager, otherwise scheduler forwards it directly
       // Skip flow compilation as well, since we recompile after receiving event from DagActionStoreChangeMonitor later
       if (flowTriggerHandler.isPresent()) {
-        // If triggerTimestampMillis was not set by the job trigger handler, then we do not handle this event
-        if (triggerTimestampMillis == Long.parseLong(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_NEVER_SET_VAL)) {
-          _log.warn("Skipping execution of spec: {} because missing trigger timestamp in job properties",
-              jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
-          flowMetadata.put(TimingEvent.METADATA_MESSAGE, "Flow orchestration skipped because no trigger timestamp "
-              + "associated with flow action.");
-          new TimingEvent(this.eventSubmitter, TimingEvent.FlowTimings.FLOW_FAILED).stop(flowMetadata);
-          return;
-        }
 
         // Adopt consensus flowExecutionId for scheduled flows
         flowTriggerHandler.get().handleTriggerEvent(jobProps, flowAction, triggerTimestampMillis, isReminderEvent,

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -615,6 +615,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       }
       if (PropertiesUtils.getPropAsBoolean(jobConfig, ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false")) {
         _log.info("RunImmediately requested, hence executing FlowSpec: " + addedSpec);
+        // Use 0 for trigger event time of a run-immediately flow
+        jobConfig.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY, "0");
         this.jobExecutor.execute(new NonScheduledJobRunner(flowSpecUri, false, jobConfig, null));
       }
     } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -503,10 +503,10 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
   public void runJob(Properties jobProps, JobListener jobListener) throws JobException {
     try {
       Spec flowSpec = this.scheduledFlowSpecs.get(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
-      // We always expect the trigger event time to be set so the flow will be skipped by the orchestrator if it is not
+      // The trigger event time will be missing for adhoc and run-immediately flows, so we set the default here
       String triggerTimestampMillis = jobProps.getProperty(
           ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY,
-          ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_NEVER_SET_VAL);
+          ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_DEFAULT_VAL);
       boolean isReminderEvent =
           Boolean.parseBoolean(jobProps.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY, "false"));
       this.orchestrator.orchestrate(flowSpec, jobProps, Long.parseLong(triggerTimestampMillis), isReminderEvent);
@@ -615,14 +615,10 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       }
       if (PropertiesUtils.getPropAsBoolean(jobConfig, ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false")) {
         _log.info("RunImmediately requested, hence executing FlowSpec: " + addedSpec);
-        // Use 0 for trigger event time of a run-immediately flow
-        jobConfig.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY, "0");
         this.jobExecutor.execute(new NonScheduledJobRunner(flowSpecUri, false, jobConfig, null));
       }
     } else {
       _log.info("No FlowSpec schedule found, so running FlowSpec: " + addedSpec);
-      // Use 0 for trigger event time of an adhoc flow
-      jobConfig.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY, "0");
       this.jobExecutor.execute(new NonScheduledJobRunner(flowSpecUri, true, jobConfig, null));
     }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -116,6 +116,7 @@ public class GobblinServiceManagerTest {
   private static final String TEST_SINK_NAME = "testSink";
 
   private final URI TEST_URI = FlowSpec.Utils.createFlowSpecUri(TEST_FLOW_ID);
+  private final URI TEST_URI2 = FlowSpec.Utils.createFlowSpecUri(TEST_FLOW_ID2);
 
   private GobblinServiceManager gobblinServiceManager;
   private FlowConfigV2Client flowConfigClient;
@@ -328,7 +329,7 @@ public class GobblinServiceManagerTest {
     Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(uri.toString()));
   }
 
-  @Test (dependsOnMethods = "testUncompilableJob", groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testUncompilableJob", enabled = false, groups = {"disabledOnCI"})
   public void testRunOnceJob() throws Exception {
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
         .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties));
@@ -347,7 +348,7 @@ public class GobblinServiceManagerTest {
             "Waiting for job to get orchestrated...");
   }
 
-  @Test (dependsOnMethods = "testRunOnceJob")
+  @Test (dependsOnMethods = "testUncompilableJob")
   public void testRunQuotaExceeds() throws Exception {
     Map<String, String> props = flowProperties;
     props.put(ServiceAzkabanConfigKeys.AZKABAN_PROJECT_USER_TO_PROXY_KEY, "testUser");
@@ -366,7 +367,8 @@ public class GobblinServiceManagerTest {
     }
   }
 
-  @Test (dependsOnMethods = "testRunQuotaExceeds", groups = {"disabledOnCI"})
+  // TODO: re-enable the following disabled tests once we can reduce flakiness
+  @Test (dependsOnMethods = "testRunQuotaExceeds", enabled = false, groups = {"disabledOnCI"})
   public void testExplainJob() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID2)
@@ -379,7 +381,7 @@ public class GobblinServiceManagerTest {
     Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_FLOW_ID2.toString()));
   }
 
-  @Test (dependsOnMethods = "testExplainJob")
+  @Test (dependsOnMethods = "testRunQuotaExceeds", groups = {"disabledOnCI"})
   public void testCreate() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
@@ -391,9 +393,9 @@ public class GobblinServiceManagerTest {
     Assert.assertTrue(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_URI.toString()));
   }
 
-  @Test (dependsOnMethods = "testCreate")
+  @Test (dependsOnMethods = "testCreate", enabled = false, groups = {"disabledOnCI"})
   public void testCreateAgain() throws Exception {
-    FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
+    FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID2)
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE))
         .setProperties(new StringMap(flowProperties));
 
@@ -407,7 +409,7 @@ public class GobblinServiceManagerTest {
     Assert.assertEquals(exception.getStatus(), HttpStatus.CONFLICT_409);
   }
 
-  @Test (dependsOnMethods = "testCreateAgain")
+  @Test (dependsOnMethods = "testCreate")
   public void testGet() throws Exception {
     FlowConfig flowConfig = this.flowConfigClient.getFlowConfig(TEST_FLOW_ID);
 
@@ -421,7 +423,7 @@ public class GobblinServiceManagerTest {
     Assert.assertEquals(flowConfig.getProperties().get("param1"), "value1");
   }
 
-  @Test (dependsOnMethods = "testCreateAgain")
+  @Test (dependsOnMethods = "testGet")
   public void testGetAll() throws Exception {
     FlowConfig flowConfig2 = new FlowConfig().setId(TEST_FLOW_ID2)
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE))
@@ -434,7 +436,7 @@ public class GobblinServiceManagerTest {
     this.flowConfigClient.deleteFlowConfig(TEST_FLOW_ID2);
   }
 
-  @Test (dependsOnMethods = "testCreateAgain", enabled = false)
+  @Test (dependsOnMethods = "testGetAll", enabled = false)
   public void testGetFilteredFlows() throws Exception {
     // Not implemented for FsSpecStore
 
@@ -451,7 +453,7 @@ null, null, null, null);
     Assert.assertEquals(flowConfigs.size(), 2);
   }
 
-  @Test (dependsOnMethods = "testGet")
+  @Test (dependsOnMethods = "testGetAll") // depends on testGetAll until testGetFilteredFlows is enabled
   public void testUpdate() throws Exception {
     FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME);
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -116,7 +116,6 @@ public class GobblinServiceManagerTest {
   private static final String TEST_SINK_NAME = "testSink";
 
   private final URI TEST_URI = FlowSpec.Utils.createFlowSpecUri(TEST_FLOW_ID);
-  private final URI TEST_URI2 = FlowSpec.Utils.createFlowSpecUri(TEST_FLOW_ID2);
 
   private GobblinServiceManager gobblinServiceManager;
   private FlowConfigV2Client flowConfigClient;
@@ -329,7 +328,7 @@ public class GobblinServiceManagerTest {
     Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(uri.toString()));
   }
 
-  @Test (dependsOnMethods = "testUncompilableJob", enabled = false, groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testUncompilableJob", groups = {"disabledOnCI"})
   public void testRunOnceJob() throws Exception {
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
         .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties));
@@ -348,7 +347,7 @@ public class GobblinServiceManagerTest {
             "Waiting for job to get orchestrated...");
   }
 
-  @Test (dependsOnMethods = "testUncompilableJob")
+  @Test (dependsOnMethods = "testRunOnceJob")
   public void testRunQuotaExceeds() throws Exception {
     Map<String, String> props = flowProperties;
     props.put(ServiceAzkabanConfigKeys.AZKABAN_PROJECT_USER_TO_PROXY_KEY, "testUser");
@@ -367,8 +366,7 @@ public class GobblinServiceManagerTest {
     }
   }
 
-  // TODO: re-enable the following disabled tests once we can reduce flakiness
-  @Test (dependsOnMethods = "testRunQuotaExceeds", enabled = false, groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testRunQuotaExceeds", groups = {"disabledOnCI"})
   public void testExplainJob() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID2)
@@ -381,7 +379,7 @@ public class GobblinServiceManagerTest {
     Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_FLOW_ID2.toString()));
   }
 
-  @Test (dependsOnMethods = "testRunQuotaExceeds", groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testExplainJob")
   public void testCreate() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
@@ -393,9 +391,9 @@ public class GobblinServiceManagerTest {
     Assert.assertTrue(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_URI.toString()));
   }
 
-  @Test (dependsOnMethods = "testCreate", enabled = false, groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testCreate")
   public void testCreateAgain() throws Exception {
-    FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID2)
+    FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE))
         .setProperties(new StringMap(flowProperties));
 
@@ -409,7 +407,7 @@ public class GobblinServiceManagerTest {
     Assert.assertEquals(exception.getStatus(), HttpStatus.CONFLICT_409);
   }
 
-  @Test (dependsOnMethods = "testCreate")
+  @Test (dependsOnMethods = "testCreateAgain")
   public void testGet() throws Exception {
     FlowConfig flowConfig = this.flowConfigClient.getFlowConfig(TEST_FLOW_ID);
 
@@ -423,7 +421,7 @@ public class GobblinServiceManagerTest {
     Assert.assertEquals(flowConfig.getProperties().get("param1"), "value1");
   }
 
-  @Test (dependsOnMethods = "testGet")
+  @Test (dependsOnMethods = "testCreateAgain")
   public void testGetAll() throws Exception {
     FlowConfig flowConfig2 = new FlowConfig().setId(TEST_FLOW_ID2)
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE))
@@ -436,7 +434,7 @@ public class GobblinServiceManagerTest {
     this.flowConfigClient.deleteFlowConfig(TEST_FLOW_ID2);
   }
 
-  @Test (dependsOnMethods = "testGetAll", enabled = false)
+  @Test (dependsOnMethods = "testCreateAgain", enabled = false)
   public void testGetFilteredFlows() throws Exception {
     // Not implemented for FsSpecStore
 
@@ -453,7 +451,7 @@ null, null, null, null);
     Assert.assertEquals(flowConfigs.size(), 2);
   }
 
-  @Test (dependsOnMethods = "testGetAll") // depends on testGetAll until testGetFilteredFlows is enabled
+  @Test (dependsOnMethods = "testGet")
   public void testUpdate() throws Exception {
     FlowId flowId = new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME);
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -328,7 +328,7 @@ public class GobblinServiceManagerTest {
     Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(uri.toString()));
   }
 
-  @Test (dependsOnMethods = "testUncompilableJob", groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testUncompilableJob")
   public void testRunOnceJob() throws Exception {
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
         .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties));
@@ -336,15 +336,12 @@ public class GobblinServiceManagerTest {
     this.flowConfigClient.createFlowConfig(flowConfig);
 
     // runOnce job is deleted soon after it is orchestrated
-    AssertWithBackoff.create().maxSleepMs(200L).timeoutMs(60000L).backoffFactor(1)
+    AssertWithBackoff.create().maxSleepMs(200L).timeoutMs(2000L).backoffFactor(1)
         .assertTrue(input -> this.gobblinServiceManager.getFlowCatalog().getSpecs().size() == 0,
           "Waiting for job to get orchestrated...");
-    AssertWithBackoff.create().maxSleepMs(100L).timeoutMs(2000L).backoffFactor(1)
+    AssertWithBackoff.create().maxSleepMs(100L).timeoutMs(1000L).backoffFactor(1)
           .assertTrue(input -> !this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_URI.toString()),
               "Waiting for job to get orchestrated...");
-    AssertWithBackoff.create().maxSleepMs(200L).timeoutMs(2000L).backoffFactor(1)
-        .assertTrue(input -> !this.gobblinServiceManager.getScheduler().getLastUpdatedTimeForFlowSpec().containsKey(TEST_URI.toString()),
-            "Waiting for job to get orchestrated...");
   }
 
   @Test (dependsOnMethods = "testRunOnceJob")
@@ -366,28 +363,27 @@ public class GobblinServiceManagerTest {
     }
   }
 
-  @Test (dependsOnMethods = "testRunQuotaExceeds", groups = {"disabledOnCI"})
+  @Test (dependsOnMethods = "testRunQuotaExceeds")
   public void testExplainJob() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
-    FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID2)
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
         .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties)).setExplain(true);
 
     this.flowConfigClient.createFlowConfig(flowConfig);
 
     // explain job should not be persisted
     Assert.assertEquals(this.gobblinServiceManager.getFlowCatalog().getSpecs().size(), sizeBeforeTest);
-    Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_FLOW_ID2.toString()));
+    Assert.assertFalse(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_URI.toString()));
   }
 
   @Test (dependsOnMethods = "testExplainJob")
   public void testCreate() throws Exception {
-    int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowConfig flowConfig = new FlowConfig().setId(TEST_FLOW_ID)
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).setRunImmediately(true))
         .setProperties(new StringMap(flowProperties));
 
     this.flowConfigClient.createFlowConfig(flowConfig);
-    Assert.assertEquals(this.gobblinServiceManager.getFlowCatalog().getSpecs().size(), sizeBeforeTest + 1);
+    Assert.assertEquals(this.gobblinServiceManager.getFlowCatalog().getSpecs().size(), 1);
     Assert.assertTrue(this.gobblinServiceManager.getScheduler().getScheduledFlowSpecs().containsKey(TEST_URI.toString()));
   }
 
@@ -584,7 +580,7 @@ null, null, null, null);
         this.gobblinServiceManager.getRestLiServerListeningURI().getPort()), transportClientProperties);
   }
 
-  @Test (dependsOnMethods = "testBadUpdate")
+  @Test (dependsOnMethods = "testGitCreate")
   public void testGetAllPaginated() throws Exception {
     // Order of the flows by descending modified_time, and ascending flow.name should be: testFlow, testFlow2, testFlow3, testFlow4
     FlowConfig flowConfig1 = new FlowConfig().setId(TEST_FLOW_ID)
@@ -661,7 +657,7 @@ null, null, null, null);
     this.flowConfigClient.deleteFlowConfig(TEST_FLOW_ID4);
   }
 
-  @Test (dependsOnMethods = "testGetAllPaginated")
+  @Test (dependsOnMethods = "testGitCreate")
   public void testGetFilteredFlowsPaginated() throws Exception {
     // Attempt pagination with one element from the start of the specStore configurations stored. Filter by the owningGroup of "Keep.this"
     FlowConfig flowConfig2 = new FlowConfig().setId(TEST_FLOW_ID5).setOwningGroup("Filter.this")


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1987


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Run-immediate flows are missing an event trigger timestamp and being skipped in multi-active mode orchestration step. Code https://github.com/apache/gobblin/blob/913d580fe19e7a6adc60d3294bac44e5a32d7bba/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java#L241
`Skipping execution of spec: .... because missing trigger timestamp in job properties`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

