### PR TITLE
[GOBBLIN-2048] Integrate `AutomaticTroubleshooter` with gobblin-on-temporal `CommitActivityImpl`

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
@@ -256,15 +256,15 @@ public class Help {
    * refine {@link AutomaticTroubleshooter} issues then report them to the {@link EventSubmitter} and log an issues summary via `logger`;
    * gracefully handle `null` `troubleshooter`
    */
-  public static void finalizeTroubleshooting(AutomaticTroubleshooter troubleshooter, EventSubmitter eventSubmitter, Logger logger, String correlator) {
+  public static void finalizeTroubleshooting(AutomaticTroubleshooter troubleshooter, EventSubmitter eventSubmitter, Logger logger, String errCorrelator) {
     try {
       if (troubleshooter == null) {
-        logger.warn("{} - No troubleshooter to report issues from automatic troubleshooter", correlator);
+        logger.warn("{} - No troubleshooter to report issues from automatic troubleshooter", errCorrelator);
       } else {
         Help.reportTroubleshooterIssues(troubleshooter, eventSubmitter);
       }
     } catch (TroubleshooterException e) {
-      logger.error(String.format("%s - Failed to report issues from automatic troubleshooter", correlator), e);
+      logger.error(String.format("%s - Failed to report issues from automatic troubleshooter", errCorrelator), e);
     }
   }
 


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2048


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

the `AutomaticTroubleshooter`'s existing integration with gobblin-on-temporal is for "Work Processing", within `ProcessWorkUnitImpl` and for "Work Discovery", within `GenerateWorkUnitsImpl`. any issues arising within "Commit" fall outside of that, and go unseen. to include those, integrate the AutomaticTroubleshooter with `CommitActivityImpl`

NOTE: follow-up to https://github.com/apache/gobblin/pull/3924

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manual execution, then verified both "issues" GTEs seen by gaas plus issues summary logging

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

