### PR TITLE
[GOBBLIN-2062] Ensure the `Orchestrator` always has `DagManager` remove `FlowSpec` - even when orchestration has failed

### DIFF
--- a/gobblin-restli/server.gradle
+++ b/gobblin-restli/server.gradle
@@ -45,6 +45,7 @@ dependencies {
   }
 
   compile externalDependency.gson
+  compile externalDependency.lombok
   compile externalDependency.pegasus.restliServer
   compile externalDependency.pegasus.restliCommon
   compile externalDependency.pegasus.restliNettyStandalone

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -278,18 +278,10 @@ public class DagManager extends AbstractIdleService {
   }
 
   /**
-   * Method to submit a {@link Dag} to the {@link DagManager} and delete adhoc flowSpecs from the FlowCatalog after
-   * persisting it in the other addDag method called. The DagManager's failure recovery method ensures the flow will be
-   * executed in the event of downtime.
-   * @param flowSpec
-   * @param dag
-   * @param persist
-   * @param setStatus
-   * @throws IOException
+   * Delete adhoc flowSpecs from the {@link FlowCatalog} after (separately) persisting via {@link DagManager#addDag(Dag, boolean, boolean)}.
+   * This DagManager's failure recovery mechanisms ensure the flow will be executed, even in the event of downtime.
    */
-  public synchronized void addDagAndRemoveAdhocFlowSpec(FlowSpec flowSpec, Dag<JobExecutionPlan> dag, boolean persist, boolean setStatus)
-      throws IOException {
-    addDag(dag, persist, setStatus);
+  public synchronized void removeFlowSpecIfAdhoc(FlowSpec flowSpec) throws IOException {
     // Only the active dagManager should delete the flowSpec
     if (isActive) {
       deleteSpecFromCatalogIfAdhoc(flowSpec);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 
@@ -60,6 +61,8 @@ public abstract class LeaseAttemptStatus {
    completeLease method from a caller without access to the {@link MultiActiveLeaseArbiter}.
   */
   @Data
+  // avoid - warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object
+  @EqualsAndHashCode(callSuper=false)
   public static class LeaseObtainedStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction consensusDagAction;
     private final long eventTimeMillis;
@@ -86,6 +89,8 @@ public abstract class LeaseAttemptStatus {
   the lease has completed or expired
    */
   @Data
+  // avoid - warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object
+  @EqualsAndHashCode(callSuper=false)
   public static class LeasedToAnotherStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction consensusDagAction;
     private final long eventTimeMillis;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -825,7 +825,6 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
               }
             }
           }
-          // Note that we only remove the spec from the flow catalog after it is orchestrated
           GobblinServiceJobScheduler.this.scheduledFlowSpecs.remove(specUri.toString());
           GobblinServiceJobScheduler.this.lastUpdatedTimeForFlowSpec.remove(specUri.toString());
         }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -145,7 +145,7 @@ public class FlowCompilationValidationHelper {
     }
     addFlowExecutionIdIfAbsent(flowMetadata, jobExecutionPlanDag);
 
-    if (isExecutionPermitted(flowStatusGenerator, flowName, flowGroup, allowConcurrentExecution,
+    if (isExecutionPermitted(flowStatusGenerator, flowGroup, flowName, allowConcurrentExecution,
         Long.parseLong(flowMetadata.get(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD)))) {
       return Optional.fromNullable(jobExecutionPlanDag);
     } else {
@@ -176,7 +176,7 @@ public class FlowCompilationValidationHelper {
    * @param allowConcurrentExecution
    * @return true if the {@link FlowSpec} allows concurrent executions or if no other instance of the flow is currently RUNNING.
    */
-  private boolean isExecutionPermitted(FlowStatusGenerator flowStatusGenerator, String flowName, String flowGroup,
+  private boolean isExecutionPermitted(FlowStatusGenerator flowStatusGenerator, String flowGroup, String flowName,
       boolean allowConcurrentExecution, long flowExecutionId) {
     return allowConcurrentExecution || !flowStatusGenerator.isFlowRunning(flowName, flowGroup, flowExecutionId);
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -231,6 +231,8 @@ public class GobblinServiceManagerTest {
 
     DagManager spiedDagManager = spy(gobblinServiceManager.getDagManager());
     doNothing().when(spiedDagManager).setActive(anyBoolean());
+    // WARNING: this `spiedDagManager` WILL NOT BE the one used by the `Orchestrator`: its DM has apparently already been
+    // provided to the `Orchestrator` ctor, prior to this replacement here of `GobblinServiceManager.dagManager`
     gobblinServiceManager.dagManager = spiedDagManager;
     return gobblinServiceManager;
   }
@@ -367,7 +369,7 @@ public class GobblinServiceManagerTest {
 
     this.flowConfigClient.createFlowConfig(flowConfig);
 
-    // FlowSpec still remains it is only deleted by inactiveDagManager
+    // FlowSpec still remains: it is only deleted by activeDagManager
     AssertWithBackoff.create().maxSleepMs(200L).timeoutMs(4000L).backoffFactor(1)
         .assertTrue(input -> this.gobblinServiceManager.getFlowCatalog().getSpecs().size() == 1,
             "Waiting for job to get orchestrated...");
@@ -822,7 +824,7 @@ public class GobblinServiceManagerTest {
   /*
   Creates a unique flowId for a given group using the current timestamp as the flowName.
    */
-  public FlowId createFlowIdWithUniqueName(String groupName) {
+  public static FlowId createFlowIdWithUniqueName(String groupName) {
     return new FlowId().setFlowGroup(groupName).setFlowName(String.valueOf(System.currentTimeMillis()));
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -278,7 +278,10 @@ public class GobblinServiceManagerTest {
     }
 
     mysql.stop();
-    testMetastoreDatabase.close();
+
+    if (testMetastoreDatabase != null) {
+      testMetastoreDatabase.close();
+    }
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -98,6 +98,7 @@ public class OrchestratorTest {
 
   @BeforeClass
   public void setUpClass() throws Exception {
+    // PERF: when within `@{Before,After}Class` the 7 current tests take only 33s; when `@{Before,After}Method` `.get()`s a per-test DB, the same take 1m49s!
     this.testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
   }
 
@@ -132,7 +133,7 @@ public class OrchestratorTest {
     Config config = ConfigBuilder.create()
         .addPrimitive(MostlyMySqlDagManagementStateStore.DAG_STATESTORE_CLASS_KEY,
             MostlyMySqlDagManagementStateStoreTest.TestMysqlDagStateStore.class.getName())
-        .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_URL_KEY), testMetastoreDatabase.getJdbcUrl())
+        .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_URL_KEY), this.testMetastoreDatabase.getJdbcUrl())
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_USER_KEY), TEST_USER)
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY), TEST_PASSWORD)
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY), TEST_TABLE).build();
@@ -169,8 +170,8 @@ public class OrchestratorTest {
 
   @AfterClass(alwaysRun = true)
   public void tearDownClass() throws Exception {
-    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
     if (this.testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
       this.testMetastoreDatabase.close();
     }
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -26,11 +26,14 @@ import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.codahale.metrics.MetricRegistry;
@@ -53,6 +56,8 @@ import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_catalog.TopologyCatalog;
 import org.apache.gobblin.runtime.spec_executorInstance.InMemorySpecExecutor;
+import org.apache.gobblin.service.FlowId;
+import org.apache.gobblin.service.GobblinServiceManagerTest;
 import org.apache.gobblin.service.modules.flow.IdentityFlowToJobSpecCompiler;
 import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 import org.apache.gobblin.service.modules.utils.SharedFlowMetricsSingleton;
@@ -60,8 +65,7 @@ import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 
 
@@ -72,6 +76,7 @@ public class OrchestratorTest {
   private static final String SPEC_STORE_PARENT_DIR = "/tmp/orchestrator/";
   private static final String SPEC_DESCRIPTION = "Test Orchestrator";
   private static final String SPEC_VERSION = FlowSpec.Builder.DEFAULT_VERSION;
+  private static final String TEST_FLOW_GROUP_NAME = "myTestFlowGroup";
   private static final String TOPOLOGY_SPEC_STORE_DIR = "/tmp/orchestrator/topologyTestSpecStore";
   private static final String FLOW_SPEC_STORE_DIR = "/tmp/orchestrator/flowTestSpecStore";
   private static final String FLOW_SPEC_GROUP_DIR = "/tmp/orchestrator/flowTestSpecStore/flowTestGroupDir";
@@ -82,14 +87,22 @@ public class OrchestratorTest {
 
   private FlowCatalog flowCatalog;
   private FlowSpec flowSpec;
-  private Orchestrator orchestrator;
+
+  private ITestMetastoreDatabase testMetastoreDatabase;
+  private FlowStatusGenerator mockFlowStatusGenerator;
+  private DagManager mockDagManager;
+  private Orchestrator dagMgrNotFlowLaunchHandlerBasedOrchestrator;
   private static final String TEST_USER = "testUser";
   private static final String TEST_PASSWORD = "testPassword";
   private static final String TEST_TABLE = "quotas";
-  private static ITestMetastoreDatabase testDb;
+
   @BeforeClass
-  public void setup() throws Exception {
-    testDb = TestMetastoreDatabaseFactory.get();
+  public void setUpClass() throws Exception {
+    this.testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
+  }
+
+  @BeforeMethod
+  public void setUp() throws Exception {
     cleanUpDir(TOPOLOGY_SPEC_STORE_DIR);
     cleanUpDir(FLOW_SPEC_STORE_DIR);
 
@@ -112,14 +125,14 @@ public class OrchestratorTest {
         Optional.of(logger), Optional.<MetricContext>absent(), true, true);
 
     this.serviceLauncher.addService(flowCatalog);
-    FlowStatusGenerator mockStatusGenerator = mock(FlowStatusGenerator.class);
-    FlowLaunchHandler mockFlowTriggerHandler = mock(FlowLaunchHandler.class);
-    DagManager mockDagManager = mock(DagManager.class);
-    doNothing().when(mockDagManager).setTopologySpecMap(anyMap());
+    this.mockFlowStatusGenerator = mock(FlowStatusGenerator.class);
+    this.mockDagManager = mock(DagManager.class);
+    Mockito.doNothing().when(mockDagManager).setTopologySpecMap(anyMap());
+
     Config config = ConfigBuilder.create()
         .addPrimitive(MostlyMySqlDagManagementStateStore.DAG_STATESTORE_CLASS_KEY,
             MostlyMySqlDagManagementStateStoreTest.TestMysqlDagStateStore.class.getName())
-        .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_URL_KEY), testDb.getJdbcUrl())
+        .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_URL_KEY), testMetastoreDatabase.getJdbcUrl())
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_USER_KEY), TEST_USER)
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY), TEST_PASSWORD)
         .addPrimitive(MysqlUserQuotaManager.qualify(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY), TEST_TABLE).build();
@@ -129,17 +142,37 @@ public class OrchestratorTest {
 
     SharedFlowMetricsSingleton sharedFlowMetricsSingleton = new SharedFlowMetricsSingleton(ConfigUtils.propertiesToConfig(orchestratorProperties));
 
-    this.orchestrator = new Orchestrator(ConfigUtils.propertiesToConfig(orchestratorProperties),
-        this.topologyCatalog, mockDagManager, Optional.of(logger), mockStatusGenerator,
-        Optional.of(mockFlowTriggerHandler), sharedFlowMetricsSingleton, Optional.of(mock(FlowCatalog.class)), Optional.of(dagManagementStateStore),
-        new FlowCompilationValidationHelper(config, sharedFlowMetricsSingleton, mock(UserQuotaManager.class), mockStatusGenerator));
-    this.topologyCatalog.addListener(orchestrator);
-    this.flowCatalog.addListener(orchestrator);
+    FlowCompilationValidationHelper flowCompilationValidationHelper = new FlowCompilationValidationHelper(config, sharedFlowMetricsSingleton, mock(UserQuotaManager.class), mockFlowStatusGenerator);
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator = new Orchestrator(ConfigUtils.propertiesToConfig(orchestratorProperties),
+        this.topologyCatalog, mockDagManager, Optional.of(logger), mockFlowStatusGenerator,
+        Optional.absent(), sharedFlowMetricsSingleton, Optional.of(mock(FlowCatalog.class)), Optional.of(dagManagementStateStore),
+        flowCompilationValidationHelper);
+    this.topologyCatalog.addListener(dagMgrNotFlowLaunchHandlerBasedOrchestrator);
+    this.flowCatalog.addListener(dagMgrNotFlowLaunchHandlerBasedOrchestrator);
     // Start application
     this.serviceLauncher.start();
     // Create Spec to play with
     this.topologySpec = initTopologySpec();
     this.flowSpec = initFlowSpec();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    // Shutdown Catalog
+    this.serviceLauncher.stop();
+
+    File specStoreDir = new File(SPEC_STORE_PARENT_DIR);
+    if (specStoreDir.exists()) {
+      FileUtils.deleteDirectory(specStoreDir);
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDownClass() throws Exception {
+    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+    if (this.testMetastoreDatabase != null) {
+      this.testMetastoreDatabase.close();
+    }
   }
 
   private void cleanUpDir(String dir) throws Exception {
@@ -221,24 +254,10 @@ public class OrchestratorTest {
     return uri;
   }
 
-  @AfterClass
-  public void cleanUp() throws Exception {
-    // Shutdown Catalog
-    this.serviceLauncher.stop();
-
-    File specStoreDir = new File(SPEC_STORE_PARENT_DIR);
-    if (specStoreDir.exists()) {
-      FileUtils.deleteDirectory(specStoreDir);
-    }
-
-    if (testDb != null) {
-      testDb.close();
-    }
-  }
-
+  // TODO: this test doesn't exercise `Orchestrator` and so belongs elsewhere - move it, then rework into `@BeforeMethod` init (since others depend on this)
   @Test
   public void createTopologySpec() {
-    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.orchestrator.getSpecCompiler();
+    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.getSpecCompiler();
 
     // List Current Specs
     Collection<Spec> specs = topologyCatalog.getSpecs();
@@ -271,11 +290,12 @@ public class OrchestratorTest {
     Assert.assertTrue(specCompiler.getTopologySpecMap().size() == 1, "SpecCompiler should contain 1 Spec after addition");
   }
 
-  @Test (dependsOnMethods = "createTopologySpec")
+  @Test
   public void createFlowSpec() throws Throwable {
-    // Since only 1 Topology with 1 SpecProducer has been added in previous test
-    // .. it should be available and responsible for our new FlowSpec
-    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.orchestrator.getSpecCompiler();
+    // TODO: fix this lingering inter-test dep from when `@BeforeClass` init, which we've since replaced by `Mockito.verify`-friendly `@BeforeMethod`
+    createTopologySpec(); // make 1 Topology with 1 SpecProducer available and responsible for our new FlowSpec
+
+    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.getSpecCompiler();
     SpecExecutor sei = specCompiler.getTopologySpecMap().values().iterator().next().getSpecExecutor();
 
     // List Current Specs
@@ -314,10 +334,12 @@ public class OrchestratorTest {
         + "Spec after addition");
   }
 
-  @Test (dependsOnMethods = "createFlowSpec")
-  public void deleteFlowSpec() throws Exception {
-    // Since only 1 Flow has been added in previous test it should be available
-    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.orchestrator.getSpecCompiler();
+  @Test
+  public void deleteFlowSpec() throws Throwable {
+    // TODO: fix this lingering inter-test dep from when `@BeforeClass` init, which we've since replaced by `Mockito.verify`-friendly `@BeforeMethod`
+    createFlowSpec(); // make 1 Flow available (for deletion herein)
+
+    IdentityFlowToJobSpecCompiler specCompiler = (IdentityFlowToJobSpecCompiler) this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.getSpecCompiler();
     SpecExecutor sei = specCompiler.getTopologySpecMap().values().iterator().next().getSpecExecutor();
 
     // List Current Specs
@@ -355,26 +377,101 @@ public class OrchestratorTest {
         + "Spec after deletion");
   }
 
-  @Test (dependsOnMethods = "deleteFlowSpec")
-  public void doNotRegisterMetricsAdhocFlows() throws Exception {
-    MetricContext metricContext = this.orchestrator.getSharedFlowMetricsSingleton().getMetricContext();
+  @Test
+  public void doNotRegisterMetricsAdhocFlows() throws Throwable {
+    // TODO: fix this lingering inter-test dep from when `@BeforeClass` init, which we've since replaced by `Mockito.verify`-friendly `@BeforeMethod`
+    createTopologySpec(); // for flow compilation to pass
+
+    FlowId flowId = GobblinServiceManagerTest.createFlowIdWithUniqueName(TEST_FLOW_GROUP_NAME);
+    MetricContext metricContext = this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.getSharedFlowMetricsSingleton().getMetricContext();
+    String metricName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, flowId.getFlowGroup(), flowId.getFlowName(), ServiceMetricNames.COMPILED);
+
     this.topologyCatalog.getInitComplete().countDown(); // unblock orchestration
-    Properties flowProps = new Properties();
-    flowProps.setProperty(ConfigurationKeys.FLOW_NAME_KEY, "flow0");
-    flowProps.setProperty(ConfigurationKeys.FLOW_GROUP_KEY, "group0");
-    flowProps.put("specStore.fs.dir", FLOW_SPEC_STORE_DIR);
-    flowProps.put("specExecInstance.capabilities", "source:destination");
-    flowProps.put("gobblin.flow.sourceIdentifier", "source");
-    flowProps.put("gobblin.flow.destinationIdentifier", "destination");
-    flowProps.put("flow.allowConcurrentExecution", false);
-    FlowSpec adhocSpec = new FlowSpec(URI.create("flow0/group0"), "1", "", ConfigUtils.propertiesToConfig(flowProps) , flowProps, Optional.absent(), Optional.absent());
-    this.orchestrator.orchestrate(adhocSpec, flowProps, 0, false);
-    String metricName = MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX, "group0", "flow0", ServiceMetricNames.COMPILED);
+
+    FlowSpec adhocSpec = createBasicFlowSpecForFlowId(flowId);
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.orchestrate(adhocSpec, new Properties(), 0, false);
     Assert.assertNull(metricContext.getParent().get().getGauges().get(metricName));
 
-    flowProps.setProperty("job.schedule", "0/2 * * * * ?");
-    FlowSpec scheduledSpec = new FlowSpec(URI.create("flow0/group0"), "1", "", ConfigUtils.propertiesToConfig(flowProps) , flowProps, Optional.absent(), Optional.absent());
-    this.orchestrator.orchestrate(scheduledSpec, flowProps, 0, false);
+    Properties scheduledProps = new Properties();
+    scheduledProps.setProperty("job.schedule", "0/2 * * * * ?");
+    FlowSpec scheduledSpec = createBasicFlowSpecForFlowId(flowId, scheduledProps);
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.orchestrate(scheduledSpec, new Properties(), 0, false);
     Assert.assertNotNull(metricContext.getParent().get().getGauges().get(metricName));
+  }
+
+  @Test
+  public void removeFlowSpecWhenDagAdded() throws Throwable {
+    // TODO: fix this lingering inter-test dep from when `@BeforeClass` init, which we've since replaced by `Mockito.verify`-friendly `@BeforeMethod`
+    createTopologySpec(); // for flow compilation to pass
+
+    FlowId flowId = GobblinServiceManagerTest.createFlowIdWithUniqueName(TEST_FLOW_GROUP_NAME);
+    FlowSpec flowSpec = createBasicFlowSpecForFlowId(flowId);
+    this.topologyCatalog.getInitComplete().countDown(); // unblock orchestration
+
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.orchestrate(flowSpec, new Properties(), 0, false);
+
+    Mockito.verify(this.mockDagManager, Mockito.times(1)).addDag(any(), eq(true), eq(true));
+    Mockito.verify(this.mockDagManager, Mockito.times(1)).removeFlowSpecIfAdhoc(any());
+  }
+
+  @Test
+  public void removeFlowSpecEvenWhenDagNotAddedDueToCompilationFailure() throws Throwable {
+    // to cause flow compilation to fail, DO NOT EXECUTE: createTopologySpec();
+
+    FlowId flowId = GobblinServiceManagerTest.createFlowIdWithUniqueName(TEST_FLOW_GROUP_NAME);
+    FlowSpec flowSpec = createBasicFlowSpecForFlowId(flowId);
+    this.topologyCatalog.getInitComplete().countDown(); // unblock orchestration
+
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.orchestrate(flowSpec, new Properties(), 0, false);
+
+    // (verifies that compilation failure precedes enforcement of concurrent flow executions)
+    Mockito.verify(this.mockFlowStatusGenerator, Mockito.never()).isFlowRunning(any(), any(), anyLong());
+
+    Mockito.verify(this.mockDagManager, Mockito.never()).addDag(any(), anyBoolean(), anyBoolean());
+    Mockito.verify(this.mockDagManager, Mockito.times(1)).removeFlowSpecIfAdhoc(any());
+  }
+
+  @Test
+  public void removeFlowSpecEvenWhenDagNotAddedDueToConcurrentExecution() throws Throwable {
+    // TODO: fix this lingering inter-test dep from when `@BeforeClass` init, which we've since replaced by `Mockito.verify`-friendly `@BeforeMethod`
+    createTopologySpec(); // for flow compilation to pass
+
+    FlowId flowId = GobblinServiceManagerTest.createFlowIdWithUniqueName(TEST_FLOW_GROUP_NAME);
+    Properties noConcurrentExecsProps = new Properties();
+    noConcurrentExecsProps.setProperty("flow.allowConcurrentExecution", "false");
+    FlowSpec flowSpec = createBasicFlowSpecForFlowId(flowId, noConcurrentExecsProps);
+    this.topologyCatalog.getInitComplete().countDown(); // unblock orchestration
+
+    Mockito.when(this.mockFlowStatusGenerator.isFlowRunning(eq(flowId.getFlowName()), eq(flowId.getFlowGroup()), anyLong())).thenReturn(true);
+
+    this.dagMgrNotFlowLaunchHandlerBasedOrchestrator.orchestrate(flowSpec, new Properties(), 0, false);
+
+    // (verifies enforcement of concurrent flow executions)
+    Mockito.verify(this.mockFlowStatusGenerator, Mockito.times(1)).isFlowRunning(eq(flowId.getFlowName()), eq(flowId.getFlowGroup()), anyLong());
+
+    Mockito.verify(this.mockDagManager, Mockito.never()).addDag(any(), anyBoolean(), anyBoolean());
+    Mockito.verify(this.mockDagManager, Mockito.times(1)).removeFlowSpecIfAdhoc(any());
+  }
+
+  public static FlowSpec createBasicFlowSpecForFlowId(FlowId flowId) throws URISyntaxException {
+    return createBasicFlowSpecForFlowId(flowId, new Properties());
+  }
+
+  public static FlowSpec createBasicFlowSpecForFlowId(FlowId flowId, Properties moreProps) throws URISyntaxException {
+    URI flowUri = FlowSpec.Utils.createFlowSpecUri(flowId);
+    Properties flowProps = new Properties();
+    // needed by - Orchestrator::orchestrate
+    flowProps.setProperty(ConfigurationKeys.FLOW_GROUP_KEY, flowId.getFlowGroup());
+    flowProps.setProperty(ConfigurationKeys.FLOW_NAME_KEY, flowId.getFlowName());
+    // needed by - IdentityFlowToJobSpecCompiler::compileFlow
+    flowProps.put("gobblin.flow.sourceIdentifier", "source");
+    flowProps.put("gobblin.flow.destinationIdentifier", "destination");
+    // needed by - IdentityFlowToJobSpecCompiler::getJobExecutionPlans
+    flowProps.put("specExecInstance.capabilities", "source:destination");
+
+    moreProps.entrySet().forEach(entry ->
+        flowProps.put(entry.getKey(), entry.getValue()));
+
+    return new FlowSpec(flowUri, "1", "", ConfigUtils.propertiesToConfig(flowProps), flowProps, Optional.absent(), Optional.absent());
   }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PathUtils.java
@@ -50,8 +50,8 @@ public class PathUtils {
 
   /**
    * Checks whether possibleAncestor is an ancestor of fullPath.
-   * @param possibleAncestor Possible ancestor of fullPath.
-   * @param fullPath path to check.
+   * @param possibleAncestor Possible ancestor of fullPath, where scheme and authority are IGNORED
+   * @param fullPath path to check, where scheme and authority are IGNORED
    * @return true if possibleAncestor is an ancestor of fullPath.
    */
   public static boolean isAncestor(Path possibleAncestor, Path fullPath) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
@@ -83,8 +83,8 @@ public class PropertiesUtils {
   /** @throws {@link NullPointerException} when `key` not in `properties` */
   public static String getRequiredPropRaw(Properties properties, String key, Optional<String> desc) {
     String value = properties.getProperty(key);
-    Preconditions.checkNotNull(value, "'" + key + "' must be set" + desc.transform
-        (s -> " (to " + desc + ")").or(""));
+    Preconditions.checkNotNull(value, "'" + key + "' must be set" + desc.transform((String s) ->
+        " (to " + desc + ")").or(""));
     return value;
   }
 


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2062


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

the Orchestrator + DagManager MUST remove adhoc flows from the FlowCatalog that fail compilation or violate concurrent execs. otherwise gaas will continue to return '409 Conflict' to each subsequent attempt to subsequently create an adhoc flow with the same flowGroup+flowName.  this is despite the fact that the flow (still remaining in the FlowCatalog, when it shouldn't be) already has the status of FAILED, which is a "final status".

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

added test cases (herein)

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

