### PR TITLE
[GOBBLIN-2065] Increase `TestMetastoreDatabaseServer` concurrent cnxns; plus make closing `ITestMetastoreDatabase` `alwaysRun = true` and doc reason

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableMysqlDatasetStoreDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/CleanableMysqlDatasetStoreDatasetTest.java
@@ -112,6 +112,7 @@ public class CleanableMysqlDatasetStoreDatasetTest {
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
     if (testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
       testMetastoreDatabase.close();
     }
   }

--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
@@ -96,6 +96,8 @@ class TestMetastoreDatabaseServer implements Closeable {
         .withPort(this.dbPort)
         .withUser(this.dbUserName, this.dbUserPassword)
         .withServerVariable("explicit_defaults_for_timestamp", "off")
+        // default `max_connections` is apparently 151 - see: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections
+        .withServerVariable("max_connections", "501")
         .build();
     if (this.embeddedMysqlEnabled) {
       testingMySqlServer = EmbeddedMysql.anEmbeddedMysql(config).start();

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.runtime;
 
-import java.io.IOException;
 import java.net.URI;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -124,8 +123,9 @@ public class DagActionStoreChangeMonitorTest {
     this.testDb = TestMetastoreDatabaseFactory.get();
   }
 
-  @AfterClass
-  public void tearDown() throws IOException {
+  @AfterClass(alwaysRun = true)
+  public void tearDown() throws Exception {
+    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
     this.testDb.close();
   }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/MysqlDatasetStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/MysqlDatasetStateStoreTest.java
@@ -328,11 +328,12 @@ public class MysqlDatasetStateStoreTest {
     Assert.assertNull(datasetState);
   }
 
-  @AfterClass
-  public void tearDown() throws IOException {
+  @AfterClass(alwaysRun = true)
+  public void tearDown() throws Exception {
     dbJobStateStore.delete(TEST_JOB_NAME);
     dbDatasetStateStore.delete(TEST_JOB_NAME);
     if (testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
       testMetastoreDatabase.close();
     }
   }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/cli/JobStateStoreCliTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/cli/JobStateStoreCliTest.java
@@ -132,6 +132,14 @@ public class JobStateStoreCliTest {
         jobState);
   }
 
+  @AfterClass(alwaysRun = true)
+  public void tearDown() throws Exception {
+    if (this.testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testMetastoreDatabase.close();
+    }
+  }
+
   @Test
   public void testClBulkDelete() throws Exception {
     String deleteFileText = TEST_JOB_NAME +"\n" + TEST_JOB_NAME2;
@@ -174,12 +182,5 @@ public class JobStateStoreCliTest {
         TEST_JOB_ID);
 
     Assert.assertNull(jobState);
-  }
-
-  @AfterClass(alwaysRun = true)
-  public void tearDown() throws Exception {
-    if (this.testMetastoreDatabase != null) {
-      this.testMetastoreDatabase.close();
-    }
   }
 }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStoreTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlBaseSpecStoreTest.java
@@ -48,11 +48,11 @@ public class MysqlBaseSpecStoreTest {
   private static final String PASSWORD = "testPassword";
   private static final String TABLE = "base_spec_store";
 
+  private ITestMetastoreDatabase testDb;
   private MysqlBaseSpecStore specStore;
   private final URI uri1 = new URI(new TopologySpec.Builder().getDefaultTopologyCatalogURI().toString() + "1");
   private final URI uri2 = new URI(new TopologySpec.Builder().getDefaultTopologyCatalogURI().toString() + "2");
   private TopologySpec topoSpec1, topoSpec2;
-  private static ITestMetastoreDatabase testDb;
 
   public MysqlBaseSpecStoreTest()
       throws URISyntaxException { // (based on `uri1` and other initializations just above)
@@ -60,11 +60,11 @@ public class MysqlBaseSpecStoreTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    testDb = TestMetastoreDatabaseFactory.get();
+    this.testDb = TestMetastoreDatabaseFactory.get();
 
     // prefix keys to demonstrate disambiguation mechanism used to side-step intentially-sabatoged non-prefixed, 'fallback'
     Config config = ConfigBuilder.create()
-        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, " SABATOGE! !" + testDb.getJdbcUrl())
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, " SABATOGE! !" + this.testDb.getJdbcUrl())
         .addPrimitive(MysqlBaseSpecStore.CONFIG_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
         .addPrimitive(MysqlBaseSpecStore.CONFIG_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
         .addPrimitive(MysqlBaseSpecStore.CONFIG_PREFIX + "." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
@@ -93,8 +93,9 @@ public class MysqlBaseSpecStoreTest {
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    if (testDb != null) {
-      testDb.close();
+    if (this.testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testDb.close();
     }
   }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreTest.java
@@ -58,6 +58,7 @@ public class MysqlSpecStoreTest {
   private static final String PASSWORD = "testPassword";
   private static final String TABLE = "spec_store";
 
+  private ITestMetastoreDatabase testDb;
   private MysqlSpecStore specStore;
   private MysqlSpecStore oldSpecStore;
   private final URI uri1 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg1").setFlowGroup("fn1"));
@@ -65,7 +66,6 @@ public class MysqlSpecStoreTest {
   private final URI uri3 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg3").setFlowGroup("fn3"));
   private final URI uri4 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg4").setFlowGroup("fn4"));
   private FlowSpec flowSpec1, flowSpec2, flowSpec3, flowSpec4;
-  private static ITestMetastoreDatabase testDb;
 
   public MysqlSpecStoreTest()
       throws URISyntaxException { // (based on `uri1` and other initializations just above)
@@ -73,10 +73,10 @@ public class MysqlSpecStoreTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    testDb = TestMetastoreDatabaseFactory.get();
+    this.testDb = TestMetastoreDatabaseFactory.get();
 
     Config config = ConfigBuilder.create()
-        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, this.testDb.getJdbcUrl())
         .addPrimitive(ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
         .addPrimitive(ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
         .addPrimitive(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
@@ -134,8 +134,9 @@ public class MysqlSpecStoreTest {
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    if (testDb != null) {
-      testDb.close();
+    if (this.testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testDb.close();
     }
   }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreWithUpdateTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreWithUpdateTest.java
@@ -58,6 +58,7 @@ public class MysqlSpecStoreWithUpdateTest {
   private static final String PASSWORD = "testPassword";
   private static final String TABLE = "spec_store";
 
+  private ITestMetastoreDatabase testDb;
   private MysqlSpecStoreWithUpdate specStore;
   private MysqlSpecStore oldSpecStore;
   private final URI uri1 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg1").setFlowGroup("fn1"));
@@ -65,7 +66,6 @@ public class MysqlSpecStoreWithUpdateTest {
   private final URI uri3 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg3").setFlowGroup("fn3"));
   private final URI uri4 = FlowSpec.Utils.createFlowSpecUri(new FlowId().setFlowName("fg4").setFlowGroup("fn4"));
   private FlowSpec flowSpec1, flowSpec2, flowSpec3, flowSpec4, flowSpec4_update;
-  private static ITestMetastoreDatabase testDb;
 
   public MysqlSpecStoreWithUpdateTest()
       throws URISyntaxException { // (based on `uri1` and other initializations just above)
@@ -73,7 +73,7 @@ public class MysqlSpecStoreWithUpdateTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    testDb = TestMetastoreDatabaseFactory.get();
+    this.testDb = TestMetastoreDatabaseFactory.get();
 
     Config config = ConfigBuilder.create()
         .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
@@ -144,8 +144,9 @@ public class MysqlSpecStoreWithUpdateTest {
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    if (testDb != null) {
-      testDb.close();
+    if (this.testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testDb.close();
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceHATest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceHATest.java
@@ -101,8 +101,8 @@ public class GobblinServiceHATest {
 
   private TestingServer testingZKServer;
 
+  private ITestMetastoreDatabase testMetastoreDatabase;
   private MySQLContainer mysql;
-  private static ITestMetastoreDatabase testMetastoreDatabase;
 
   @BeforeClass
   public void setup() throws Exception {
@@ -121,7 +121,6 @@ public class GobblinServiceHATest {
     this.testingZKServer = new TestingServer(-1);
     logger.info("Testing ZK Server listening on: " + testingZKServer.getConnectString());
     HelixUtils.createGobblinHelixCluster(testingZKServer.getConnectString(), TEST_HELIX_CLUSTER_NAME);
-
 
     testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
 
@@ -202,9 +201,6 @@ public class GobblinServiceHATest {
 
   @AfterClass(alwaysRun = true)
   public void cleanUp() throws Exception {
-    if (testMetastoreDatabase != null) {
-      testMetastoreDatabase.close();
-    }
     // Shutdown Node 1
     try {
       logger.info("+++++++++++++++++++ start shutdown noad1");
@@ -255,6 +251,8 @@ public class GobblinServiceHATest {
     cleanUpDir(COMMON_SPEC_STORE_PARENT_DIR);
 
     mysql.stop();
+    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+    testMetastoreDatabase.close();
   }
 
   @Test

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceHATest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceHATest.java
@@ -250,7 +250,12 @@ public class GobblinServiceHATest {
 
     cleanUpDir(COMMON_SPEC_STORE_PARENT_DIR);
 
-    mysql.stop();
+    try {
+      mysql.stop();
+    } catch (Exception e) {
+      logger.warn("Could not completely stop Mysql");
+    }
+
     // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
     testMetastoreDatabase.close();
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceRedirectTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GobblinServiceRedirectTest.java
@@ -108,8 +108,8 @@ public class GobblinServiceRedirectTest {
   private Properties node1ServiceCoreProperties;
   private Properties node2ServiceCoreProperties;
 
+  private ITestMetastoreDatabase testMetastoreDatabase;
   private MySQLContainer mysql;
-  private static ITestMetastoreDatabase testMetastoreDatabase;
 
   @BeforeClass
   public void setup() throws Exception {
@@ -124,7 +124,7 @@ public class GobblinServiceRedirectTest {
     logger.info("Testing ZK Server listening on: " + testingZKServer.getConnectString());
     HelixUtils.createGobblinHelixCluster(testingZKServer.getConnectString(), TEST_HELIX_CLUSTER_NAME);
 
-    testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
+    this.testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
 
     Properties commonServiceCoreProperties = new Properties();
 
@@ -224,8 +224,9 @@ public class GobblinServiceRedirectTest {
     }
 
     mysql.stop();
-    if (testMetastoreDatabase != null) {
-      testMetastoreDatabase.close();
+    if (this.testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testMetastoreDatabase.close();
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -73,17 +73,17 @@ public class DagManagerFlowTest {
   private static final String flowName = "testFlowName";
   private static final String flowExecutionId = "12345677";
   private static final String flowExecutionId_2 = "12345678";
+  private ITestMetastoreDatabase testDb;
   private DagActionStore dagActionStore;
-  private static ITestMetastoreDatabase testDb;
 
   @BeforeClass
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.put(DagManager.JOB_STATUS_POLLING_INTERVAL_KEY, 1);
-    testDb = TestMetastoreDatabaseFactory.get();
+    this.testDb = TestMetastoreDatabaseFactory.get();
 
     Config config = ConfigBuilder.create()
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, this.testDb.getJdbcUrl())
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
@@ -99,11 +99,12 @@ public class DagManagerFlowTest {
     Thread.sleep(30000);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void cleanUp() throws Exception {
     dagManager.setActive(false);
     Assert.assertEquals(dagManager.getHouseKeepingThreadPool().isShutdown(), true);
     if (testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
       testDb.close();
     }
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStoreTest.java
@@ -57,24 +57,25 @@ import static org.mockito.Mockito.mock;
  */
 public class MostlyMySqlDagManagementStateStoreTest {
 
+  private ITestMetastoreDatabase testDb;
   private MostlyMySqlDagManagementStateStore dagManagementStateStore;
   private static final String TEST_USER = "testUser";
   private static final String TEST_PASSWORD = "testPassword";
   private static final String TEST_DAG_STATE_STORE = "TestDagStateStore";
   private static final String TEST_TABLE = "quotas";
-  private static ITestMetastoreDatabase testDb;
 
   @BeforeClass
   public void setUp() throws Exception {
     // Setting up mock DB
-    testDb = TestMetastoreDatabaseFactory.get();
-    this.dagManagementStateStore = getDummyDMSS(testDb);
+    this.testDb = TestMetastoreDatabaseFactory.get();
+    this.dagManagementStateStore = getDummyDMSS(this.testDb);
   }
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    if (testDb != null) {
-      testDb.close();
+    if (this.testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testDb.close();
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
@@ -45,15 +45,14 @@ public class MysqlDagActionStoreTest {
   private static final String flowExecutionId = "12345677";
   private static final String flowExecutionId_2 = "12345678";
   private static final String flowExecutionId_3 = "12345679";
-  private MysqlDagActionStore mysqlDagActionStore;
-
   private ITestMetastoreDatabase testDb;
+  private MysqlDagActionStore mysqlDagActionStore;
 
   @BeforeClass
   public void setUp() throws Exception {
     this.testDb = TestMetastoreDatabaseFactory.get();
     Config config = ConfigBuilder.create()
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, this.testDb.getJdbcUrl())
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
@@ -62,8 +61,9 @@ public class MysqlDagActionStoreTest {
     this.mysqlDagActionStore = new MysqlDagActionStore(config);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws IOException {
+    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
     this.testDb.close();
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreTest.java
@@ -73,6 +73,7 @@ public class MysqlDagStateStoreTest {
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
     if (testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
       testDb.close();
     }
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
@@ -64,12 +64,12 @@ import static org.mockito.Mockito.spy;
 
 public class KillDagProcTest {
   private MostlyMySqlDagManagementStateStore dagManagementStateStore;
-  private static ITestMetastoreDatabase testDb;
+  private ITestMetastoreDatabase testDb;
 
   @BeforeClass
   public void setUp() throws Exception {
-    testDb = TestMetastoreDatabaseFactory.get();
-    this.dagManagementStateStore = spy(MostlyMySqlDagManagementStateStoreTest.getDummyDMSS(testDb));
+    this.testDb = TestMetastoreDatabaseFactory.get();
+    this.dagManagementStateStore = spy(MostlyMySqlDagManagementStateStoreTest.getDummyDMSS(this.testDb));
     doReturn(FlowSpec.builder().build()).when(this.dagManagementStateStore).getFlowSpec(any());
     doNothing().when(this.dagManagementStateStore).tryAcquireQuota(any());
     doNothing().when(this.dagManagementStateStore).addDagNodeState(any(), any());
@@ -77,8 +77,9 @@ public class KillDagProcTest {
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    if (testDb != null) {
-      testDb.close();
+    if (this.testDb != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testDb.close();
     }
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -62,8 +62,8 @@ import static org.mockito.Mockito.spy;
 
 
 public class LaunchDagProcTest {
-  private MostlyMySqlDagManagementStateStore dagManagementStateStore;
   private ITestMetastoreDatabase testMetastoreDatabase;
+  private MostlyMySqlDagManagementStateStore dagManagementStateStore;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -72,6 +72,12 @@ public class LaunchDagProcTest {
     doReturn(FlowSpec.builder().build()).when(this.dagManagementStateStore).getFlowSpec(any());
     doNothing().when(this.dagManagementStateStore).tryAcquireQuota(any());
     doNothing().when(this.dagManagementStateStore).addDagNodeState(any(), any());
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() throws Exception {
+    // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+    this.testMetastoreDatabase.close();
   }
 
   @Test
@@ -91,11 +97,6 @@ public class LaunchDagProcTest {
     Assert.assertEquals(expectedNumOfSavingDagNodeStates,
         Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
             .filter(a -> a.getMethod().getName().equals("addDagNodeState")).count());
-  }
-
-  @AfterClass
-  public void tearDown() throws Exception {
-    this.testMetastoreDatabase.close();
   }
 
   // This creates a dag like this

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -189,8 +190,12 @@ public class MysqlJobStatusRetrieverTest extends JobStatusRetrieverTest {
     this.dbJobStateStore.delete(KafkaJobStatusMonitor.jobStatusStoreName(FLOW_GROUP, FLOW_NAME));
   }
 
+  @AfterClass(alwaysRun = true)
   @Override
   public void tearDown() throws Exception {
-    this.testMetastoreDatabase.close();
+    if (this.testMetastoreDatabase != null) {
+      // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
+      this.testMetastoreDatabase.close();
+    }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2065


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

We continue to face the "Too many connections" error while running `gobblin-service` tests; see, e.g. GH actions workflow failures for https://github.com/apache/gobblin/pull/3944

this shows up as
```
java.io.IOException: Failure creation table TestDagStateStore
   ...
Caused by: java.sql.SQLNonTransientConnectionException: Too many connections
   ...
```

Adjusting the server variable `max_connections` (in [TestMetastoreDatabaseServer.java](https://github.com/apache/gobblin/compare/master...phet:gobblin:fix_gobblin-service_tests_too_many_connections?expand=1#diff-3a1f64166bc336495b2d153fe1f8bc0fdc9dd28450cb8de1d32578c2f2727517)) to `501` has fixed local execution.

While debugging, I realized not all of the `@AfterClass` annotations use `(alwaysRun = true)`, so following on to the recent mods in https://github.com/apache/gobblin/pull/3946

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

updated tests herein

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

