### PR TITLE
[GOBBLIN-2025] Add always false predicate

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/AlwaysFalse.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/AlwaysFalse.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.predicates;
+
+import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Predicate that is always false.
+ */
+public class AlwaysFalse<T> implements Predicate<T> {
+
+  @Override
+  public boolean apply(@Nullable T input) {
+    return false;
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2025


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
For some use cases of predicates, we want an `alwaysFalse` semantic. Normally this is easy to import from Guava via `Predicate.alwaysFalse()` but due to Gobblin relying on classloading this is not feasible.



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial class added that can only be enabled via configuration

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

