### PR TITLE
[GOBBLIN-2047] Gracefully handle duplicate dagAction entry insertion

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -91,7 +91,8 @@ public interface DagActionStore {
   boolean exists(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType) throws IOException, SQLException;
 
   /**
-   * Persist the dag action in {@link DagActionStore} for durability
+   * Persist the dag action in {@link DagActionStore} for durability. Throws exception for failed insert due to a
+   * duplicate key error.
    * @param flowGroup flow group for the dag action
    * @param flowName flow name for the dag action
    * @param flowExecutionId flow execution for the dag action
@@ -102,7 +103,21 @@ public interface DagActionStore {
   void addJobDagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType) throws IOException;
 
   /**
-   * Persist the dag action in {@link DagActionStore} for durability. This method assumes an empty jobName.
+   * Persist the dag action in {@link DagActionStore} for durability
+   * @param flowGroup flow group for the dag action
+   * @param flowName flow name for the dag action
+   * @param flowExecutionId flow execution for the dag action
+   * @param jobName job name for the dag action
+   * @param dagActionType the value of the dag action
+   * @param ignoreDuplicates boolean value used to indicate whether duplicate insertions will result in an exception
+   *                         being thrown or ignored
+   * @throws IOException
+   */
+  void addJobDagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, boolean ignoreDuplicates) throws IOException;
+
+  /**
+   * Persist the dag action in {@link DagActionStore} for durability. This method assumes an empty jobName and throws
+   *    * exception for a failed insert to a duplicate key error.
    * @param flowGroup flow group for the dag action
    * @param flowName flow name for the dag action
    * @param flowExecutionId flow execution for the dag action
@@ -110,6 +125,18 @@ public interface DagActionStore {
    * @throws IOException
    */
   void addFlowDagAction(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType) throws IOException;
+
+  /**
+   * Persist the dag action in {@link DagActionStore} for durability. This method assumes an empty jobName.
+   * @param flowGroup flow group for the dag action
+   * @param flowName flow name for the dag action
+   * @param flowExecutionId flow execution for the dag action
+   * @param dagActionType the value of the dag action
+   * @param ignoreDuplicates boolean value used to indicate whether duplicate insertions will result in an exception
+   *                         being thrown or ignored
+   * @throws IOException
+   */
+  void addFlowDagAction(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType, boolean ignoreDuplicates) throws IOException;
 
   /**
    * delete the dag action from {@link DagActionStore}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -130,12 +130,14 @@ public class FlowLaunchHandler {
       // Otherwise leaseAttemptStatus instanceof MultiActiveLeaseArbiter.NoLongerLeasingStatus & no need to do anything
   }
 
-  // Called after obtaining a lease to persist the dag action to {@link DagActionStore} and mark the lease as done
+  /* Called after obtaining a lease to persist the dag action to {@link DagActionStore} and mark the lease as done.
+  If a duplicate dag action already exists in the store, the lease is still marked as the action need only occur once. 
+   */
   private boolean persistDagAction(LeaseAttemptStatus.LeaseObtainedStatus leaseStatus) {
     if (this.dagActionStore.isPresent()) {
       try {
         DagActionStore.DagAction dagAction = leaseStatus.getDagAction();
-        this.dagActionStore.get().addFlowDagAction(dagAction.getFlowGroup(), dagAction.getFlowName(), dagAction.getFlowExecutionId(), dagAction.getDagActionType());
+        this.dagActionStore.get().addFlowDagAction(dagAction.getFlowGroup(), dagAction.getFlowName(), dagAction.getFlowExecutionId(), dagAction.getDagActionType(), true);
         // If the dag action has been persisted to the {@link DagActionStore} we can close the lease
         this.numFlowsSubmitted.mark();
         return this.multiActiveLeaseArbiter.recordLeaseSuccess(leaseStatus);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2047


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
If a previous `dagAction` has not been processed already (in the event of service downtime for example), then we want to gracefully handle an attempt to re-add the same action by ignoring the add and completing the MALA lease. 
```
java.lang.RuntimeException: java.io.IOException: Failure adding action for DagAction: DagActionStore.DagAction(flowGroup=FILE_BASED_COPY-mufn, flowName=mufn-holdem_1792467993, flowExecutionId=1713211305981, jobName=, dagActionType=LAUNCH) in table dag_action_store
java.io.IOException: Failure adding action for DagAction: DagActionStore.DagAction(flowGroup=FILE_BASED_COPY-mufn, flowName=mufn-holdem_1792467993, flowExecutionId=1713211305981, jobName=, dagActionType=LAUNCH) in table dag_action_store
java.sql.SQLIntegrityConstraintViolationException: Duplicate entry 'FILE_BASED_COPY-mufn-mufn-holdem_1792467993-1713211305981-LAUNCH' for key 'dag_action_store.PRIMARY'
```

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

