### PR TITLE
GOBBLIN-2033 set unique writer output dir by appending taskAttemptId to writer output path

### DIFF
--- a/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
@@ -90,13 +90,12 @@ public abstract class FlushingExtractor<S, D> extends EventBasedExtractor<S, D> 
   public static final String WATERMARK_COMMIT_TIME_METRIC = "state.store.metrics.watermarkCommitTime";
   public static final String COMMIT_STEP_METRIC_PREFIX = "commit.step.";
   /**
-   * this property is used to append task attempt id to the output directory on startup.
+   * this property is used to append task attempt id with timestamp to the output directory on startup.
    * The purpose of this change is to make sure each task writes to a unique directory. In case corrupted files from
-   * previous run getting picked up by the next run in the same output directory, corrupted files can be easily cleaned
-   * up from publishers. <br><br>
+   * previous run generated, next run will start from a new path and will not pick those corrupted files. <br><br>
    *
-   * NOTE: This feature must be executed before the publisher is initialized. If this assumption is violated,
-   * then this feature will have nondeterministic behavior w.r.t. data loss.
+   * NOTE: This feature must be executed before the publisher is initialized for publisher to use the same path.
+   * If this assumption is violated, then this feature will have nondeterministic behavior w.r.t. data loss.
    */
   public static final String ENABLE_UNIQUE_WRITER_OUTPUT_DIR_WITH_TASK_ATTEMPT_ID =
       "flush.extractor.enableUniqueWriterOutputDirWithTaskAttemptId";
@@ -157,7 +156,8 @@ public abstract class FlushingExtractor<S, D> extends EventBasedExtractor<S, D> 
             ConfigurationKeys.WRITER_OUTPUT_DIR, ENABLE_UNIQUE_WRITER_OUTPUT_DIR_WITH_TASK_ATTEMPT_ID));
     String taskAttemptId = workUnitState.getProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY);
     String writerOutputDirWithTaskAttemptId =
-            new Path(this.workUnitState.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR), taskAttemptId).toString();
+            new Path(this.workUnitState.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+                taskAttemptId + "_" + System.currentTimeMillis()).toString();
     this.workUnitState.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, writerOutputDirWithTaskAttemptId);
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
@@ -142,8 +142,8 @@ public class KafkaStreamingExtractorTest {
     Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR), "/tmp/test");
     state.setProp(FlushingExtractor.ENABLE_UNIQUE_WRITER_OUTPUT_DIR_WITH_TASK_ATTEMPT_ID, true);
     new KafkaStreamingExtractor(state);
-    Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
-        "/tmp/test/GobblinYarnTaskRunner_1");
+    Assert.assertTrue(
+        state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR).contains("/tmp/test/GobblinYarnTaskRunner_1_"));
   }
 
   static class TestDataPublisher extends DataPublisher {

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -128,6 +129,21 @@ public class KafkaStreamingExtractorTest {
       RecordEnvelope<DecodeableKafkaRecord> recordEnvelope = streamingExtractorWithNulls.readRecordEnvelopeImpl();
       Assert.assertNotNull(recordEnvelope.getRecord().getValue() != null);
     }
+  }
+
+  @Test
+  public void testWriteOutputDirUpdate() {
+    WorkUnitState state = KafkaExtractorUtils.getWorkUnitState("testTopic", numPartitions);
+    state.setProp(FlushingExtractor.FLUSH_DATA_PUBLISHER_CLASS, TestDataPublisher.class.getName());
+    state.setProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY, "GobblinYarnTaskRunner_1");
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, "/tmp/test");
+    state.setProp(FlushingExtractor.WRITER_OUTPUT_DIR_UPDATE_ENABLED, false);
+    new KafkaStreamingExtractor(state);
+    Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR), "/tmp/test");
+    state.setProp(FlushingExtractor.WRITER_OUTPUT_DIR_UPDATE_ENABLED, true);
+    new KafkaStreamingExtractor(state);
+    Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+        "/tmp/test/GobblinYarnTaskRunner_1");
   }
 
   static class TestDataPublisher extends DataPublisher {

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractorTest.java
@@ -137,10 +137,10 @@ public class KafkaStreamingExtractorTest {
     state.setProp(FlushingExtractor.FLUSH_DATA_PUBLISHER_CLASS, TestDataPublisher.class.getName());
     state.setProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY, "GobblinYarnTaskRunner_1");
     state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, "/tmp/test");
-    state.setProp(FlushingExtractor.WRITER_OUTPUT_DIR_UPDATE_ENABLED, false);
+    state.setProp(FlushingExtractor.ENABLE_UNIQUE_WRITER_OUTPUT_DIR_WITH_TASK_ATTEMPT_ID, false);
     new KafkaStreamingExtractor(state);
     Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR), "/tmp/test");
-    state.setProp(FlushingExtractor.WRITER_OUTPUT_DIR_UPDATE_ENABLED, true);
+    state.setProp(FlushingExtractor.ENABLE_UNIQUE_WRITER_OUTPUT_DIR_WITH_TASK_ATTEMPT_ID, true);
     new KafkaStreamingExtractor(state);
     Assert.assertEquals(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
         "/tmp/test/GobblinYarnTaskRunner_1");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2033


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
This PR allows appending taskAttemptId + timestamp to writer output directory to make writer output directory unique for each task.
Context for this change is there is a chance that some corrupted files could be created when previous tasks were interrupted. To avoid moving orphan files from previous run, each task should have a unique writer output and corrupted files will not be picked up.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test added:
KafkaStreamingExtractorTest.testWriteOutputDirUpdate
- verified if config.WRITER_OUTPUT_DIR_UPDATE_ENABLED is set to false, there is no change to taskOutput dir
- verified if config.WRITER_OUTPUT_DIR_UPDATE_ENABLED is set to true, taskAttemptId is appened to taskOutput

end to end test performed:
1. verified data is renamed into desired taskOutput path:
![Screenshot 2024-04-10 at 3 47 52 PM](https://github.com/apache/gobblin/assets/7811200/228d48fd-2ed1-4b85-920c-73f626751e67)

2. verified data is published into destination path:
![Screenshot 2024-04-10 at 3 48 43 PM](https://github.com/apache/gobblin/assets/7811200/e1cbd9f3-f001-4542-ac85-7f993d978c52)

3. verified in container log below log exists:
```
2024-04-10 15:41:48 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.writer.FsDataWriter  - Renaming /data/ci_parallel/tracking/streaming_parallel_test/MemberScrapingScoreEvent/.temp/taskStaging/KafkaHdfsStreamingTrackingOrcRongTest/job_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681/MemberScrapingScoreEvent/GobblinYarnTaskRunner_10/hourly/2024/04/10/15/part.task_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681_8_1712788607706_0.orc to /data/ci_parallel/tracking/streaming_parallel_test/MemberScrapingScoreEvent/.temp/taskStaging/KafkaHdfsStreamingTrackingOrcRongTest/job_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681/MemberScrapingScoreEvent/GobblinYarnTaskRunner_10/hourly/2024/04/10/15/part.task_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681_8_1712788607706_0.503234.orc
2024-04-10 15:41:48 PDT INFO  [StreamModelTaskRunner] org.apache.gobblin.writer.FsDataWriter  - Moving data from /data/ci_parallel/tracking/streaming_parallel_test/MemberScrapingScoreEvent/.temp/taskStaging/KafkaHdfsStreamingTrackingOrcRongTest/job_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681/MemberScrapingScoreEvent/GobblinYarnTaskRunner_10/hourly/2024/04/10/15/part.task_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681_8_1712788607706_0.503234.orc to /data/ci_parallel/tracking/streaming_parallel_test/MemberScrapingScoreEvent/.temp/taskOutput/KafkaHdfsStreamingTrackingOrcRongTest/job_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681/8/GobblinYarnTaskRunner_10_1712788607773/MemberScrapingScoreEvent/hourly/2024/04/10/15/part.task_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681_8_1712788607706_0.503234.orc
``` 
4. Tested scenario where publisher enabled deleteOrphanFiles function, verified clean up directory is same as write output directory with helix attempt id from log:
```
2024-04-10 15:36:48 PDT INFO  [TaskStateModelFactory-task_thread-0] org.apache.gobblin.prototype.kafka.TimePartitionedStreamingDataPublisherWithAuditCounts  - Cleaning up garbage files in output directories from previous runs for each writer branch. numBranches=1
2024-04-10 15:36:48 PDT INFO  [TaskStateModelFactory-task_thread-0] org.apache.gobblin.util.deprecation.DeprecationUtils  - Copying the value of deprecated key writer.file.path.type into key writer.file.pathType
2024-04-10 15:36:48 PDT INFO  [TaskStateModelFactory-task_thread-0] org.apache.gobblin.prototype.kafka.TimePartitionedStreamingDataPublisherWithAuditCounts  - The writer output directory does not exist, so no clean up will be performed. writerOutputDir=/data/ci_parallel/tracking/streaming_parallel_test/MemberScrapingScoreEvent/.temp/taskOutput/KafkaHdfsStreamingTrackingOrcRongTest/job_KafkaHdfsStreamingTrackingOrcRongTest_1712788508681/8/GobblinYarnTaskRunner_10_1712788607773/MemberScrapingScoreEvent
``` 



### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    6. Subject does not end with a period
    7. Subject uses the imperative mood ("add", not "adding")
    8. Body wraps at 72 characters
    9. Body explains "what" and "why", not "how"

