### PR TITLE
[GOBBLIN-2046] Generalize gobblin-on-temporal `ProcessWorkUnitImpl` logging not to presume `CopyEntity`

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
@@ -117,10 +117,10 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
 
     SharedResourcesBroker<GobblinScopeTypes> resourcesBroker = JobStateUtils.getSharedResourcesBroker(jobState);
     Optional<String> optWorkUnitsDesc = getOptWorkUnitsDesc(workUnits, wu.getWorkUnitPath(), jobState);
-    log.info("WU [{}] - submitting {} workUnits{}",
+    log.info("WU [{}] - submitting {} workUnits {}",
         wu.getCorrelator(),
         workUnits.size(),
-        optWorkUnitsDesc.map(x -> " " + x).orElse(""));
+        optWorkUnitsDesc.orElse(""));
     log.debug("WU [{}] - (first) workUnit: {}", wu.getCorrelator(), workUnits.isEmpty() ? "<<absent>>" : workUnits.get(0).toJsonString());
 
     GobblinMultiTaskAttempt taskAttempt = GobblinMultiTaskAttempt.runWorkUnits(
@@ -167,6 +167,7 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
         .map(Optional::get)
         .collect(Collectors.toList());
     if (fileSourcePaths.isEmpty()) {
+      // TODO - describe WorkUnits other than `CopyableFile`
       return Optional.empty();
     } else {
       return Optional.of(getSourcePathsToLog(fileSourcePaths, jobState)).map(pathsToLog ->
@@ -178,7 +179,7 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
   }
 
   protected static Optional<String> getOptCopyableFileSourcePathDesc(WorkUnit workUnit, String workUnitPath) {
-    return getOptWorkUnitCopyEntityClass(workUnit, "workUnit '" + workUnitPath + "'").flatMap(copyEntityClass ->
+    return getOptWorkUnitCopyEntityClass(workUnit, workUnitPath).flatMap(copyEntityClass ->
         getOptCopyableFile(copyEntityClass, workUnit).map(copyableFile ->
             copyableFile.getOrigin().getPath().toString()));
   }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -647,33 +647,40 @@ public class GobblinYarnAppLauncher {
     Map<String, LocalResource> appMasterResources = Maps.newHashMap();
     FileSystem localFs = FileSystem.getLocal(new Configuration());
 
+    // NOTE: log after each step below for insight into what takes bulk of time
     if (this.config.hasPath(GobblinYarnConfigurationKeys.LIB_JARS_DIR_KEY)) {
       Path libJarsDestDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.LIB_JARS_DIR_NAME);
       addLibJars(new Path(this.config.getString(GobblinYarnConfigurationKeys.LIB_JARS_DIR_KEY)),
           Optional.of(appMasterResources), libJarsDestDir, localFs);
+      LOGGER.info("Added lib jars to directory: {}", libJarsDestDir.toString());
     }
     if (this.config.hasPath(GobblinYarnConfigurationKeys.APP_MASTER_JARS_KEY)) {
       Path appJarsDestDir = new Path(appMasterWorkDir, GobblinYarnConfigurationKeys.APP_JARS_DIR_NAME);
       addAppJars(this.config.getString(GobblinYarnConfigurationKeys.APP_MASTER_JARS_KEY),
           Optional.of(appMasterResources), appJarsDestDir, localFs);
+      LOGGER.info("Added app jars to directory: {}", appJarsDestDir.toString());
     }
     if (this.config.hasPath(GobblinYarnConfigurationKeys.APP_MASTER_FILES_LOCAL_KEY)) {
       Path appFilesDestDir = new Path(appMasterWorkDir, GobblinYarnConfigurationKeys.APP_FILES_DIR_NAME);
       addAppLocalFiles(this.config.getString(GobblinYarnConfigurationKeys.APP_MASTER_FILES_LOCAL_KEY),
           Optional.of(appMasterResources), appFilesDestDir, localFs);
+      LOGGER.info("Added app local files to directory: {}", appFilesDestDir.toString());
     }
     if (this.config.hasPath(GobblinYarnConfigurationKeys.APP_MASTER_FILES_REMOTE_KEY)) {
       YarnHelixUtils.addRemoteFilesToLocalResources(this.config.getString(GobblinYarnConfigurationKeys.APP_MASTER_FILES_REMOTE_KEY),
           appMasterResources, yarnConfiguration);
+      LOGGER.info("Added remote files to local resources");
     }
     if (this.config.hasPath(GobblinYarnConfigurationKeys.APP_MASTER_ZIPS_REMOTE_KEY)) {
       YarnHelixUtils.addRemoteZipsToLocalResources(this.config.getString(GobblinYarnConfigurationKeys.APP_MASTER_ZIPS_REMOTE_KEY),
           appMasterResources, yarnConfiguration);
+      LOGGER.info("Added remote zips to local resources");
     }
     if (this.config.hasPath(GobblinClusterConfigurationKeys.JOB_CONF_PATH_KEY)) {
       Path appFilesDestDir = new Path(appMasterWorkDir, GobblinYarnConfigurationKeys.APP_FILES_DIR_NAME);
       addJobConfPackage(this.config.getString(GobblinClusterConfigurationKeys.JOB_CONF_PATH_KEY), appFilesDestDir,
           appMasterResources);
+      LOGGER.info("Added job conf package to directory: {}", appFilesDestDir.toString());
     }
 
     return appMasterResources;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2046


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

there are many kinds of `WorkUnit`, beyond the `CopyEntity` produced by `CopySource`.

as it remains helpful, continue to log `CopyEntity`-specific info, but do so w/o suggesting something is missing when the WU is not a `CopyEntity`

in addition, add logging to `GobblinYarnAppLauncher::addAppMasterLocalResources` for a rough indication of where this lengthy phase of pre-launch init is spending so much time

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manually executed `CopyEntity`-workload and non-`CopyEntity`-workload and verified intended logging

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

