### PR TITLE
[GOBBLIN-2059] Send empty resource if no custom configs are specified

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
@@ -86,12 +86,16 @@ public class OpenTelemetryMetrics extends OpenTelemetryMetricsBase {
     log.info("Initializing OpenTelemetry metrics");
     Properties metricProps = PropertiesUtils.extractChildProperties(state.getProperties(),
         ConfigurationKeys.METRICS_REPORTING_OPENTELEMETRY_CONFIGS_PREFIX);
-    AttributesBuilder attributesBuilder = Attributes.builder();
-    for (String key : metricProps.stringPropertyNames()) {
-      attributesBuilder.put(AttributeKey.stringKey(key), metricProps.getProperty(key));
+    Resource metricsResource = Resource.empty();
+    if (metricProps.isEmpty()) {
+      log.warn("No OpenTelemetry metrics properties found, sending empty resource");
+    } else {
+      AttributesBuilder attributesBuilder = Attributes.builder();
+      for (String key : metricProps.stringPropertyNames()) {
+        attributesBuilder.put(AttributeKey.stringKey(key), metricProps.getProperty(key));
+      }
+      metricsResource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
     }
-    Resource metricsResource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
-
     SdkMeterProvider meterProvider = SdkMeterProvider.builder()
         .setResource(metricsResource)
         .registerMetricReader(

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
@@ -86,6 +86,7 @@ public class OpenTelemetryMetrics extends OpenTelemetryMetricsBase {
     log.info("Initializing OpenTelemetry metrics");
     Properties metricProps = PropertiesUtils.extractChildProperties(state.getProperties(),
         ConfigurationKeys.METRICS_REPORTING_OPENTELEMETRY_CONFIGS_PREFIX);
+    // Default to empty resource because default resource still populates some values
     Resource metricsResource = Resource.empty();
     if (metricProps.isEmpty()) {
       log.warn("No OpenTelemetry metrics properties found, sending empty resource");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2059


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Opentelemetry sends empty attributes even though no custom configurations are being specified. We want to just send the empty resource for consistency.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

