### PR TITLE
[GOBBLIN-2077] create flow finish deadline dag action after the launch of first job

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1068,7 +1068,7 @@ public class ConfigurationKeys {
   public static final String FLOW_RUN_IMMEDIATELY = "flow.runImmediately";
   public static final String GOBBLIN_FLOW_SLA_TIME = "gobblin.flow.sla.time";
   public static final String GOBBLIN_FLOW_SLA_TIME_UNIT = "gobblin.flow.sla.timeunit";
-  public static final String DEFAULT_GOBBLIN_FLOW_SLA_TIME_UNIT = "MINUTES";
+  public static final String DEFAULT_GOBBLIN_FLOW_SLA_TIME_UNIT = TimeUnit.MINUTES.name();
   public static final String GOBBLIN_JOB_START_SLA_TIME = "gobblin.job.start.sla.time";
   public static final String GOBBLIN_JOB_START_SLA_TIME_UNIT = "gobblin.job.start.sla.timeunit";
   public static final long FALLBACK_GOBBLIN_JOB_START_SLA_TIME = 10L;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -147,7 +147,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
           }
         } catch (Exception e) {
           //TODO: need to handle exceptions gracefully
-          log.error("Exception getting DagAction from the queue / creating DagTask {}", dagAction == null ? "" : dagAction, e);
+          log.error("Exception getting DagAction from the queue or creating DagTask. dagAction - {}", dagAction == null ? "<null>" : dagAction, e);
         }
       }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -125,8 +125,9 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
   @Override
   public DagTask next() {
       while (true) {
+        DagActionStore.DagAction dagAction = null;
         try {
-          DagActionStore.DagAction dagAction = this.dagActionQueue.take();
+          dagAction = this.dagActionQueue.take();
           /* Create triggers for original (non-reminder) dag actions of type ENFORCE_JOB_START_DEADLINE and ENFORCE_FLOW_FINISH_DEADLINE.
              Reminder triggers are used to inform hosts once the job start deadline and flow finish deadline are passed;
              then only is lease arbitration done to enforce the deadline violation and fail the job or flow if needed */
@@ -146,7 +147,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
           }
         } catch (Exception e) {
           //TODO: need to handle exceptions gracefully
-          log.error("Exception getting DagAction from the queue / creating DagTask", e);
+          log.error("Exception getting DagAction from the queue / creating DagTask {}", dagAction == null ? "" : dagAction, e);
         }
       }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
@@ -129,7 +129,7 @@ public class DagProcessingEngine extends AbstractIdleService {
           log.warn("Received a null dag task, ignoring.");
           continue;
         }
-        DagProc dagProc = dagTask.host(dagProcFactory);
+        DagProc<?> dagProc = dagTask.host(dagProcFactory);
         try {
           // todo - add retries
           dagProc.process(dagManagementStateStore);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -50,7 +50,6 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.ServiceMetricNames;
 import org.apache.gobblin.scheduler.JobScheduler;
 import org.apache.gobblin.scheduler.SchedulerService;
-import org.apache.gobblin.service.modules.orchestration.proc.DagProcUtils;
 import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -141,7 +140,6 @@ public class FlowLaunchHandler {
     DagActionStore.DagAction launchDagAction = leaseStatus.getConsensusDagAction();
     try {
       this.dagManagementStateStore.addDagAction(launchDagAction);
-      DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, launchDagAction);
       this.numFlowsSubmitted.mark();
       // after successfully persisting, close the lease
       return this.multiActiveLeaseArbiter.recordLeaseSuccess(leaseStatus);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -81,7 +81,7 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
       // todo - add metrics
     } else {
       submitNextNodes(dagManagementStateStore, dag.get());
-      //Checkpoint the dag state, it should have an updated value of dag nodes
+      // Checkpoint the dag state, it should have an updated value of dag nodes
       dagManagementStateStore.checkpointDag(dag.get());
       DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
       orchestrationDelayCounter.set(System.currentTimeMillis() - DagManagerUtils.getFlowExecId(dag.get()));
@@ -91,8 +91,7 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
   /**
    * Submit next set of Dag nodes in the provided Dag.
    */
-   private void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag)
-       throws IOException {
+   private void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag) {
      Set<Dag.DagNode<JobExecutionPlan>> nextNodes = DagManagerUtils.getNext(dag);
 
      if (nextNodes.size() > 1) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -90,7 +90,8 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
   /**
    * Submit next set of Dag nodes in the provided Dag.
    */
-   private void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag) {
+   private void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag)
+       throws IOException {
      Set<Dag.DagNode<JobExecutionPlan>> nextNodes = DagManagerUtils.getNext(dag);
 
      if (nextNodes.size() > 1) {
@@ -102,6 +103,8 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
        DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
        log.info("Submitted job {} for dagId {}", DagManagerUtils.getJobName(dagNode), getDagId());
      }
+
+     DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
    }
 
   private void handleMultipleJobs(Set<Dag.DagNode<JobExecutionPlan>> nextNodes) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -83,6 +83,7 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
       submitNextNodes(dagManagementStateStore, dag.get());
       //Checkpoint the dag state, it should have an updated value of dag nodes
       dagManagementStateStore.checkpointDag(dag.get());
+      DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
       orchestrationDelayCounter.set(System.currentTimeMillis() - DagManagerUtils.getFlowExecId(dag.get()));
     }
   }
@@ -103,8 +104,6 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
        DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
        log.info("Submitted job {} for dagId {}", DagManagerUtils.getJobName(dagNode), getDagId());
      }
-
-     DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
    }
 
   private void handleMultipleJobs(Set<Dag.DagNode<JobExecutionPlan>> nextNodes) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -171,7 +171,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
         log.warn("It should not reach here. Job status {} is unexpected.", executionStatus);
     }
 
-    //Checkpoint the dag state, it should have an updated value of dag fields
+    // Checkpoint the dag state, it should have an updated value of dag fields
     dagManagementStateStore.checkpointDag(dag);
     dagManagementStateStore.deleteDagNodeState(getDagId(), dagNode);
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProc.java
@@ -93,6 +93,8 @@ public class ResumeDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
     dagManagementStateStore.deleteFailedDag(failedDag.get());
 
     resumeDag(dagManagementStateStore, failedDag.get());
+
+    DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
   }
 
   private void resumeDag(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -57,6 +57,7 @@ import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 import org.apache.gobblin.util.ConfigUtils;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -103,7 +104,8 @@ public class LaunchDagProcTest {
     List<Invocation> invocations = Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
         .filter(a -> a.getMethod().getName().equals("addFlowDagAction")).collect(Collectors.toList());
     Assert.assertEquals(invocations.size(), 1);
-    Assert.assertEquals(invocations.get(0).getArguments()[3], DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE);
+    Mockito.verify(this.dagManagementStateStore, Mockito.times(1))
+        .addFlowDagAction(any(), any(), any(), eq(DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE));
   }
 
   // This creates a dag like this

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -22,10 +22,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
-import org.mockito.invocation.Invocation;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -101,9 +99,6 @@ public class LaunchDagProcTest {
         Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
             .filter(a -> a.getMethod().getName().equals("addDagNodeState")).count());
 
-    List<Invocation> invocations = Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
-        .filter(a -> a.getMethod().getName().equals("addFlowDagAction")).collect(Collectors.toList());
-    Assert.assertEquals(invocations.size(), 1);
     Mockito.verify(this.dagManagementStateStore, Mockito.times(1))
         .addFlowDagAction(any(), any(), any(), eq(DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE));
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -22,8 +22,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -97,6 +99,11 @@ public class LaunchDagProcTest {
     Assert.assertEquals(expectedNumOfSavingDagNodeStates,
         Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
             .filter(a -> a.getMethod().getName().equals("addDagNodeState")).count());
+
+    List<Invocation> invocations = Mockito.mockingDetails(this.dagManagementStateStore).getInvocations().stream()
+        .filter(a -> a.getMethod().getName().equals("addFlowDagAction")).collect(Collectors.toList());
+    Assert.assertEquals(invocations.size(), 1);
+    Assert.assertEquals(invocations.get(0).getArguments()[3], DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE);
   }
 
   // This creates a dag like this


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2077


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
create flow finish deadline dag action after the launch of first job, because otherwise the dag action, which is created by the first job will not be available to find flow sla and flow start time in while ingesting flow_finish_deadline_enforcement dag action in DagManagementTaskStreamImpl

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial change, tested manually

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

