### PR TITLE
[GOBBLIN-2054] Fix `CommitActivityImpl` to succeed for `TaskState`s that did not originate with `CopySource`

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -544,8 +544,7 @@ public class JobContext implements Closeable {
    * or {@link ConfigurationKeys#PUBLISH_DATA_AT_JOB_LEVEL} is set to true.
    */
   public static boolean shouldCommitDataInJob(State state) {
-    boolean jobCommitPolicyIsFull =
-        JobCommitPolicy.getCommitPolicy(state.getProperties()) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
+    boolean jobCommitPolicyIsFull = JobCommitPolicy.getCommitPolicy(state) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
     boolean publishDataAtJobLevel = state.getPropAsBoolean(ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL,
         ConfigurationKeys.DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL);
     boolean jobDataPublisherSpecified =

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
@@ -392,16 +392,21 @@ public class JobState extends SourceState implements JobProgress {
    * @return a {@link Map} from dataset URNs to {@link DatasetState}s representing the dataset states
    */
   public Map<String, DatasetState> createDatasetStatesByUrns() {
+    return calculateDatasetStatesByUrns(this.taskStates.values(), this.skippedTaskStates.values());
+  }
+
+  /** {@see JobState#createDatasetStatesByUrns} */
+  public Map<String, DatasetState> calculateDatasetStatesByUrns(Collection<TaskState> allTaskStates, Collection<TaskState> allSkippedTaskStates) {
     Map<String, DatasetState> datasetStatesByUrns = Maps.newHashMap();
 
-    for (TaskState taskState : this.taskStates.values()) {
+    for (TaskState taskState : allTaskStates) {
       String datasetUrn = createDatasetUrn(datasetStatesByUrns, taskState);
 
       datasetStatesByUrns.get(datasetUrn).incrementTaskCount();
       datasetStatesByUrns.get(datasetUrn).addTaskState(taskState);
     }
 
-    for (TaskState taskState : this.skippedTaskStates.values()) {
+    for (TaskState taskState : allSkippedTaskStates) {
       String datasetUrn = createDatasetUrn(datasetStatesByUrns, taskState);
       datasetStatesByUrns.get(datasetUrn).addSkippedTaskState(taskState);
     }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
@@ -138,7 +138,7 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
         // TODO: if metrics configured, report them now
         log.info("WU [{} = {}] - finished commit after {}ms with state {}{}", wu.getCorrelator(), task.getTaskId(),
             taskState.getTaskDuration(), taskState.getWorkingState(),
-            taskState.getWorkingState().equals(WorkUnitState.WorkingState.SUCCESSFUL)
+            taskState.getWorkingState().equals(WorkUnitState.WorkingState.SUCCESSFUL) && taskState.contains(ConfigurationKeys.WRITER_OUTPUT_DIR)
                 ? (" to: " + taskState.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR)) : "");
         log.debug("WU [{} = {}] - task state: {}", wu.getCorrelator(), task.getTaskId(),
             taskState.toJsonString(shouldUseExtendedLogging(wu)));

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
@@ -104,8 +104,7 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
       throw ApplicationFailure.newNonRetryableFailureWithCause(
           String.format("Failed Gobblin job %s", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY)),
           e.getClass().toString(),
-          e,
-          null
+          e
       );
     }
     return numWUsGenerated;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2054


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

thus far, gobblin-on-temporal has only worked for iceberg-distcp (`CopySource`), not other job types that gobblin-on-MR succeeds with.  Commit fails with:
```
java.lang.IllegalArgumentException: Missing required property writer.output.dir
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122)
	at org.apache.gobblin.util.WriterUtils.getWriterOutputDir(WriterUtils.java:121)
	at org.apache.gobblin.publisher.BaseDataPublisher.publishData(BaseDataPublisher.java:390)
...
```
that prop was already used just prior to commit, while processing the `WorkUnit`, so something is clearly off...

still, even after hard-coding that property, this later error arises:
```
Caused by: java.lang.IllegalArgumentException: Can not create a Path from a null string
	at org.apache.hadoop.fs.Path.checkPathArg(Path.java:159)
	at org.apache.hadoop.fs.Path.<init>(Path.java:175)
	at org.apache.hadoop.fs.Path.<init>(Path.java:110)
	at org.apache.gobblin.runtime.FsDatasetStateStore.sanitizeDatasetStatestoreNameFromDatasetURN(FsDatasetStateStore.java:175)
...
```

upon investigation, these were due to two aspects of the gobblin-on-MR impl that did not carry over to gobblin-on-temporal:
1. the `JobState` must be added back to the `TaskState`, when the latter is deserialized, since only `CopySource::FileSetWorkUnitGenerator` adds all `JobState` props to the `WorkUnit`s it creates.  without that `JobState` props are not serialized with the `TaskState`
2. every `JobState.DatasetState` must be given a non-`null` `jobName`

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manual execution using `org.apache.gobblin.source.extractor.extract.jdbc.MysqlSource`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

