### PR TITLE
[GOBBLIN-1994] Ensure iceberg-distcp consistency by using same `TableMetadata` for both WU planning and final commit

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -315,13 +315,14 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
 
     if (readTimeTableMetadataHolder.size() != 1) {
       final int firstNumToShow = 5;
+      String newline = System.lineSeparator();
       String errMsg = readTimeTableMetadataHolder.size() == 0
           ? String.format("~%s~ no table metadata ever encountered!", this.getFileSetId())
           : String.format("~%s~ multiple metadata (%d) encountered (exactly 1 expected) - first %d: [%s]",
               this.getFileSetId(), readTimeTableMetadataHolder.size(), firstNumToShow,
               readTimeTableMetadataHolder.stream().limit(firstNumToShow).map(md ->
-                  md.uuid() + " - " + md.location()
-              ).collect(Collectors.joining("\n", "\n", "\n")));
+                  md.uuid() + " - " + md.metadataFileLocation()
+              ).collect(Collectors.joining(newline, newline, newline)));
       throw new RuntimeException(errMsg);
     }
     return new GetFilePathsToFileStatusResult(results, readTimeTableMetadataHolder.get(0));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -40,8 +40,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.iceberg.TableMetadata;
 
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
 import org.apache.gobblin.data.management.copy.CopyEntity;
@@ -126,6 +129,14 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     return Iterators.singletonIterator(fileSet);
   }
 
+  /** Conveys {@link Path}-to-{@link FileStatus} mapping in combination with {@link TableMetadata} originating from the same atomic read of those paths */
+  @Data
+  @VisibleForTesting
+  protected static final class GetFilePathsToFileStatusResult {
+    private final Map<Path, FileStatus> pathsToFileStatus;
+    private final TableMetadata tableMetadata;
+  }
+
   /**
    * Finds all files, data and metadata, as {@link CopyEntity}s that comprise the table and fully specify remaining
    * table replication.
@@ -134,7 +145,9 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   Collection<CopyEntity> generateCopyEntities(FileSystem targetFs, CopyConfiguration copyConfig) throws IOException {
     String fileSet = this.getFileSetId();
     List<CopyEntity> copyEntities = Lists.newArrayList();
-    Map<Path, FileStatus> pathToFileStatus = getFilePathsToFileStatus(targetFs, copyConfig, this.shouldIncludeMetadataPath);
+    TableMetadata destTableMetadataBeforeSrcRead = getCurrentDestTableMetadata();
+    GetFilePathsToFileStatusResult atomicGetPathsResult = getFilePathsToFileStatus(targetFs, copyConfig, this.shouldIncludeMetadataPath);
+    Map<Path, FileStatus> pathToFileStatus = atomicGetPathsResult.getPathsToFileStatus();
     log.info("~{}~ found {} candidate source paths", fileSet, pathToFileStatus.size());
 
     Configuration defaultHadoopConfiguration = new Configuration();
@@ -160,17 +173,31 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       copyEntities.add(fileEntity);
     }
     // TODO: Filter properties specific to iceberg registration and avoid serializing every global property
-    copyEntities.add(createPostPublishStep());
+    copyEntities.add(createPostPublishStep(atomicGetPathsResult.getTableMetadata(), destTableMetadataBeforeSrcRead));
     log.info("~{}~ generated {} copy entities", fileSet, copyEntities.size());
     return copyEntities;
   }
 
   /**
+   * @return {@link TableMetadata} current at destination
+   * @throws {@link IOException} if `this.destIcebergTable` does not exist
+   */
+  protected TableMetadata getCurrentDestTableMetadata() throws IOException {
+    try {
+      return destIcebergTable.accessTableMetadata();
+    } catch (IcebergTable.TableNotFoundException tnfe) {
+      log.error("No destination TableMetadata because table not found: '" + destIcebergTable.getTableId() + "'" , tnfe);
+      throw new IOException(tnfe);
+    }
+  }
+
+  /**
    * Finds all files of the Iceberg's current snapshot
    * @param shouldIncludeMetadataPath whether to consider "metadata.json" (`getMetadataPath()`) as eligible for inclusion
-   * @return a map of path, file status for each file that needs to be copied
+   * @return combined result: both a map of path to file status for each file to copy plus the {@link TableMetadata}, atomically observed with those paths
    */
-  protected Map<Path, FileStatus> getFilePathsToFileStatus(FileSystem targetFs, CopyConfiguration copyConfig, boolean shouldIncludeMetadataPath) throws IOException {
+  protected GetFilePathsToFileStatusResult getFilePathsToFileStatus(FileSystem targetFs, CopyConfiguration copyConfig, boolean shouldIncludeMetadataPath)
+      throws IOException {
     IcebergTable icebergTable = this.getSrcIcebergTable();
     /** @return whether `pathStr` is present on `targetFs`, caching results while tunneling checked exceptions outward */
     Function<String, Boolean> isPresentOnTarget = CheckedExceptionFunction.wrapToTunneled(pathStr ->
@@ -188,11 +215,19 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
           this.getFileSetId(), currentSnapshotOverview.getSnapshotId(),
           currentSnapshotOverview.getManifestListPath(),
           currentSnapshotOverview.getMetadataPath().orElse("<<ERROR: MISSING!>>"));
-      return Maps.newHashMap();
+      TableMetadata readTimeTableMetadata = currentSnapshotOverview.getTableMetadata().orElseThrow(() -> new RuntimeException(
+          String.format("~%s~ no table metadata for current snapshot '%s' at '%s' with metadata path '%s'",
+              this.getFileSetId(), currentSnapshotOverview.getSnapshotId(),
+              currentSnapshotOverview.getManifestListPath(),
+              currentSnapshotOverview.getMetadataPath().orElse("<<ERROR: MISSING!>>"))));
+      return new GetFilePathsToFileStatusResult(Maps.newHashMap(), readTimeTableMetadata);
     }
+
+    List<TableMetadata> readTimeTableMetadataHolder = Lists.newArrayList(); // expecting exactly one elem
     Iterator<IcebergSnapshotInfo> icebergIncrementalSnapshotInfos = icebergTable.getIncrementalSnapshotInfosIterator();
     Iterator<String> filePathsIterator = Iterators.concat(
         Iterators.transform(icebergIncrementalSnapshotInfos, snapshotInfo -> {
+          snapshotInfo.getTableMetadata().ifPresent(readTimeTableMetadataHolder::add);
           // log each snapshot, for context, in case of `FileNotFoundException` during `FileSystem.getFileStatus()`
           String manListPath = snapshotInfo.getManifestListPath();
           log.info("~{}~ loaded snapshot '{}' at '{}' from metadata path: '{}'", this.getFileSetId(),
@@ -276,7 +311,11 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     } catch (CheckedExceptionFunction.WrappedIOException wrapper) {
       wrapper.rethrowWrapped();
     }
-    return results;
+
+    if (readTimeTableMetadataHolder.size() == 0) {
+      throw new RuntimeException(String.format("~%s~ no table metadata ever encountered!", this.getFileSetId()));
+    }
+    return new GetFilePathsToFileStatusResult(results, readTimeTableMetadataHolder.get(0));
   }
 
   /**
@@ -329,8 +368,9 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
     return this.destIcebergTable.getDatasetDescriptor(targetFs);
   }
 
-  private PostPublishStep createPostPublishStep() {
-    IcebergRegisterStep icebergRegisterStep = new IcebergRegisterStep(this.srcIcebergTable.getTableId(), this.destIcebergTable.getTableId(), this.properties);
+  private PostPublishStep createPostPublishStep(TableMetadata readTimeSrcTableMetadata, TableMetadata justPriorDestTableMetadata) {
+    IcebergRegisterStep icebergRegisterStep = new IcebergRegisterStep(
+        this.srcIcebergTable.getTableId(), this.destIcebergTable.getTableId(), readTimeSrcTableMetadata, justPriorDestTableMetadata, this.properties);
     return new PostPublishStep(getFileSetId(), Maps.newHashMap(), icebergRegisterStep, 0);
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDataset.java
@@ -105,6 +105,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   public Iterator<FileSet<CopyEntity>> getFileSetIterator(FileSystem targetFs, CopyConfiguration configuration) {
     return createFileSets(targetFs, configuration);
   }
+
   /**
    * Finds all files read by the table and generates CopyableFiles.
    * For the specific semantics see {@link #createFileSets}.
@@ -173,7 +174,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
       fileEntity.setDestinationData(getDestinationDataset(targetFs));
       copyEntities.add(fileEntity);
     }
-    // TODO: Filter properties specific to iceberg registration and avoid serializing every global property
+
     copyEntities.add(createPostPublishStep(atomicGetPathsResult.getTableMetadata(), destTableMetadataBeforeSrcRead));
     log.info("~{}~ generated {} copy entities", fileSet, copyEntities.size());
     return copyEntities;
@@ -193,7 +194,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   /**
-   * Finds all files of the Iceberg's current snapshot
+   * Finds all files of the Iceberg's current snapshot and also returns the {@link TableMetadata} atomically accessed while reading those paths
    * @param shouldIncludeMetadataPath whether to consider "metadata.json" (`getMetadataPath()`) as eligible for inclusion
    * @return combined result: both a map of path to file status for each file to copy plus the {@link TableMetadata}, atomically observed with those paths
    */
@@ -379,6 +380,7 @@ public class IcebergDataset implements PrioritizedCopyableDataset {
   }
 
   private PostPublishStep createPostPublishStep(TableMetadata readTimeSrcTableMetadata, TableMetadata justPriorDestTableMetadata) {
+    // TODO: Filter properties specific to iceberg registration and avoid serializing every global property
     IcebergRegisterStep icebergRegisterStep = new IcebergRegisterStep(
         this.srcIcebergTable.getTableId(), this.destIcebergTable.getTableId(), readTimeSrcTableMetadata, justPriorDestTableMetadata, this.properties);
     return new PostPublishStep(getFileSetId(), Maps.newHashMap(), icebergRegisterStep, 0);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -53,7 +53,7 @@ import org.apache.gobblin.util.HadoopUtils;
 public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDataset> {
   public static final String ICEBERG_DATASET_PREFIX = DatasetConstants.PLATFORM_ICEBERG + ".dataset";
 
-  public static final String ICEBERG_DATASET_SHOULD_COPY_METADATA_PATH = ICEBERG_DATASET_PREFIX + ".copy.metadata.path";
+  public static final String ICEBERG_DATASET_SHOULD_COPY_METADATA_PATH = ICEBERG_DATASET_PREFIX + ".should.copy.metadata.path";
   public static final String DEFAULT_ICEBERG_DATASET_SHOULD_COPY_METADATA_PATH = "false";
 
   public static final String DEFAULT_ICEBERG_CATALOG_CLASS = "org.apache.gobblin.data.management.copy.iceberg.IcebergHiveCatalog";

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -64,6 +64,7 @@ public class IcebergRegisterStep implements CommitStep {
     TableMetadata unusedNowCurrentDestMetadata = null;
     try {
       unusedNowCurrentDestMetadata = destIcebergTable.accessTableMetadata(); // probe... (first access could throw)
+      unusedNowCurrentDestMetadata.uuid(); // access to prevent findbugs "dead store to..." (Dodgy code Warning)
     } catch (IcebergTable.TableNotFoundException tnfe) {
       log.warn("Destination TableMetadata doesn't exist because: " , tnfe);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -64,7 +64,11 @@ public class IcebergRegisterStep implements CommitStep {
     TableMetadata unusedNowCurrentDestMetadata = null;
     try {
       unusedNowCurrentDestMetadata = destIcebergTable.accessTableMetadata(); // probe... (first access could throw)
-      unusedNowCurrentDestMetadata.uuid(); // access to prevent findbugs "dead store to..." (Dodgy code Warning)
+      log.info("~{}~ (destination) (using) TableMetadata: {} - {} {} (current) TableMetadata: {} - {}",
+          destTableIdStr,
+          justPriorDestTableMetadata.uuid(), justPriorDestTableMetadata.metadataFileLocation(),
+          unusedNowCurrentDestMetadata.uuid().equals(justPriorDestTableMetadata.uuid()) ? "==" : "!=",
+          unusedNowCurrentDestMetadata.uuid(), unusedNowCurrentDestMetadata.metadataFileLocation());
     } catch (IcebergTable.TableNotFoundException tnfe) {
       log.warn("Destination TableMetadata doesn't exist because: " , tnfe);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergSnapshotInfo.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergSnapshotInfo.java
@@ -27,6 +27,8 @@ import lombok.Data;
 
 import com.google.common.collect.Lists;
 
+import org.apache.iceberg.TableMetadata;
+
 
 /**
  * Information about the metadata file and data file paths of a single Iceberg Snapshot.
@@ -43,8 +45,10 @@ public class IcebergSnapshotInfo {
 
   private final Long snapshotId;
   private final Instant timestamp;
-  /** only for the current snapshot, being whom the metadata file 'belongs to'; `isEmpty()` for all other snapshots */
+  /** only for the snapshot designated 'current', being whom the metadata file 'belongs to'; `isEmpty()` for all other snapshots */
   private final Optional<String> metadataPath;
+  /** only for the snapshot designated 'current', being whom the metadata 'belong to'; `isEmpty()` for all other snapshots */
+  private final Optional<TableMetadata> tableMetadata;
   private final String manifestListPath;
   private final List<ManifestFileInfo> manifestFiles;
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -41,8 +41,10 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.TableIdentifier;
+
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -398,7 +400,8 @@ public class IcebergDatasetTest {
     FileSystem destFs = destFsBuilder.build();
     CopyConfiguration copyConfiguration = createEmptyCopyConfiguration(destFs);
 
-    Map<Path, FileStatus> filePathsToFileStatus = icebergDataset.getFilePathsToFileStatus(destFs, copyConfiguration, shouldIncludeMetadataPath);
+    IcebergDataset.GetFilePathsToFileStatusResult pathsResult = icebergDataset.getFilePathsToFileStatus(destFs, copyConfiguration, shouldIncludeMetadataPath);
+    Map<Path, FileStatus> filePathsToFileStatus = pathsResult.getPathsToFileStatus();
     Assert.assertEquals(filePathsToFileStatus.keySet(), expectedResultPaths);
     // verify solely the path portion of the `FileStatus`, since that's all mock sets up
     Assert.assertEquals(
@@ -595,6 +598,7 @@ public class IcebergDatasetTest {
       private final Optional<String> metadataPath;
       private final String manifestListPath;
       private final List<IcebergSnapshotInfo.ManifestFileInfo> manifestFiles;
+      private static final TableMetadata unusedStubMetadata = Mockito.mock(TableMetadata.class);
 
       public IcebergSnapshotInfo asSnapshotInfo() {
         return asSnapshotInfo(0L);
@@ -606,7 +610,7 @@ public class IcebergDatasetTest {
       }
 
       public IcebergSnapshotInfo asSnapshotInfo(Long snapshotId, Instant timestamp) {
-        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath, this.manifestListPath, this.manifestFiles);
+        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath, Optional.of(unusedStubMetadata), this.manifestListPath, this.manifestFiles);
       }
     }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -598,6 +598,7 @@ public class IcebergDatasetTest {
       private final Optional<String> metadataPath;
       private final String manifestListPath;
       private final List<IcebergSnapshotInfo.ManifestFileInfo> manifestFiles;
+
       private static final TableMetadata unusedStubMetadata = Mockito.mock(TableMetadata.class);
 
       public IcebergSnapshotInfo asSnapshotInfo() {
@@ -610,7 +611,9 @@ public class IcebergDatasetTest {
       }
 
       public IcebergSnapshotInfo asSnapshotInfo(Long snapshotId, Instant timestamp) {
-        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath, Optional.of(unusedStubMetadata), this.manifestListPath, this.manifestFiles);
+        return new IcebergSnapshotInfo(snapshotId, timestamp, this.metadataPath,
+            this.metadataPath.map(ignore -> unusedStubMetadata), // only set when `metadataPath.isPresent()`
+            this.manifestListPath, this.manifestFiles);
       }
     }
 


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1994


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Iceberg-distcp replication currently risks introducing inconsistency to the destination/replication-target table, because the current snapshot version of the tables may change between the planning phase (of creating WorkUnits) and the final post-copy commit to the destination table.

To inoculate against any concurrent commits, ensure correctness by committing:

1. the same source-side metadata observed while first listing the source table during the Planning Phase and
2. the same dest-side metadata observed just prior to that first listing of the source table.

This guarantees that:

1. any later-modified source table metadata would not be committed to dest (at least not until a subsequent execution)
2. any interim commit to the dest table would result in the distcp replication commit failing (which may then be resolved by launching a new iceberg distcp execution on the same table)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

updated unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    4. Subject is limited to 50 characters
    5. Subject does not end with a period
    6. Subject uses the imperative mood ("add", not "adding")
    7. Body wraps at 72 characters
    8. Body explains "what" and "why", not "how"

