### PR TITLE
[GOBBLIN-2050] Add settings to allow for full cleanup in GobblinYarnAppLauncher

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -51,6 +51,9 @@ public class GobblinClusterConfigurationKeys {
   // Root working directory for Gobblin cluster
   public static final String CLUSTER_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "workDir";
   // Root working dir without appending the application name, keeping CLUSTER_WORK_DIR property for backward compatibility
+  // This is used in scenarios where we want to encapsulate multiple files inside of this work dir without coupling it to the YARN application
+  // Example: Yarn security token refresh location, gobblin cluster worker directories.
+  // However for concurrent jobs need to ensure that this property is distinct for each job otherwise it can lead to folder conflicts and pre-emptive deletion of files.
   public static final String CLUSTER_EXACT_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "exact.workDir";
 
   public static final String DISTRIBUTED_JOB_LAUNCHER_ENABLED = GOBBLIN_CLUSTER_PREFIX + "distributedJobLauncherEnabled";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -51,7 +51,7 @@ public class GobblinClusterConfigurationKeys {
   // Root working directory for Gobblin cluster
   public static final String CLUSTER_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "workDir";
   // Root working dir without appending the application name, keeping CLUSTER_WORK_DIR property for backward compatibility
-  public static final String CLUSTER_ABSOLUTE_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "absolute.workDir";
+  public static final String CLUSTER_EXACT_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "exact.workDir";
 
   public static final String DISTRIBUTED_JOB_LAUNCHER_ENABLED = GOBBLIN_CLUSTER_PREFIX + "distributedJobLauncherEnabled";
   public static final boolean DEFAULT_DISTRIBUTED_JOB_LAUNCHER_ENABLED = false;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -50,6 +50,8 @@ public class GobblinClusterConfigurationKeys {
   public static final boolean DEFAULT_STANDALONE_CLUSTER_MODE = false;
   // Root working directory for Gobblin cluster
   public static final String CLUSTER_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "workDir";
+  // Root working dir without appending the application name, keeping CLUSTER_WORK_DIR property for backward compatibility
+  public static final String CLUSTER_ABSOLUTE_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "absolute.workDir";
 
   public static final String DISTRIBUTED_JOB_LAUNCHER_ENABLED = GOBBLIN_CLUSTER_PREFIX + "distributedJobLauncherEnabled";
   public static final boolean DEFAULT_DISTRIBUTED_JOB_LAUNCHER_ENABLED = false;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -131,6 +131,9 @@ public class GobblinClusterUtils {
    */
   public static Path getAppWorkDirPathFromConfig(Config config, FileSystem fs,
       String applicationName, String applicationId) {
+    if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_ABSOLUTE_WORK_DIR)) {
+      return new Path(new Path(fs.getUri()), config.getString(GobblinClusterConfigurationKeys.CLUSTER_ABSOLUTE_WORK_DIR));
+    }
     if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR)) {
       return new Path(new Path(fs.getUri()), PathUtils.combinePaths(config.getString(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR),
           getAppWorkDirPath(applicationName, applicationId)));
@@ -253,5 +256,14 @@ public class GobblinClusterUtils {
     return config.hasPath(ConfigurationKeys.FS_URI_KEY) ? FileSystem
         .get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), conf)
         : FileSystem.get(conf);
+  }
+
+  public static FileSystem buildNewInstanceFileSystem(Config config, Configuration conf) throws IOException {
+    Config hadoopOverrides = ConfigUtils.getConfigOrEmpty(config, GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX);
+    //Add any Hadoop-specific overrides into the Configuration object
+    JobConfigurationUtils.putPropertiesIntoConfiguration(ConfigUtils.configToProperties(hadoopOverrides), conf);
+    return config.hasPath(ConfigurationKeys.FS_URI_KEY) ? FileSystem
+        .newInstance(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), conf)
+        : FileSystem.newInstance(conf);
   }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -258,7 +258,7 @@ public class GobblinClusterUtils {
         : FileSystem.get(conf);
   }
 
-  public static FileSystem buildNewInstanceFileSystem(Config config, Configuration conf) throws IOException {
+  public static FileSystem createFileSystem(Config config, Configuration conf) throws IOException {
     Config hadoopOverrides = ConfigUtils.getConfigOrEmpty(config, GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX);
     //Add any Hadoop-specific overrides into the Configuration object
     JobConfigurationUtils.putPropertiesIntoConfiguration(ConfigUtils.configToProperties(hadoopOverrides), conf);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -133,12 +133,12 @@ public class GobblinClusterUtils {
       String applicationName, String applicationId) {
     if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_EXACT_WORK_DIR)) {
       return new Path(new Path(fs.getUri()), config.getString(GobblinClusterConfigurationKeys.CLUSTER_EXACT_WORK_DIR));
-    }
-    if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR)) {
+    } else if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR)) {
       return new Path(new Path(fs.getUri()), PathUtils.combinePaths(config.getString(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR),
           getAppWorkDirPath(applicationName, applicationId)));
+    } else {
+      return new Path(fs.getHomeDirectory(), getAppWorkDirPath(applicationName, applicationId));
     }
-    return new Path(fs.getHomeDirectory(), getAppWorkDirPath(applicationName, applicationId));
   }
 
   /**

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -131,8 +131,8 @@ public class GobblinClusterUtils {
    */
   public static Path getAppWorkDirPathFromConfig(Config config, FileSystem fs,
       String applicationName, String applicationId) {
-    if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_ABSOLUTE_WORK_DIR)) {
-      return new Path(new Path(fs.getUri()), config.getString(GobblinClusterConfigurationKeys.CLUSTER_ABSOLUTE_WORK_DIR));
+    if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_EXACT_WORK_DIR)) {
+      return new Path(new Path(fs.getUri()), config.getString(GobblinClusterConfigurationKeys.CLUSTER_EXACT_WORK_DIR));
     }
     if (config.hasPath(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR)) {
       return new Path(new Path(fs.getUri()), PathUtils.combinePaths(config.getString(GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR),

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -99,7 +99,6 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
   private void setupMetrics(State state) {
     this.opentelemetryMetrics = getOpentelemetryMetrics(state);
     if (this.opentelemetryMetrics != null) {
-      log.info("Setting up Opentelemetry metrics");
       this.jobStatusMetric = this.opentelemetryMetrics.getMeter(state.getProp(GAAS_OBSERVABILITY_GROUP_NAME))
           .gaugeBuilder(GAAS_OBSERVABILITY_JOB_STATUS_METRIC_NAME)
           .ofLongs()
@@ -109,8 +108,6 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
             for (GaaSObservabilityEventExperimental event : this.eventCollector) {
               Attributes tags = getEventAttributes(event);
               int status = event.getJobStatus() != JobStatus.SUCCEEDED ? 1 : 0;
-              // TODO: change to debug log
-              log.info("Emitting job status metric: " + status + " with tags: " + tags.toString());
               this.jobStatusMetric.record(status, tags);
             }
             // Empty the list of events as they are all emitted at this point.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSObservabilityEventProducer.java
@@ -99,6 +99,7 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
   private void setupMetrics(State state) {
     this.opentelemetryMetrics = getOpentelemetryMetrics(state);
     if (this.opentelemetryMetrics != null) {
+      log.info("Setting up Opentelemetry metrics");
       this.jobStatusMetric = this.opentelemetryMetrics.getMeter(state.getProp(GAAS_OBSERVABILITY_GROUP_NAME))
           .gaugeBuilder(GAAS_OBSERVABILITY_JOB_STATUS_METRIC_NAME)
           .ofLongs()
@@ -108,6 +109,8 @@ public abstract class GaaSObservabilityEventProducer implements Closeable {
             for (GaaSObservabilityEventExperimental event : this.eventCollector) {
               Attributes tags = getEventAttributes(event);
               int status = event.getJobStatus() != JobStatus.SUCCEEDED ? 1 : 0;
+              // TODO: change to debug log
+              log.info("Emitting job status metric: " + status + " with tags: " + tags.toString());
               this.jobStatusMetric.record(status, tags);
             }
             // Empty the list of events as they are all emitted at this point.

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -884,7 +884,8 @@ public class GobblinYarnAppLauncher {
 
   @VisibleForTesting
   void cleanUpAppWorkDirectory(ApplicationId applicationId) throws IOException {
-    FileSystem fs = GobblinClusterUtils.buildNewInstanceFileSystem(this.config, this.yarnConfiguration);
+    // Create a new filesystem as this.fs may have been closed by the Yarn Application, and FS.get() will return a cached instance of the closed FS
+    FileSystem fs = GobblinClusterUtils.createFileSystem(this.config, this.yarnConfiguration);
     Path appWorkDir = GobblinClusterUtils.getAppWorkDirPathFromConfig(this.config, fs, this.applicationName, applicationId.toString());
     if (fs.exists(appWorkDir)) {
       LOGGER.info("Deleting application working directory " + appWorkDir);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -863,8 +863,7 @@ public class GobblinYarnAppLauncher {
    * @throws IOException
    */
   private AbstractTokenRefresher buildTokenRefreshManager() throws IOException {
-    Path tokenFilePath = new Path(this.fs.getHomeDirectory(), this.applicationName + Path.SEPARATOR +
-        GobblinYarnConfigurationKeys.TOKEN_FILE_NAME);
+    Path tokenFilePath = YarnContainerSecurityManager.getYarnTokenFilePath(this.config, this.fs);
     String securityManagerClassName = ConfigUtils.getString(config, GobblinYarnConfigurationKeys.SECURITY_MANAGER_CLASS, GobblinYarnConfigurationKeys.DEFAULT_SECURITY_MANAGER_CLASS);
 
     try {
@@ -885,10 +884,11 @@ public class GobblinYarnAppLauncher {
 
   @VisibleForTesting
   void cleanUpAppWorkDirectory(ApplicationId applicationId) throws IOException {
-    Path appWorkDir = GobblinClusterUtils.getAppWorkDirPathFromConfig(this.config, this.fs, this.applicationName, applicationId.toString());
-    if (this.fs.exists(appWorkDir)) {
+    FileSystem fs = GobblinClusterUtils.buildNewInstanceFileSystem(this.config, this.yarnConfiguration);
+    Path appWorkDir = GobblinClusterUtils.getAppWorkDirPathFromConfig(this.config, fs, this.applicationName, applicationId.toString());
+    if (fs.exists(appWorkDir)) {
       LOGGER.info("Deleting application working directory " + appWorkDir);
-      this.fs.delete(appWorkDir, true);
+      fs.delete(appWorkDir, true);
     }
   }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -113,6 +113,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String KEYTAB_FILE_PATH = GOBBLIN_YARN_PREFIX + "keytab.file.path";
   public static final String KEYTAB_PRINCIPAL_NAME = GOBBLIN_YARN_PREFIX + "keytab.principal.name";
   public static final String TOKEN_FILE_NAME = ".token";
+  public static final String TOKEN_FILE_PATH_KEY = GOBBLIN_YARN_PREFIX + "token.file.path";
   public static final String LOGIN_INTERVAL_IN_MINUTES = GOBBLIN_YARN_PREFIX + "login.interval.minutes";
   public static final Long DEFAULT_LOGIN_INTERVAL_IN_MINUTES = Long.MAX_VALUE;
   public static final String TOKEN_RENEW_INTERVAL_IN_MINUTES = GOBBLIN_YARN_PREFIX + "token.renew.interval.minutes";

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnContainerSecurityManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnContainerSecurityManager.java
@@ -24,7 +24,6 @@ import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.typesafe.config.Config;
 import java.io.IOException;
-import java.util.Optional;
 
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.logs.LogCopier;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2050


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Gobblin Yarn Application Launcher has some issues where directories used for the job can persist after the job ends. It also creates a number of temporary files which can grow out of control.

This PR creates a new instance of a file system for cleaning up as the previous filesystem instance gets closed by the Yarn application and the cache becomes problematic with mount table FS.
It also allows a user to define `gobblin.cluster.absolute.workDir` for the exact path their cluster temp files and jars are stored, and `gobblin.yarn.token.file.path` to determine where to store their yarn security token.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested E2E and did not see regressions

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

