### PR TITLE
[GOBBLIN-2045] Integrate `AutomaticTroubleshooter` with gobblin-on-temporal `GenerateWorkUnitsImpl`

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/troubleshooter/AutomaticTroubleshooter.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/troubleshooter/AutomaticTroubleshooter.java
@@ -44,7 +44,7 @@ public interface AutomaticTroubleshooter {
    * Those events can be consumed by upstream and analytical systems.
    *
    * Can be disabled with
-   * {@link org.apache.gobblin.configuration.ConfigurationKeys.TROUBLESHOOTER_DISABLE_EVENT_REPORTING}.
+   * {@link org.apache.gobblin.configuration.ConfigurationKeys#TROUBLESHOOTER_DISABLE_EVENT_REPORTING}.
    * */
   void reportJobIssuesAsEvents(EventSubmitter eventSubmitter)
       throws TroubleshooterException;

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
@@ -82,17 +82,7 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
     } finally {
-      try {
-        if (troubleshooter == null) {
-          log.warn("{} - No troubleshooter to report issues from automatic troubleshooter", correlator);
-        } else {
-          troubleshooter.refineIssues();
-          troubleshooter.logIssueSummary();
-          troubleshooter.reportJobIssuesAsEvents(eventSubmitter);
-        }
-      } catch (Exception e) {
-        log.error(String.format("%s - Failed to report issues from automatic troubleshooter", correlator), e);
-      }
+      Help.finalizeTroubleshooting(troubleshooter, eventSubmitter, log, correlator);
     }
   }
 

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
@@ -32,6 +32,7 @@ import com.google.common.cache.CacheBuilder;
 
 import com.typesafe.config.Config;
 
+import org.slf4j.Logger;
 import org.slf4j.MDC;
 
 import org.apache.hadoop.conf.Configuration;
@@ -41,8 +42,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.troubleshooter.AutomaticTroubleshooter;
+import org.apache.gobblin.runtime.troubleshooter.TroubleshooterException;
 import org.apache.gobblin.temporal.ddm.util.JobStateUtils;
 import org.apache.gobblin.temporal.ddm.work.styles.FileSystemJobStateful;
 import org.apache.gobblin.temporal.ddm.work.styles.FileSystemApt;
@@ -246,5 +250,34 @@ public class Help {
     MDC.put(ConfigurationKeys.FLOW_GROUP_KEY, String.format("%s:%s",ConfigurationKeys.FLOW_GROUP_KEY, flowGroup));
     MDC.put(ConfigurationKeys.FLOW_NAME_KEY, String.format("%s:%s",ConfigurationKeys.FLOW_NAME_KEY, flowName));
     MDC.put(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, String.format("%s:%s",ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecId));
+  }
+
+  /**
+   * refine {@link AutomaticTroubleshooter} issues then report them to the {@link EventSubmitter} and log an issues summary via `logger`;
+   * gracefully handle `null` `troubleshooter`
+   */
+  public static void finalizeTroubleshooting(AutomaticTroubleshooter troubleshooter, EventSubmitter eventSubmitter, Logger logger, String correlator) {
+    try {
+      if (troubleshooter == null) {
+        logger.warn("{} - No troubleshooter to report issues from automatic troubleshooter", correlator);
+      } else {
+        Help.reportTroubleshooterIssues(troubleshooter, eventSubmitter);
+      }
+    } catch (TroubleshooterException e) {
+      logger.error(String.format("%s - Failed to report issues from automatic troubleshooter", correlator), e);
+    }
+  }
+
+
+  /**
+   * refine and report {@link AutomaticTroubleshooter} issues to the {@link EventSubmitter}; additionally {@link AutomaticTroubleshooter#logIssueSummary()}
+   *
+   * ATTENTION: `troubleshooter` MUST NOT be `null`
+   */
+  public static void reportTroubleshooterIssues(AutomaticTroubleshooter troubleshooter, EventSubmitter eventSubmitter)
+      throws TroubleshooterException {
+    troubleshooter.refineIssues();
+    troubleshooter.logIssueSummary();
+    troubleshooter.reportJobIssuesAsEvents(eventSubmitter);
   }
 }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
@@ -268,7 +268,6 @@ public class Help {
     }
   }
 
-
   /**
    * refine and report {@link AutomaticTroubleshooter} issues to the {@link EventSubmitter}; additionally {@link AutomaticTroubleshooter#logIssueSummary()}
    *


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2045


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

the `AutomaticTroubleshooter`'s only integration with gobblin-on-temporal is for "Work Processing", within `ProcessWorkUnitImpl`.  any issues arising during "Work Discovery" fall outside of that, and go unseen.  to include those, integrate the `AutomaticTroubleshooter` with `GenerateWorkUnitsImpl`

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manual execution, then verified both "issues" GTEs seen by gaas plus issues summary logging

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

