### PR TITLE
[GOBBLIN-2026] Fail the dataset cleaner flow during any Exception

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
@@ -155,6 +155,9 @@ public class DatasetCleaner implements Instrumentable, Closeable {
         public void onFailure(Throwable throwable) {
           DatasetCleaner.this.finishCleanSignal.get().countDown();
           LOG.warn("Exception caught when cleaning " + dataset.datasetURN() + ".", throwable);
+          if (throwable instanceof OutOfMemoryError) {
+            throw new RuntimeException(throwable);
+          }
           DatasetCleaner.this.throwables.add(throwable);
           Instrumented.markMeter(DatasetCleaner.this.datasetsCleanFailureMeter);
           DatasetCleaner.this.eventSubmitter.submit(RetentionEvents.CleanFailed.EVENT_NAME,

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
@@ -42,8 +42,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.typesafe.config.Config;
 
-import lombok.SneakyThrows;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.DynamicConfigGenerator;
 import org.apache.gobblin.configuration.State;
@@ -153,21 +151,17 @@ public class DatasetCleaner implements Instrumentable, Closeable {
         }
       });
       Futures.addCallback(future, new FutureCallback<Void>() {
-        @SneakyThrows
         @Override
         public void onFailure(Throwable throwable) {
-          DatasetCleaner.this.finishCleanSignal.get().countDown();
           LOG.warn("Exception caught when cleaning " + dataset.datasetURN() + ".", throwable);
-          // Avoid consuming OutOfMemoryError to clean other datasets
-          if (throwable instanceof OutOfMemoryError) {
-            throw throwable;
-          }
           DatasetCleaner.this.throwables.add(throwable);
           Instrumented.markMeter(DatasetCleaner.this.datasetsCleanFailureMeter);
           DatasetCleaner.this.eventSubmitter.submit(RetentionEvents.CleanFailed.EVENT_NAME,
               ImmutableMap.of(RetentionEvents.CleanFailed.FAILURE_CONTEXT_METADATA_KEY,
                   ExceptionUtils.getFullStackTrace(throwable), RetentionEvents.DATASET_URN_METADATA_KEY,
                   dataset.datasetURN()));
+          // Moving the countDown at the end, avoid race-condition with close waiting for the countDown to be 0
+          DatasetCleaner.this.finishCleanSignal.get().countDown();
         }
 
         @Override

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -327,7 +327,9 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
     boolean isCleanSuccess = true;
     Collections.sort(versions, Collections.reverseOrder());
     Collection<T> deletableVersions = selectionPolicy.listSelectedVersions(versions);
-    cleanImpl(deletableVersions);
+    if (!deletableVersions.isEmpty()) {
+      cleanImpl(deletableVersions);
+    }
     List<DatasetVersion> allVersions = Lists.newArrayList(versions);
     for (RetentionAction retentionAction : retentionActions) {
       try {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -322,12 +322,12 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
   }
 
   private boolean cleanDatasetVersions(List<T> versions, VersionSelectionPolicy<T> selectionPolicy,
-      List<RetentionAction> retentionActions, boolean shouldLogDeletableVersion)
+      List<RetentionAction> retentionActions, boolean runningInBatchMode)
       throws IOException {
     boolean isCleanSuccess = true;
     Collections.sort(versions, Collections.reverseOrder());
     Collection<T> deletableVersions = selectionPolicy.listSelectedVersions(versions);
-    if (!deletableVersions.isEmpty() || shouldLogDeletableVersion) {
+    if (!deletableVersions.isEmpty() || runningInBatchMode) {
       cleanImpl(deletableVersions);
     }
     List<DatasetVersion> allVersions = Lists.newArrayList(versions);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -292,13 +292,13 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
           cleanableVersionsBatch.add(version);
           if (cleanableVersionsBatch.size() >= CLEANABLE_DATASET_BATCH_SIZE) {
             boolean isCleanSuccess = cleanDatasetVersions(cleanableVersionsBatch, selectionPolicy,
-                versionFinderAndPolicy.getRetentionActions());
+                versionFinderAndPolicy.getRetentionActions(), false);
             atLeastOneFailureSeen = atLeastOneFailureSeen || !isCleanSuccess;
           }
         }
         if (!cleanableVersionsBatch.isEmpty()) {
           boolean isCleanSuccess = cleanDatasetVersions(cleanableVersionsBatch, selectionPolicy,
-              versionFinderAndPolicy.getRetentionActions());
+              versionFinderAndPolicy.getRetentionActions(), false);
           atLeastOneFailureSeen = atLeastOneFailureSeen || !isCleanSuccess;
         }
       } else {
@@ -309,7 +309,7 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
           continue;
         }
         boolean isCleanSuccess =
-            cleanDatasetVersions(versions, selectionPolicy, versionFinderAndPolicy.getRetentionActions());
+            cleanDatasetVersions(versions, selectionPolicy, versionFinderAndPolicy.getRetentionActions(), true);
         atLeastOneFailureSeen = !isCleanSuccess || atLeastOneFailureSeen;
       }
     }
@@ -322,12 +322,12 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
   }
 
   private boolean cleanDatasetVersions(List<T> versions, VersionSelectionPolicy<T> selectionPolicy,
-      List<RetentionAction> retentionActions)
+      List<RetentionAction> retentionActions, boolean shouldLogDeletableVersion)
       throws IOException {
     boolean isCleanSuccess = true;
     Collections.sort(versions, Collections.reverseOrder());
     Collection<T> deletableVersions = selectionPolicy.listSelectedVersions(versions);
-    if (!deletableVersions.isEmpty()) {
+    if (!deletableVersions.isEmpty() || shouldLogDeletableVersion) {
       cleanImpl(deletableVersions);
     }
     List<DatasetVersion> allVersions = Lists.newArrayList(versions);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableDatasetBaseTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableDatasetBaseTest.java
@@ -185,27 +185,6 @@ public class CleanableDatasetBaseTest {
         .equals(dataset1Version2.getPathsToDelete().iterator().next()));
   }
 
-  @Test (expectedExceptions = RuntimeException.class)
-  public void test_OutOfMemoryError() throws IOException {
-    FileSystem fs = mock(FileSystem.class);
-
-    Path datasetRoot = new Path("/test/dataset");
-
-    DatasetVersion dataset1Version1 = new StringDatasetVersion("version1", new Path(datasetRoot, "version1"));
-    DatasetVersion dataset1Version2 = new StringDatasetVersion("version2", new Path(datasetRoot, "version2"));
-
-    when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
-    when(fs.exists(any(Path.class))).thenReturn(true);
-
-    DatasetImpl dataset = new DatasetImpl(fs, false, false, false, false, datasetRoot);
-
-    when(dataset.versionFinder.useIteratorForFindingVersions()).thenReturn(false);
-
-    when(dataset.versionFinder.findDatasetVersions(dataset)).thenThrow(new OutOfMemoryError());
-
-    dataset.clean();
-  }
-
   private void mockDatasetVersion(DatasetImpl dataset, DatasetVersion dataset1Version1, DatasetVersion dataset1Version2)
       throws IOException {
     RemoteIterator<DatasetVersion> versionRemoteIterator = mock(RemoteIterator.class);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableDatasetBaseTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableDatasetBaseTest.java
@@ -185,6 +185,27 @@ public class CleanableDatasetBaseTest {
         .equals(dataset1Version2.getPathsToDelete().iterator().next()));
   }
 
+  @Test (expectedExceptions = RuntimeException.class)
+  public void test_OutOfMemoryError() throws IOException {
+    FileSystem fs = mock(FileSystem.class);
+
+    Path datasetRoot = new Path("/test/dataset");
+
+    DatasetVersion dataset1Version1 = new StringDatasetVersion("version1", new Path(datasetRoot, "version1"));
+    DatasetVersion dataset1Version2 = new StringDatasetVersion("version2", new Path(datasetRoot, "version2"));
+
+    when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
+    when(fs.exists(any(Path.class))).thenReturn(true);
+
+    DatasetImpl dataset = new DatasetImpl(fs, false, false, false, false, datasetRoot);
+
+    when(dataset.versionFinder.useIteratorForFindingVersions()).thenReturn(false);
+
+    when(dataset.versionFinder.findDatasetVersions(dataset)).thenThrow(new OutOfMemoryError());
+
+    dataset.clean();
+  }
+
   private void mockDatasetVersion(DatasetImpl dataset, DatasetVersion dataset1Version1, DatasetVersion dataset1Version2)
       throws IOException {
     RemoteIterator<DatasetVersion> versionRemoteIterator = mock(RemoteIterator.class);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [GOBBLIN-2026](https://issues.apache.org/jira/browse/GOBBLIN-2026) issues and references them in the PR title. 


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   - Currently in the cleaner job, if OOM error or any exception occurs in the cleaner job, the flow is terminated successfully. Why? 
   - This is due to a race condition in Data cleaner job, where the `close()` waits for the countDownLatch to be 0, and when the cleaner job onFailure Method counts it down to 0. There is a race condition, where the close() method checks for the `throwables` which is empty, as the failure() method has not added the throwable in this list. Thus, the exception which was supposed to be thrown is never thrown. Resulting in the process to be completed successfully. 
   - Due to the changes done in [PR](https://github.com/apache/gobblin/pull/3883) the log where no deletable version exists was being printed for every 100 datasets. This PR avoids writing log when there are no deletable versions.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"