### PR TITLE
[GOBBLIN-2007] Implement Distributed Data Movement (DDM) Gobblin-on-Temporal `WorkUnit` generation (for arbitrary `Source`)

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -301,7 +301,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     WorkUnitStream workUnitStream = new BasicWorkUnitStream.Builder(workUnits).build();
     // For streaming use case, this might be a necessary step to find dataset specific namespace so that each workUnit
     // can create staging and temp directories with the correct determination of shard-path
-    workUnitStream = this.executeHandlers(workUnitStream, this.destDatasetHandlerService);
+    workUnitStream = this.destDatasetHandlerService.executeHandlers(workUnitStream);
     workUnitStream = this.processWorkUnitStream(workUnitStream, jobState);
     workUnits = materializeWorkUnitList(workUnitStream);
     try {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -516,7 +516,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         this.canCleanUpStagingData = this.canCleanStagingData(this.jobContext.getJobState());
         this.destDatasetHandlerService = new DestinationDatasetHandlerService(jobState, canCleanUpStagingData, this.eventSubmitter);
         closer.register(this.destDatasetHandlerService);
-        workUnitStream = this.executeHandlers(workUnitStream, this.destDatasetHandlerService);
+        workUnitStream = this.destDatasetHandlerService.executeHandlers(workUnitStream);
 
         //Initialize writer and converter(s)
         closer.register(WriterInitializerFactory.newInstace(jobState, workUnitStream)).initialize();
@@ -696,10 +696,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       }
       commitSequenceStore.delete(jobName, datasetUrn);
     }
-  }
-
-  protected WorkUnitStream executeHandlers(WorkUnitStream workUnitStream, DestinationDatasetHandlerService datasetHandlerService) {
-    return datasetHandlerService.executeHandlers(workUnitStream);
   }
 
   protected WorkUnitStream processWorkUnitStream(WorkUnitStream workUnitStream, JobState jobState) {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
@@ -42,6 +42,7 @@ public interface GobblinTemporalConfigurationKeys {
   String DEFAULT_GOBBLIN_TEMPORAL_JOB_LAUNCHER_CLASS = HelloWorldJobLauncher.class.getName();
 
   String GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_PREFIX = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "arg.";
+  String GOBBLIN_TEMPORAL_JOB_LAUNCHER_CONFIG_OVERRIDES = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "config.overrides";
 
   /**
    * Suffix for metrics emitted by GobblinTemporalJobLauncher for preventing collisions with prod jobs

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/AbstractTemporalWorker.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/AbstractTemporalWorker.java
@@ -78,7 +78,7 @@ public abstract class AbstractTemporalWorker implements TemporalWorker {
     protected abstract Object[] getActivityImplInstances();
 
     private final void stashWorkerConfig(Config cfg) {
-        // stash in association with...
+        // stash to associate with...
         WorkerConfig.forWorker(this.getClass(), cfg); // the worker itself
         Arrays.stream(getWorkflowImplClasses()).forEach(clazz -> WorkerConfig.withImpl(clazz, cfg)); // its workflow impls
         Arrays.stream(getActivityImplInstances()).forEach(obj -> WorkerConfig.withImpl(obj.getClass(), cfg)); // its activity impls

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
@@ -246,10 +246,12 @@ public class GobblinTemporalTaskRunner implements StandardMetricsBridge {
 
     String workerClassName = ConfigUtils.getString(clusterConfig,
         GobblinTemporalConfigurationKeys.WORKER_CLASS, GobblinTemporalConfigurationKeys.DEFAULT_WORKER_CLASS);
+    logger.info("Creating worker - class: '{}'", workerClassName);
+    Config workerConfig = clusterConfig;
     TemporalWorker worker = GobblinConstructorUtils.invokeLongestConstructor(
-        (Class<TemporalWorker>)Class.forName(workerClassName), clusterConfig, client);
+        (Class<TemporalWorker>)Class.forName(workerClassName), workerConfig, client);
     worker.start();
-    logger.info("A new worker is started.");
+    logger.info("Finished starting worker - class: '{}'", workerClassName);
     return worker;
   }
 

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/GenerateWorkUnits.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/GenerateWorkUnits.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.ddm.activity;
+
+import java.util.Properties;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.temporal.workflows.metrics.EventSubmitterContext;
+
+
+/** Activity for generating {@link WorkUnit}s and persisting them to the {@link org.apache.hadoop.fs.FileSystem}, per "job properties" */
+@ActivityInterface
+public interface GenerateWorkUnits {
+  /** @return the number of {@link WorkUnit}s generated and persisted */
+  @ActivityMethod
+  int generateWorkUnits(Properties jobProps, EventSubmitterContext eventSubmitterContext);
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/GenerateWorkUnitsImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/GenerateWorkUnitsImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.ddm.activity.impl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import com.google.api.client.util.Lists;
+import com.google.common.io.Closer;
+import com.typesafe.config.Config;
+
+import io.temporal.failure.ApplicationFailure;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.gobblin.commit.DeliverySemantics;
+import org.apache.gobblin.converter.initializer.ConverterInitializerFactory;
+import org.apache.gobblin.destination.DestinationDatasetHandlerService;
+import org.apache.gobblin.runtime.AbstractJobLauncher;
+import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.source.Source;
+import org.apache.gobblin.source.WorkUnitStreamSource;
+import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
+import org.apache.gobblin.temporal.cluster.WorkerConfig;
+import org.apache.gobblin.temporal.ddm.activity.GenerateWorkUnits;
+import org.apache.gobblin.temporal.ddm.util.JobStateUtils;
+import org.apache.gobblin.temporal.workflows.metrics.EventSubmitterContext;
+import org.apache.gobblin.writer.initializer.WriterInitializerFactory;
+
+
+@Slf4j
+public class GenerateWorkUnitsImpl implements GenerateWorkUnits {
+
+  @Override
+  public int generateWorkUnits(Properties jobProps, EventSubmitterContext eventSubmitterContext) {
+    // TODO: decide whether to acquire a job lock (as MR did)!
+    // TODO: provide for job cancellation (unless handling at the temporal-level of parent workflows)!
+    JobState jobState = new JobState(jobProps);
+    log.info("Created jobState: {}", jobState.toJsonString(true));
+    Optional<Config> thisClassConfig = WorkerConfig.of(this);
+    log.info("Obtained class config: {}", thisClassConfig.isPresent() ? thisClassConfig.get() : "NO WORKER CONFIG: ERROR!");
+
+    Path workDirRoot = JobStateUtils.getWorkDirRoot(jobState);
+    log.info("Using work dir root path for job '{}' - '{}'", jobState.getJobId(), workDirRoot);
+
+    // TODO: determine whether these are actually necessary to do (as MR/AbstractJobLauncher did)!
+    // SharedResourcesBroker<GobblinScopeTypes> jobBroker = JobStateUtils.getSharedResourcesBroker(jobState);
+    // jobState.setBroker(jobBroker);
+    // jobState.setWorkUnitAndDatasetStateFunctional(new CombinedWorkUnitAndDatasetStateGenerator(this.datasetStateStore, this.jobName));
+
+    try (Closer closer = Closer.create()) {
+      // before embarking on (potentially expensive) WU creation, first pre-check that the FS is available
+      FileSystem fs = JobStateUtils.openFileSystem(jobState);
+      fs.mkdirs(workDirRoot);
+
+      List<WorkUnit> workUnits = generateWorkUnitsForJobState(jobState, eventSubmitterContext, closer);
+
+      JobStateUtils.writeWorkUnits(workUnits, workDirRoot, jobState, fs);
+      JobStateUtils.writeJobState(jobState, workDirRoot, fs);
+
+      return workUnits.size();
+    } catch (ReflectiveOperationException roe) {
+      String errMsg = "Unable to construct a source for generating workunits for job " + jobState.getJobId();
+      log.error(errMsg, roe);
+      throw ApplicationFailure.newNonRetryableFailureWithCause(errMsg, "Failure: new Source()", roe);
+    } catch (IOException ioe) {
+      String errMsg = "Failed to generate workunits for job " + jobState.getJobId();
+      log.error(errMsg, ioe);
+      throw ApplicationFailure.newFailureWithCause(errMsg, "Failure: generating/writing workunits", ioe);
+    } finally {
+      // TODO: implement Troubleshooter integration!
+    }
+  }
+
+  protected static List<WorkUnit> generateWorkUnitsForJobState(JobState jobState, EventSubmitterContext eventSubmitterContext, Closer closer)
+      throws ReflectiveOperationException {
+    Source<?, ?> source = JobStateUtils.createSource(jobState);
+    WorkUnitStream workUnitStream = source instanceof WorkUnitStreamSource
+        ? ((WorkUnitStreamSource) source).getWorkunitStream(jobState)
+        : new BasicWorkUnitStream.Builder(source.getWorkunits(jobState)).build();
+
+    // TODO: report (timer) metrics for workunits creation
+    if (workUnitStream == null || workUnitStream.getWorkUnits() == null) { // indicates a problem getting the WUs
+      String errMsg = "Failure in getting work units for job " + jobState.getJobId();
+      log.error(errMsg);
+      // TODO: decide whether a non-retryable failure is too severe... (in most circumstances, it's likely what we want)
+      throw ApplicationFailure.newNonRetryableFailure(errMsg, "Failure: Source.getWorkUnits()");
+    }
+
+    if (!workUnitStream.getWorkUnits().hasNext()) { // no work unit to run: entirely normal result (not a failure)
+      log.warn("No work units created for job " + jobState.getJobId());
+      return Lists.newArrayList();
+    }
+
+    // TODO: count total bytes for progress tracking!
+
+    boolean canCleanUp = canCleanStagingData(jobState);
+    DestinationDatasetHandlerService datasetHandlerService = closer.register(
+        new DestinationDatasetHandlerService(jobState, canCleanUp, eventSubmitterContext.create()));
+    WorkUnitStream handledWorkUnitStream = datasetHandlerService.executeHandlers(workUnitStream);
+
+    // initialize writer and converter(s)
+    // TODO: determine whether registration here is effective, or the lifecycle of this activity is too brief (as is likely!)
+    closer.register(WriterInitializerFactory.newInstace(jobState, handledWorkUnitStream)).initialize();
+    closer.register(ConverterInitializerFactory.newInstance(jobState, handledWorkUnitStream)).initialize();
+
+    // update jobState before it gets serialized
+    long startTime = System.currentTimeMillis();
+    jobState.setStartTime(startTime);
+    jobState.setState(JobState.RunningState.RUNNING);
+
+    log.info("Starting job " + jobState.getJobId());
+    // TODO: report (timer) metrics for workunits preparation
+    WorkUnitStream preparedWorkUnitStream = AbstractJobLauncher.prepareWorkUnits(handledWorkUnitStream, jobState);
+
+    // TODO: gobblinJobMetricsReporter.reportWorkUnitCountMetrics(this.jobContext.getJobState().getPropAsInt(NUM_WORKUNITS), jobState);
+
+    // dump the work unit if tracking logs are enabled (post any materialization for counting)
+    WorkUnitStream trackedWorkUnitStream = AbstractJobLauncher.addWorkUnitTrackingPerConfig(preparedWorkUnitStream, jobState, log);
+
+    return AbstractJobLauncher.materializeWorkUnitList(trackedWorkUnitStream);
+  }
+
+  protected static boolean canCleanStagingData(JobState jobState) {
+    if (DeliverySemantics.EXACTLY_ONCE.equals(DeliverySemantics.parse(jobState))) {
+      String errMsg = "DeliverySemantics.EXACTLY_ONCE NOT currently supported; job " + jobState.getJobId();
+      log.error(errMsg);
+      throw ApplicationFailure.newNonRetryableFailure(errMsg, "Unsupported: DeliverySemantics.EXACTLY_ONCE");
+    }
+    return true;
+  }
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/GenerateWorkUnitsJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/GenerateWorkUnitsJobLauncher.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.ddm.launcher;
+
+import com.typesafe.config.Config;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.eventbus.EventBus;
+import com.typesafe.config.ConfigFactory;
+
+import io.temporal.client.WorkflowOptions;
+
+import org.apache.hadoop.fs.Path;
+
+import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.runtime.JobLauncher;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.temporal.cluster.GobblinTemporalTaskRunner;
+import org.apache.gobblin.temporal.ddm.work.assistance.Help;
+import org.apache.gobblin.temporal.ddm.workflow.GenerateWorkUnitsWorkflow;
+import org.apache.gobblin.temporal.joblauncher.GobblinTemporalJobLauncher;
+import org.apache.gobblin.temporal.joblauncher.GobblinTemporalJobScheduler;
+import org.apache.gobblin.temporal.workflows.metrics.EventSubmitterContext;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * A {@link JobLauncher} for the initial triggering of a Temporal workflow that generates {@link WorkUnit}s per an arbitrary
+ * {@link org.apache.gobblin.source.Source}; see: {@link GenerateWorkUnitsWorkflow}
+ *
+ * <p>
+ *   This class is instantiated by the {@link GobblinTemporalJobScheduler#buildJobLauncher(Properties)} on every job submission to launch the Gobblin job.
+ *   The actual task execution happens in the {@link GobblinTemporalTaskRunner}, usually in a different process.
+ * </p>
+ */
+@Slf4j
+public class GenerateWorkUnitsJobLauncher extends GobblinTemporalJobLauncher {
+
+  public static final String WORKFLOW_ID_BASE = "GenerateWorkUnits";
+
+  public GenerateWorkUnitsJobLauncher(
+      Properties jobProps,
+      Path appWorkDir,
+      List<? extends Tag<?>> metadataTags,
+      ConcurrentHashMap<String, Boolean> runningMap,
+      EventBus eventBus
+  ) throws Exception {
+    super(jobProps, appWorkDir, metadataTags, runningMap, eventBus);
+  }
+
+  @Override
+  public void submitJob(List<WorkUnit> workunits) {
+    try {
+      WorkflowOptions options = WorkflowOptions.newBuilder()
+          .setTaskQueue(this.queueName)
+          .setWorkflowId(Help.qualifyNamePerExecWithFlowExecId(WORKFLOW_ID_BASE, ConfigFactory.parseProperties(jobProps)))
+          .build();
+      GenerateWorkUnitsWorkflow workflow = this.client.newWorkflowStub(GenerateWorkUnitsWorkflow.class, options);
+
+      Config jobConfigWithOverrides = applyJobLauncherOverrides(ConfigUtils.propertiesToConfig(this.jobProps));
+
+      Help.propagateGaaSFlowExecutionContext(this.jobProps);
+      EventSubmitterContext eventSubmitterContext = new EventSubmitterContext(this.eventSubmitter);
+
+      int numWorkUnits = workflow.generate(ConfigUtils.configToProperties(jobConfigWithOverrides), eventSubmitterContext);
+      log.info("FINISHED - GenerateWorkUnitsWorkflow.generate = {}", numWorkUnits);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/ProcessWorkUnitsJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/ProcessWorkUnitsJobLauncher.java
@@ -98,7 +98,7 @@ public class ProcessWorkUnitsJobLauncher extends GobblinTemporalJobLauncher {
 
       WorkflowOptions options = WorkflowOptions.newBuilder()
           .setTaskQueue(this.queueName)
-          .setWorkflowId(Help.qualifyNamePerExec(WORKFLOW_ID_BASE, wuSpec, ConfigFactory.parseProperties(jobProps)))
+          .setWorkflowId(Help.qualifyNamePerExecWithFlowExecId(WORKFLOW_ID_BASE, wuSpec, ConfigFactory.parseProperties(jobProps)))
           .build();
       ProcessWorkUnitsWorkflow workflow = this.client.newWorkflowStub(ProcessWorkUnitsWorkflow.class, options);
       workflow.process(wuSpec);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/util/JobStateUtils.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/util/JobStateUtils.java
@@ -141,7 +141,7 @@ public class JobStateUtils {
       for (WorkUnit workUnit : workUnits) {
         Path workUnitFile = pathCalculator.calcNextPath(workUnit, jobId, targetDirPath);
         if (i++ == 0) {
-          log.info("Writing work unit file [{}]: '{}'", i - 1, i == 1 ? workUnitFile : ("./" + workUnitFile.getName()));
+          log.info("Writing work unit file [first of {}]: '{}'", workUnits.size(), workUnitFile);
         }
         parallelRunner.serializeToFile(workUnit, workUnitFile);
       }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/worker/WorkFulfillmentWorker.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/worker/WorkFulfillmentWorker.java
@@ -25,8 +25,10 @@ import io.temporal.worker.WorkerOptions;
 
 import org.apache.gobblin.temporal.cluster.AbstractTemporalWorker;
 import org.apache.gobblin.temporal.ddm.activity.impl.CommitActivityImpl;
+import org.apache.gobblin.temporal.ddm.activity.impl.GenerateWorkUnitsImpl;
 import org.apache.gobblin.temporal.ddm.activity.impl.ProcessWorkUnitImpl;
 import org.apache.gobblin.temporal.ddm.workflow.impl.CommitStepWorkflowImpl;
+import org.apache.gobblin.temporal.ddm.workflow.impl.GenerateWorkUnitsWorkflowImpl;
 import org.apache.gobblin.temporal.ddm.workflow.impl.NestingExecOfProcessWorkUnitWorkflowImpl;
 import org.apache.gobblin.temporal.ddm.workflow.impl.ProcessWorkUnitsWorkflowImpl;
 import org.apache.gobblin.temporal.workflows.metrics.SubmitGTEActivityImpl;
@@ -43,12 +45,12 @@ public class WorkFulfillmentWorker extends AbstractTemporalWorker {
 
     @Override
     protected Class<?>[] getWorkflowImplClasses() {
-        return new Class[] { ProcessWorkUnitsWorkflowImpl.class, NestingExecOfProcessWorkUnitWorkflowImpl.class, CommitStepWorkflowImpl.class };
+        return new Class[] { CommitStepWorkflowImpl.class, GenerateWorkUnitsWorkflowImpl.class, NestingExecOfProcessWorkUnitWorkflowImpl.class, ProcessWorkUnitsWorkflowImpl.class };
     }
 
     @Override
     protected Object[] getActivityImplInstances() {
-        return new Object[] { new ProcessWorkUnitImpl(), new CommitActivityImpl(), new SubmitGTEActivityImpl() };
+        return new Object[] { new CommitActivityImpl(), new GenerateWorkUnitsImpl(), new ProcessWorkUnitImpl(), new SubmitGTEActivityImpl() };
     }
 
     @Override

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/GenerateWorkUnitsWorkflow.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/GenerateWorkUnitsWorkflow.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.ddm.workflow;
+
+import java.util.Properties;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.temporal.workflows.metrics.EventSubmitterContext;
+
+
+/** Workflow simply to generate {@link WorkUnit}s from a {@link org.apache.gobblin.source.Source} (and persist them for subsequent processing) */
+@WorkflowInterface
+public interface GenerateWorkUnitsWorkflow {
+  /** @return the number of {@link WorkUnit}s generated and persisted */
+  @WorkflowMethod
+  int generate(Properties props, EventSubmitterContext eventSubmitterContext);
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/GenerateWorkUnitsWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/GenerateWorkUnitsWorkflowImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.ddm.workflow.impl;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.workflow.Workflow;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.temporal.ddm.activity.GenerateWorkUnits;
+import org.apache.gobblin.temporal.ddm.workflow.GenerateWorkUnitsWorkflow;
+import org.apache.gobblin.temporal.workflows.metrics.EventSubmitterContext;
+
+
+@Slf4j
+public class GenerateWorkUnitsWorkflowImpl implements GenerateWorkUnitsWorkflow {
+  public static final Duration startToCloseTimeout = Duration.ofMinutes(90); // TODO: make configurable
+
+  private static final RetryOptions ACTIVITY_RETRY_OPTS = RetryOptions.newBuilder()
+      .setInitialInterval(Duration.ofSeconds(3))
+      .setMaximumInterval(Duration.ofSeconds(100))
+      .setBackoffCoefficient(2)
+      .setMaximumAttempts(4)
+      .build();
+
+  private static final ActivityOptions ACTIVITY_OPTS = ActivityOptions.newBuilder()
+      .setStartToCloseTimeout(startToCloseTimeout)
+      .setRetryOptions(ACTIVITY_RETRY_OPTS)
+      .build();
+
+  private final GenerateWorkUnits activityStub = Workflow.newActivityStub(GenerateWorkUnits.class, ACTIVITY_OPTS);
+
+  @Override
+  public int generate(Properties jobProps, EventSubmitterContext eventSubmitterContext) {
+    return activityStub.generateWorkUnits(jobProps, eventSubmitterContext);
+  }
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ProcessWorkUnitsWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ProcessWorkUnitsWorkflowImpl.java
@@ -117,7 +117,7 @@ public class ProcessWorkUnitsWorkflowImpl implements ProcessWorkUnitsWorkflow {
   protected NestingExecWorkflow<WorkUnitClaimCheck> createProcessingWorkflow(FileSystemJobStateful f) {
     ChildWorkflowOptions childOpts = ChildWorkflowOptions.newBuilder()
         .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON)
-        .setWorkflowId(Help.qualifyNamePerExec(CHILD_WORKFLOW_ID_BASE, f, WorkerConfig.of(this).orElse(ConfigFactory.empty())))
+        .setWorkflowId(Help.qualifyNamePerExecWithFlowExecId(CHILD_WORKFLOW_ID_BASE, f, WorkerConfig.of(this).orElse(ConfigFactory.empty())))
         .build();
     // TODO: to incorporate multiple different concrete `NestingExecWorkflow` sub-workflows in the same super-workflow... shall we use queues?!?!?
     return Workflow.newChildWorkflowStub(NestingExecWorkflow.class, childOpts);
@@ -126,7 +126,7 @@ public class ProcessWorkUnitsWorkflowImpl implements ProcessWorkUnitsWorkflow {
   protected CommitStepWorkflow createCommitStepWorkflow() {
     ChildWorkflowOptions childOpts = ChildWorkflowOptions.newBuilder()
         .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON)
-        .setWorkflowId(Help.qualifyNamePerExec(COMMIT_STEP_WORKFLOW_ID_BASE, WorkerConfig.of(this).orElse(ConfigFactory.empty())))
+        .setWorkflowId(Help.qualifyNamePerExecWithFlowExecId(COMMIT_STEP_WORKFLOW_ID_BASE, WorkerConfig.of(this).orElse(ConfigFactory.empty())))
         .build();
 
     return Workflow.newChildWorkflowStub(CommitStepWorkflow.class, childOpts);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
@@ -93,7 +93,7 @@ public abstract class GobblinJobLauncher extends AbstractJobLauncher {
       List<? extends Tag<?>> metadataTags, ConcurrentHashMap<String, Boolean> runningMap, EventBus eventbus)
       throws Exception {
     super(jobProps, HelixUtils.initBaseEventTags(jobProps, metadataTags));
-    log.debug("GobblinJobLauncher: jobProps {}, appWorkDir {}", jobProps, appWorkDir);
+    log.debug("GobblinJobLauncher: appWorkDir {}; jobProps {}", appWorkDir, jobProps);
     this.runningMap = runningMap;
     this.appWorkDir = appWorkDir;
     this.inputWorkUnitDir = new Path(appWorkDir, GobblinClusterConfigurationKeys.INPUT_WORK_UNIT_DIR_NAME);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2007


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Adds the `GenerateWorkUnits` Activity to generate `WorkUnit`s, bin pack them, and write in serialized form to the FileSystem.   The activity creates the specified `Source` and `.getWorkUnits()` on it, as directed by `JobState` config.

Hereafter it is no longer necessary to use another platform, such as the `MRJobLauncher` to generate the WUs that Temporal would execute.

Included is a demonstration-only `GenerateWorkUnitsWorkflow` that exercises solely the new activity and then exits.  A full end-to-end Temporal workflow is forthcoming in a future PR.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

so-far: successful manual execution on `CopySource` with `IcebergDatasetFinder`
future: automated unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

