### PR TITLE
[GOBBLIN-2032] Make log sink config optional

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/GobblinTemporalApplicationMaster.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/GobblinTemporalApplicationMaster.java
@@ -79,13 +79,14 @@ public class GobblinTemporalApplicationMaster extends GobblinTemporalClusterMana
             ConfigValueFactory.fromAnyRef(YarnHelixUtils.getContainerNum(containerId.toString()))),
         Optional.<Path>absent());
 
-    String containerLogDir = config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY);
-    GobblinYarnLogSource gobblinYarnLogSource = new GobblinYarnLogSource();
-    if (gobblinYarnLogSource.isLogSourcePresent()) {
-      Path appWorkDir = PathUtils.combinePaths(containerLogDir, GobblinClusterUtils.getAppWorkDirPath(this.clusterName, this.applicationId), "AppMaster");
-      logCopier = gobblinYarnLogSource.buildLogCopier(this.config, containerId.toString(), this.fs, appWorkDir);
-      this.applicationLauncher
-          .addService(logCopier);
+    if (config.hasPath(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY)) {
+      String containerLogDir = config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY);
+      GobblinYarnLogSource gobblinYarnLogSource = new GobblinYarnLogSource();
+      if (gobblinYarnLogSource.isLogSourcePresent()) {
+        Path appWorkDir = PathUtils.combinePaths(containerLogDir, GobblinClusterUtils.getAppWorkDirPath(this.clusterName, this.applicationId), "AppMaster");
+        logCopier = gobblinYarnLogSource.buildLogCopier(this.config, containerId.toString(), this.fs, appWorkDir);
+        this.applicationLauncher.addService(logCopier);
+      }
     }
     YarnHelixUtils.setYarnClassPath(config, yarnConfiguration);
     YarnHelixUtils.setAdditionalYarnClassPath(config, yarnConfiguration);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -204,7 +204,7 @@ public class GobblinYarnAppLauncher {
 
   private final Optional<String> appMasterJvmArgs;
 
-  private final Path sinkLogRootDir;
+  private final String sinkLogRootDir;
 
   private final Closer closer = Closer.create();
 
@@ -269,8 +269,7 @@ public class GobblinYarnAppLauncher {
         Optional.of(config.getString(GobblinYarnConfigurationKeys.APP_MASTER_JVM_ARGS_KEY)) :
         Optional.<String>absent();
 
-    this.sinkLogRootDir = config.hasPath(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY) ?
-      new Path(config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY)) : null;
+    this.sinkLogRootDir = ConfigUtils.getString(config, GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY, null);
 
     this.maxGetApplicationReportFailures = config.getInt(GobblinYarnConfigurationKeys.MAX_GET_APP_REPORT_FAILURES_KEY);
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -269,7 +269,8 @@ public class GobblinYarnAppLauncher {
         Optional.of(config.getString(GobblinYarnConfigurationKeys.APP_MASTER_JVM_ARGS_KEY)) :
         Optional.<String>absent();
 
-    this.sinkLogRootDir = new Path(config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY));
+    this.sinkLogRootDir = config.hasPath(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY) ?
+      new Path(config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY)) : null;
 
     this.maxGetApplicationReportFailures = config.getInt(GobblinYarnConfigurationKeys.MAX_GET_APP_REPORT_FAILURES_KEY);
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2032


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In Gobblin cluster, there is a configuration to set the log sink in order to create a log copier service which copies logs to HDFS from Yarn cluster.

This PR makes the configuration for log dir sinks optional so that the application does not need to set up a log copying service. Additionally it makes the file name suffix configurable in case the user wants a non-stdout file.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran E2E, confirms it works without log dir sinks set up.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

