### PR TITLE
[GOBBLIN-2072] Fix permission issue where child dir gets the incorrect permission se…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -440,6 +440,10 @@ public class CopyableFile extends CopyEntity implements File {
       Path toPath, CopyConfiguration copyConfiguration, Cache<String, OwnerAndPermission> permissionMap)
       throws IOException, ExecutionException {
 
+    if (fromPath == null) {
+      return Lists.newArrayList();
+    }
+
     if (!PathUtils.isAncestor(toPath, fromPath)) {
       throw new IOException(String.format("toPath %s must be an ancestor of fromPath %s.", toPath, fromPath));
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -135,7 +135,7 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
             // Always grab the parent since the above permission setting should be setting the permission for a folder itself
             Path fromPath = fileToCopy.getParent();
             // Avoid duplicate calculation for the same ancestor
-            if (!ancestorOwnerAndPermissions.containsKey(PathUtils.getPathWithoutSchemeAndAuthority(fromPath).toString())) {
+            if (fromPath != null && !ancestorOwnerAndPermissions.containsKey(PathUtils.getPathWithoutSchemeAndAuthority(fromPath).toString())) {
               ancestorOwnerAndPermissions.putAll(
                   CopyableFile.resolveReplicatedAncestorOwnerAndPermissionsRecursively(srcFs, fromPath,
                       new Path(commonFilesParent), configuration));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -132,7 +132,8 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
             copyableFile.setFsDatasets(srcFs, targetFs);
             copyEntities.add(copyableFile);
 
-            Path fromPath = srcFs.getFileStatus(fileToCopy).isDirectory() ? fileToCopy : fileToCopy.getParent();
+            // Always grab the parent since the above permission setting should be setting the permission for a folder itself
+            Path fromPath = fileToCopy.getParent();
             // Avoid duplicate calculation for the same ancestor
             if (!ancestorOwnerAndPermissions.containsKey(PathUtils.getPathWithoutSchemeAndAuthority(fromPath).toString())) {
               ancestorOwnerAndPermissions.putAll(

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -133,6 +133,7 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
             copyEntities.add(copyableFile);
 
             // Always grab the parent since the above permission setting should be setting the permission for a folder itself
+            // {@link CopyDataPublisher#preserveFileAttrInPublisher} will be setting the permission for the empty child dir
             Path fromPath = fileToCopy.getParent();
             // Avoid duplicate calculation for the same ancestor
             if (fromPath != null && !ancestorOwnerAndPermissions.containsKey(PathUtils.getPathWithoutSchemeAndAuthority(fromPath).toString())) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -188,7 +188,7 @@ public class ManifestBasedDatasetFinderTest {
     Assert.assertEquals(datasets.size(), 1);
     FileSystem sourceFs = Mockito.mock(FileSystem.class);
     FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
-    FileSystem destFs = Mockito.mock(FileSystem.class)
+    FileSystem destFs = Mockito.mock(FileSystem.class);
     Path manifestPath = new Path(manifestLocation);
     setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
     Iterator<FileSet<CopyEntity>> fileSets = new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs,

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -186,20 +186,17 @@ public class ManifestBasedDatasetFinderTest {
     ManifestBasedDatasetFinder finder = new ManifestBasedDatasetFinder(localFs, props);
     List<ManifestBasedDataset> datasets = finder.findDatasets();
     Assert.assertEquals(datasets.size(), 1);
-    try (
-        FileSystem sourceFs = Mockito.mock(FileSystem.class);
-        FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
-        FileSystem destFs = Mockito.mock(FileSystem.class)
-    ) {
-      Path manifestPath = new Path(manifestLocation);
-      setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
-      Iterator<FileSet<CopyEntity>> fileSets = new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs,
-          CopyConfiguration.builder(destFs, props).build());
-      Assert.assertTrue(fileSets.hasNext());
-      FileSet<CopyEntity> fileSet = fileSets.next();
-      Assert.assertEquals(fileSet.getFiles().size(), 2);  // 1 files to copy + 1 post publish step
-      Assert.assertTrue(((PostPublishStep) fileSet.getFiles().get(1)).getStep() instanceof SetPermissionCommitStep);
-    }
+    FileSystem sourceFs = Mockito.mock(FileSystem.class);
+    FileSystem manifestReadFs = Mockito.mock(FileSystem.class);
+    FileSystem destFs = Mockito.mock(FileSystem.class)
+    Path manifestPath = new Path(manifestLocation);
+    setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
+    Iterator<FileSet<CopyEntity>> fileSets = new ManifestBasedDataset(sourceFs, manifestReadFs, manifestPath, props).getFileSetIterator(destFs,
+        CopyConfiguration.builder(destFs, props).build());
+    Assert.assertTrue(fileSets.hasNext());
+    FileSet<CopyEntity> fileSet = fileSets.next();
+    Assert.assertEquals(fileSet.getFiles().size(), 2);  // 1 files to copy + 1 post publish step
+    Assert.assertTrue(((PostPublishStep) fileSet.getFiles().get(1)).getStep() instanceof SetPermissionCommitStep);
   }
 
   private void setSourceAndDestFsMocks(FileSystem sourceFs, FileSystem destFs, Path manifestPath, FileSystem manifestReadFs) throws IOException, URISyntaxException {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -94,7 +94,8 @@ public class ManifestBasedDatasetFinderTest {
       Assert.assertEquals(fileSet.getFiles().size(), 3);  // 2 files to copy + 1 post publish step
       Assert.assertTrue(((PostPublishStep) fileSet.getFiles().get(2)).getStep() instanceof SetPermissionCommitStep);
       SetPermissionCommitStep step = (SetPermissionCommitStep) ((PostPublishStep) fileSet.getFiles().get(2)).getStep();
-      Assert.assertEquals(step.getPathAndPermissions().keySet().size(), 2);
+
+      Assert.assertEquals(step.getPathAndPermissions().keySet().size(), 1); // SetPermissionCommitStep only applies to ancestors
       Mockito.verify(manifestReadFs, Mockito.times(1)).exists(manifestPath);
       Mockito.verify(manifestReadFs, Mockito.times(1)).getFileStatus(manifestPath);
       Mockito.verify(manifestReadFs, Mockito.times(1)).open(manifestPath);

--- a/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/manifestRootDirEmpty.json
+++ b/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/manifestRootDirEmpty.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id":"1",
+    "fileName":"/",
+    "fileGroup":"/",
+    "fileSizeInBytes":"0"
+  }
+]


### PR DESCRIPTION
…t in setpermissionstep

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In Manifest distcp, empty folders are being set with the incorrect permissions in SetPermissionStep after being correctly set in the CopyDataPublisher.

The suspected reason is that the empty child folders themselves are being treated as ancestors, and this causes the permission checking of the source and destination ancestors to act incorrectly. 

In the long run, we should consolidate our permission comparison and logic given that there are a multitude of different implementations and they each seem to have their own quirks.

Correct CopyDataPublisher logs:

```
Setting destination directory hdfs://cluster/a/b/c owner and permission to rwxr-x---
```

Incorrect SetPermissionCommitStep logs:
```
Setting permission rwxr-xr-x on path /a/b/c
```

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

