### PR TITLE
[GOBBLIN-2073] Use previous eventTime for lease arbitration of reminder dagActions

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.quartz.Job;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
-import java.rmi.dgc.Lease;
 import java.util.Date;
 import java.util.function.Supplier;
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -50,6 +50,7 @@ public interface DagActionStore {
     final String jobName;
     final DagActionType dagActionType;
     final boolean isReminder;
+    long eventTimeMillis;
 
     public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType) {
       this(flowGroup, flowName, flowExecutionId, jobName, dagActionType, false);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
-import java.rmi.dgc.Lease;
 import java.sql.SQLException;
 import java.util.Collection;
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -82,7 +82,7 @@ public interface DagActionStore {
 
   @Data
   @RequiredArgsConstructor
-  class LeaseObject  {
+  class DagActionLeaseObject {
     final DagAction dagAction;
     final boolean isReminder;
     final long eventTimeMillis;
@@ -90,7 +90,7 @@ public interface DagActionStore {
     /**
      * Creates a lease object for a dagAction and eventTimeMillis representing an original event (isReminder is False)
      */
-    public LeaseObject(DagAction dagAction, long eventTimeMillis) {
+    public DagActionLeaseObject(DagAction dagAction, long eventTimeMillis) {
       this.dagAction = dagAction;
       this.isReminder = false;
       this.eventTimeMillis = eventTimeMillis;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -49,15 +49,24 @@ public interface DagActionStore {
     final String flowExecutionId;
     final String jobName;
     final DagActionType dagActionType;
-    final boolean isReminder;
+    boolean isReminder;
     long eventTimeMillis;
 
-    public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType) {
-      this(flowGroup, flowName, flowExecutionId, jobName, dagActionType, false);
+    public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, boolean isReminder, long eventTimeMillis) {
+      this(flowGroup, flowName, flowExecutionId, jobName, dagActionType);
+      this.setReminder(isReminder);
+      this.setEventTimeMillis(eventTimeMillis);
+    }
+    public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, long eventTimeMillis) {
+      this(flowGroup, flowName, flowExecutionId, jobName, dagActionType, false, eventTimeMillis);
     }
 
     public static DagAction forFlow(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType) {
-      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType);
+      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType, false, System.currentTimeMillis());
+    }
+
+    public static DagAction forFlow(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType, boolean isReminder, long eventTimeMillis) {
+      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType, isReminder, eventTimeMillis);
     }
 
     public FlowId getFlowId() {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
+import java.rmi.dgc.Lease;
 import java.sql.SQLException;
 import java.util.Collection;
 
@@ -49,25 +50,9 @@ public interface DagActionStore {
     final String flowExecutionId;
     final String jobName;
     final DagActionType dagActionType;
-    boolean isReminder;
-    long eventTimeMillis;
-
-    public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, boolean isReminder, long eventTimeMillis) {
-      this(flowGroup, flowName, flowExecutionId, jobName, dagActionType);
-      this.setReminder(isReminder);
-      this.setEventTimeMillis(eventTimeMillis);
-    }
-
-    public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, long eventTimeMillis) {
-      this(flowGroup, flowName, flowExecutionId, jobName, dagActionType, false, eventTimeMillis);
-    }
 
     public static DagAction forFlow(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType) {
-      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType, false, System.currentTimeMillis());
-    }
-
-    public static DagAction forFlow(String flowGroup, String flowName, String flowExecutionId, DagActionType dagActionType, boolean isReminder, long eventTimeMillis) {
-      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType, isReminder, eventTimeMillis);
+      return new DagAction(flowGroup, flowName, flowExecutionId, NO_JOB_NAME_DEFAULT, dagActionType);
     }
 
     public FlowId getFlowId() {
@@ -97,6 +82,24 @@ public interface DagActionStore {
       return new DagManager.DagId(this.flowGroup, this.flowName, this.flowExecutionId);
     }
   }
+
+  @Data
+  @RequiredArgsConstructor
+  class LeaseObject  {
+    final DagAction dagAction;
+    final boolean isReminder;
+    final long eventTimeMillis;
+
+    /**
+     * Creates a lease object for a dagAction and eventTimeMillis representing an original event (isReminder is False)
+     */
+    public LeaseObject(DagAction dagAction, long eventTimeMillis) {
+      this.dagAction = dagAction;
+      this.isReminder = false;
+      this.eventTimeMillis = eventTimeMillis;
+    }
+  }
+
 
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -57,6 +57,7 @@ public interface DagActionStore {
       this.setReminder(isReminder);
       this.setEventTimeMillis(eventTimeMillis);
     }
+
     public DagAction(String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionType dagActionType, long eventTimeMillis) {
       this(flowGroup, flowName, flowExecutionId, jobName, dagActionType, false, eventTimeMillis);
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagement.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagement.java
@@ -27,5 +27,13 @@ import java.io.IOException;
  */
 public interface DagManagement {
 
+  /**
+   * Used to add a dagAction event to DagManagement
+   */
   void addDagAction(DagActionStore.DagAction dagAction) throws IOException;
+
+  /**
+   * Used to add reminder dagActions to the queue that already contain an eventTimestamp from the previous lease attempt
+   */
+  void addDagAction(DagActionStore.LeaseObject reminderDagActionLeaseObject) throws IOException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagement.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagement.java
@@ -35,5 +35,5 @@ public interface DagManagement {
   /**
    * Used to add reminder dagActions to the queue that already contain an eventTimestamp from the previous lease attempt
    */
-  void addDagAction(DagActionStore.LeaseObject reminderDagActionLeaseObject) throws IOException;
+  void addReminderDagAction(DagActionStore.DagActionLeaseObject reminderDagActionLeaseObject) throws IOException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -138,7 +138,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
         DagActionStore.DagAction dagAction = null;
         try {
           DagActionStore.LeaseObject dagActionLeaseObject = this.dagActionQueue.take();
-          DagActionStore.DagAction dagAction = dagActionLeaseObject.getDagAction();
+          dagAction = dagActionLeaseObject.getDagAction();
           /* Create triggers for original (non-reminder) dag actions of type ENFORCE_JOB_START_DEADLINE and ENFORCE_FLOW_FINISH_DEADLINE.
              Reminder triggers are used to inform hosts once the job start deadline and flow finish deadline are passed;
              then only is lease arbitration done to enforce the deadline violation and fail the job or flow if needed */

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
-import java.rmi.dgc.Lease;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -232,15 +232,6 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
   */
   protected void scheduleReminderForEvent(LeaseAttemptStatus leaseStatus)
       throws SchedulerException {
-    DagActionStore.DagAction consensusDagAction = leaseStatus.getConsensusDagAction();
-    if (leaseStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
-      consensusDagAction.setEventTimeMillis(((LeaseAttemptStatus.LeaseObtainedStatus) leaseStatus).getEventTimeMillis());
-    } else if (leaseStatus instanceof LeaseAttemptStatus.LeasedToAnotherStatus) {
-      consensusDagAction.setEventTimeMillis(((LeaseAttemptStatus.LeasedToAnotherStatus) leaseStatus).getEventTimeMillis());
-    } else {
-      throw new RuntimeException(
-          String.format("Reminder event should not be scheduled for a NoLongerLeasing status. Status: %s", leaseStatus));
-    }
-    dagActionReminderScheduler.get().scheduleReminder(consensusDagAction, leaseStatus.getMinimumLingerDurationMillis());
+    dagActionReminderScheduler.get().scheduleReminder(leaseStatus.getConsensusDagAction(), leaseStatus.getMinimumLingerDurationMillis());
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -185,7 +185,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
   /**
    * Returns a {@link LeaseAttemptStatus} associated with the
    * `dagAction` by calling
-   * {@link MultiActiveLeaseArbiter#tryAcquireLease(DagActionStore.DagAction, long, boolean, boolean)}.
+   * {@link MultiActiveLeaseArbiter#tryAcquireLease(DagActionStore.DagAction, boolean)}.
    * @param dagAction
    * @return
    * @throws IOException
@@ -195,9 +195,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
       throws IOException, SchedulerException {
     // Uses reminder flag to determine whether to use current time as event time or previously saved event time
     LeaseAttemptStatus leaseAttemptStatus = this.dagActionProcessingLeaseArbiter
-        .tryAcquireLease(dagAction,
-            dagAction.isReminder && dagAction.getEventTimeMillis() != 0L ? dagAction.getEventTimeMillis() : System.currentTimeMillis(),
-            dagAction.isReminder, false);
+        .tryAcquireLease(dagAction, false);
         /* Schedule a reminder for the event unless the lease has been completed to safeguard against the case where even
         we, when we might become the lease owner still fail to complete processing
         */

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -105,11 +105,12 @@ public class FlowLaunchHandler {
    * event triggered by the scheduler by attempting a lease for the launch event and processing the result depending on
    * the status of the attempt.
    */
-  public void handleFlowLaunchTriggerEvent(Properties jobProps, DagActionStore.LeaseObject leaseObject,
-      boolean adoptConsensusFlowExecutionId) throws IOException {
-    long previousEventTimeMillis = leaseObject.getEventTimeMillis();
+  public void handleFlowLaunchTriggerEvent(Properties jobProps,
+      DagActionStore.DagActionLeaseObject dagActionLeaseObject, boolean adoptConsensusFlowExecutionId)
+      throws IOException {
+    long previousEventTimeMillis = dagActionLeaseObject.getEventTimeMillis();
     LeaseAttemptStatus leaseAttempt = this.multiActiveLeaseArbiter.tryAcquireLease(
-        leaseObject, adoptConsensusFlowExecutionId);
+        dagActionLeaseObject, adoptConsensusFlowExecutionId);
     if (leaseAttempt instanceof LeaseAttemptStatus.LeaseObtainedStatus
         && persistLaunchDagAction((LeaseAttemptStatus.LeaseObtainedStatus) leaseAttempt)) {
       log.info("Successfully persisted lease: [{}, eventTimestamp: {}] ", leaseAttempt.getConsensusDagAction(),
@@ -128,7 +129,7 @@ public class FlowLaunchHandler {
       return Optional.of((LeaseAttemptStatus.LeasedToAnotherStatus) leaseAttempt);
     } else if (leaseAttempt instanceof LeaseAttemptStatus.LeaseObtainedStatus) { // remind w/o delay to immediately re-attempt handling
       return Optional.of(new LeaseAttemptStatus.LeasedToAnotherStatus(
-          ((LeaseAttemptStatus.LeaseObtainedStatus) leaseAttempt).getConsensusLeaseObject(), 0L));
+          ((LeaseAttemptStatus.LeaseObtainedStatus) leaseAttempt).getConsensusDagActionLeaseObject(), 0L));
     } else {
       throw new RuntimeException("unexpected `LeaseAttemptStatus` derived type: '" + leaseAttempt.getClass().getName() + "' in '" + leaseAttempt + "'");
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
@@ -72,13 +72,14 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
   }
 
   @Override
-  public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseObject leaseObject, boolean skipFlowExecutionIdReplacement) throws IOException {
+  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagActionLeaseObject dagActionLeaseObject, boolean skipFlowExecutionIdReplacement) throws IOException {
     LeaseAttemptStatus leaseAttemptStatus =
-        decoratedMultiActiveLeaseArbiter.tryAcquireLease(leaseObject, skipFlowExecutionIdReplacement);
+        decoratedMultiActiveLeaseArbiter.tryAcquireLease(dagActionLeaseObject, skipFlowExecutionIdReplacement);
     log.info("Multi-active scheduler lease attempt for leaseObject: {} received type of leaseAttemptStatus: [{}, "
-            + "eventTimestamp: {}] ", leaseObject, leaseAttemptStatus.getClass().getName(), leaseObject.getEventTimeMillis());
+            + "eventTimestamp: {}] ", dagActionLeaseObject, leaseAttemptStatus.getClass().getName(),
+        dagActionLeaseObject.getEventTimeMillis());
     if (leaseAttemptStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
-      if (leaseObject.isReminder()) {
+      if (dagActionLeaseObject.isReminder()) {
         this.leasesObtainedDueToReminderCount.mark();
       }
       this.leaseObtainedCount.inc();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
@@ -72,16 +72,13 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
   }
 
   @Override
-  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, long eventTimeMillis,
-      boolean isReminderEvent, boolean skipFlowExecutionIdReplacement) throws IOException {
-
+  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, boolean skipFlowExecutionIdReplacement) throws IOException {
     LeaseAttemptStatus leaseAttemptStatus =
-        decoratedMultiActiveLeaseArbiter.tryAcquireLease(dagAction, eventTimeMillis, isReminderEvent,
-            skipFlowExecutionIdReplacement);
+        decoratedMultiActiveLeaseArbiter.tryAcquireLease(dagAction, skipFlowExecutionIdReplacement);
     log.info("Multi-active scheduler lease attempt for dagAction: {} received type of leaseAttemptStatus: [{}, "
-            + "eventTimestamp: {}] ", dagAction, leaseAttemptStatus.getClass().getName(), eventTimeMillis);
+            + "eventTimestamp: {}] ", dagAction, leaseAttemptStatus.getClass().getName(), dagAction.getEventTimeMillis());
     if (leaseAttemptStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
-      if (isReminderEvent) {
+      if (dagAction.isReminder()) {
         this.leasesObtainedDueToReminderCount.mark();
       }
       this.leaseObtainedCount.inc();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
@@ -72,13 +72,13 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
   }
 
   @Override
-  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, boolean skipFlowExecutionIdReplacement) throws IOException {
+  public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseObject leaseObject, boolean skipFlowExecutionIdReplacement) throws IOException {
     LeaseAttemptStatus leaseAttemptStatus =
-        decoratedMultiActiveLeaseArbiter.tryAcquireLease(dagAction, skipFlowExecutionIdReplacement);
-    log.info("Multi-active scheduler lease attempt for dagAction: {} received type of leaseAttemptStatus: [{}, "
-            + "eventTimestamp: {}] ", dagAction, leaseAttemptStatus.getClass().getName(), dagAction.getEventTimeMillis());
+        decoratedMultiActiveLeaseArbiter.tryAcquireLease(leaseObject, skipFlowExecutionIdReplacement);
+    log.info("Multi-active scheduler lease attempt for leaseObject: {} received type of leaseAttemptStatus: [{}, "
+            + "eventTimestamp: {}] ", leaseObject, leaseAttemptStatus.getClass().getName(), leaseObject.getEventTimeMillis());
     if (leaseAttemptStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
-      if (dagAction.isReminder()) {
+      if (leaseObject.isReminder()) {
         this.leasesObtainedDueToReminderCount.mark();
       }
       this.leaseObtainedCount.inc();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
@@ -34,10 +34,10 @@ import lombok.Getter;
  */
 public abstract class LeaseAttemptStatus {
   /**
-   * @return the {@link DagActionStore.LeaseObject}, containing the dagAction, eventTimeMillis of the event, and boolean
+   * @return the {@link DagActionStore.DagActionLeaseObject}, containing the dagAction, eventTimeMillis of the event, and boolean
    * indicating if it's a reminder event; {@see MultiActiveLeaseArbiter#tryAcquireLease}
    */
-  public DagActionStore.LeaseObject getConsensusLeaseObject() {
+  public DagActionStore.DagActionLeaseObject getConsensusDagActionLeaseObject() {
     return null;
   }
 
@@ -73,7 +73,7 @@ public abstract class LeaseAttemptStatus {
   // avoid - warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object
   @EqualsAndHashCode(callSuper=false)
   public static class LeaseObtainedStatus extends LeaseAttemptStatus {
-    private final DagActionStore.LeaseObject consensusLeaseObject;
+    private final DagActionStore.DagActionLeaseObject consensusDagActionLeaseObject;
     private final long leaseAcquisitionTimestamp;
     private final long minimumLingerDurationMillis;
     @Getter(AccessLevel.NONE)
@@ -81,7 +81,7 @@ public abstract class LeaseAttemptStatus {
 
     @Override
     public DagActionStore.DagAction getConsensusDagAction() {
-      return consensusLeaseObject.getDagAction();
+      return consensusDagActionLeaseObject.getDagAction();
     }
 
     /**
@@ -94,7 +94,7 @@ public abstract class LeaseAttemptStatus {
     }
 
     public long getEventTimeMillis() {
-      return consensusLeaseObject.getEventTimeMillis();
+      return consensusDagActionLeaseObject.getEventTimeMillis();
     }
   }
 
@@ -109,16 +109,16 @@ public abstract class LeaseAttemptStatus {
   // avoid - warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object
   @EqualsAndHashCode(callSuper=false)
   public static class LeasedToAnotherStatus extends LeaseAttemptStatus {
-    private final DagActionStore.LeaseObject consensusLeaseObject;
+    private final DagActionStore.DagActionLeaseObject consensusDagActionLeaseObject;
     private final long minimumLingerDurationMillis;
 
     @Override
     public DagActionStore.DagAction getConsensusDagAction() {
-      return consensusLeaseObject.getDagAction();
+      return consensusDagActionLeaseObject.getDagAction();
     }
 
     public long getEventTimeMillis() {
-      return consensusLeaseObject.getEventTimeMillis();
+      return consensusDagActionLeaseObject.getEventTimeMillis();
     }
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
@@ -52,17 +52,17 @@ public abstract class LeaseAttemptStatus {
 
   /*
   The participant calling this method acquired the lease for the event in question.
-  The timestamp associated with the lease is stored in `eventTimeMillis` field and the time the caller obtained the
-  lease is stored within the`leaseAcquisitionTimestamp` field. Note that the `Dag action` returned by the lease
-   arbitration attempt will be unchanged for flows that do not adopt the consensus eventTimeMillis as the flow execution
-   id, so a separate field must be maintained to track the eventTimeMillis for lease completion. The
-   `multiActiveLeaseArbiter` reference is used to recordLeaseSuccess for the current LeaseObtainedStatus via the
-   completeLease method from a caller without access to the {@link MultiActiveLeaseArbiter}.
+  The `Dag action` returned by the lease arbitration attempt includes an updated value in the `eventTimeMillis` field,
+  which represents the consensus timestamp associated with the lease. For flows that do not adopt the consensus
+  `eventTimeMillis` as the flow execution ID, the `flowExecutionId` will remain unchanged. The consensus
+  `eventTimeMillis` must be tracked for lease completion.
+  The time the caller obtained the lease is stored within the`leaseAcquisitionTimestamp` field.
+  The `multiActiveLeaseArbiter` reference is used to recordLeaseSuccess for the current LeaseObtainedStatus via the
+  completeLease method from a caller without access to the {@link MultiActiveLeaseArbiter}.
   */
   @Data
   public static class LeaseObtainedStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction consensusDagAction;
-    private final long eventTimeMillis;
     private final long leaseAcquisitionTimestamp;
     private final long minimumLingerDurationMillis;
     @Getter(AccessLevel.NONE)
@@ -76,11 +76,15 @@ public abstract class LeaseAttemptStatus {
     public boolean completeLease() throws IOException {
       return multiActiveLeaseArbiter.recordLeaseSuccess(this);
     }
+
+    public long getEventTimeMillis() {
+      return consensusDagAction.getEventTimeMillis();
+    }
   }
 
   /*
   This dag action event already has a valid lease owned by another participant.
-  `eventTimeMillis' corresponds to the timestamp of the existing lease associated with this dag action, however the dag
+  See doc for {@link LeaseObtainedStatus} for details about consensusDagAction. Note, that the dag
   action event it corresponds to may be a different and distinct occurrence of the same event.
   `minimumLingerDurationMillis` is the minimum amount of time to wait before this participant should return to check if
   the lease has completed or expired
@@ -88,7 +92,10 @@ public abstract class LeaseAttemptStatus {
   @Data
   public static class LeasedToAnotherStatus extends LeaseAttemptStatus {
     private final DagActionStore.DagAction consensusDagAction;
-    private final long eventTimeMillis;
     private final long minimumLingerDurationMillis;
+
+    public long getEventTimeMillis() {
+      return consensusDagAction.getEventTimeMillis();
+    }
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
@@ -49,7 +49,7 @@ public interface MultiActiveLeaseArbiter {
    * added by the previous write). Based on the transaction results, it will return {@link LeaseAttemptStatus} to
    * determine the next action.
    *
-   * @param leaseObject                   uniquely identifies the flow, the present action upon it, the time the action
+   * @param dagActionLeaseObject                   uniquely identifies the flow, the present action upon it, the time the action
    *                                      was triggered, and if the dag action event we're checking on is a reminder event
    * @param adoptConsensusFlowExecutionId if true then replaces the dagAction flowExecutionId returned in
    *                                      LeaseAttemptStatuses with the consensus eventTime, accessed via
@@ -58,8 +58,7 @@ public interface MultiActiveLeaseArbiter {
    * {@link DagActionStore.DagAction} with a possibly updated ("laundered") flow execution id that MUST be used thereafter
    * @throws IOException
    */
-  // todo: change to use leaseObject here that contains dagAction with reminder, eventTime
-  LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseObject leaseObject, boolean adoptConsensusFlowExecutionId)
+  LeaseAttemptStatus tryAcquireLease(DagActionStore.DagActionLeaseObject dagActionLeaseObject, boolean adoptConsensusFlowExecutionId)
       throws IOException;
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
@@ -49,8 +49,8 @@ public interface MultiActiveLeaseArbiter {
    * added by the previous write). Based on the transaction results, it will return {@link LeaseAttemptStatus} to
    * determine the next action.
    *
-   * @param dagAction                     uniquely identifies the flow, the present action upon it, the time the action was triggered, and
-   *                                      if the dag action event we're checking on is a reminder event
+   * @param leaseObject                   uniquely identifies the flow, the present action upon it, the time the action
+   *                                      was triggered, and if the dag action event we're checking on is a reminder event
    * @param adoptConsensusFlowExecutionId if true then replaces the dagAction flowExecutionId returned in
    *                                      LeaseAttemptStatuses with the consensus eventTime, accessed via
    *                                      {@link LeaseAttemptStatus#getConsensusDagAction()}
@@ -58,7 +58,8 @@ public interface MultiActiveLeaseArbiter {
    * {@link DagActionStore.DagAction} with a possibly updated ("laundered") flow execution id that MUST be used thereafter
    * @throws IOException
    */
-  LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, boolean adoptConsensusFlowExecutionId)
+  // todo: change to use leaseObject here that contains dagAction with reminder, eventTime
+  LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseObject leaseObject, boolean adoptConsensusFlowExecutionId)
       throws IOException;
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
@@ -48,19 +48,17 @@ public interface MultiActiveLeaseArbiter {
    * acquisition timestamp of the entry for that dag action event (it could have pre-existed in the table or been newly
    * added by the previous write). Based on the transaction results, it will return {@link LeaseAttemptStatus} to
    * determine the next action.
-   * @param dagAction uniquely identifies the flow and the present action upon it
-   * @param eventTimeMillis is the time this dag action was triggered
-   * @param isReminderEvent true if the dag action event we're checking on is a reminder event
+   *
+   * @param dagAction                     uniquely identifies the flow, the present action upon it, the time the action was triggered, and
+   *                                      if the dag action event we're checking on is a reminder event
    * @param adoptConsensusFlowExecutionId if true then replaces the dagAction flowExecutionId returned in
    *                                      LeaseAttemptStatuses with the consensus eventTime, accessed via
    *                                      {@link LeaseAttemptStatus#getConsensusDagAction()}
-   *
    * @return {@link LeaseAttemptStatus}, containing, when `adoptConsensusFlowExecutionId`, a universally-agreed-upon
    * {@link DagActionStore.DagAction} with a possibly updated ("laundered") flow execution id that MUST be used thereafter
    * @throws IOException
    */
-  LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, long eventTimeMillis, boolean isReminderEvent,
-      boolean adoptConsensusFlowExecutionId)
+  LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, boolean adoptConsensusFlowExecutionId)
       throws IOException;
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -243,20 +243,21 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   }
 
   @Override
-  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, long eventTimeMillis,
-      boolean isReminderEvent, boolean adoptConsensusFlowExecutionId) throws IOException {
+  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagAction dagAction, boolean adoptConsensusFlowExecutionId) throws IOException {
     log.info("Multi-active scheduler about to handle trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
-        dagAction, isReminderEvent ? "reminder" : "original", eventTimeMillis);
+        dagAction, dagAction.isReminder() ? "reminder" : "original", dagAction.getEventTimeMillis());
     // Query lease arbiter table about this dag action
-    Optional<GetEventInfoResult> getResult = getExistingEventInfo(dagAction, isReminderEvent, eventTimeMillis);
+    Optional<GetEventInfoResult> getResult = getExistingEventInfo(dagAction, dagAction.isReminder(),
+        dagAction.getEventTimeMillis());
 
     try {
       if (!getResult.isPresent()) {
         log.debug("tryAcquireLease for [{}, is; {}, eventTimestamp: {}] - CASE 1: no existing row for this dag action,"
-            + " then go ahead and insert", dagAction, isReminderEvent ? "reminder" : "original", eventTimeMillis);
+            + " then go ahead and insert", dagAction, dagAction.isReminder() ? "reminder" : "original",
+            dagAction.getEventTimeMillis());
         int numRowsUpdated = attemptLeaseIfNewRow(dagAction);
        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagAction, Optional.empty(),
-           isReminderEvent, adoptConsensusFlowExecutionId);
+           dagAction.isReminder(), adoptConsensusFlowExecutionId);
       }
 
       // Extract values from result set
@@ -270,30 +271,30 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
 
       // For reminder event, we can stop early if the reminder eventTimeMillis is older than the current event in the db
       // because db laundering tells us that the currently worked on db event is newer and will have its own reminders
-      if (isReminderEvent) {
-        if (eventTimeMillis < dbEventTimestamp.getTime()) {
+      if (dagAction.isReminder()) {
+        if (dagAction.getEventTimeMillis() < dbEventTimestamp.getTime()) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - A new event trigger "
                   + "is being worked on, so this older reminder will be dropped.", dagAction,
-              isReminderEvent ? "reminder" : "original", eventTimeMillis, dbEventTimestamp);
+              dagAction.isReminder ? "reminder" : "original", dagAction.getEventTimeMillis(), dbEventTimestamp);
           return new LeaseAttemptStatus.NoLongerLeasingStatus();
         }
-        if (eventTimeMillis > dbEventTimestamp.getTime()) {
+        if (dagAction.getEventTimeMillis() > dbEventTimestamp.getTime()) {
           // TODO: emit metric here to capture this unexpected behavior
           log.warn("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Severe constraint "
                   + "violation encountered: a reminder event newer than db event was found when db laundering should "
                   + "ensure monotonically increasing laundered event times.", dagAction,
-              isReminderEvent ? "reminder" : "original", eventTimeMillis, dbEventTimestamp.getTime());
+              dagAction.isReminder ? "reminder" : "original", dagAction.getEventTimeMillis(), dbEventTimestamp.getTime());
         }
-        if (eventTimeMillis == dbEventTimestamp.getTime()) {
+        if (dagAction.getEventTimeMillis() == dbEventTimestamp.getTime()) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Reminder event time "
-                  + "is the same as db event.", dagAction, isReminderEvent ? "reminder" : "original",
-              eventTimeMillis, dbEventTimestamp);
+                  + "is the same as db event.", dagAction, dagAction.isReminder ? "reminder" : "original",
+              dagAction.getEventTimeMillis(), dbEventTimestamp);
         }
       }
 
       log.info("Multi-active arbiter replacing local trigger event timestamp [{}, is: {}, triggerEventTimestamp: {}] "
-          + "with database eventTimestamp {} (in epoch-millis)", dagAction, isReminderEvent ? "reminder" : "original",
-          eventTimeMillis, dbCurrentTimestamp.getTime());
+          + "with database eventTimestamp {} (in epoch-millis)", dagAction, dagAction.isReminder ? "reminder" : "original",
+          dagAction.getEventTimeMillis(), dbCurrentTimestamp.getTime());
 
       /* Note that we use `adoptConsensusFlowExecutionId` parameter's value to determine whether we should use the db
       laundered event timestamp as the flowExecutionId or maintain the original one
@@ -305,24 +306,26 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
           DagActionStore.DagAction updatedDagAction =
               adoptConsensusFlowExecutionId ? dagAction.updateFlowExecutionId(dbEventTimestamp.getTime()) : dagAction;
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 2: Same event, lease is valid",
-              updatedDagAction, isReminderEvent ? "reminder" : "original", dbCurrentTimestamp.getTime());
+              updatedDagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
           // Utilize db timestamp for reminder
-          return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction, dbEventTimestamp.getTime(),
+          dagAction.setEventTimeMillis(dbEventTimestamp.getTime());
+          return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction,
               dbLeaseAcquisitionTimestamp.getTime() + dbLinger - dbCurrentTimestamp.getTime());
         }
         DagActionStore.DagAction updatedDagAction =
             adoptConsensusFlowExecutionId ? dagAction.updateFlowExecutionId(dbCurrentTimestamp.getTime()) : dagAction;
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 3: Distinct event, lease is valid",
-            updatedDagAction, isReminderEvent ? "reminder" : "original", dbCurrentTimestamp.getTime());
+            updatedDagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
         // Utilize db lease acquisition timestamp for wait time
-        return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction, dbCurrentTimestamp.getTime(),
+        dagAction.setEventTimeMillis(dbCurrentTimestamp.getTime());
+        return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction,
             dbLeaseAcquisitionTimestamp.getTime() + dbLinger  - dbCurrentTimestamp.getTime());
       } // Lease is invalid
       else if (leaseValidityStatus == 2) {
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 4: Lease is out of date (regardless of "
-            + "whether same or distinct event)", dagAction, isReminderEvent ? "reminder" : "original",
+            + "whether same or distinct event)", dagAction, dagAction.isReminder ? "reminder" : "original",
             dbCurrentTimestamp.getTime());
-        if (isWithinEpsilon && !isReminderEvent) {
+        if (isWithinEpsilon && !dagAction.isReminder) {
           log.warn("Lease should not be out of date for the same trigger event since epsilon << linger for dagAction"
                   + " {}, db eventTimestamp {}, db leaseAcquisitionTimestamp {}, linger {}", dagAction,
               dbEventTimestamp, dbLeaseAcquisitionTimestamp, dbLinger);
@@ -331,20 +334,20 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfMatchingAllStatement, dagAction,
             true,true, dbEventTimestamp, dbLeaseAcquisitionTimestamp);
         return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagAction, Optional.of(dbCurrentTimestamp),
-            isReminderEvent, adoptConsensusFlowExecutionId);
+            dagAction.isReminder, adoptConsensusFlowExecutionId);
       } // No longer leasing this event
         if (isWithinEpsilon) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 5: Same event, no longer leasing event"
-              + " in db", dagAction, isReminderEvent ? "reminder" : "original", dbCurrentTimestamp.getTime());
+              + " in db", dagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
           return new LeaseAttemptStatus.NoLongerLeasingStatus();
         }
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 6: Distinct event, no longer leasing "
-            + "event in db", dagAction, isReminderEvent ? "reminder" : "original", dbCurrentTimestamp.getTime());
+            + "event in db", dagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
         // Use our event to acquire lease, check for previous db eventTimestamp and NULL leaseAcquisitionTimestamp
         int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfFinishedStatement, dagAction,
             true, false, dbEventTimestamp, null);
         return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagAction, Optional.of(dbCurrentTimestamp),
-            isReminderEvent, adoptConsensusFlowExecutionId);
+            dagAction.isReminder, adoptConsensusFlowExecutionId);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -355,6 +358,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
    */
   protected Optional<GetEventInfoResult> getExistingEventInfo(DagActionStore.DagAction dagAction,
       boolean isReminderEvent, long eventTimeMillis) throws IOException {
+    // TODO: remove isReminderEvent and event time property from here and just get from the dagAction
     return dbStatementExecutor.withPreparedStatement(isReminderEvent ? thisTableGetInfoStatementForReminder : thisTableGetInfoStatement,
         getInfoStatement -> {
           int i = 0;
@@ -507,6 +511,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     }
     DagActionStore.DagAction updatedDagAction =
         adoptConsensusFlowExecutionId ? dagAction.updateFlowExecutionId(selectInfoResult.eventTimeMillis) : dagAction;
+    updatedDagAction.setEventTimeMillis(selectInfoResult.getEventTimeMillis());
     // If no db current timestamp is present, then use the full db linger value for duration
     long minimumLingerDurationMillis = dbCurrentTimestamp.isPresent() ?
         selectInfoResult.getLeaseAcquisitionTimeMillis().get() + selectInfoResult.getDbLinger()
@@ -514,14 +519,13 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     if (numRowsUpdated == 1) {
       log.info("Obtained lease for [{}, is: {}, eventTimestamp: {}] successfully!", updatedDagAction,
           isReminderEvent ? "reminder" : "original", selectInfoResult.eventTimeMillis);
-      return new LeaseAttemptStatus.LeaseObtainedStatus(updatedDagAction, selectInfoResult.eventTimeMillis,
+      return new LeaseAttemptStatus.LeaseObtainedStatus(updatedDagAction,
           selectInfoResult.getLeaseAcquisitionTimeMillis().get(), minimumLingerDurationMillis, this);
     }
     log.info("Another participant acquired lease in between for [{}, is: {}, eventTimestamp: {}] - num rows updated: {}",
         updatedDagAction, isReminderEvent ? "reminder" : "original", selectInfoResult.eventTimeMillis, numRowsUpdated);
     // Another participant acquired lease in between
-    return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction, selectInfoResult.eventTimeMillis,
-        minimumLingerDurationMillis);
+    return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction, minimumLingerDurationMillis);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -243,20 +243,20 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   }
 
   @Override
-  public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseObject leaseObject, boolean adoptConsensusFlowExecutionId) throws IOException {
+  public LeaseAttemptStatus tryAcquireLease(DagActionStore.DagActionLeaseObject dagActionLeaseObject, boolean adoptConsensusFlowExecutionId) throws IOException {
     log.info("Multi-active scheduler about to handle trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
-       leaseObject.getDagAction(), leaseObject.isReminder() ? "reminder" : "original", leaseObject.getEventTimeMillis());
+       dagActionLeaseObject.getDagAction(), dagActionLeaseObject.isReminder() ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis());
     // Query lease arbiter table about this dag action
-    Optional<GetEventInfoResult> getResult = getExistingEventInfo(leaseObject);
+    Optional<GetEventInfoResult> getResult = getExistingEventInfo(dagActionLeaseObject);
 
     try {
       if (!getResult.isPresent()) {
         log.debug("tryAcquireLease for [{}, is; {}, eventTimestamp: {}] - CASE 1: no existing row for this dag action,"
-            + " then go ahead and insert", leaseObject.getDagAction(), leaseObject.isReminder() ? "reminder" : "original",
-           leaseObject.getEventTimeMillis());
-        int numRowsUpdated = attemptLeaseIfNewRow(leaseObject.getDagAction());
-       return evaluateStatusAfterLeaseAttempt(numRowsUpdated, leaseObject.getDagAction(), Optional.empty(),
-          leaseObject.isReminder(), adoptConsensusFlowExecutionId);
+            + " then go ahead and insert", dagActionLeaseObject.getDagAction(),
+            dagActionLeaseObject.isReminder() ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis());
+        int numRowsUpdated = attemptLeaseIfNewRow(dagActionLeaseObject.getDagAction());
+       return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagActionLeaseObject.getDagAction(),
+           Optional.empty(), dagActionLeaseObject.isReminder(), adoptConsensusFlowExecutionId);
       }
 
       // Extract values from result set
@@ -270,30 +270,34 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
 
       // For reminder event, we can stop early if the reminder eventTimeMillis is older than the current event in the db
       // because db laundering tells us that the currently worked on db event is newer and will have its own reminders
-      if (leaseObject.isReminder()) {
-        if (leaseObject.getEventTimeMillis() < dbEventTimestamp.getTime()) {
+      if (dagActionLeaseObject.isReminder()) {
+        if (dagActionLeaseObject.getEventTimeMillis() < dbEventTimestamp.getTime()) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - A new event trigger "
-                  + "is being worked on, so this older reminder will be dropped.", leaseObject.getDagAction(),
-             leaseObject.isReminder ? "reminder" : "original", leaseObject.getEventTimeMillis(), dbEventTimestamp);
+                  + "is being worked on, so this older reminder will be dropped.", dagActionLeaseObject.getDagAction(),
+             dagActionLeaseObject.isReminder ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis(),
+              dbEventTimestamp);
           return new LeaseAttemptStatus.NoLongerLeasingStatus();
         }
-        if (leaseObject.getEventTimeMillis() > dbEventTimestamp.getTime()) {
+        if (dagActionLeaseObject.getEventTimeMillis() > dbEventTimestamp.getTime()) {
           // TODO: emit metric here to capture this unexpected behavior
           log.warn("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Severe constraint "
                   + "violation encountered: a reminder event newer than db event was found when db laundering should "
-                  + "ensure monotonically increasing laundered event times.", leaseObject.getDagAction(),
-             leaseObject.isReminder ? "reminder" : "original", leaseObject.getEventTimeMillis(), dbEventTimestamp.getTime());
+                  + "ensure monotonically increasing laundered event times.", dagActionLeaseObject.getDagAction(),
+             dagActionLeaseObject.isReminder ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis(),
+              dbEventTimestamp.getTime());
         }
-        if (leaseObject.getEventTimeMillis() == dbEventTimestamp.getTime()) {
+        if (dagActionLeaseObject.getEventTimeMillis() == dbEventTimestamp.getTime()) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - dbEventTimeMillis: {} - Reminder event time "
-                  + "is the same as db event.", leaseObject.getDagAction(), leaseObject.isReminder ? "reminder" : "original",
-             leaseObject.getEventTimeMillis(), dbEventTimestamp);
+                  + "is the same as db event.", dagActionLeaseObject.getDagAction(),
+              dagActionLeaseObject.isReminder ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis(),
+              dbEventTimestamp);
         }
       }
 
       log.info("Multi-active arbiter replacing local trigger event timestamp [{}, is: {}, triggerEventTimestamp: {}] "
-          + "with database eventTimestamp {} (in epoch-millis)", leaseObject.getDagAction(), leaseObject.isReminder ? "reminder" : "original",
-         leaseObject.getEventTimeMillis(), dbCurrentTimestamp.getTime());
+          + "with database eventTimestamp {} (in epoch-millis)", dagActionLeaseObject.getDagAction(),
+          dagActionLeaseObject.isReminder ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis(),
+          dbCurrentTimestamp.getTime());
 
       /* Note that we use `adoptConsensusFlowExecutionId` parameter's value to determine whether we should use the db
       laundered event timestamp as the flowExecutionId or maintain the original one
@@ -303,50 +307,54 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
       if (leaseValidityStatus == 1) {
         if (isWithinEpsilon) {
          DagActionStore.DagAction updatedDagAction =
-              adoptConsensusFlowExecutionId ? leaseObject.getDagAction().updateFlowExecutionId(dbEventTimestamp.getTime()) : leaseObject.getDagAction();
+              adoptConsensusFlowExecutionId ? dagActionLeaseObject.getDagAction().updateFlowExecutionId(dbEventTimestamp.getTime()) : dagActionLeaseObject.getDagAction();
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 2: Same event, lease is valid",
-              updatedDagAction, leaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
+              updatedDagAction, dagActionLeaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
           // Utilize db timestamp for reminder
           return new LeaseAttemptStatus.LeasedToAnotherStatus(
-              new DagActionStore.LeaseObject(updatedDagAction, dbEventTimestamp.getTime()),
+              new DagActionStore.DagActionLeaseObject(updatedDagAction, dbEventTimestamp.getTime()),
               dbLeaseAcquisitionTimestamp.getTime() + dbLinger - dbCurrentTimestamp.getTime());
         }
         DagActionStore.DagAction updatedDagAction =
-            adoptConsensusFlowExecutionId ? leaseObject.getDagAction().updateFlowExecutionId(dbCurrentTimestamp.getTime()) : leaseObject.getDagAction();
+            adoptConsensusFlowExecutionId ? dagActionLeaseObject.getDagAction().updateFlowExecutionId(dbCurrentTimestamp.getTime()) : dagActionLeaseObject.getDagAction();
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 3: Distinct event, lease is valid",
-            updatedDagAction, leaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
+            updatedDagAction, dagActionLeaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
         // Utilize db lease acquisition timestamp for wait time and currentTimestamp as the new eventTimestamp
         return new LeaseAttemptStatus.LeasedToAnotherStatus(
-            new DagActionStore.LeaseObject(updatedDagAction, dbCurrentTimestamp.getTime()),
+            new DagActionStore.DagActionLeaseObject(updatedDagAction, dbCurrentTimestamp.getTime()),
             dbLeaseAcquisitionTimestamp.getTime() + dbLinger  - dbCurrentTimestamp.getTime());
       } // Lease is invalid
       else if (leaseValidityStatus == 2) {
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 4: Lease is out of date (regardless of "
-            + "whether same or distinct event)", leaseObject.getDagAction(),
-            leaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
-        if (isWithinEpsilon && !leaseObject.isReminder) {
+            + "whether same or distinct event)", dagActionLeaseObject.getDagAction(),
+            dagActionLeaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
+        if (isWithinEpsilon && !dagActionLeaseObject.isReminder) {
           log.warn("Lease should not be out of date for the same trigger event since epsilon << linger for "
                   + "leaseObject.getDagAction() {}, db eventTimestamp {}, db leaseAcquisitionTimestamp {}, linger {}",
-              leaseObject.getDagAction(), dbEventTimestamp, dbLeaseAcquisitionTimestamp, dbLinger);
+              dagActionLeaseObject.getDagAction(), dbEventTimestamp, dbLeaseAcquisitionTimestamp, dbLinger);
         }
         // Use our event to acquire lease, check for previous db eventTimestamp and leaseAcquisitionTimestamp
-        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfMatchingAllStatement, leaseObject.getDagAction(),
-            true,true, dbEventTimestamp, dbLeaseAcquisitionTimestamp);
-        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, leaseObject.getDagAction(), Optional.of(dbCurrentTimestamp),
-           leaseObject.isReminder, adoptConsensusFlowExecutionId);
+        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfMatchingAllStatement,
+            dagActionLeaseObject.getDagAction(), true,true, dbEventTimestamp,
+            dbLeaseAcquisitionTimestamp);
+        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagActionLeaseObject.getDagAction(),
+            Optional.of(dbCurrentTimestamp), dagActionLeaseObject.isReminder, adoptConsensusFlowExecutionId);
       } // No longer leasing this event
         if (isWithinEpsilon) {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 5: Same event, no longer leasing event"
-              + " in db", leaseObject.getDagAction(), leaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
+              + " in db", dagActionLeaseObject.getDagAction(),
+              dagActionLeaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
           return new LeaseAttemptStatus.NoLongerLeasingStatus();
         }
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 6: Distinct event, no longer leasing "
-            + "event in db", leaseObject.getDagAction(), leaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
+            + "event in db", dagActionLeaseObject.getDagAction(),
+            dagActionLeaseObject.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
         // Use our event to acquire lease, check for previous db eventTimestamp and NULL leaseAcquisitionTimestamp
-        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfFinishedStatement, leaseObject.getDagAction(),
-            true, false, dbEventTimestamp, null);
-        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, leaseObject.getDagAction(), Optional.of(dbCurrentTimestamp),
-           leaseObject.isReminder, adoptConsensusFlowExecutionId);
+        int numRowsUpdated = attemptLeaseIfExistingRow(thisTableAcquireLeaseIfFinishedStatement,
+            dagActionLeaseObject.getDagAction(), true, false, dbEventTimestamp,
+            null);
+        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagActionLeaseObject.getDagAction(),
+            Optional.of(dbCurrentTimestamp), dagActionLeaseObject.isReminder, adoptConsensusFlowExecutionId);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -355,17 +363,19 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   /**
    * Checks leaseArbiterTable for an existing entry for this dag action and event time
    */
-  protected Optional<GetEventInfoResult> getExistingEventInfo(DagActionStore.LeaseObject leaseObject) throws IOException {
-    return dbStatementExecutor.withPreparedStatement(leaseObject.isReminder ? thisTableGetInfoStatementForReminder : thisTableGetInfoStatement,
+  protected Optional<GetEventInfoResult> getExistingEventInfo(DagActionStore.DagActionLeaseObject dagActionLeaseObject)
+      throws IOException {
+    return dbStatementExecutor.withPreparedStatement(
+        dagActionLeaseObject.isReminder ? thisTableGetInfoStatementForReminder : thisTableGetInfoStatement,
         getInfoStatement -> {
           int i = 0;
-          if (leaseObject.isReminder) {
-            getInfoStatement.setTimestamp(++i, new Timestamp(leaseObject.getEventTimeMillis()), UTC_CAL.get());
+          if (dagActionLeaseObject.isReminder) {
+            getInfoStatement.setTimestamp(++i, new Timestamp(dagActionLeaseObject.getEventTimeMillis()), UTC_CAL.get());
           }
-          getInfoStatement.setString(++i, leaseObject.getDagAction().getFlowGroup());
-          getInfoStatement.setString(++i, leaseObject.getDagAction().getFlowName());
-          getInfoStatement.setString(++i, leaseObject.getDagAction().getJobName());
-          getInfoStatement.setString(++i, leaseObject.getDagAction().getDagActionType().toString());
+          getInfoStatement.setString(++i, dagActionLeaseObject.getDagAction().getFlowGroup());
+          getInfoStatement.setString(++i, dagActionLeaseObject.getDagAction().getFlowName());
+          getInfoStatement.setString(++i, dagActionLeaseObject.getDagAction().getJobName());
+          getInfoStatement.setString(++i, dagActionLeaseObject.getDagAction().getDagActionType().toString());
           ResultSet resultSet = getInfoStatement.executeQuery();
           try {
             if (!resultSet.next()) {
@@ -384,7 +394,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     try {
       // Extract values from result set
       Timestamp dbEventTimestamp = resultSet.getTimestamp("utc_event_timestamp", UTC_CAL.get());
-      Timestamp dbLeaseAcquisitionTimestamp = resultSet.getTimestamp("utc_lease_acquisition_timestamp", UTC_CAL.get());
+      Timestamp dbLeaseAcquisitionTimestamp = resultSet.getTimestamp("utc_lease_acquisition_timestamp",
+          UTC_CAL.get());
       boolean withinEpsilon = resultSet.getBoolean("is_within_epsilon");
       int leaseValidityStatus = resultSet.getInt("lease_validity_status");
       int dbLinger = resultSet.getInt("linger");
@@ -508,8 +519,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     }
    DagActionStore.DagAction updatedDagAction =
         adoptConsensusFlowExecutionId ? dagAction.updateFlowExecutionId(selectInfoResult.eventTimeMillis) : dagAction;
-    DagActionStore.LeaseObject consensusLeaseObject = new DagActionStore.LeaseObject(updatedDagAction,
-        selectInfoResult.getEventTimeMillis());
+    DagActionStore.DagActionLeaseObject consensusDagActionLeaseObject =
+        new DagActionStore.DagActionLeaseObject(updatedDagAction, selectInfoResult.getEventTimeMillis());
     // If no db current timestamp is present, then use the full db linger value for duration
     long minimumLingerDurationMillis = dbCurrentTimestamp.isPresent() ?
         selectInfoResult.getLeaseAcquisitionTimeMillis().get() + selectInfoResult.getDbLinger()
@@ -517,13 +528,13 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     if (numRowsUpdated == 1) {
       log.info("Obtained lease for [{}, is: {}, eventTimestamp: {}] successfully!", updatedDagAction,
           isReminderEvent ? "reminder" : "original", selectInfoResult.eventTimeMillis);
-      return new LeaseAttemptStatus.LeaseObtainedStatus(consensusLeaseObject,
+      return new LeaseAttemptStatus.LeaseObtainedStatus(consensusDagActionLeaseObject,
           selectInfoResult.getLeaseAcquisitionTimeMillis().get(), minimumLingerDurationMillis, this);
     }
     log.info("Another participant acquired lease in between for [{}, is: {}, eventTimestamp: {}] - num rows updated: {}",
         updatedDagAction, isReminderEvent ? "reminder" : "original", selectInfoResult.eventTimeMillis, numRowsUpdated);
     // Another participant acquired lease in between
-    return new LeaseAttemptStatus.LeasedToAnotherStatus(consensusLeaseObject, minimumLingerDurationMillis);
+    return new LeaseAttemptStatus.LeasedToAnotherStatus(consensusDagActionLeaseObject, minimumLingerDurationMillis);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -39,7 +39,6 @@ import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.MysqlDataSourceFactory;
 import org.apache.gobblin.service.ServiceConfigKeys;
-import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.DBStatementExecutor;
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -308,7 +308,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
           log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 2: Same event, lease is valid",
               updatedDagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
           // Utilize db timestamp for reminder
-          dagAction.setEventTimeMillis(dbEventTimestamp.getTime());
+          updatedDagAction.setEventTimeMillis(dbEventTimestamp.getTime());
           return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction,
               dbLeaseAcquisitionTimestamp.getTime() + dbLinger - dbCurrentTimestamp.getTime());
         }
@@ -317,7 +317,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         log.debug("tryAcquireLease for [{}, is: {}, eventTimestamp: {}] - CASE 3: Distinct event, lease is valid",
             updatedDagAction, dagAction.isReminder ? "reminder" : "original", dbCurrentTimestamp.getTime());
         // Utilize db lease acquisition timestamp for wait time
-        dagAction.setEventTimeMillis(dbCurrentTimestamp.getTime());
+        updatedDagAction.setEventTimeMillis(dbCurrentTimestamp.getTime());
         return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedDagAction,
             dbLeaseAcquisitionTimestamp.getTime() + dbLinger  - dbCurrentTimestamp.getTime());
       } // Lease is invalid

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -219,7 +219,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
         DagActionStore.DagAction launchDagAction = DagActionStore.DagAction.forFlow(
             flowGroup,
             flowName,
-            String.valueOf(FlowUtils.getOrCreateFlowExecutionId(flowSpec)),
+            FlowUtils.getOrCreateFlowExecutionId(flowSpec),
             DagActionStore.DagActionType.LAUNCH);
         DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(launchDagAction, isReminderEvent,
             triggerTimestampMillis);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -220,12 +220,11 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
             flowGroup,
             flowName,
             String.valueOf(FlowUtils.getOrCreateFlowExecutionId(flowSpec)),
-            DagActionStore.DagActionType.LAUNCH,
-            isReminderEvent,
+            DagActionStore.DagActionType.LAUNCH);
+        DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(launchDagAction, isReminderEvent,
             triggerTimestampMillis);
-
         // `flowSpec.isScheduled()` ==> adopt consensus `flowExecutionId` as clock drift safeguard, yet w/o disrupting API-layer's ad hoc ID assignment
-        flowLaunchHandler.get().handleFlowLaunchTriggerEvent(jobProps, launchDagAction, flowSpec.isScheduled());
+        flowLaunchHandler.get().handleFlowLaunchTriggerEvent(jobProps, leaseObject, flowSpec.isScheduled());
         _log.info("Multi-active scheduler finished handling trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
             launchDagAction, isReminderEvent ? "reminder" : "original", triggerTimestampMillis);
       } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -221,7 +221,8 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
             flowName,
             FlowUtils.getOrCreateFlowExecutionId(flowSpec),
             DagActionStore.DagActionType.LAUNCH);
-        DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(launchDagAction, isReminderEvent,
+        DagActionStore.DagActionLeaseObject
+            leaseObject = new DagActionStore.DagActionLeaseObject(launchDagAction, isReminderEvent,
             triggerTimestampMillis);
         // `flowSpec.isScheduled()` ==> adopt consensus `flowExecutionId` as clock drift safeguard, yet w/o disrupting API-layer's ad hoc ID assignment
         flowLaunchHandler.get().handleFlowLaunchTriggerEvent(jobProps, leaseObject, flowSpec.isScheduled());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -220,12 +220,12 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
             flowGroup,
             flowName,
             String.valueOf(FlowUtils.getOrCreateFlowExecutionId(flowSpec)),
-            DagActionStore.DagActionType.LAUNCH
-        );
+            DagActionStore.DagActionType.LAUNCH,
+            isReminderEvent,
+            triggerTimestampMillis);
 
         // `flowSpec.isScheduled()` ==> adopt consensus `flowExecutionId` as clock drift safeguard, yet w/o disrupting API-layer's ad hoc ID assignment
-        flowLaunchHandler.get().handleFlowLaunchTriggerEvent(jobProps, launchDagAction, triggerTimestampMillis, isReminderEvent,
-            flowSpec.isScheduled());
+        flowLaunchHandler.get().handleFlowLaunchTriggerEvent(jobProps, launchDagAction, flowSpec.isScheduled());
         _log.info("Multi-active scheduler finished handling trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
             launchDagAction, isReminderEvent ? "reminder" : "original", triggerTimestampMillis);
       } else {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
@@ -60,7 +60,8 @@ public class DagActionReminderSchedulerTest {
 
   @Test
   public void testCreateReminderJobDetail() {
-    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(launchDagAction);
+    long expectedEventTimeMillis = 55L;
+    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(new DagActionStore.LeaseObject(launchDagAction, false, expectedEventTimeMillis));
     Assert.assertEquals(jobDetail.getKey().toString(), flowGroup + "." + expectedKey);
     JobDataMap dataMap = jobDetail.getJobDataMap();
     Assert.assertEquals(dataMap.get(ConfigurationKeys.FLOW_GROUP_KEY), flowGroup);
@@ -69,5 +70,6 @@ public class DagActionReminderSchedulerTest {
     Assert.assertEquals(dataMap.get(ConfigurationKeys.JOB_NAME_KEY), jobName);
     Assert.assertEquals(dataMap.get(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_TYPE_KEY),
         DagActionStore.DagActionType.LAUNCH);
+    Assert.assertEquals(dataMap.get(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_EVENT_TIME_KEY), expectedEventTimeMillis);
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
@@ -63,7 +63,7 @@ public class DagActionReminderSchedulerTest {
   @Test
   public void testCreateReminderJobDetail() {
     long expectedEventTimeMillis = 55L;
-    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(new DagActionStore.LeaseObject(launchDagAction, false, expectedEventTimeMillis));
+    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(new DagActionStore.DagActionLeaseObject(launchDagAction, false, expectedEventTimeMillis));
     Assert.assertEquals(jobDetail.getKey().toString(), flowGroup + "." + expectedKey);
     JobDataMap dataMap = jobDetail.getJobDataMap();
     Assert.assertEquals(dataMap.get(ConfigurationKeys.FLOW_GROUP_KEY), flowGroup);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
@@ -107,10 +107,10 @@ public class DagManagementTaskStreamImplTest {
     dagManagementTaskStream.addDagAction(launchAction);
     dagManagementTaskStream.addDagAction(launchAction);
     when(dagManagementTaskStream.getDagActionProcessingLeaseArbiter()
-        .tryAcquireLease(any(DagActionStore.DagAction.class), anyBoolean()))
+        .tryAcquireLease(any(DagActionStore.LeaseObject.class), anyBoolean()))
         .thenReturn(new LeaseAttemptStatus.NoLongerLeasingStatus(),
-            new LeaseAttemptStatus.LeasedToAnotherStatus(launchAction, 15),
-            new LeaseAttemptStatus.LeaseObtainedStatus(launchAction, 0, 5, null));
+            new LeaseAttemptStatus.LeasedToAnotherStatus(new DagActionStore.LeaseObject(launchAction, true, 1), 15),
+            new LeaseAttemptStatus.LeaseObtainedStatus(new DagActionStore.LeaseObject(launchAction, true, 1), 0, 5, null));
     DagTask dagTask = dagManagementTaskStream.next();
     Assert.assertTrue(dagTask instanceof LaunchDagTask);
     DagProc dagProc = dagTask.host(this.dagProcFactory);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
@@ -108,10 +108,10 @@ public class DagManagementTaskStreamImplTest {
     dagManagementTaskStream.addDagAction(launchAction);
     dagManagementTaskStream.addDagAction(launchAction);
     when(dagManagementTaskStream.getDagActionProcessingLeaseArbiter()
-        .tryAcquireLease(any(DagActionStore.LeaseObject.class), anyBoolean()))
+        .tryAcquireLease(any(DagActionStore.DagActionLeaseObject.class), anyBoolean()))
         .thenReturn(new LeaseAttemptStatus.NoLongerLeasingStatus(),
-            new LeaseAttemptStatus.LeasedToAnotherStatus(new DagActionStore.LeaseObject(launchAction, true, 1), 15),
-            new LeaseAttemptStatus.LeaseObtainedStatus(new DagActionStore.LeaseObject(launchAction, true, 1), 0, 5, null));
+            new LeaseAttemptStatus.LeasedToAnotherStatus(new DagActionStore.DagActionLeaseObject(launchAction, true, 1), 15),
+            new LeaseAttemptStatus.LeaseObtainedStatus(new DagActionStore.DagActionLeaseObject(launchAction, true, 1), 0, 5, null));
     DagTask dagTask = dagManagementTaskStream.next();
     Assert.assertTrue(dagTask instanceof LaunchDagTask);
     DagProc dagProc = dagTask.host(this.dagProcFactory);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
@@ -109,8 +109,8 @@ public class DagManagementTaskStreamImplTest {
     when(dagManagementTaskStream.getDagActionProcessingLeaseArbiter()
         .tryAcquireLease(any(DagActionStore.DagAction.class), anyBoolean()))
         .thenReturn(new LeaseAttemptStatus.NoLongerLeasingStatus(),
-            new LeaseAttemptStatus.LeasedToAnotherStatus(launchAction, 3, 15),
-            new LeaseAttemptStatus.LeaseObtainedStatus(launchAction, 5, 0, 5, null));
+            new LeaseAttemptStatus.LeasedToAnotherStatus(launchAction, 15),
+            new LeaseAttemptStatus.LeaseObtainedStatus(launchAction, 0, 5, null));
     DagTask dagTask = dagManagementTaskStream.next();
     Assert.assertTrue(dagTask instanceof LaunchDagTask);
     DagProc dagProc = dagTask.host(this.dagProcFactory);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
@@ -41,7 +41,6 @@ import org.apache.gobblin.service.modules.orchestration.task.LaunchDagTask;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -108,7 +107,7 @@ public class DagManagementTaskStreamImplTest {
     dagManagementTaskStream.addDagAction(launchAction);
     dagManagementTaskStream.addDagAction(launchAction);
     when(dagManagementTaskStream.getDagActionProcessingLeaseArbiter()
-        .tryAcquireLease(any(DagActionStore.DagAction.class), anyLong(), anyBoolean(), anyBoolean()))
+        .tryAcquireLease(any(DagActionStore.DagAction.class), anyBoolean()))
         .thenReturn(new LeaseAttemptStatus.NoLongerLeasingStatus(),
             new LeaseAttemptStatus.LeasedToAnotherStatus(launchAction, 3, 15),
             new LeaseAttemptStatus.LeaseObtainedStatus(launchAction, 5, 0, 5, null));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -35,7 +35,7 @@ public class FlowLaunchHandlerTest {
   String cronExpressionSuffix = truncateFirstTwoFieldsOfCronExpression(cronExpression);
   int schedulerBackOffMillis = 10;
   DagActionStore.DagAction dagAction = new DagActionStore.DagAction("flowName", "flowGroup",
-      String.valueOf(flowExecutionId), "jobName", DagActionStore.DagActionType.LAUNCH);
+      flowExecutionId, "jobName", DagActionStore.DagActionType.LAUNCH);
   DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(dagAction, false, eventToRevisit);
   LeaseAttemptStatus.LeasedToAnotherStatus leasedToAnotherStatus =
       new LeaseAttemptStatus.LeasedToAnotherStatus(leaseObject, minimumLingerDurationMillis);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -36,7 +36,8 @@ public class FlowLaunchHandlerTest {
   int schedulerBackOffMillis = 10;
   DagActionStore.DagAction dagAction = new DagActionStore.DagAction("flowName", "flowGroup",
       flowExecutionId, "jobName", DagActionStore.DagActionType.LAUNCH);
-  DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(dagAction, false, eventToRevisit);
+  DagActionStore.DagActionLeaseObject
+      leaseObject = new DagActionStore.DagActionLeaseObject(dagAction, false, eventToRevisit);
   LeaseAttemptStatus.LeasedToAnotherStatus leasedToAnotherStatus =
       new LeaseAttemptStatus.LeasedToAnotherStatus(leaseObject, minimumLingerDurationMillis);
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -35,9 +35,10 @@ public class FlowLaunchHandlerTest {
   String cronExpressionSuffix = truncateFirstTwoFieldsOfCronExpression(cronExpression);
   int schedulerBackOffMillis = 10;
   DagActionStore.DagAction dagAction = new DagActionStore.DagAction("flowName", "flowGroup",
-      String.valueOf(flowExecutionId), "jobName", DagActionStore.DagActionType.LAUNCH, eventToRevisit);
+      String.valueOf(flowExecutionId), "jobName", DagActionStore.DagActionType.LAUNCH);
+  DagActionStore.LeaseObject leaseObject = new DagActionStore.LeaseObject(dagAction, false, eventToRevisit);
   LeaseAttemptStatus.LeasedToAnotherStatus leasedToAnotherStatus =
-      new LeaseAttemptStatus.LeasedToAnotherStatus(dagAction, minimumLingerDurationMillis);
+      new LeaseAttemptStatus.LeasedToAnotherStatus(leaseObject, minimumLingerDurationMillis);
 
   /**
    * Remove first two fields from cron expression representing seconds and minutes to return truncated cron expression

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -35,9 +35,9 @@ public class FlowLaunchHandlerTest {
   String cronExpressionSuffix = truncateFirstTwoFieldsOfCronExpression(cronExpression);
   int schedulerBackOffMillis = 10;
   DagActionStore.DagAction dagAction = new DagActionStore.DagAction("flowName", "flowGroup",
-      String.valueOf(flowExecutionId), "jobName", DagActionStore.DagActionType.LAUNCH);
+      String.valueOf(flowExecutionId), "jobName", DagActionStore.DagActionType.LAUNCH, eventToRevisit);
   LeaseAttemptStatus.LeasedToAnotherStatus leasedToAnotherStatus =
-      new LeaseAttemptStatus.LeasedToAnotherStatus(dagAction, eventToRevisit, minimumLingerDurationMillis);
+      new LeaseAttemptStatus.LeasedToAnotherStatus(dagAction, minimumLingerDurationMillis);
 
   /**
    * Remove first two fields from cron expression representing seconds and minutes to return truncated cron expression

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -52,7 +52,7 @@ public class MysqlMultiActiveLeaseArbiterTest {
   private static final String flowGroup2 = "testFlowGroup2";
   private static final String flowName = "testFlowName";
   private static final String jobName = "testJobName";
-  private static final String flowExecutionId = "12345677";
+  private static final long flowExecutionId = 12345677L;
   private static final long eventTimeMillis = System.currentTimeMillis();
   // Dag actions with the same flow info but different flow action types are considered unique
   private static DagActionStore.DagAction launchDagAction =
@@ -116,8 +116,8 @@ public class MysqlMultiActiveLeaseArbiterTest {
     // Make sure consensusEventTimeMillis is set and it's not 0 or the original event time
     Assert.assertFalse(consensusEventTimeMillis != eventTimeMillis && consensusEventTimeMillis != 0);
     Assert.assertTrue(firstObtainedStatus.getConsensusDagAction().equals(
-        new DagActionStore.DagAction(flowGroup, flowName, String.valueOf(consensusEventTimeMillis),
-            jobName, DagActionStore.DagActionType.LAUNCH)));
+        new DagActionStore.DagAction(flowGroup, flowName, consensusEventTimeMillis, jobName,
+            DagActionStore.DagActionType.LAUNCH)));
     Assert.assertEquals(firstObtainedStatus.getEventTimeMillis(), consensusEventTimeMillis);
     Assert.assertEquals(firstObtainedStatus.getConsensusLeaseObject().isReminder, true);
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -57,13 +57,16 @@ public class MysqlMultiActiveLeaseArbiterTest {
   // Dag actions with the same flow info but different flow action types are considered unique
   private static DagActionStore.DagAction launchDagAction =
       new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.LAUNCH);
-  private static DagActionStore.LeaseObject launchLeaseObject = new DagActionStore.LeaseObject(launchDagAction, false, eventTimeMillis);
+  private static DagActionStore.DagActionLeaseObject
+      launchLeaseObject = new DagActionStore.DagActionLeaseObject(launchDagAction, false, eventTimeMillis);
   private static DagActionStore.DagAction resumeDagAction =
       new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.RESUME);
-  private static DagActionStore.LeaseObject resumeLeaseObject = new DagActionStore.LeaseObject(resumeDagAction, false, eventTimeMillis);
+  private static DagActionStore.DagActionLeaseObject
+      resumeLeaseObject = new DagActionStore.DagActionLeaseObject(resumeDagAction, false, eventTimeMillis);
   private static DagActionStore.DagAction launchDagAction2 =
       new DagActionStore.DagAction(flowGroup2, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.LAUNCH);
-  private static DagActionStore.LeaseObject launchLeaseObject2 = new DagActionStore.LeaseObject(launchDagAction2, false, eventTimeMillis);
+  private static DagActionStore.DagActionLeaseObject
+      launchLeaseObject2 = new DagActionStore.DagActionLeaseObject(launchDagAction2, false, eventTimeMillis);
   private static final Timestamp dummyTimestamp = new Timestamp(99999);
   private ITestMetastoreDatabase testDb;
   private MysqlMultiActiveLeaseArbiter mysqlMultiActiveLeaseArbiter;
@@ -119,14 +122,14 @@ public class MysqlMultiActiveLeaseArbiterTest {
         new DagActionStore.DagAction(flowGroup, flowName, consensusEventTimeMillis, jobName,
             DagActionStore.DagActionType.LAUNCH)));
     Assert.assertEquals(firstObtainedStatus.getEventTimeMillis(), consensusEventTimeMillis);
-    Assert.assertEquals(firstObtainedStatus.getConsensusLeaseObject().isReminder, true);
+    Assert.assertEquals(firstObtainedStatus.getConsensusDagActionLeaseObject().isReminder, true);
 
     // Verify that different DagAction types for the same flow can have leases at the same time
     DagActionStore.DagAction killDagAction = new
         DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.KILL);
     LeaseAttemptStatus killStatus =
         mysqlMultiActiveLeaseArbiter.tryAcquireLease(
-            new DagActionStore.LeaseObject(killDagAction, false, eventTimeMillis), true);
+            new DagActionStore.DagActionLeaseObject(killDagAction, false, eventTimeMillis), true);
     Assert.assertTrue(killStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus);
     LeaseAttemptStatus.LeaseObtainedStatus killObtainedStatus =
         (LeaseAttemptStatus.LeaseObtainedStatus) killStatus;
@@ -265,14 +268,14 @@ public class MysqlMultiActiveLeaseArbiterTest {
    */
   @Test
   public void testOlderReminderEventAcquireLease() throws IOException {
-    DagActionStore.LeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
+    DagActionStore.DagActionLeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
     mysqlMultiActiveLeaseArbiter.tryAcquireLease(newLaunchLeaseObject, false);
     // Read database to obtain existing db eventTimeMillis and use it to construct an older event
     MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult =
         mysqlMultiActiveLeaseArbiter.getRowInfo(newLaunchLeaseObject.getDagAction());
     long olderEventTimestamp = selectInfoResult.getEventTimeMillis() - 1;
-    DagActionStore.LeaseObject updatedLeaseObject =
-        new DagActionStore.LeaseObject(newLaunchLeaseObject.getDagAction(), true, olderEventTimestamp);
+    DagActionStore.DagActionLeaseObject updatedLeaseObject =
+        new DagActionStore.DagActionLeaseObject(newLaunchLeaseObject.getDagAction(), true, olderEventTimestamp);
     LeaseAttemptStatus attemptStatus =
         mysqlMultiActiveLeaseArbiter.tryAcquireLease(updatedLeaseObject, true);
     Assert.assertTrue(attemptStatus instanceof LeaseAttemptStatus.NoLongerLeasingStatus);
@@ -285,12 +288,12 @@ public class MysqlMultiActiveLeaseArbiterTest {
    */
   @Test
   public void testReminderEventAcquireLeaseOnValidLease() throws IOException {
-    DagActionStore.LeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
+    DagActionStore.DagActionLeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
     LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus =
         (LeaseAttemptStatus.LeaseObtainedStatus) mysqlMultiActiveLeaseArbiter.tryAcquireLease(newLaunchLeaseObject, false);
     // Use the consensusLeaseObject containing the new eventTimeMillis for the reminder event time
-    DagActionStore.LeaseObject updatedLeaseObject =
-        new DagActionStore.LeaseObject(newLaunchLeaseObject.getDagAction(), true,
+    DagActionStore.DagActionLeaseObject updatedLeaseObject =
+        new DagActionStore.DagActionLeaseObject(newLaunchLeaseObject.getDagAction(), true,
             newLaunchLeaseObject.getEventTimeMillis());
     LeaseAttemptStatus attemptStatus =
         mysqlMultiActiveLeaseArbiter.tryAcquireLease(updatedLeaseObject, true);
@@ -305,7 +308,7 @@ public class MysqlMultiActiveLeaseArbiterTest {
    */
   @Test
   public void testReminderEventAcquireLeaseOnInvalidLease() throws IOException, InterruptedException {
-    DagActionStore.LeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
+    DagActionStore.DagActionLeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
     mysqlMultiActiveLeaseArbiter.tryAcquireLease(newLaunchLeaseObject, false);
     MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult = mysqlMultiActiveLeaseArbiter.getRowInfo(newLaunchLeaseObject.getDagAction());
     // Wait enough time for the lease to expire
@@ -327,7 +330,7 @@ public class MysqlMultiActiveLeaseArbiterTest {
    @Test
    public void testReminderEventAcquireLeaseOnCompletedLease() throws IOException, InterruptedException {
      // Create a new dag action and complete the lease
-     DagActionStore.LeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
+     DagActionStore.DagActionLeaseObject newLaunchLeaseObject = getUniqueLaunchLeaseObject();
      mysqlMultiActiveLeaseArbiter.tryAcquireLease(newLaunchLeaseObject, false);
      MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult = completeLeaseHelper(newLaunchLeaseObject);
 
@@ -336,8 +339,8 @@ public class MysqlMultiActiveLeaseArbiterTest {
      // Now have a reminder event check-in on the completed lease
      DagActionStore.DagAction updatedDagAction = newLaunchLeaseObject.getDagAction().updateFlowExecutionId(
          selectInfoResult.getEventTimeMillis());
-     DagActionStore.LeaseObject updatedLeaseObject =
-         new DagActionStore.LeaseObject(updatedDagAction, true, newLaunchLeaseObject.getEventTimeMillis());
+     DagActionStore.DagActionLeaseObject updatedLeaseObject =
+         new DagActionStore.DagActionLeaseObject(updatedDagAction, true, newLaunchLeaseObject.getEventTimeMillis());
      LeaseAttemptStatus attemptStatus =
          mysqlMultiActiveLeaseArbiter.tryAcquireLease(updatedLeaseObject, true);
      Assert.assertTrue(attemptStatus instanceof LeaseAttemptStatus.NoLongerLeasingStatus);
@@ -361,7 +364,7 @@ public class MysqlMultiActiveLeaseArbiterTest {
     Assert.assertTrue(firstObtainedStatus.getEventTimeMillis() != Long.valueOf(firstObtainedStatus.getConsensusDagAction().getFlowExecutionId()));
     Assert.assertTrue(firstObtainedStatus.getConsensusDagAction().equals(
         new DagActionStore.DagAction(flowGroup2, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.LAUNCH)));
-    Assert.assertEquals(firstObtainedStatus.getConsensusLeaseObject().isReminder(), false);
+    Assert.assertEquals(firstObtainedStatus.getConsensusDagActionLeaseObject().isReminder(), false);
 
     // A second attempt to obtain a lease on the same action should return a LeasedToAnotherStatus which also contains
     // the original flowExecutionId and the same event time from the previous LeaseAttemptStatus
@@ -373,7 +376,7 @@ public class MysqlMultiActiveLeaseArbiterTest {
     Assert.assertEquals(firstObtainedStatus.getEventTimeMillis(), secondLeasedToAnotherStatus.getEventTimeMillis());
     Assert.assertTrue(secondLeasedToAnotherStatus.getConsensusDagAction().equals(
         new DagActionStore.DagAction(flowGroup2, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.LAUNCH)));
-    Assert.assertEquals(firstObtainedStatus.getConsensusLeaseObject().isReminder(), false);
+    Assert.assertEquals(firstObtainedStatus.getConsensusDagActionLeaseObject().isReminder(), false);
 
     Assert.assertTrue(mysqlMultiActiveLeaseArbiter.recordLeaseSuccess(firstObtainedStatus));
   }
@@ -395,20 +398,22 @@ public class MysqlMultiActiveLeaseArbiterTest {
   /**
    * Returns a unique launch type leaseObject using #getUniqueLaunchDagAction() to create a unique flowName
    */
-  public DagActionStore.LeaseObject getUniqueLaunchLeaseObject() {
-    return new DagActionStore.LeaseObject(getUniqueLaunchDagAction(), false, eventTimeMillis);
+  public DagActionStore.DagActionLeaseObject getUniqueLaunchLeaseObject() {
+    return new DagActionStore.DagActionLeaseObject(getUniqueLaunchDagAction(), false, eventTimeMillis);
   }
 
   /**
    * Marks the lease associated with the dagAction as completed by fabricating a LeaseObtainedStatus
    * @return SelectInfoResult object containing the event information used to complete the lease
    */
-  public MysqlMultiActiveLeaseArbiter.SelectInfoResult completeLeaseHelper(DagActionStore.LeaseObject previouslyLeasedLeaseObj) throws IOException {
+  public MysqlMultiActiveLeaseArbiter.SelectInfoResult completeLeaseHelper(
+      DagActionStore.DagActionLeaseObject previouslyLeasedLeaseObj) throws IOException {
     MysqlMultiActiveLeaseArbiter.SelectInfoResult selectInfoResult =
         mysqlMultiActiveLeaseArbiter.getRowInfo(previouslyLeasedLeaseObj.getDagAction());
     DagActionStore.DagAction updatedDagAction = previouslyLeasedLeaseObj.getDagAction().updateFlowExecutionId(
         selectInfoResult.getEventTimeMillis());
-    DagActionStore.LeaseObject updatedLeaseObject = new DagActionStore.LeaseObject(updatedDagAction, false, selectInfoResult.getEventTimeMillis());
+    DagActionStore.DagActionLeaseObject
+        updatedLeaseObject = new DagActionStore.DagActionLeaseObject(updatedDagAction, false, selectInfoResult.getEventTimeMillis());
     boolean markedSuccess = mysqlMultiActiveLeaseArbiter.recordLeaseSuccess(new LeaseAttemptStatus.LeaseObtainedStatus(
         updatedLeaseObject, selectInfoResult.getLeaseAcquisitionTimeMillis().get(), LINGER, null));
     Assert.assertTrue(markedSuccess);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -101,7 +101,6 @@ public class MysqlMultiActiveLeaseArbiterTest {
   // TODO: refactor this to break it into separate test cases as much is possible
   @Test
   public void testAcquireLeaseSingleParticipant() throws Exception {
-    // TODO: need to add eventTimestamp into all the dagActions
     // Tests CASE 1 of acquire lease for a flow action event not present in DB
     LeaseAttemptStatus firstLaunchStatus =
         mysqlMultiActiveLeaseArbiter.tryAcquireLease(launchDagAction, true);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2073

### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
An event timestamp and reminder flag are used in conjunction with `DagActions` for lease arbitration and for reminder `dagActions`. It makes sense to create a new object `LeaseObject` with these fields and the `DagAction` object to easily transfer the information from one location to another. In particular for reminder events used to check back in on incomplete `dagAction` leases, these two fields are utilized and it's easiest to keep track of them when it's maintained within the `consensusDagAction` returned in a `LeaseAttemptStatus`

Besides the refactoring the key piece in doing the bug fix is the following: storing `eventTimestamp` from the first `leaseAttemptStatus` in the `DagActionReminderScheduler` and using that when trying lease on reminder `MALA`. Otherwise it would use current ts as the `eventTimestamp` and treat every reminder as new event and do duplicate processing of `dagAction` once for original once for reminder (see DagActionReminderScheduler::execute and DagActionReminderScheduler::createReminderJobDetail)

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated tests that utilize these two fields

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

