### PR TITLE
[GOBBLIN-2055] Only sets opentelemetry to be built locally rather than global

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
@@ -102,7 +102,7 @@ public class OpenTelemetryMetrics extends OpenTelemetryMetricsBase {
                 .build())
         .build();
 
-    this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).buildAndRegisterGlobal();
+    this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
   }
 
   protected static Map<String, String> parseHttpHeaders(String headersString) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2055


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Since GaaS Opentelemetry is still in the early stages and hasn't been rolled out service-wide, it should not be configuring the opentelemetry instance as global otherwise it can run into the following errors when combined with existing servlet infrastructure that uses Opentelemetry as well:

```
Caused by: java.lang.IllegalStateException: GlobalOpenTelemetry.set has already been called. GlobalOpenTelemetry.set must be called only once before any calls to GlobalOpenTelemetry.get. If you are using the OpenTelemetrySdk, use OpenTelemetrySdkBuilder.buildAndRegisterGlobal instead. Previous invocation set to cause of this exception.
```

Since Opentelemetry is initialized here as a singleton, it should still be "global" in the sense that it's only initialized with one configuration in this class.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Passes unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

