### PR TITLE
[GOBBLIN-2011] Fix bug where another host could report the job as skipped, then the …

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -156,18 +156,17 @@ public class FlowStatusGenerator {
     List<FlowStatus> flowStatusList = getLatestFlowStatus(flowName, flowGroup, 2, null);
     if (flowStatusList == null || flowStatusList.isEmpty()) {
       return false;
+    }
+    FlowStatus flowStatus = flowStatusList.get(0);
+    ExecutionStatus flowExecutionStatus = flowStatus.getFlowExecutionStatus();
+    log.info("Comparing flow execution status with flowExecutionId: " + flowStatus.getFlowExecutionId() + " and flowStatus: " + flowExecutionStatus + " with incoming flowExecutionId: " + flowExecutionId);
+    // If the latest flow status is the current job about to get kicked off, we should ignore this check
+    if (flowStatus.getFlowExecutionId() == flowExecutionId) {
+      // Another host may have already emitted a flow status that skipped this flow execution, so compare against the previous flow status
+      FlowStatus previousFlowStatus = flowStatusList.size() > 1 ? flowStatusList.get(1) : null;
+      return previousFlowStatus != null && FINISHED_STATUSES.contains(previousFlowStatus.getFlowExecutionStatus().name());
     } else {
-      FlowStatus flowStatus = flowStatusList.get(0);
-      ExecutionStatus flowExecutionStatus = flowStatus.getFlowExecutionStatus();
-      log.info("Comparing flow execution status with flowExecutionId: " + flowStatus.getFlowExecutionId() + " and flowStatus: " + flowExecutionStatus + " with incoming flowExecutionId: " + flowExecutionId);
-      // If the latest flow status is the current job about to get kicked off, we should ignore this check
-      if (flowStatus.getFlowExecutionId() == flowExecutionId) {
-        // Another host may have already emitted a flow status that skipped this flow execution, so compare against the previous flow status
-        FlowStatus previousFlowStatus = flowStatusList.size() > 1 ? flowStatusList.get(1) : null;
-        return previousFlowStatus != null && FINISHED_STATUSES.contains(previousFlowStatus.getFlowExecutionStatus().name());
-      } else {
-        return !FINISHED_STATUSES.contains(flowExecutionStatus.name());
-      }
+      return !FINISHED_STATUSES.contains(flowExecutionStatus.name());
     }
   }
 


### PR DESCRIPTION
…skipped jobstatus is used to check for concurrent flows

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2011


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
There's a bug that causes GaaS multileader to kick off unintended concurrent flows which happens in the order described below:

1. Host A checks the latest flow execution status to ensure the prior flow is not running, sees that the prior execution is still running.
2. Host A fails the flow pending execution as it cannot run concurrent flow, this emits a FAILED event to GaaS which is ingested by the JobStatusMonitor.
3. Host B checks the latest flow execution status, sees the current flow execution ID which is FAILED (considered a finished flow).
4. Host B kicks off the pending flow execution when it shouldn't be.

To resolve this, we need to ensure that we are looking at the past 2 flow executions, and follow the behavior:
1. If there is no prior execution, kick off the pending flow
2. If the prior execution is IN PROGRESS, we want to indicate that there is a concurrent flow and block the pending execution.
3. If the prior execution is FINISHED, then we want to kick off the pending execution (rely on the DagManager for deduplication of flows because we do not know if the host managing this pending flow is running behind the other hosts).

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

