### PR TITLE
[GOBBLIN-2041] Fix NPE in `CopySource::getCopyEntityClass`

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -552,10 +552,13 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
     state.setProp(COPY_ENTITY_CLASS, copyEntity.getClass().getName());
   }
 
-  public static Class<?> getCopyEntityClass(State state)
-      throws IOException {
+  public static Class<?> getCopyEntityClass(State state) throws IOException {
+    Optional<String> optClassName = Optional.fromNullable(state.getProp(COPY_ENTITY_CLASS));
+    if (!optClassName.isPresent()) {
+      throw new IOException("property '" + COPY_ENTITY_CLASS + "' not found in state: " + state);
+    }
     try {
-      return Class.forName(state.getProp(COPY_ENTITY_CLASS));
+      return Class.forName(optClassName.get());
     } catch (ClassNotFoundException cnfe) {
       throw new IOException(cnfe);
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2041


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Access to the property `gobblin.copy.copy.entity.class`, which is NOT mandatory in a `WorkUnit` can cause `CopySource::getCopyEntityClass` to throw NPE:
```
java.lang.NullPointerException:
	at java.lang.Class.forName0(Native Method:0)
	at java.lang.Class.forName(Class.java:264)
	at org.apache.gobblin.data.management.copy.CopySource.getCopyEntityClass(CopySource.java:558)
	at org.apache.gobblin.temporal.ddm.activity.impl.ProcessWorkUnitImpl.getOptCopyEntityClass(ProcessWorkUnitImpl.java:204)
	at org.apache.gobblin.temporal.ddm.activity.impl.ProcessWorkUnitImpl.getOptCopyableFile(ProcessWorkUnitImpl.java:184)
        ...
```

This change adds a guard, to avoid the NPE and now log, such as:
```
java.io.IOException: property 'gobblin.copy.copy.entity.class' not found in state: WorkUnit(super=Common:{}
 Specific: {source.filebased.fs.snapshot=<<redacted-URL>>, converter.avro.jdbc.date_fields={}, writer.staging.table=stage_2663272993647806, source.filebased.files.to.pull=<<redacted-URL>>, job.id=<<job-id>>, task.key=0, task.id=<<task-id>>}, extract=Common:{}
 Specific: {extract.extract.id=20240412013924, extract.table.name=<<path>>, extract.table.type=APPEND_ONLY, extract.namespace=<<namespace>>, extract.extractIdTimeZone=UTC, extract.is.full=false})
	at org.apache.gobblin.data.management.copy.CopySource.getCopyEntityClass(CopySource.java:558)
	at org.apache.gobblin.temporal.ddm.activity.impl.ProcessWorkUnitImpl.getOptCopyEntityClass(ProcessWorkUnitImpl.java:194)
	at org.apache.gobblin.temporal.ddm.activity.impl.ProcessWorkUnitImpl.getOptCopyableFile(ProcessWorkUnitImpl.java:174)
	...
```



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manual verification

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

