### PR TITLE
[GOBBLIN-2052] release those containers which are running helix task that are stuck in any of the given state

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixConstants.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixConstants.java
@@ -24,4 +24,6 @@ public class GobblinHelixConstants {
 
   public static final String SHUTDOWN_MESSAGE_TYPE = "SHUTDOWN";
 
+  public static final String HELIX_INSTANCE_NAME_KEY = "HelixInstanceName";
+
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnEventConstants.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnEventConstants.java
@@ -45,5 +45,6 @@ public class GobblinYarnEventConstants {
     public static final String ERROR = "Error";
     public static final String HELIX_INSTANCE_COMPLETION = "HelixInstanceCompletion";
     public static final String SHUTDOWN_REQUEST = "ShutdownRequest";
+    public static final String HELIX_PARTITION_STUCK_IN_INIT = "HelixPartitionStuckInInit";
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnEventConstants.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnEventConstants.java
@@ -45,6 +45,6 @@ public class GobblinYarnEventConstants {
     public static final String ERROR = "Error";
     public static final String HELIX_INSTANCE_COMPLETION = "HelixInstanceCompletion";
     public static final String SHUTDOWN_REQUEST = "ShutdownRequest";
-    public static final String HELIX_PARTITION_STUCK_IN_INIT = "HelixPartitionStuckInInit";
+    public static final String HELIX_PARTITION_STUCK = "HelixPartitionStuck";
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.yarn;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -329,8 +329,8 @@ public class YarnAutoScalingManager extends AbstractIdleService {
         if(instancesInInitState.contains(participant)) {
           instanceInitStateSince.putIfAbsent(participant, System.currentTimeMillis());
           if (!isInstanceStuckInInitState(participant)) {
-            // kill the corresponding container as the helix task is stuck in INIT state for a long time
-            log.info("Instance {} is stuck in INIT state for a long time, killing the container", participant);
+            // release the corresponding container as the helix task is stuck in INIT state for a long time
+            log.info("Instance {} is stuck in INIT state for a long time, releasing the container", participant);
             // get containerInfo of the helix participant
             YarnService.ContainerInfo containerInfo = yarnService.getContainerInfoGivenHelixParticipant(participant);
             if(containerInfo != null) {
@@ -346,8 +346,10 @@ public class YarnAutoScalingManager extends AbstractIdleService {
         }
       }
 
-      // release the containers which are running helix tasks which are stuck in INIT state
-      this.yarnService.getEventBus().post(new ContainerReleaseRequest(containersToRelease, true));
+      // release the containers
+      if(!containersToRelease.isEmpty()) {
+        this.yarnService.getEventBus().post(new ContainerReleaseRequest(containersToRelease, true));
+      }
 
       slidingWindowReservoir.add(yarnContainerRequestBundle);
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -45,7 +45,6 @@ import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
 import org.apache.helix.task.JobDag;
 import org.apache.helix.task.TargetState;
-import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskPartitionState;
 import org.apache.helix.task.TaskState;

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -116,7 +116,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
   private final int maxTimeInMinutesBeforeReleasingContainerHavingStuckTask;
   private final boolean enableReleasingContainerHavingStuckTask;
   private final boolean enableDetectionStuckTask;
-  private final HashSet<TaskPartitionState> detectionForTaskStates;
+  private final HashSet<TaskPartitionState> detectionForStuckTaskStates;
   private static final HashSet<TaskPartitionState>
       UNUSUAL_HELIX_TASK_STATES = Sets.newHashSet(TaskPartitionState.ERROR, TaskPartitionState.DROPPED, TaskPartitionState.COMPLETED, TaskPartitionState.TIMED_OUT);
 
@@ -154,7 +154,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
     this.enableReleasingContainerHavingStuckTask = ConfigUtils.getBoolean(this.config,
         RELEASE_CONTAINER_IF_TASK_IS_STUCK, false);
     this.enableDetectionStuckTask = ConfigUtils.getBoolean(this.config, DETECT_IF_TASK_IS_STUCK, false);
-    this.detectionForTaskStates = getTaskStatesForWhichDetectionIsEnabled();
+    this.detectionForStuckTaskStates = getTaskStatesForWhichDetectionIsEnabled();
   }
 
   private HashSet<TaskPartitionState> getTaskStatesForWhichDetectionIsEnabled() {
@@ -192,7 +192,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
             this.slidingFixedSizeWindow, this.helixManager.getHelixDataAccessor(), this.defaultHelixInstanceTags,
             this.defaultContainerMemoryMbs, this.defaultContainerCores, this.taskAttemptsThreshold,
             this.splitWorkUnitReachThreshold, this.maxTimeInMinutesBeforeReleasingContainerHavingStuckTask,
-            this.enableReleasingContainerHavingStuckTask, this.enableDetectionStuckTask, this.detectionForTaskStates),
+            this.enableReleasingContainerHavingStuckTask, this.enableDetectionStuckTask, this.detectionForStuckTaskStates),
         initialDelay, scheduleInterval, TimeUnit.SECONDS);
   }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -328,7 +328,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
 
         if(instancesInInitState.contains(participant)) {
           instanceInitStateSince.putIfAbsent(participant, System.currentTimeMillis());
-          if (!isInstanceStuckInInitState(participant)) {
+          if (isInstanceStuckInInitState(participant)) {
             // release the corresponding container as the helix task is stuck in INIT state for a long time
             log.info("Instance {} is stuck in INIT state for a long time, releasing the container", participant);
             // get containerInfo of the helix participant

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -111,7 +111,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
   private final double overProvisionFactor;
   private final SlidingWindowReservoir slidingFixedSizeWindow;
   private static int maxIdleTimeInMinutesBeforeScalingDown = DEFAULT_MAX_CONTAINER_IDLE_TIME_BEFORE_SCALING_DOWN_MINUTES;
-  private static int maxTimeInMinutesBeforeReleasingContainerHavingTaskStuckInINITState;
+  private final int maxTimeInMinutesBeforeReleasingContainerHavingTaskStuckInINITState;
   private static final HashSet<TaskPartitionState>
       UNUSUAL_HELIX_TASK_STATES = Sets.newHashSet(TaskPartitionState.ERROR, TaskPartitionState.DROPPED, TaskPartitionState.COMPLETED, TaskPartitionState.TIMED_OUT);
 
@@ -160,7 +160,8 @@ public class YarnAutoScalingManager extends AbstractIdleService {
     this.autoScalingExecutor.scheduleAtFixedRate(new YarnAutoScalingRunnable(new TaskDriver(this.helixManager),
             this.yarnService, this.partitionsPerContainer, this.overProvisionFactor,
             this.slidingFixedSizeWindow, this.helixManager.getHelixDataAccessor(), this.defaultHelixInstanceTags,
-            this.defaultContainerMemoryMbs, this.defaultContainerCores, this.taskAttemptsThreshold, this.splitWorkUnitReachThreshold),
+            this.defaultContainerMemoryMbs, this.defaultContainerCores, this.taskAttemptsThreshold,
+            this.splitWorkUnitReachThreshold, this.maxTimeInMinutesBeforeReleasingContainerHavingTaskStuckInINITState),
         initialDelay, scheduleInterval, TimeUnit.SECONDS);
   }
 
@@ -189,6 +190,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
     private final int defaultContainerCores;
     private final int taskAttemptsThreshold;
     private final boolean splitWorkUnitReachThreshold;
+    private final int maxTimeInMinutesBeforeReleasingContainerHavingTaskStuckInINITState;
 
     /**
      * A static map that keep track of an idle instance and its latest beginning idle time.

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -346,13 +346,13 @@ public class YarnAutoScalingManager extends AbstractIdleService {
             log.info("Instance {} has some helix partition that is stuck in INIT state for {} minutes, "
                 + "releasing the container", participant,
                 TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - instanceInitStateSince.get(participant)));
-            // get containerInfo of the helix participant
-            YarnService.ContainerInfo containerInfo = yarnService.getContainerInfoGivenHelixParticipant(participant);
+            // get container of the helix participant
+            Container container = yarnService.getContainerInfoGivenHelixParticipant(participant);
             instanceInitStateSince.remove(participant);
-            if(containerInfo != null) {
-              containersToRelease.add(containerInfo.getContainer());
+            if(container != null) {
+              containersToRelease.add(container);
             } else {
-              log.warn("ContainerInfo for participant {} is not found", participant);
+              log.warn("Container information for participant {} is not found", participant);
             }
           }
         } else {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAutoScalingManager.java
@@ -101,7 +101,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
   private final String AUTO_SCALING_WINDOW_SIZE = AUTO_SCALING_PREFIX + "windowSize";
 
   public final static int DEFAULT_MAX_CONTAINER_IDLE_TIME_BEFORE_SCALING_DOWN_MINUTES = 10;
-  public final static int DEFAULT_MAX_TIME_MINUTES_TO_RELEASE_CONTAINER_HAVING_HELIX_TASK_STUCK_IN_INIT_STATE = 10;
+  private final static int DEFAULT_MAX_TIME_MINUTES_TO_RELEASE_CONTAINER_HAVING_HELIX_TASK_STUCK_IN_INIT_STATE = 10;
 
   private final Config config;
   private final HelixManager helixManager;
@@ -234,7 +234,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
     }
 
 
-    private String getParticipantInInitStateForHelixPartition(JobContext jobContext, int partition) {
+    private String getParticipantInInitStateForHelixPartition(final JobContext jobContext, final int partition) {
       if (TaskPartitionState.INIT.equals(jobContext.getPartitionState(partition))) {
         log.info("Helix task {} is in {} state at helix participant {}",
             jobContext.getTaskIdForPartition(partition), jobContext.getPartitionState(partition),
@@ -321,7 +321,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
       // and potentially replanner-instance.
       Set<String> allParticipants = HelixUtils.getParticipants(helixDataAccessor, HELIX_YARN_INSTANCE_NAME_PREFIX);
 
-      Set<Container> containersToRelease = new HashSet<>();
+      final Set<Container> containersToRelease = new HashSet<>();
 
       // Find all joined participants not in-use for this round of inspection.
       // If idle time is beyond tolerance, mark the instance as unused by assigning timestamp as -1.
@@ -392,7 +392,7 @@ public class YarnAutoScalingManager extends AbstractIdleService {
      * not tag that instance as stuck and the container will not be scaled down.
      */
     @VisibleForTesting
-    boolean isInstanceStuckInInitState(String participant) {
+    boolean isInstanceStuckInInitState(final String participant) {
       return System.currentTimeMillis() - instanceInitStateSince.get(participant) >
           TimeUnit.MINUTES.toMillis(maxTimeInMinutesBeforeReleasingContainerHavingTaskStuckInINITState);
     }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -314,15 +314,15 @@ public class YarnService extends AbstractIdleService {
   }
 
   /**
-   *  getContainerInfoGivenHelixParticipant returns the containerInfo of the given helixParticipant if it exists else
+   *  getContainerInfoGivenHelixParticipant returns the container of the given helixParticipant if it exists else
    *  return null
    * @param helixParticipant
-   * @return ContainerInfo
+   * @return Container
    */
-  public ContainerInfo getContainerInfoGivenHelixParticipant(final String helixParticipant) {
+  public Container getContainerInfoGivenHelixParticipant(final String helixParticipant) {
     for (ContainerInfo containerInfo : this.containerMap.values()) {
       if (containerInfo.getHelixParticipantId().equals(helixParticipant)) {
-        return containerInfo;
+        return containerInfo.getContainer();
       }
     }
     return null;

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -313,6 +313,21 @@ public class YarnService extends AbstractIdleService {
         newContainerRequest.getResource());
   }
 
+  /**
+   *  getContainerInfoGivenHelixParticipant returns the containerInfo of the given helixParticipant if it exists else
+   *  return null
+   * @param helixParticipant
+   * @return ContainerInfo
+   */
+  public ContainerInfo getContainerInfoGivenHelixParticipant(String helixParticipant) {
+    for (ContainerInfo containerInfo : this.containerMap.values()) {
+      if (containerInfo.getHelixParticipantId().equals(helixParticipant)) {
+        return containerInfo;
+      }
+    }
+    return null;
+  }
+
   protected NMClientCallbackHandler getNMClientCallbackHandler() {
     return new NMClientCallbackHandler();
   }
@@ -335,13 +350,15 @@ public class YarnService extends AbstractIdleService {
     for (Container container : containerReleaseRequest.getContainers()) {
       LOGGER.info(String.format("Releasing container %s running on %s", container.getId(), container.getNodeId()));
 
-      // Record that this container was explicitly released so that a new one is not spawned to replace it
-      // Put the container id in the releasedContainerCache before releasing it so that handleContainerCompletion()
-      // can check for the container id and skip spawning a replacement container.
-      // Note that this is the best effort since these are asynchronous operations and a container may abort concurrently
-      // with the release call. So in some cases a replacement container may have already been spawned before
-      // the container is put into the black list.
-      this.releasedContainerCache.put(container.getId(), "");
+      if(!containerReleaseRequest.isSpinUpReplacementContainers()) {
+        // Record that this container was explicitly released so that a new one is not spawned to replace it
+        // Put the container id in the releasedContainerCache before releasing it so that handleContainerCompletion()
+        // can check for the container id and skip spawning a replacement container.
+        // Note that this is the best effort since these are asynchronous operations and a container may abort concurrently
+        // with the release call. So in some cases a replacement container may have already been spawned before
+        // the container is put into the black list.
+        this.releasedContainerCache.put(container.getId(), "");
+      }
       this.amrmClientAsync.releaseAssignedContainer(container.getId());
     }
   }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -350,7 +350,7 @@ public class YarnService extends AbstractIdleService {
     for (Container container : containerReleaseRequest.getContainers()) {
       LOGGER.info(String.format("Releasing container %s running on %s", container.getId(), container.getNodeId()));
 
-      if(!containerReleaseRequest.isSpinUpReplacementContainers()) {
+      if(!containerReleaseRequest.isDoSpinUpReplacementContainers()) {
         // Record that this container was explicitly released so that a new one is not spawned to replace it
         // Put the container id in the releasedContainerCache before releasing it so that handleContainerCompletion()
         // can check for the container id and skip spawning a replacement container.

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -142,6 +142,7 @@ public class YarnService extends AbstractIdleService {
   private final FileSystem fs;
 
   private final Optional<GobblinMetrics> gobblinMetrics;
+  @Getter
   private final Optional<EventSubmitter> eventSubmitter;
 
   @VisibleForTesting

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -316,17 +316,17 @@ public class YarnService extends AbstractIdleService {
 
   /**
    *  getContainerInfoGivenHelixParticipant returns the container of the given helixParticipant if it exists else
-   *  return null
+   *  return Optional<Container>
    * @param helixParticipant
    * @return Container
    */
-  public Container getContainerInfoGivenHelixParticipant(final String helixParticipant) {
+  public Optional<Container> getContainerInfoGivenHelixParticipant(final String helixParticipant) {
     for (ContainerInfo containerInfo : this.containerMap.values()) {
       if (containerInfo.getHelixParticipantId().equals(helixParticipant)) {
-        return containerInfo.getContainer();
+        return Optional.fromNullable(containerInfo.getContainer());
       }
     }
-    return null;
+    return Optional.absent();
   }
 
   protected NMClientCallbackHandler getNMClientCallbackHandler() {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -319,7 +319,7 @@ public class YarnService extends AbstractIdleService {
    * @param helixParticipant
    * @return ContainerInfo
    */
-  public ContainerInfo getContainerInfoGivenHelixParticipant(String helixParticipant) {
+  public ContainerInfo getContainerInfoGivenHelixParticipant(final String helixParticipant) {
     for (ContainerInfo containerInfo : this.containerMap.values()) {
       if (containerInfo.getHelixParticipantId().equals(helixParticipant)) {
         return containerInfo;
@@ -350,7 +350,7 @@ public class YarnService extends AbstractIdleService {
     for (Container container : containerReleaseRequest.getContainers()) {
       LOGGER.info(String.format("Releasing container %s running on %s", container.getId(), container.getNodeId()));
 
-      if(!containerReleaseRequest.isDoSpinUpReplacementContainers()) {
+      if(!containerReleaseRequest.isShouldSpinUpReplacementContainers()) {
         // Record that this container was explicitly released so that a new one is not spawned to replace it
         // Put the container id in the releasedContainerCache before releasing it so that handleContainerCompletion()
         // can check for the container id and skip spawning a replacement container.

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 
 import org.apache.hadoop.yarn.api.records.Container;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
@@ -31,6 +32,7 @@ import lombok.Getter;
  * Node Manager
  */
 @Getter
+@AllArgsConstructor
 public class ContainerReleaseRequest {
   /**
    * -- GETTER --
@@ -39,15 +41,11 @@ public class ContainerReleaseRequest {
    * @return the IDs of the containers to release
    */
   private final Collection<Container> containers;
-  private final boolean spinUpReplacementContainers;
+  // doSpinUpReplacementContainers is used to indicate whether to replace the released containers with new ones or not
+  private final boolean doSpinUpReplacementContainers;
 
   public ContainerReleaseRequest(Collection<Container> containers) {
     this.containers = containers;
-    this.spinUpReplacementContainers = false;
-  }
-
-  public ContainerReleaseRequest(Collection<Container> containers, boolean spinUpReplacementContainers) {
-    this.containers = containers;
-    this.spinUpReplacementContainers = spinUpReplacementContainers;
+    this.doSpinUpReplacementContainers = false;
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 
 import org.apache.hadoop.yarn.api.records.Container;
 
+import lombok.Getter;
+
 
 /**
  * A type of event for container release requests to be used with a {@link com.google.common.eventbus.EventBus}.
@@ -28,19 +30,24 @@ import org.apache.hadoop.yarn.api.records.Container;
  * the Resource Manager, while {@link ContainerShutdownRequest} shuts down a container through the
  * Node Manager
  */
+@Getter
 public class ContainerReleaseRequest {
-  private final Collection<Container> containers;
-
-  public ContainerReleaseRequest(Collection<Container> containers) {
-    this.containers = containers;
-  }
-
   /**
-   * Get the IDs of the containers to release.
+   * -- GETTER --
+   *  Get the IDs of the containers to release.
    *
    * @return the IDs of the containers to release
    */
-  public Collection<Container> getContainers() {
-    return this.containers;
+  private final Collection<Container> containers;
+  private final boolean spinUpReplacementContainers;
+
+  public ContainerReleaseRequest(Collection<Container> containers) {
+    this.containers = containers;
+    this.spinUpReplacementContainers = false;
+  }
+
+  public ContainerReleaseRequest(Collection<Container> containers, boolean spinUpReplacementContainers) {
+    this.containers = containers;
+    this.spinUpReplacementContainers = spinUpReplacementContainers;
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/event/ContainerReleaseRequest.java
@@ -41,11 +41,11 @@ public class ContainerReleaseRequest {
    * @return the IDs of the containers to release
    */
   private final Collection<Container> containers;
-  // doSpinUpReplacementContainers is used to indicate whether to replace the released containers with new ones or not
-  private final boolean doSpinUpReplacementContainers;
+  // shouldSpinUpReplacementContainers is used to indicate whether to replace the released containers with new ones or not
+  private final boolean shouldSpinUpReplacementContainers;
 
   public ContainerReleaseRequest(Collection<Container> containers) {
     this.containers = containers;
-    this.doSpinUpReplacementContainers = false;
+    this.shouldSpinUpReplacementContainers = false;
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -79,7 +79,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
     ArgumentCaptor<YarnContainerRequestBundle> argument = ArgumentCaptor.forClass(YarnContainerRequestBundle.class);
@@ -110,7 +110,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
 
@@ -148,7 +148,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
 
@@ -188,7 +188,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
 
@@ -216,7 +216,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 2,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
 
@@ -240,7 +240,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable1 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.2, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable1.run();
 
@@ -253,7 +253,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable2 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             0.1, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable2.run();
 
@@ -266,7 +266,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable3 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             6.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable3.run();
 
@@ -393,7 +393,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false);
+            defaultContainerCores, 20, false, 10);
 
     runnable.run();
 
@@ -479,7 +479,7 @@ public class YarnAutoScalingManagerTest {
         HelixDataAccessor helixDataAccessor) {
       super(taskDriver, yarnService, partitionsPerContainer, 1.0,
           noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-          defaultContainerCores, 20, false);
+          defaultContainerCores, 20, false, 10);
     }
 
     @Override

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -86,7 +86,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
     ArgumentCaptor<YarnContainerRequestBundle> argument = ArgumentCaptor.forClass(YarnContainerRequestBundle.class);
@@ -117,7 +119,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
 
@@ -155,7 +159,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
 
@@ -195,7 +201,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
 
@@ -223,7 +231,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 2,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
 
@@ -247,7 +257,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable1 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.2, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable1.run();
 
@@ -260,7 +272,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable2 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             0.1, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable2.run();
 
@@ -273,7 +287,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable3 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             6.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable3.run();
 
@@ -401,7 +417,9 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10, false);
+            defaultContainerCores, 20, false,
+            10,
+            false, false);
 
     runnable.run();
 
@@ -528,7 +546,9 @@ public class YarnAutoScalingManagerTest {
         HelixDataAccessor helixDataAccessor) {
       super(taskDriver, yarnService, partitionsPerContainer, 1.0,
           noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-          defaultContainerCores, 20, false, 10, true);
+          defaultContainerCores, 20, false,
+          10,
+          true, true);
     }
 
     @Override

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -86,7 +86,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
     ArgumentCaptor<YarnContainerRequestBundle> argument = ArgumentCaptor.forClass(YarnContainerRequestBundle.class);
@@ -117,7 +117,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
 
@@ -155,7 +155,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
 
@@ -195,7 +195,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
 
@@ -223,7 +223,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 2,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
 
@@ -247,7 +247,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable1 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.2, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable1.run();
 
@@ -260,7 +260,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable2 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             0.1, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable2.run();
 
@@ -273,7 +273,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable3 =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             6.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable3.run();
 
@@ -401,7 +401,7 @@ public class YarnAutoScalingManagerTest {
     YarnAutoScalingManager.YarnAutoScalingRunnable runnable =
         new YarnAutoScalingManager.YarnAutoScalingRunnable(mockTaskDriver, mockYarnService, 1,
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-            defaultContainerCores, 20, false, 10);
+            defaultContainerCores, 20, false, 10, false);
 
     runnable.run();
 
@@ -528,7 +528,7 @@ public class YarnAutoScalingManagerTest {
         HelixDataAccessor helixDataAccessor) {
       super(taskDriver, yarnService, partitionsPerContainer, 1.0,
           noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
-          defaultContainerCores, 20, false, 10);
+          defaultContainerCores, 20, false, 10, true);
     }
 
     @Override

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
@@ -39,11 +40,11 @@ import org.apache.helix.task.TaskState;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
@@ -440,9 +441,13 @@ public class YarnAutoScalingManagerTest {
     Mockito.when(mockJobContext.getPartitionState(2)).thenReturn(TaskPartitionState.INIT);
     Mockito.when(mockYarnService.getContainerInfoGivenHelixParticipant("GobblinYarnTaskRunner-2")).thenReturn(mockContainer);
     Mockito.when(mockYarnService.getEventBus()).thenReturn(mockEventBus);
+    Mockito.when(mockYarnService.getEventSubmitter()).thenReturn(Optional.absent());
     Set<Container> containers = new HashSet<>();
     containers.add(mockContainer);
     mockEventBus.post(new ContainerReleaseRequest(containers, true));
+    ContainerId mockContainerId = mock(ContainerId.class);
+    Mockito.when(mockContainer.getId()).thenReturn(mockContainerId);
+    Mockito.when(mockContainerId.toString()).thenReturn("container-1");
     HelixDataAccessor helixDataAccessor = getHelixDataAccessor(Arrays.asList("GobblinYarnTaskRunner-1", "GobblinYarnTaskRunner-2"));
 
     TestYarnAutoScalingRunnable runnable = new TestYarnAutoScalingRunnable(mockTaskDriver, mockYarnService,

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnAutoScalingManagerTest.java
@@ -88,7 +88,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
     ArgumentCaptor<YarnContainerRequestBundle> argument = ArgumentCaptor.forClass(YarnContainerRequestBundle.class);
@@ -121,7 +121,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
 
@@ -161,7 +161,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
 
@@ -203,7 +203,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
 
@@ -233,7 +233,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
 
@@ -259,7 +259,7 @@ public class YarnAutoScalingManagerTest {
             1.2, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable1.run();
 
@@ -274,7 +274,7 @@ public class YarnAutoScalingManagerTest {
             0.1, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable2.run();
 
@@ -289,7 +289,7 @@ public class YarnAutoScalingManagerTest {
             6.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable3.run();
 
@@ -419,7 +419,7 @@ public class YarnAutoScalingManagerTest {
             1.0, noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
             defaultContainerCores, 20, false,
             10,
-            false, false);
+            false, false, new HashSet<>());
 
     runnable.run();
 
@@ -457,7 +457,7 @@ public class YarnAutoScalingManagerTest {
     JobContext mockJobContext = getJobContext(mockTaskDriver, ImmutableMap.of(1,"GobblinYarnTaskRunner-1", 2, "GobblinYarnTaskRunner-2"), "job1");
     Mockito.when(mockJobContext.getPartitionState(1)).thenReturn(TaskPartitionState.RUNNING);
     Mockito.when(mockJobContext.getPartitionState(2)).thenReturn(TaskPartitionState.INIT);
-    Mockito.when(mockYarnService.getContainerInfoGivenHelixParticipant("GobblinYarnTaskRunner-2")).thenReturn(mockContainer);
+    Mockito.when(mockYarnService.getContainerInfoGivenHelixParticipant("GobblinYarnTaskRunner-2")).thenReturn(Optional.of(mockContainer));
     Mockito.when(mockYarnService.getEventBus()).thenReturn(mockEventBus);
     Mockito.when(mockYarnService.getEventSubmitter()).thenReturn(Optional.absent());
     Set<Container> containers = new HashSet<>();
@@ -548,7 +548,9 @@ public class YarnAutoScalingManagerTest {
           noopQueue, helixDataAccessor, defaultHelixTag, defaultContainerMemory,
           defaultContainerCores, 20, false,
           10,
-          true, true);
+          true, true, new HashSet<TaskPartitionState>() {{
+            add(TaskPartitionState.INIT);
+          }});
     }
 
     @Override
@@ -578,8 +580,8 @@ public class YarnAutoScalingManagerTest {
     }
 
     @Override
-    boolean isInstanceStuckInInitState(String participant) {
-      return alwaysInINITState || super.isInstanceStuckInInitState(participant);
+    boolean isInstanceStuck(String participant) {
+      return alwaysInINITState || super.isInstanceStuck(participant);
     }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [GOBBLIN-2052](https://issues.apache.org/jira/browse/GOBBLIN-2052) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2052


### Description
- [ ] My PR addresses the following issue:
- [ ] We have observed that some of the times the helix task is being stuck in INIT state in container where there is mismatch observed between the state of helix task at GAM (controller) and participant end. At participant end on receiving the state transition message to go from INIT -> RUNNING, since there is a mismatch, the message keeps on getting dropped. This is causing topic/partition starvation. This is actually issue on helix side but this is more of a workaround to check if any partition is stuck in INIT state for so long. 
- [ ]   This pr checks for helix participant that contains partition that is being in INIT state (default can be configurable) for more than configured amount of time (timeout) and releases the corresponding container. This will ensure that the helix participant will be assigned new container which will create a new session with zk of helix and hopefully the issue might be remediated.  


### Tests
- [ ] My PR adds the unit tests in YarnAutoScalingManagerTest file.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

