### PR TITLE
[GOBBLIN-2040] Remove the assumption that value of ComparableWatermark has to be comparable

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/ComparableWatermark.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/ComparableWatermark.java
@@ -20,7 +20,7 @@ package org.apache.gobblin.source.extractor;
 /**
  * {@link Watermark} that is also {@link Comparable}.
  */
-public interface ComparableWatermark<V extends Comparable<V>> extends Watermark, Comparable<ComparableWatermark>{
+public interface ComparableWatermark<V> extends Watermark, Comparable<ComparableWatermark>{
 
   V getValue();
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,6 +149,8 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
+      } else {
+        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -149,8 +149,6 @@ public abstract class RestApiConnector implements Closeable {
           .createClient();
       if (httpClient instanceof Closeable) {
         this.closer.register((Closeable)httpClient);
-      } else {
-        log.warn("httpClient is not closable, we will not be able to handle the resources close, please make sure the implementation handle it correctly");
       }
     }
     return this.httpClient;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

Remove the assumption that value of ComparableWatermark has to be comparable
### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2040


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Remove the assumption that value of ComparableWatermark has to be comparable, as we just need to make sure the watermark itself is comparable, and the value of it can be / not be comparable, since for some special class, we can use value combine with other field to do compare

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
local test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

