### PR TITLE
[GOBBLIN-2001] Add configuration to disable task failed event from emitting

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -574,11 +574,14 @@ public class Task implements TaskIFace {
         .setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, Throwables.getStackTraceAsString(cleanedException));
 
     // Send task failure event
-    FailureEventBuilder failureEvent = new FailureEventBuilder(FAILED_TASK_EVENT);
-    failureEvent.setRootCause(cleanedException);
-    failureEvent.addMetadata(TASK_STATE, this.taskState.toString());
-    failureEvent.addAdditionalMetadata(this.taskEventMetadataGenerator.getMetadata(this.taskState, failureEvent.getName()));
-    failureEvent.submit(taskContext.getTaskMetrics().getMetricContext());
+    if (!this.taskState.getPropAsBoolean(TaskConfigurationKeys.TASK_DISABLE_FAILED_EVENTS,
+        TaskConfigurationKeys.DEFAULT_TASK_DISABLE_FAILED_EVENTS)) {
+      FailureEventBuilder failureEvent = new FailureEventBuilder(FAILED_TASK_EVENT);
+      failureEvent.setRootCause(cleanedException);
+      failureEvent.addMetadata(TASK_STATE, this.taskState.toString());
+      failureEvent.addAdditionalMetadata(this.taskEventMetadataGenerator.getMetadata(this.taskState, failureEvent.getName()));
+      failureEvent.submit(taskContext.getTaskMetrics().getMetricContext());
+    }
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
@@ -38,7 +38,7 @@ public class TaskConfigurationKeys {
   public static final String TASK_SKIP_ERROR_RECORDS = "task.skip.error.records";
   public static final long DEFAULT_TASK_SKIP_ERROR_RECORDS = 0;
 
-  public static final String TASK_DISABLE_FAILED_EVENTS = "gobblin.task.disable.failed.events";
+  public static final String TASK_DISABLE_FAILED_EVENTS = "gobblin.task.failure.disable.event.emission";
 
   public static final boolean DEFAULT_TASK_DISABLE_FAILED_EVENTS = false;
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
@@ -38,7 +38,7 @@ public class TaskConfigurationKeys {
   public static final String TASK_SKIP_ERROR_RECORDS = "task.skip.error.records";
   public static final long DEFAULT_TASK_SKIP_ERROR_RECORDS = 0;
 
-  public static final String TASK_DISABLE_FAILED_EVENTS = "gobblin.task.failure.disable.event.emission";
+  public static final String TASK_DISABLE_FAILED_EVENTS = "gobblin.task.disable.failed.event.emission";
 
   public static final boolean DEFAULT_TASK_DISABLE_FAILED_EVENTS = false;
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
@@ -35,7 +35,11 @@ public class TaskConfigurationKeys {
   public static final String TASK_IS_SINGLE_BRANCH_SYNCHRONOUS = "gobblin.task.is.single.branch.synchronous";
   public static final String DEFAULT_TASK_IS_SINGLE_BRANCH_SYNCHRONOUS = Boolean.toString(false);
 
-
   public static final String TASK_SKIP_ERROR_RECORDS = "task.skip.error.records";
   public static final long DEFAULT_TASK_SKIP_ERROR_RECORDS = 0;
+
+  public static final String TASK_DISABLE_FAILED_EVENTS = "gobblin.task.disable.failed.events";
+
+  public static final boolean DEFAULT_TASK_DISABLE_FAILED_EVENTS = false;
+
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2001


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Currently in the Gobblin framework all failed tasks will emit events when they fail and include some stacktrace to provide context on the failure. This is problematic when there are Gobblin jobs with hundreds of thousands of tasks (e.g. iceberg distcp) and causes Kafka partitions to lag under the larger events. 

We want to enable a config to disable this, and potentially extend this solution to disable all task level events as they can get quite noisy and logs generally provide better context.

This PR disables emitting failed events if `gobblin.task.disable.failed.events` is set to true (defaults to false so no change)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

