### PR TITLE
[GOBBLIN-2039] Handle failure scenarios multileader compilation startup

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
@@ -254,7 +254,8 @@ public class DagActionStoreChangeMonitorTest {
     DagManager mockDagManager = mock(DagManager.class);
     FlowCatalog mockFlowCatalog = mock(FlowCatalog.class);
     Orchestrator mockOrchestrator = mock(Orchestrator.class);
-    when(mockFlowCatalog.getSpecs(any(URI.class))).thenThrow(new SpecNotFoundException(new URI("test")));
+    // Throw an uncaught exception during startup sequence
+    when(mockFlowCatalog.getSpecs(any(URI.class))).thenThrow(new RuntimeException("Uncaught exception"));
     mockDagActionStoreChangeMonitor =  new MockDagActionStoreChangeMonitor("dummyTopic", monitorConfig, 5,
         true, mysqlDagActionStore, mockDagManager, mockFlowCatalog, mockOrchestrator);
     try {

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
@@ -21,12 +21,10 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.Before;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.typesafe.config.Config;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -136,7 +136,7 @@ public class FlowCompilationValidationHelper {
         ConfigurationKeys.FLOW_ALLOW_CONCURRENT_EXECUTION, String.valueOf(this.isFlowConcurrencyEnabled)));
 
     Dag<JobExecutionPlan> jobExecutionPlanDag = specCompiler.compileFlow(flowSpec);
-    if (jobExecutionPlanDag.isEmpty()) {
+    if (jobExecutionPlanDag == null || jobExecutionPlanDag.isEmpty()) {
       return Optional.absent();
     }
     addFlowExecutionIdIfAbsent(flowMetadata, jobExecutionPlanDag);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -147,7 +147,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
       try {
         handleDagAction(action, true);
       } catch (Exception e) {
-        log.warn("Ran into an unexpected error processing DagActionStore changes during initialization for action {}", action, e);
+        log.error("Ran into an unexpected error processing DagActionStore changes during initialization for action {}", action, e);
         this.unexpectedErrors.mark();
       }
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -147,7 +147,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
       try {
         handleDagAction(action, true);
       } catch (Exception e) {
-        log.error("Ran into an unexpected error processing DagActionStore changes during initialization for action {}", action, e);
+        log.error("Unexpected error initializing from DagActionStore changes, upon {}", action, e);
         this.unexpectedErrors.mark();
       }
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -144,7 +144,12 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer {
     }
     // TODO: make this multi-threaded to add parallelism
     for (DagActionStore.DagAction action : dagActions) {
-      handleDagAction(action, true);
+      try {
+        handleDagAction(action, true);
+      } catch (Exception e) {
+        log.warn("Ran into an unexpected error processing DagActionStore changes during initialization for action {}", action, e);
+        this.unexpectedErrors.mark();
+      }
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,10 +47,11 @@ public class MysqlDagActionStoreTest {
   private static final String flowExecutionId_3 = "12345679";
   private MysqlDagActionStore mysqlDagActionStore;
 
+  private ITestMetastoreDatabase testDb;
+
   @BeforeClass
   public void setUp() throws Exception {
-    ITestMetastoreDatabase testDb = TestMetastoreDatabaseFactory.get();
-
+    this.testDb = TestMetastoreDatabaseFactory.get();
     Config config = ConfigBuilder.create()
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
@@ -58,6 +60,11 @@ public class MysqlDagActionStoreTest {
         .build();
 
     this.mysqlDagActionStore = new MysqlDagActionStore(config);
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.testDb.close();
   }
 
   @Test
@@ -94,12 +101,12 @@ public class MysqlDagActionStoreTest {
 
   @Test(dependsOnMethods = "testGetActions")
   public void testDeleteAction() throws IOException, SQLException {
-   this.mysqlDagActionStore.deleteDagAction(
-       new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.KILL));
-   Assert.assertEquals(this.mysqlDagActionStore.getDagActions().size(), 2);
-   Assert.assertFalse(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.KILL));
-    Assert.assertTrue(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.RESUME));
-   Assert.assertTrue(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId_2, jobName, DagActionStore.DagActionType.KILL));
+     this.mysqlDagActionStore.deleteDagAction(
+         new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.KILL));
+     Assert.assertEquals(this.mysqlDagActionStore.getDagActions().size(), 2);
+     Assert.assertFalse(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.KILL));
+     Assert.assertTrue(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.RESUME));
+     Assert.assertTrue(this.mysqlDagActionStore.exists(flowGroup, flowName, flowExecutionId_2, jobName, DagActionStore.DagActionType.KILL));
   }
 
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
DagActionChangeStoreMonitor will try to load all the dag actions in the mysql db on startup and submit them to the dagmanager.

Sometimes there are issues during this startup process that can cause errors, we want to handle these issues gracefully and not block the dag action change monitor from initialization, otherwise it will block any dags from being processed.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

