### PR TITLE
[GOBBLIN-1991] set (target) dataset path correctly in RecursiveCopyableDataset

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
@@ -19,12 +19,6 @@ package org.apache.gobblin.data.management.copy;
 
 import java.util.Properties;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-
-import org.apache.gobblin.util.PropertiesUtils;
-import org.apache.gobblin.util.request_allocation.RequestAllocatorConfig;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -32,11 +26,17 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.typesafe.config.Config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.data.management.copy.prioritization.FileSetComparator;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+import org.apache.gobblin.util.request_allocation.RequestAllocatorConfig;
 import org.apache.gobblin.util.request_allocation.ResourcePool;
 
 
@@ -120,11 +120,8 @@ public class CopyConfiguration {
           properties.containsKey(DESTINATION_GROUP_KEY) ? Optional.of(properties.getProperty(DESTINATION_GROUP_KEY))
               : Optional.<String>absent();
       this.preserve = PreserveAttributes.fromMnemonicString(properties.getProperty(PRESERVE_ATTRIBUTES_KEY));
-      Path publishDirTmp = new Path(properties.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
-      if (!publishDirTmp.isAbsolute()) {
-        publishDirTmp = new Path(targetFs.getWorkingDirectory(), publishDirTmp);
-      }
-      this.publishDir = publishDirTmp;
+
+      this.publishDir = calculatePublishDir(targetFs, properties);
       this.copyContext = new CopyContext();
       this.targetFs = targetFs;
       if (properties.containsKey(PRIORITIZER_ALIAS_KEY)) {
@@ -148,6 +145,14 @@ public class CopyConfiguration {
         this.abortOnSingleDatasetFailure = this.config.getBoolean(ABORT_ON_SINGLE_DATASET_FAILURE);
       }
     }
+  }
+
+  static Path calculatePublishDir(FileSystem targetFs, Properties properties) {
+    Path publishDirTmp = new Path(properties.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
+    if (!publishDirTmp.isAbsolute()) {
+      publishDirTmp = new Path(targetFs.getWorkingDirectory(), publishDirTmp);
+    }
+    return publishDirTmp;
   }
 
   public static CopyConfigurationBuilder builder(FileSystem targetFs, Properties properties) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -238,7 +238,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
 
   @Override
   // this is more like a getTargetDatasetPath
-  // this should preferably be called after the call to getCopyableFiles() because
+  // this should preferably be called after the call to getCopyableFiles() because targetPath is set in getCopyableFiles
   public String getDatasetPath() {
     if (this.targetPath == null) {
       // if getCopyableFiles() is not called that sets targetPath, it will try to

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -66,10 +66,11 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   public static final String USE_NEW_PRESERVE_LOGIC_KEY = CONFIG_PREFIX + ".useNewPreserveLogic";
 
   private final Path rootPath;
+  private Path targetPath;
   private final FileSystem fs;
   private final PathFilter pathFilter;
-  // Glob used to find this dataset
-  private final Path glob;
+  // deepest non glob search path used to find this dataset
+  private final Path nonGlobSearchPath;
   private final CopyableFileFilter copyableFileFilter;
   private final boolean update;
   private final boolean delete;
@@ -89,11 +90,8 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
 
     this.rootPath = PathUtils.getPathWithoutSchemeAndAuthority(rootPath);
     this.fs = fs;
-
     this.pathFilter = DatasetUtils.instantiatePathFilter(properties);
     this.copyableFileFilter = DatasetUtils.instantiateCopyableFileFilter(properties);
-    this.glob = glob;
-
     this.update = Boolean.parseBoolean(properties.getProperty(UPDATE_KEY));
     this.delete = Boolean.parseBoolean(properties.getProperty(DELETE_KEY));
     this.deleteEmptyDirectories = Boolean.parseBoolean(properties.getProperty(DELETE_EMPTY_DIRECTORIES_KEY));
@@ -103,6 +101,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
         Boolean.parseBoolean(properties.getProperty(CopyConfiguration.APPLY_FILTER_TO_DIRECTORIES, "false"));
     this.useNewPreserveLogic = Boolean.parseBoolean(properties.getProperty(USE_NEW_PRESERVE_LOGIC_KEY));
     this.properties = properties;
+    this.nonGlobSearchPath = PathUtils.deepestNonGlobPath(glob);
   }
 
   protected Collection<? extends CopyEntity> getCopyableFilesImpl(CopyConfiguration configuration,
@@ -190,9 +189,8 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   public Collection<? extends CopyEntity> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration)
       throws IOException {
 
-    Path nonGlobSearchPath = PathUtils.deepestNonGlobPath(this.glob);
-    Path targetPath =
-        new Path(configuration.getPublishDir(), PathUtils.relativizePath(this.rootPath, nonGlobSearchPath));
+    this.targetPath =
+        new Path(configuration.getPublishDir(), PathUtils.relativizePath(this.rootPath, this.nonGlobSearchPath));
 
     Map<Path, FileStatus> filesInSource =
         createPathMap(getFilesAtPath(this.fs, this.rootPath, this.pathFilter), this.rootPath);
@@ -239,7 +237,14 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   }
 
   @Override
+  // this is more like a getTargetDatasetPath
+  // this should preferably be called after the call to getCopyableFiles() because
   public String getDatasetPath() {
-    return Path.getPathWithoutSchemeAndAuthority(this.rootPath).toString();
+    if (this.targetPath == null) {
+      // if getCopyableFiles() is not called that sets targetPath, it will try to
+      this.targetPath = new Path(CopyConfiguration.calculatePublishDir(this.fs, this.properties),
+          PathUtils.relativizePath(this.rootPath, this.nonGlobSearchPath));;
+    }
+    return Path.getPathWithoutSchemeAndAuthority(this.targetPath).toString();
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
@@ -33,22 +33,37 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
+import javax.annotation.Nullable;
+import lombok.Data;
 
 import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.data.management.copy.entities.CommitStepCopyEntity;
 import org.apache.gobblin.util.commit.DeleteFileCommitStep;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import javax.annotation.Nullable;
-import lombok.Data;
-
 
 public class RecursiveCopyableDatasetTest {
+
+  @Test
+  public void testTargetDatasetPath() throws Exception {
+    Path source = new Path("/source");
+    Path target = new Path("/target");
+
+    List<FileStatus> sourceFiles = Lists.newArrayList(createFileStatus(source, "file1"), createFileStatus(source, "file2"));
+    List<FileStatus> targetFiles = Lists.newArrayList(createFileStatus(target, "file3"));
+
+    Properties properties = new Properties();
+    properties.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, target.toString());
+    RecursiveCopyableDataset dataset = new TestRecursiveCopyableDataset(source, target, sourceFiles, targetFiles, properties);
+
+    Assert.assertEquals(dataset.getDatasetPath(), target.toString());
+  }
 
   @Test
   public void testSimpleCopy() throws Exception {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1991


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
RecursiveCopyableDataset.getDatasetPath() is returning the source dataset's path. But the use of this method is to calculate the shard path by destination dataset handlers. This method should return the target dataset's path.
This bug will fail the jobs where source path and target paths are different and source path cannot be created on target filesystem.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test, which fails without the code change in this PR

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

