### PR TITLE
[GOBBLIN-1994] Fix iceberg-distcp dest-side `TableMetadata` consistency check to accurately detect "stale table metadata"

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -73,7 +73,7 @@ public class IcebergRegisterStep implements CommitStep {
       // CRITICAL: verify current dest-side metadata remains the same as observed just prior to first loading source catalog table metadata
       boolean isJustPriorDestMetadataStillCurrent = currentDestMetadata.uuid().equals(justPriorDestTableMetadata.uuid())
           && currentDestMetadata.metadataFileLocation().equals(justPriorDestTableMetadata.metadataFileLocation());
-      String determinationMsg = String.format("(just prior) TableMetadata: {} - {} {}= (current) TableMetadata: {} - {}",
+      String determinationMsg = String.format("(just prior) TableMetadata: %s - %s %s= (current) TableMetadata: %s - %s",
           justPriorDestTableMetadata.uuid(), justPriorDestTableMetadata.metadataFileLocation(),
           isJustPriorDestMetadataStillCurrent ? "=" : "!",
           currentDestMetadata.uuid(), currentDestMetadata.metadataFileLocation());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -20,6 +20,8 @@ package org.apache.gobblin.data.management.copy.iceberg;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 
@@ -65,26 +67,40 @@ public class IcebergRegisterStep implements CommitStep {
 
   @Override
   public void execute() throws IOException {
-    IcebergTable destIcebergTable = IcebergDatasetFinder.createIcebergCatalog(this.properties, IcebergDatasetFinder.CatalogLocation.DESTINATION)
-        .openTable(TableIdentifier.parse(destTableIdStr));
-    // NOTE: solely by-product of probing table's existence: metadata recorded just prior to reading from source catalog is what's actually used
-    TableMetadata unusedNowCurrentDestMetadata = null;
+    IcebergTable destIcebergTable = createDestinationCatalog().openTable(TableIdentifier.parse(destTableIdStr));
     try {
-      unusedNowCurrentDestMetadata = destIcebergTable.accessTableMetadata(); // probe... (first access could throw)
-      log.info("~{}~ (destination) (using) TableMetadata: {} - {} {}= (current) TableMetadata: {} - {}",
-          destTableIdStr,
+      TableMetadata currentDestMetadata = destIcebergTable.accessTableMetadata(); // probe... (first access could throw)
+      // CRITICAL: verify current dest-side metadata remains the same as observed just prior to first loading source catalog table metadata
+      boolean isJustPriorDestMetadataStillCurrent = currentDestMetadata.uuid().equals(justPriorDestTableMetadata.uuid())
+          && currentDestMetadata.metadataFileLocation().equals(justPriorDestTableMetadata.metadataFileLocation());
+      String determinationMsg = String.format("(just prior) TableMetadata: {} - {} {}= (current) TableMetadata: {} - {}",
           justPriorDestTableMetadata.uuid(), justPriorDestTableMetadata.metadataFileLocation(),
-          unusedNowCurrentDestMetadata.uuid().equals(justPriorDestTableMetadata.uuid()) ? "=" : "!",
-          unusedNowCurrentDestMetadata.uuid(), unusedNowCurrentDestMetadata.metadataFileLocation());
+          isJustPriorDestMetadataStillCurrent ? "=" : "!",
+          currentDestMetadata.uuid(), currentDestMetadata.metadataFileLocation());
+      log.info("~{}~ [destination] {}", destTableIdStr, determinationMsg);
+
+      // NOTE: we originally expected the dest-side catalog to enforce this match, but the client-side `BaseMetastoreTableOperations.commit`
+      // uses `==`, rather than `.equals` (value-cmp), and that invariably leads to:
+      //   org.apache.iceberg.exceptions.CommitFailedException: Cannot commit: stale table metadata
+      if (!isJustPriorDestMetadataStillCurrent) {
+        throw new IOException("error: likely concurrent writing to destination: " + determinationMsg);
+      }
+      destIcebergTable.registerIcebergTable(readTimeSrcTableMetadata, currentDestMetadata);
     } catch (IcebergTable.TableNotFoundException tnfe) {
-      log.warn("Destination TableMetadata doesn't exist because: " , tnfe);
+      String msg = "Destination table (with TableMetadata) does not exist: " + tnfe.getMessage();
+      log.error(msg);
+      throw new IOException(msg, tnfe);
     }
-    // TODO: decide whether helpful to construct a more detailed error message about `justPriorDestTableMetadata` being no-longer current
-    destIcebergTable.registerIcebergTable(readTimeSrcTableMetadata, justPriorDestTableMetadata);
   }
 
   @Override
   public String toString() {
     return String.format("Registering Iceberg Table: {%s} (dest); (src: {%s})", this.destTableIdStr, this.srcTableIdStr);
+  }
+
+  /** Purely because the static `IcebergDatasetFinder.createIcebergCatalog` proved challenging to mock, even w/ `Mockito::mockStatic` */
+  @VisibleForTesting
+  protected IcebergCatalog createDestinationCatalog() throws IOException {
+    return IcebergDatasetFinder.createIcebergCatalog(this.properties, IcebergDatasetFinder.CatalogLocation.DESTINATION);
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -59,7 +59,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import joptsimple.internal.Strings;
 import lombok.Data;
 
 import org.apache.gobblin.data.management.copy.CopyConfiguration;
@@ -684,8 +683,8 @@ public class IcebergDatasetTest {
     private static FileOwnerAndPermissions getFileOwnerAndPermissions(JsonObject jsonObject) {
       FileOwnerAndPermissions fileOwnerAndPermissions = new FileOwnerAndPermissions();
       JsonObject objData = jsonObject.getAsJsonObject("object-data");
-      fileOwnerAndPermissions.owner = objData.has("owner") ? objData.getAsJsonPrimitive("owner").getAsString() : Strings.EMPTY;
-      fileOwnerAndPermissions.group = objData.has("group") ? objData.getAsJsonPrimitive("group").getAsString() : Strings.EMPTY;
+      fileOwnerAndPermissions.owner = objData.has("owner") ? objData.getAsJsonPrimitive("owner").getAsString() : "";
+      fileOwnerAndPermissions.group = objData.has("group") ? objData.getAsJsonPrimitive("group").getAsString() : "";
 
       JsonObject fsPermission = objData.has("fsPermission") ? objData.getAsJsonObject("fsPermission") : null;
       if (fsPermission != null) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.iceberg;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/** Tests for {@link org.apache.gobblin.data.management.copy.iceberg.IcebergRegisterStep} */
+public class IcebergRegisterStepTest {
+
+  private TableIdentifier srcTableId = TableIdentifier.of("db", "foo");
+  private TableIdentifier destTableId = TableIdentifier.of("db", "bar");
+
+  @Test
+  public void testDestSideMetadataMatchSucceeds() throws IOException {
+    TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
+    TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class); // (no mocked behavior)
+    IcebergTable mockTable = mockIcebergTable("foo", "bar"); // matches!
+    IcebergRegisterStep regStep =
+        new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
+          @Override
+          protected IcebergCatalog createDestinationCatalog() throws IOException {
+            return mockSingleTableIcebergCatalog(mockTable);
+          }
+        };
+    try {
+      regStep.execute();
+      Mockito.verify(mockTable, Mockito.times(1)).registerIcebergTable(any(), any());
+    } catch (IOException ioe) {
+      Assert.fail("got unexpected IOException", ioe);
+    }
+  }
+
+  @Test
+  public void testDestSideMetadataMismatchThrowsIOException() throws IOException {
+    TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
+    TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class); // (no mocked behavior)
+    IcebergRegisterStep regStep =
+        new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
+          @Override
+          protected IcebergCatalog createDestinationCatalog() throws IOException {
+            return mockSingleTableIcebergCatalog("foo", "notBar");
+          }
+        };
+    try {
+      regStep.execute();
+      Assert.fail("expected IOException");
+    } catch (IOException ioe) {
+      Assert.assertTrue(ioe.getMessage().startsWith("error: likely concurrent writing to destination"), ioe.getMessage());
+    }
+  }
+
+  protected TableMetadata mockTableMetadata(String uuid, String metadataFileLocation) throws IOException {
+    TableMetadata mockMetadata = Mockito.mock(TableMetadata.class);
+    Mockito.when(mockMetadata.uuid()).thenReturn(uuid);
+    Mockito.when(mockMetadata.metadataFileLocation()).thenReturn(metadataFileLocation);
+    return mockMetadata;
+  }
+
+  protected IcebergTable mockIcebergTable(String tableUuid, String tableMetadataFileLocation) throws IOException {
+    TableMetadata mockMetadata = mockTableMetadata(tableUuid, tableMetadataFileLocation);
+
+    IcebergTable mockTable = Mockito.mock(IcebergTable.class);
+    Mockito.when(mockTable.accessTableMetadata()).thenReturn(mockMetadata);
+    return mockTable;
+  }
+
+  protected IcebergCatalog mockSingleTableIcebergCatalog(String tableUuid, String tableMetadataFileLocation) throws IOException {
+    IcebergTable mockTable = mockIcebergTable(tableUuid, tableMetadataFileLocation);
+    return mockSingleTableIcebergCatalog(mockTable);
+  }
+
+  protected IcebergCatalog mockSingleTableIcebergCatalog(IcebergTable mockTable) throws IOException {
+    IcebergCatalog catalog = Mockito.mock(IcebergCatalog.class);
+    Mockito.when(catalog.openTable(any())).thenReturn(mockTable);
+    return catalog;
+  }
+}


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1994


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

The recent change to "ensure iceberg-distcp consistency...", https://github.com/apache/gobblin/pull/3870 , unwisely relied on the dest-side catalog to enforce matching `TableMetadata`.  Alas, the client-side `BaseMetastoreTableOperations.commit` evidently compares using `==`, rather than `.equals` (for value comparison).  Since the `TableMetadata` from WU planning will always have already been serialized and deserialized, this invariably leads to:
```
org.apache.iceberg.exceptions.CommitFailedException: Cannot commit: stale table metadata
```

Our fix is to essentially implement our own (ID-only) value comparison within `IcebergRegisterStep`.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

