### PR TITLE
[GOBBLIN-2037] Start DagActionMonitor functionality after its dependencies

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -271,7 +271,8 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
       throw new RuntimeException(String.format("getClass called to obtain %s without calling create method to "
           + "initialize GobblinServiceGuiceModule.", classToGet));
     }
-    Injector injector = Guice.createInjector(Stage.PRODUCTION, GOBBLIN_SERVICE_GUICE_MODULE);
+    // Use development stage to enable more verbose error messages and runtime checks 
+    Injector injector = Guice.createInjector(Stage.DEVELOPMENT, GOBBLIN_SERVICE_GUICE_MODULE);
     return injector.getInstance(classToGet);
   }
 
@@ -536,6 +537,11 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
     if (!this.helixManager.isPresent() || this.helixManager.get().isLeader()){
       this.dagManager.setActive(true);
       this.eventBus.register(this.dagManager);
+    }
+
+    // Activate the DagActionStoreChangeMonitor last as it's dependent on DagManager & SpecCompiler
+    if (configuration.isWarmStandbyEnabled()) {
+      this.dagActionStoreChangeMonitor.setActive();
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitorFactory.java
@@ -74,7 +74,6 @@ public class DagActionStoreChangeMonitorFactory implements Provider<DagActionSto
   @Override
   public DagActionStoreChangeMonitor get() {
     DagActionStoreChangeMonitor changeMonitor = createDagActionStoreMonitor();
-    changeMonitor.initializeMonitor();
     return changeMonitor;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
@@ -74,7 +74,6 @@ public class DagManagementDagActionStoreChangeMonitorFactory implements Provider
   @Override
   public DagActionStoreChangeMonitor get() {
     DagActionStoreChangeMonitor changeMonitor = createDagActionStoreMonitor();
-    changeMonitor.initializeMonitor();
     return changeMonitor;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
@@ -78,6 +78,7 @@ public class SpecStoreChangeMonitor extends HighLevelConsumer {
   protected FlowCatalog flowCatalog;
 
   protected GobblinServiceJobScheduler scheduler;
+  private volatile boolean isActive;
 
   // Note that the topic is an empty string (rather than null to avoid NPE) because this monitor relies on the consumer
   // client itself to determine all Kafka related information dynamically rather than through the config.
@@ -95,6 +96,28 @@ public class SpecStoreChangeMonitor extends HighLevelConsumer {
     // Expects underlying consumer to handle initializing partitions and offset for the topic -
     // subscribe to all partitions from latest offset
     return;
+  }
+
+  /*
+ Override this method to do nothing, instead only start processing the queues after #setActive is called to make sure
+ dependent services are initialized properly.
+*/
+  @Override
+  protected void startUp() {}
+
+  /*
+   This method should be called once by the {@link GobblinServiceManager} only after the Scheduler is active to ensure
+   calls to onAddSpec don't fail specCompilation.
+   */
+  public synchronized void setActive() {
+    if (this.isActive) {
+      return;
+    }
+
+    if (isActive) {
+      this.isActive = true;
+      super.startUp();
+    }
   }
 
   @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2037


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The `DagActionStoreChangeMonitor` cannot be started before the `Flowgraph, DagManager, and SpecCompiler` are up and running. When the monitor is initialized by Guice, it was previously also starting to load dagActions from the store immediately to compile and process. There is a race condition created where the actions can be loaded too quickly from the store and passed to the `specCompiler` before it's ready. The `SpecCompiler` hangs waiting for the `flowGraph` to load, causing startup to fail. A similar dependency exists between the `SpecStoreChangeMonitor` and `SpecCompiler` + `Scheduler`. 

The solution is the bind the monitor in Guice but only enable processing of actions and specs after the `GobblinServiceManager` ensures other classes are ready to be called by the `DagActionStoreChangeMonitor` & `SpecStoreChangeMonitor`. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test a local deployment

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

