### PR TITLE
[GOBBLIN-2071] Adds execution start timer to temporal

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
@@ -75,6 +75,7 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
   @Override
   public ExecGobblinStats execute(Properties jobProps, EventSubmitterContext eventSubmitterContext) {
     TemporalEventTimer.Factory timerFactory = new TemporalEventTimer.Factory(eventSubmitterContext);
+    timerFactory.create(TimingEvent.LauncherTimings.JOB_PREPARE).submit();
     EventTimer timer = timerFactory.createJobTimer();
     try {
       int numWUsGenerated = genWUsActivityStub.generateWorkUnits(jobProps, eventSubmitterContext);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2071


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Currently, Gobblin-on-MR executions correctly forward their execution start time back to GaaS via the JobPrepareTimer.

The Temporal Gobblin job executions do not emit this event, thus the execution start time is 0 (epoch start). We need to forward this timer and submit it via Temporal.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested E2E on a Temporal pipeline and queried job status via GaaS API

```
{
  "id": {
    "flowGroup": "gaas-CLI",
    "flowExecutionId": 1716593541158,
    "flowName": "hxdMecLKPWrm"
  },
  "message": "",
  "executionStatistics": {
    "executionEndTime": 1716595914707,
    "executionStartTime": 1716593541158
  },
 ```

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

