### PR TITLE
[GOBBLIN-2075] Fix JobSpec fetching from DagManagerUtils so that properties are properly reflecting job configs

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -184,7 +184,7 @@ public class DagManagerUtils {
     JobSpec jobSpec = dagNode.getValue().getJobSpec();
     Map<String, String> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, String.valueOf(dagNode.getValue().getCurrentAttempts()),
         ConfigurationKeys.JOB_CURRENT_GENERATION, String.valueOf(dagNode.getValue().getCurrentGeneration()));
-    Properties configAsProperties = new Properties(jobSpec.getConfigAsProperties());
+    Properties configAsProperties = (Properties) jobSpec.getConfigAsProperties().clone();
     configAsProperties.putAll(configWithCurrentAttempts);
     //Return new spec with new config to avoid change the reference to dagNode
     return new JobSpec(jobSpec.getUri(), jobSpec.getVersion(), jobSpec.getDescription(), ConfigFactory.parseMap(configWithCurrentAttempts).withFallback(jobSpec.getConfig()),

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -46,6 +46,7 @@ import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
 import org.apache.gobblin.service.modules.orchestration.TimingEventUtils;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.PropertiesUtils;
 
 import static org.apache.gobblin.service.ExecutionStatus.CANCELLED;
 
@@ -103,7 +104,7 @@ public class DagProcUtils {
       jobExecutionPlan.setExecutionStatus(ExecutionStatus.ORCHESTRATED);
       jobMetadata.put(TimingEvent.METADATA_MESSAGE, producer.getExecutionLink(addSpecFuture, specExecutorUri));
       // Add serialized job properties as part of the orchestrated job event metadata
-      jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, dagNode.getValue().toString());
+      jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, PropertiesUtils.serialize(jobSpec.getConfigAsProperties()));
       jobOrchestrationTimer.stop(jobMetadata);
       log.info("Orchestrated job: {} on Executor: {}", DagManagerUtils.getFullyQualifiedJobName(dagNode), specExecutorUri);
       dagManagementStateStore.getDagManagerMetrics().incrementJobsSentToExecutor(dagNode);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -32,5 +32,10 @@ public class DagManagerUtilsTest {
     Dag<JobExecutionPlan> testDag = DagTestUtils.buildDag("testDag", 1000L);
     JobSpec jobSpec = DagManagerUtils.getJobSpec(testDag.getNodes().get(0));
     Assert.assertEquals(jobSpec.getConfigAsProperties().size(), jobSpec.getConfig().entrySet().size());
+    for (String key : jobSpec.getConfigAsProperties().stringPropertyNames()) {
+      Assert.assertTrue(jobSpec.getConfig().hasPath(key));
+      // Assume each key is a string because all job configs are currently strings
+      Assert.assertEquals(jobSpec.getConfigAsProperties().get(key), jobSpec.getConfig().getString(key));
+    }
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+
+
+public class DagManagerUtilsTest {
+
+  @Test
+  public void testGetJobSpecFromDag() throws Exception {
+    Dag<JobExecutionPlan> testDag = DagTestUtils.buildDag("testDag", 1000L);
+    JobSpec jobSpec = DagManagerUtils.getJobSpec(testDag.getNodes().get(0));
+    Assert.assertEquals(jobSpec.getConfigAsProperties().size(), jobSpec.getConfig().entrySet().size());
+  }
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
@@ -30,6 +30,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Maps;
+import com.google.gson.JsonParser;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
@@ -136,7 +137,7 @@ public class GaaSJobObservabilityProducerTest {
     Assert.assertEquals(event.getDatasetsMetrics().get(1).getEntitiesWritten(), Long.valueOf(dataset2.getRecordsWritten()));
     Assert.assertEquals(event.getDatasetsMetrics().get(1).getBytesWritten(), Long.valueOf(dataset2.getBytesWritten()));
     Assert.assertEquals(event.getDatasetsMetrics().get(1).getSuccessfullyCommitted(), Boolean.valueOf(dataset2.isSuccessfullyCommitted()));
-    Assert.assertEquals(event.getJobProperties(), "{\"gobblin.flow.sourceIdentifier\":\"sourceNode\",\"gobblin.flow.destinationIdentifier\":\"destinationNode\",\"user.to.proxy\":\"newUser\",\"flow.executionId\":\"1681242538558\"}");
+    JsonParser.parseString(event.getJobProperties()); // Should not throw
     Assert.assertEquals(event.getGaasId(), "testCluster");
     AvroSerializer<GaaSJobObservabilityEvent> serializer = new AvroBinarySerializer<>(
         GaaSJobObservabilityEvent.SCHEMA$, new NoopSchemaVersionWriter()


### PR DESCRIPTION
…odes rather than the other service config keys

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2075


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Job properties, and subsequently source and destination nodes are not found in the GaaSJobObservabilityEvent. More digging identified that the root cause is that `DagManagerUtils.getJobSpec` contained a bug where it would create a new Properties() object with
```
Properties clonedProperties = new Properties(oldProperties);
```

However this is not accurate as the constructor https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html sets the input properties as the default, meaning that the keys would not exist when collecting the object, only when fetching keys that don't exist.

Since this means that the configToProperties() in JobSpec is not reflective of configs, clone the object instead properly.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

