### PR TITLE
[GOBBLIN-2049] Configure Gobblin Distcp Writer to fail if setPermission fails

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -199,7 +199,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
       FileStatus dstFile = this.fs.getFileStatus(copyableFile.getDestination());
       // User specifically try to copy dir metadata, so we change the group and permissions on destination even when the dir already existed
       log.info("Setting destination directory {} owner and permission to {}", dstFile.getPath(), copyableFile.getDestinationOwnerAndPermission().getFsPermission());
-      FileAwareInputStreamDataWriter.safeSetPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.requirePermissionSetForSuccess);
+      FileAwareInputStreamDataWriter.setPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.requirePermissionSetForSuccess);
     }
     if (preserveDirModTime || copyableFile.getFileStatus().isFile()) {
       // Preserving File ModTime, and set the access time to an initializing value when ModTime is declared to be preserved.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -95,6 +95,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
   protected final DataFileVersionStrategy dstDataFileVersionStrategy;
   protected final boolean preserveDirModTime;
   protected final boolean resyncDirOwnerAndPermission;
+  protected final boolean requirePermissionSetForSuccess;
 
   /**
    * Build a new {@link CopyDataPublisher} from {@link State}. The constructor expects the following to be set in the
@@ -135,6 +136,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     // Default to be true to preserve the original behavior
     this.preserveDirModTime = state.getPropAsBoolean(CopyConfiguration.PRESERVE_MODTIME_FOR_DIR, true);
     this.resyncDirOwnerAndPermission = state.getPropAsBoolean(CopyConfiguration.RESYNC_DIR_OWNER_AND_PERMISSION_FOR_MANIFEST_COPY, false);
+    this.requirePermissionSetForSuccess = state.getPropAsBoolean(FileAwareInputStreamDataWriter.GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS, FileAwareInputStreamDataWriter.DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS);
   }
 
   @Override
@@ -197,7 +199,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
       FileStatus dstFile = this.fs.getFileStatus(copyableFile.getDestination());
       // User specifically try to copy dir metadata, so we change the group and permissions on destination even when the dir already existed
       log.info("Setting destination directory {} owner and permission to {}", dstFile.getPath(), copyableFile.getDestinationOwnerAndPermission().getFsPermission());
-      FileAwareInputStreamDataWriter.safeSetPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission());
+      FileAwareInputStreamDataWriter.safeSetPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.requirePermissionSetForSuccess);
     }
     if (preserveDirModTime || copyableFile.getFileStatus().isFile()) {
       // Preserving File ModTime, and set the access time to an initializing value when ModTime is declared to be preserved.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -95,7 +95,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
   protected final DataFileVersionStrategy dstDataFileVersionStrategy;
   protected final boolean preserveDirModTime;
   protected final boolean resyncDirOwnerAndPermission;
-  protected final boolean requirePermissionSetForSuccess;
+  protected final boolean shouldFailWhenPermissionFail;
 
   /**
    * Build a new {@link CopyDataPublisher} from {@link State}. The constructor expects the following to be set in the
@@ -136,7 +136,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     // Default to be true to preserve the original behavior
     this.preserveDirModTime = state.getPropAsBoolean(CopyConfiguration.PRESERVE_MODTIME_FOR_DIR, true);
     this.resyncDirOwnerAndPermission = state.getPropAsBoolean(CopyConfiguration.RESYNC_DIR_OWNER_AND_PERMISSION_FOR_MANIFEST_COPY, false);
-    this.requirePermissionSetForSuccess = state.getPropAsBoolean(FileAwareInputStreamDataWriter.GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS, FileAwareInputStreamDataWriter.DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS);
+    this.shouldFailWhenPermissionFail = state.getPropAsBoolean(FileAwareInputStreamDataWriter.GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL, FileAwareInputStreamDataWriter.DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL);
   }
 
   @Override
@@ -199,7 +199,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
       FileStatus dstFile = this.fs.getFileStatus(copyableFile.getDestination());
       // User specifically try to copy dir metadata, so we change the group and permissions on destination even when the dir already existed
       log.info("Setting destination directory {} owner and permission to {}", dstFile.getPath(), copyableFile.getDestinationOwnerAndPermission().getFsPermission());
-      FileAwareInputStreamDataWriter.setPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.requirePermissionSetForSuccess);
+      FileAwareInputStreamDataWriter.setPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.shouldFailWhenPermissionFail);
     }
     if (preserveDirModTime || copyableFile.getFileStatus().isFile()) {
       // Preserving File ModTime, and set the access time to an initializing value when ModTime is declared to be preserved.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -95,7 +95,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
   protected final DataFileVersionStrategy dstDataFileVersionStrategy;
   protected final boolean preserveDirModTime;
   protected final boolean resyncDirOwnerAndPermission;
-  protected final boolean shouldFailWhenPermissionFail;
+  protected final boolean shouldFailWhenPermissionsFail;
 
   /**
    * Build a new {@link CopyDataPublisher} from {@link State}. The constructor expects the following to be set in the
@@ -136,7 +136,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     // Default to be true to preserve the original behavior
     this.preserveDirModTime = state.getPropAsBoolean(CopyConfiguration.PRESERVE_MODTIME_FOR_DIR, true);
     this.resyncDirOwnerAndPermission = state.getPropAsBoolean(CopyConfiguration.RESYNC_DIR_OWNER_AND_PERMISSION_FOR_MANIFEST_COPY, false);
-    this.shouldFailWhenPermissionFail = state.getPropAsBoolean(FileAwareInputStreamDataWriter.GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL, FileAwareInputStreamDataWriter.DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL);
+    this.shouldFailWhenPermissionsFail = state.getPropAsBoolean(FileAwareInputStreamDataWriter.GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL, FileAwareInputStreamDataWriter.DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL);
   }
 
   @Override
@@ -199,7 +199,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
       FileStatus dstFile = this.fs.getFileStatus(copyableFile.getDestination());
       // User specifically try to copy dir metadata, so we change the group and permissions on destination even when the dir already existed
       log.info("Setting destination directory {} owner and permission to {}", dstFile.getPath(), copyableFile.getDestinationOwnerAndPermission().getFsPermission());
-      FileAwareInputStreamDataWriter.setPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.shouldFailWhenPermissionFail);
+      FileAwareInputStreamDataWriter.setPathPermission(this.fs, dstFile, copyableFile.getDestinationOwnerAndPermission(), this.shouldFailWhenPermissionsFail);
     }
     if (preserveDirModTime || copyableFile.getFileStatus().isFile()) {
       // Preserving File ModTime, and set the access time to an initializing value when ModTime is declared to be preserved.

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -90,6 +90,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
+  public static final String GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS = "gobblin.copy.requirePermissionSetForSuccess";
+  public static final boolean DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS = false;
 
   protected final AtomicLong bytesWritten = new AtomicLong();
   protected final AtomicLong filesWritten = new AtomicLong();
@@ -108,6 +110,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   private final Configuration conf;
 
   protected final Meter copySpeedMeter;
+  protected final boolean requirePermissionSetForSuccess;
 
   protected final Optional<String> writerAttemptIdOptional;
   /**
@@ -181,6 +184,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     } else {
       this.renameOptions = Options.Rename.NONE;
     }
+    this.requirePermissionSetForSuccess = state.getPropAsBoolean(GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS, DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS);
   }
 
   public FileAwareInputStreamDataWriter(State state, int numBranches, int branchId)
@@ -353,7 +357,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
    * Sets the {@link FsPermission}, owner, group for the path passed. It will not throw exceptions, if operations
    * cannot be executed, will warn and continue.
    */
-  public static void safeSetPathPermission(FileSystem fs, FileStatus file, OwnerAndPermission ownerAndPermission) {
+  public static void safeSetPathPermission(FileSystem fs, FileStatus file, OwnerAndPermission ownerAndPermission,
+      boolean requirePermissionSetForSuccess) throws IOException {
 
     Path path = file.getPath();
     OwnerAndPermission targetOwnerAndPermission = setOwnerExecuteBitIfDirectory(file, ownerAndPermission);
@@ -367,7 +372,12 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
         fs.setPermission(path, targetOwnerAndPermission.getFsPermission());
       }
     } catch (IOException ioe) {
-      log.warn("Failed to set permission for directory " + path, ioe);
+      String permissionFailureMessage = "Failed to set permission for directory " + path;
+      if (requirePermissionSetForSuccess) {
+        throw new IOException(permissionFailureMessage, ioe);
+      } else {
+        log.error(permissionFailureMessage, ioe);
+      }
     }
 
     String owner = Strings.isNullOrEmpty(targetOwnerAndPermission.getOwner()) ? null : targetOwnerAndPermission.getOwner();
@@ -378,7 +388,12 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
         fs.setOwner(path, owner, group);
       }
     } catch (IOException ioe) {
-      log.warn("Failed to set owner and/or group for path " + path + " to " + owner + ":" + group, ioe);
+      String ownerGroupFailureMessage = "Failed to set owner and/or group for path " + path + " to " + owner + ":" + group;
+      if (requirePermissionSetForSuccess) {
+        throw new IOException(ownerGroupFailureMessage, ioe);
+      } else {
+        log.error(ownerGroupFailureMessage, ioe);
+      }
     }
   }
 
@@ -394,7 +409,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     Collections.reverse(files);
 
     for (FileStatus file : files) {
-      safeSetPathPermission(this.fs, file, ownerAndPermission);
+      safeSetPathPermission(this.fs, file, ownerAndPermission, this.requirePermissionSetForSuccess);
     }
   }
 
@@ -480,7 +495,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       try {
         this.fs.delete(this.stagingDir, true);
       } catch (IOException ioe) {
-        log.warn("Failed to delete staging path at " + this.stagingDir);
+        log.error("Failed to delete staging path at " + this.stagingDir);
       }
     }
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -90,8 +90,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
-  public static final String GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS = "gobblin.copy.requirePermissionSetForSuccess";
-  public static final boolean DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS = false;
+  public static final String GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL = "gobblin.copy.shouldFailWhenPermissionFail";
+  public static final boolean DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL = true;
 
   protected final AtomicLong bytesWritten = new AtomicLong();
   protected final AtomicLong filesWritten = new AtomicLong();
@@ -110,7 +110,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   private final Configuration conf;
 
   protected final Meter copySpeedMeter;
-  protected final boolean requirePermissionSetForSuccess;
+  protected final boolean shouldFailWhenPermissionFail;
 
   protected final Optional<String> writerAttemptIdOptional;
   /**
@@ -184,7 +184,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     } else {
       this.renameOptions = Options.Rename.NONE;
     }
-    this.requirePermissionSetForSuccess = state.getPropAsBoolean(GOBBLIN_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS, DEFAULT_COPY_REQUIRE_PERMISSION_SET_FOR_SUCCESS);
+    this.shouldFailWhenPermissionFail = state.getPropAsBoolean(GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL,
+        DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL);
   }
 
   public FileAwareInputStreamDataWriter(State state, int numBranches, int branchId)
@@ -411,7 +412,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     Collections.reverse(files);
 
     for (FileStatus file : files) {
-      setPathPermission(this.fs, file, ownerAndPermission, this.requirePermissionSetForSuccess);
+      setPathPermission(this.fs, file, ownerAndPermission, this.shouldFailWhenPermissionFail);
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -90,8 +90,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
-  public static final String GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL = "gobblin.copy.shouldFailWhenPermissionFail";
-  public static final boolean DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL = true;
+  public static final String GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL = "gobblin.copy.shouldFailWhenPermissionsFail";
+  public static final boolean DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL = true;
 
   protected final AtomicLong bytesWritten = new AtomicLong();
   protected final AtomicLong filesWritten = new AtomicLong();
@@ -110,7 +110,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   private final Configuration conf;
 
   protected final Meter copySpeedMeter;
-  protected final boolean shouldFailWhenPermissionFail;
+  protected final boolean shouldFailWhenPermissionsFail;
 
   protected final Optional<String> writerAttemptIdOptional;
   /**
@@ -184,8 +184,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     } else {
       this.renameOptions = Options.Rename.NONE;
     }
-    this.shouldFailWhenPermissionFail = state.getPropAsBoolean(GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL,
-        DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSION_FAIL);
+    this.shouldFailWhenPermissionsFail = state.getPropAsBoolean(GOBBLIN_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL,
+        DEFAULT_COPY_SHOULD_FAIL_WHEN_PERMISSIONS_FAIL);
   }
 
   public FileAwareInputStreamDataWriter(State state, int numBranches, int branchId)
@@ -412,7 +412,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     Collections.reverse(files);
 
     for (FileStatus file : files) {
-      setPathPermission(this.fs, file, ownerAndPermission, this.shouldFailWhenPermissionFail);
+      setPathPermission(this.fs, file, ownerAndPermission, this.shouldFailWhenPermissionsFail);
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -354,10 +354,12 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   }
 
   /**
-   * Sets the {@link FsPermission}, owner, group for the path passed. It will not throw exceptions, if operations
-   * cannot be executed, will warn and continue.
+   * Sets the {@link FsPermission}, owner, group for the path passed. It uses `requirePermissionSetForSuccess` param
+   * to determine whether an exception will be thrown or only error log printed in the case of failure.
+   * @param requirePermissionSetForSuccess if true then throw exception, otherwise log error message and continue when
+   *                                       operations cannot be executed.
    */
-  public static void safeSetPathPermission(FileSystem fs, FileStatus file, OwnerAndPermission ownerAndPermission,
+  public static void setPathPermission(FileSystem fs, FileStatus file, OwnerAndPermission ownerAndPermission,
       boolean requirePermissionSetForSuccess) throws IOException {
 
     Path path = file.getPath();
@@ -409,7 +411,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     Collections.reverse(files);
 
     for (FileStatus file : files) {
-      safeSetPathPermission(this.fs, file, ownerAndPermission, this.requirePermissionSetForSuccess);
+      setPathPermission(this.fs, file, ownerAndPermission, this.requirePermissionSetForSuccess);
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2049


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Gobblin `safeSetPathPermission` does not throw an exception when setting permissions fail on a path. We want to change this behavior especially for use cases like manifest distcp where hundreds of thousands of files are involved in a distcp job and permission settings are important to replicate correctly as they cannot be updated or verified by hand. 
This PR adds a new configuration to fail writing or publishing tasks when the job is configured to report success when permissions are not replicated properly. The default behavior remains the same as before to allow the job to succeed without this for backwards compatibility. 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

