### PR TITLE
[GOBBLIN-2079] Separate GaaSJobObservabilityEvents to both flow and job level events

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
@@ -45,12 +45,6 @@
       "compliance": "NONE"
     },
     {
-      "name": "flowEdgeId",
-      "type": "string",
-      "doc": "Flow edge id, excluding the sourceNode and destinationNode",
-      "compliance": "NONE"
-    },
-    {
       "name": "flowStatus",
       "type": {
         "type": "enum",

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
@@ -1,0 +1,88 @@
+{
+  "type": "record",
+  "name": "GaaSFlowObservabilityEvent",
+  "namespace": "org.apache.gobblin.metrics",
+  "doc": "An event schema for GaaS to emit during and after a flow is executed.",
+  "fields": [
+    {
+      "name": "eventTimestamp",
+      "type": "long",
+      "doc": "Time at which event was created in milliseconds from Unix Epoch"
+    },
+    {
+      "name": "flowGroup",
+      "type": "string",
+      "doc": "Flow group for the GaaS flow",
+      "compliance": "NONE"
+    },
+    {
+      "name": "flowName",
+      "type": "string",
+      "doc": "Flow name for the GaaS flow",
+      "compliance": "NONE"
+    },
+    {
+      "name": "flowExecutionId",
+      "type": "long",
+      "doc": "Flow execution id for the GaaS flow",
+      "compliance": "NONE"
+    },
+    {
+      "name": "lastFlowModificationTimestamp",
+      "type": "long",
+      "doc": "Timestamp in millis since Epoch when the flow config was last modified"
+    },
+    {
+      "name": "sourceNode",
+      "type": "string",
+      "doc": "Source node for the flow edge",
+      "compliance": "NONE"
+    },
+    {
+      "name": "destinationNode",
+      "type": "string",
+      "doc": "Destination node for the flow edge",
+      "compliance": "NONE"
+    },
+    {
+      "name": "flowEdgeId",
+      "type": "string",
+      "doc": "Flow edge id, excluding the sourceNode and destinationNode",
+      "compliance": "NONE"
+    },
+    {
+      "name": "flowStatus",
+      "type": {
+        "type": "enum",
+        "name": "FlowStatus",
+        "symbols": [
+          "SUCCEEDED",
+          "COMPILATION_FAILURE",
+          "SUBMISSION_FAILURE",
+          "EXECUTION_FAILURE",
+          "CANCELLED"
+        ],
+        "doc": "Final flow status for the GaaS flow",
+        "compliance": "NONE"
+      }
+    },
+    {
+      "name": "effectiveUserUrn",
+      "type": [
+        "null",
+        "string"
+      ],
+      "doc": "User URN (if applicable) whose identity was used to run the underlying Gobblin job e.g. myGroup",
+      "compliance": "NONE"
+    },
+    {
+      "name": "gaasId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "The deployment ID of GaaS that is sending the event (if multiple GaaS instances are running)"
+    }
+  ]
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "GaaSFlowObservabilityEvent",
   "namespace": "org.apache.gobblin.metrics",
-  "doc": "An event schema for GaaS to emit during and after a flow is executed.",
+  "doc": "An event schema for GaaS to emit after a flow is executed.",
   "fields": [
     {
       "name": "eventTimestamp",
@@ -77,6 +77,24 @@
       ],
       "default": null,
       "doc": "The deployment ID of GaaS that is sending the event (if multiple GaaS instances are running)"
+    },
+    {
+      "name": "flowStartTimestamp",
+      "type": [
+        "null",
+        "long"
+      ],
+      "doc": "Start time of the flow - when the dag is initialized, in millis since Epoch. Null if the job was never run",
+      "compliance": "NONE"
+    },
+    {
+      "name": "flowEndTimestamp",
+      "type": [
+        "null",
+        "long"
+      ],
+      "doc": "Finish time of the job in millis since Epoch, null if the job was never run",
+      "compliance": "NONE"
     }
   ]
 }

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -734,7 +734,9 @@ public class KafkaAvroJobStatusMonitorTest {
       Thread.currentThread().interrupt();
     }
     MultiContextIssueRepository issueRepository = new InMemoryMultiContextIssueRepository();
-    MockGaaSJobObservabilityEventProducer mockEventProducer = new MockGaaSJobObservabilityEventProducer(ConfigUtils.configToState(ConfigFactory.empty()),
+    State producerState = new State();
+    producerState.setProp(GaaSJobObservabilityEventProducer.EMIT_FLOW_OBSERVABILITY_EVENT, "true");
+    MockGaaSJobObservabilityEventProducer mockEventProducer = new MockGaaSJobObservabilityEventProducer(producerState,
         issueRepository, false);
     MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty(),
         mockEventProducer, mock(DagManagementStateStore.class));
@@ -767,6 +769,66 @@ public class KafkaAvroJobStatusMonitorTest {
     Iterator<GaaSFlowObservabilityEvent> flowIterator = emittedFlowEvents.iterator();
     GaaSFlowObservabilityEvent flowEvent = flowIterator.next();
     Assert.assertEquals(flowEvent.getFlowStatus(), FlowStatus.SUCCEEDED);
+    Assert.assertEquals(flowEvent.getFlowName(), this.flowName);
+    Assert.assertEquals(flowEvent.getFlowGroup(), this.flowGroup);
+
+    jobStatusMonitor.shutDown();
+  }
+
+  @Test (dependsOnMethods = "testObservabilityEventFlowLevel")
+  public void testObservabilityEventFlowFailed() throws IOException, ReflectiveOperationException {
+    KafkaEventReporter kafkaReporter = builder.build("localhost:0000", "topic7");
+
+    //Submit GobblinTrackingEvents to Kafka
+    ImmutableList.of(
+        createFlowCompiledEvent(),
+        createJobFailedEvent(),
+        createFlowFailedEvent()
+    ).forEach(event -> {
+      context.submitEvent(event);
+      kafkaReporter.report();
+    });
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    MultiContextIssueRepository issueRepository = new InMemoryMultiContextIssueRepository();
+    State producerState = new State();
+    producerState.setProp(GaaSJobObservabilityEventProducer.EMIT_FLOW_OBSERVABILITY_EVENT, "true");
+    MockGaaSJobObservabilityEventProducer mockEventProducer = new MockGaaSJobObservabilityEventProducer(producerState,
+        issueRepository, false);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty(),
+        mockEventProducer, mock(DagManagementStateStore.class));
+    jobStatusMonitor.buildMetricsContextAndMetrics();
+    Iterator<DecodeableKafkaRecord<byte[], byte[]>> recordIterator = Iterators.transform(
+        this.kafkaTestHelper.getIteratorForTopic(TOPIC),
+        this::convertMessageAndMetadataToDecodableKafkaRecord);
+
+    State state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPILED.name());
+
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.FAILED.name());
+
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.FAILED.name());
+
+    // Only the COMPLETE event should create a GaaSJobObservabilityEvent
+    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedJobEvents();
+    Assert.assertEquals(emittedEvents.size(), 1);
+    Iterator<GaaSJobObservabilityEvent> iterator = emittedEvents.iterator();
+    GaaSJobObservabilityEvent event1 = iterator.next();
+    Assert.assertEquals(event1.getJobStatus(), JobStatus.EXECUTION_FAILURE);
+    Assert.assertEquals(event1.getFlowName(), this.flowName);
+    Assert.assertEquals(event1.getFlowGroup(), this.flowGroup);
+
+    // Only the COMPLETE event should create a GaaSFlowObservabilityEvent
+    List<GaaSFlowObservabilityEvent> emittedFlowEvents = mockEventProducer.getTestEmittedFlowEvents();
+    Assert.assertEquals(emittedFlowEvents.size(), 1);
+    Iterator<GaaSFlowObservabilityEvent> flowIterator = emittedFlowEvents.iterator();
+    GaaSFlowObservabilityEvent flowEvent = flowIterator.next();
+    Assert.assertEquals(flowEvent.getFlowStatus(), FlowStatus.EXECUTION_FAILURE);
     Assert.assertEquals(flowEvent.getFlowName(), this.flowName);
     Assert.assertEquals(flowEvent.getFlowGroup(), this.flowGroup);
 
@@ -826,7 +888,14 @@ public class KafkaAvroJobStatusMonitorTest {
     event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
     event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
     return event;
+  }
 
+  private GobblinTrackingEvent createFlowFailedEvent() {
+    GobblinTrackingEvent event = createGTE(TimingEvent.FlowTimings.FLOW_FAILED, Maps.newHashMap());
+    // Remove jobname and jobgroup as flow level events should not have them, get populated with "NA"
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
+    return event;
   }
 
   private GobblinTrackingEvent createJobFailedEvent() {

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -761,7 +761,7 @@ public class KafkaAvroJobStatusMonitorTest {
     Assert.assertEquals(event1.getFlowName(), this.flowName);
     Assert.assertEquals(event1.getFlowGroup(), this.flowGroup);
 
-    // Only the COMPLETE event should create a GaaSJobObservabilityEvent
+    // Only the COMPLETE event should create a GaaSFlowObservabilityEvent
     List<GaaSFlowObservabilityEvent> emittedFlowEvents = mockEventProducer.getTestEmittedFlowEvents();
     Assert.assertEquals(emittedFlowEvents.size(), 1);
     Iterator<GaaSFlowObservabilityEvent> flowIterator = emittedFlowEvents.iterator();

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -822,6 +822,7 @@ public class KafkaAvroJobStatusMonitorTest {
 
   private GobblinTrackingEvent createFlowSucceededEvent() {
     GobblinTrackingEvent event = createGTE(TimingEvent.FlowTimings.FLOW_SUCCEEDED, Maps.newHashMap());
+    // Remove jobname and jobgroup as flow level events should not have them, get populated with "NA"
     event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
     event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
     return event;

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -814,7 +814,7 @@ public class KafkaAvroJobStatusMonitorTest {
     state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.FAILED.name());
 
-    // Only the COMPLETE event should create a GaaSJobObservabilityEvent
+    // Only the FAILED event should create a GaaSJobObservabilityEvent
     List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedJobEvents();
     Assert.assertEquals(emittedEvents.size(), 1);
     Iterator<GaaSJobObservabilityEvent> iterator = emittedEvents.iterator();

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -59,6 +59,8 @@ import org.apache.gobblin.kafka.KafkaTestBase;
 import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.kafka.client.Kafka09ConsumerClient;
 import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.metrics.FlowStatus;
+import org.apache.gobblin.metrics.GaaSFlowObservabilityEvent;
 import org.apache.gobblin.metrics.GaaSJobObservabilityEvent;
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.JobStatus;
@@ -653,7 +655,7 @@ public class KafkaAvroJobStatusMonitorTest {
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
 
     // Only the COMPLETE event should create a GaaSJobObservabilityEvent
-    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedEvents();
+    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedJobEvents();
     Iterator<GaaSJobObservabilityEvent> iterator = emittedEvents.iterator();
     GaaSJobObservabilityEvent event1 = iterator.next();
     Assert.assertEquals(event1.getJobStatus(), JobStatus.SUCCEEDED);
@@ -702,13 +704,71 @@ public class KafkaAvroJobStatusMonitorTest {
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.CANCELLED.name());
 
     // Only the COMPLETE event should create a GaaSJobObservabilityEvent
-    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedEvents();
+    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedJobEvents();
     Assert.assertEquals(emittedEvents.size(), 1);
     Iterator<GaaSJobObservabilityEvent> iterator = emittedEvents.iterator();
     GaaSJobObservabilityEvent event1 = iterator.next();
     Assert.assertEquals(event1.getJobStatus(), JobStatus.CANCELLED);
     Assert.assertEquals(event1.getFlowName(), this.flowName);
     Assert.assertEquals(event1.getFlowGroup(), this.flowGroup);
+
+    jobStatusMonitor.shutDown();
+  }
+
+  @Test (dependsOnMethods = "testObservabilityEventSingleEmission")
+  public void testObservabilityEventFlowLevel() throws IOException, ReflectiveOperationException {
+    KafkaEventReporter kafkaReporter = builder.build("localhost:0000", "topic7");
+
+    //Submit GobblinTrackingEvents to Kafka
+    ImmutableList.of(
+        createFlowCompiledEvent(),
+        createJobSucceededEvent(),
+        createFlowSucceededEvent()
+    ).forEach(event -> {
+      context.submitEvent(event);
+      kafkaReporter.report();
+    });
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    MultiContextIssueRepository issueRepository = new InMemoryMultiContextIssueRepository();
+    MockGaaSJobObservabilityEventProducer mockEventProducer = new MockGaaSJobObservabilityEventProducer(ConfigUtils.configToState(ConfigFactory.empty()),
+        issueRepository, false);
+    MockKafkaAvroJobStatusMonitor jobStatusMonitor = createMockKafkaAvroJobStatusMonitor(new AtomicBoolean(false), ConfigFactory.empty(),
+        mockEventProducer, mock(DagManagementStateStore.class));
+    jobStatusMonitor.buildMetricsContextAndMetrics();
+    Iterator<DecodeableKafkaRecord<byte[], byte[]>> recordIterator = Iterators.transform(
+        this.kafkaTestHelper.getIteratorForTopic(TOPIC),
+        this::convertMessageAndMetadataToDecodableKafkaRecord);
+
+    State state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPILED.name());
+
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, this.jobGroup, this.jobName);
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
+
+    state = getNextJobStatusState(jobStatusMonitor, recordIterator, "NA", "NA");
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
+
+    // Only the COMPLETE event should create a GaaSJobObservabilityEvent
+    List<GaaSJobObservabilityEvent> emittedEvents = mockEventProducer.getTestEmittedJobEvents();
+    Assert.assertEquals(emittedEvents.size(), 1);
+    Iterator<GaaSJobObservabilityEvent> iterator = emittedEvents.iterator();
+    GaaSJobObservabilityEvent event1 = iterator.next();
+    Assert.assertEquals(event1.getJobStatus(), JobStatus.SUCCEEDED);
+    Assert.assertEquals(event1.getFlowName(), this.flowName);
+    Assert.assertEquals(event1.getFlowGroup(), this.flowGroup);
+
+    // Only the COMPLETE event should create a GaaSJobObservabilityEvent
+    List<GaaSFlowObservabilityEvent> emittedFlowEvents = mockEventProducer.getTestEmittedFlowEvents();
+    Assert.assertEquals(emittedFlowEvents.size(), 1);
+    Iterator<GaaSFlowObservabilityEvent> flowIterator = emittedFlowEvents.iterator();
+    GaaSFlowObservabilityEvent flowEvent = flowIterator.next();
+    Assert.assertEquals(flowEvent.getFlowStatus(), FlowStatus.SUCCEEDED);
+    Assert.assertEquals(flowEvent.getFlowName(), this.flowName);
+    Assert.assertEquals(flowEvent.getFlowGroup(), this.flowGroup);
 
     jobStatusMonitor.shutDown();
   }
@@ -761,7 +821,11 @@ public class KafkaAvroJobStatusMonitorTest {
   }
 
   private GobblinTrackingEvent createFlowSucceededEvent() {
-    return createGTE(TimingEvent.FlowTimings.FLOW_SUCCEEDED, Maps.newHashMap());
+    GobblinTrackingEvent event = createGTE(TimingEvent.FlowTimings.FLOW_SUCCEEDED, Maps.newHashMap());
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
+    event.getMetadata().remove(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
+    return event;
+
   }
 
   private GobblinTrackingEvent createJobFailedEvent() {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -999,6 +999,9 @@ public class DagManager extends AbstractIdleService {
         // Add serialized job properties as part of the orchestrated job event metadata
         jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, PropertiesUtils.serialize(jobSpec.getConfigAsProperties()));
         jobOrchestrationTimer.stop(jobMetadata);
+        if (dagNode.getParentNodes().isEmpty()) {
+          DagManagerUtils.emitFlowEvent(eventSubmitter, this.jobToDag.get(dagNode), TimingEvent.FlowTimings.FLOW_ORCHESTRATED);
+        }
         log.info("Orchestrated job: {} on Executor: {}", DagManagerUtils.getFullyQualifiedJobName(dagNode), specExecutorUri);
         this.dagManagerMetrics.incrementJobsSentToExecutor(dagNode);
       } catch (Exception e) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -77,6 +77,7 @@ import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.Dag.DagNode;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.modules.spec.SerializationConstants;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.JobStatus;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
@@ -998,10 +999,8 @@ public class DagManager extends AbstractIdleService {
         jobMetadata.put(TimingEvent.METADATA_MESSAGE, producer.getExecutionLink(addSpecFuture, specExecutorUri));
         // Add serialized job properties as part of the orchestrated job event metadata
         jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, PropertiesUtils.serialize(jobSpec.getConfigAsProperties()));
+        jobMetadata.put(SerializationConstants.FLOW_START_TIME_KEY, String.valueOf(dagNode.getValue().getFlowStartTime()));
         jobOrchestrationTimer.stop(jobMetadata);
-        if (dagNode.getParentNodes().isEmpty()) {
-          DagManagerUtils.emitFlowEvent(eventSubmitter, this.jobToDag.get(dagNode), TimingEvent.FlowTimings.FLOW_ORCHESTRATED);
-        }
         log.info("Orchestrated job: {} on Executor: {}", DagManagerUtils.getFullyQualifiedJobName(dagNode), specExecutorUri);
         this.dagManagerMetrics.incrementJobsSentToExecutor(dagNode);
       } catch (Exception e) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -45,6 +45,7 @@ import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
 import org.apache.gobblin.service.modules.orchestration.TimingEventUtils;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.modules.spec.SerializationConstants;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PropertiesUtils;
@@ -124,6 +125,7 @@ public class DagProcUtils {
       jobMetadata.put(TimingEvent.METADATA_MESSAGE, producer.getExecutionLink(addSpecFuture, specExecutorUri));
       // Add serialized job properties as part of the orchestrated job event metadata
       jobMetadata.put(JobExecutionPlan.JOB_PROPS_KEY, PropertiesUtils.serialize(jobSpec.getConfigAsProperties()));
+      jobMetadata.put(SerializationConstants.FLOW_START_TIME_KEY, String.valueOf(dagNode.getValue().getFlowStartTime()));
       jobOrchestrationTimer.stop(jobMetadata);
       log.info("Orchestrated job: {} on Executor: {}", DagManagerUtils.getFullyQualifiedJobName(dagNode), specExecutorUri);
       dagManagementStateStore.getDagManagerMetrics().incrementJobsSentToExecutor(dagNode);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -71,7 +71,7 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
   public static final String GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX = "GaaSJobObservabilityEventProducer.";
   public static final String GAAS_OBSERVABILITY_EVENT_PRODUCER_CLASS_KEY = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "class.name";
   public static final String DEFAULT_GAAS_OBSERVABILITY_EVENT_PRODUCER_CLASS = NoopGaaSJobObservabilityEventProducer.class.getName();
-  public static final String EMIT_FLOW_OBSERVABILITY_EVENT = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "emitFlowObservabilityEvent";
+  public static final String EMIT_FLOW_OBSERVABILITY_EVENT = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "emitFlowLevelEvent";
   public static final String ISSUES_READ_FAILED_METRIC_NAME =  GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "getIssuesFailedCount";
   public static final String GAAS_OBSERVABILITY_METRICS_GROUPNAME = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "metrics";
   public static final String GAAS_OBSERVABILITY_JOB_SUCCEEDED_METRIC_NAME = "jobSucceeded";
@@ -128,7 +128,7 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
 
   public void emitObservabilityEvent(final State jobState) {
     GaaSJobObservabilityEvent event = createGaaSObservabilityEvent(jobState);
-    if (jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD).equals(JobStatusRetriever.NA_KEY)) {
+    if (jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD).equals(JobStatusRetriever.NA_KEY) && this.emitFlowObservabilityEvent) {
       sendFlowLevelEvent(convertJobEventToFlowEvent(event));
     } else {
       sendJobLevelEvent(event);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -268,7 +268,7 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
         .setDestinationNode(jobEvent.getDestinationNode())
         .setEffectiveUserUrn(jobEvent.getEffectiveUserUrn())
         .setFlowStatus(FlowStatus.valueOf(jobEvent.getJobStatus().toString()))
-        .setFlowStartTimestamp(jobState.getPropAsLong(SerializationConstants.FLOW_START_TIME_KEY))
+        .setFlowStartTimestamp(jobState.getPropAsLong(SerializationConstants.FLOW_START_TIME_KEY, 0))
         .setFlowEndTimestamp(jobEvent.getJobEndTimestamp());
     return builder.build();
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -38,6 +38,8 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.ContextAwareMeter;
 import org.apache.gobblin.metrics.DatasetMetric;
+import org.apache.gobblin.metrics.FlowStatus;
+import org.apache.gobblin.metrics.GaaSFlowObservabilityEvent;
 import org.apache.gobblin.metrics.GaaSJobObservabilityEvent;
 import org.apache.gobblin.metrics.Issue;
 import org.apache.gobblin.metrics.IssueSeverity;
@@ -69,6 +71,7 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
   public static final String GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX = "GaaSJobObservabilityEventProducer.";
   public static final String GAAS_OBSERVABILITY_EVENT_PRODUCER_CLASS_KEY = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "class.name";
   public static final String DEFAULT_GAAS_OBSERVABILITY_EVENT_PRODUCER_CLASS = NoopGaaSJobObservabilityEventProducer.class.getName();
+  public static final String EMIT_FLOW_OBSERVABILITY_EVENT = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "emitFlowObservabilityEvent";
   public static final String ISSUES_READ_FAILED_METRIC_NAME =  GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "getIssuesFailedCount";
   public static final String GAAS_OBSERVABILITY_METRICS_GROUPNAME = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "metrics";
   public static final String GAAS_OBSERVABILITY_JOB_SUCCEEDED_METRIC_NAME = "jobSucceeded";
@@ -81,12 +84,14 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
   protected ObservableLongMeasurement jobStatusMetric;
   protected MultiContextIssueRepository issueRepository;
   protected boolean instrumentationEnabled;
+  protected boolean emitFlowObservabilityEvent;
   ContextAwareMeter getIssuesFailedMeter;
 
   public GaaSJobObservabilityEventProducer(State state, MultiContextIssueRepository issueRepository, boolean instrumentationEnabled) {
     this.state = state;
     this.issueRepository = issueRepository;
     this.instrumentationEnabled = instrumentationEnabled;
+    this.emitFlowObservabilityEvent = this.state.getPropAsBoolean(EMIT_FLOW_OBSERVABILITY_EVENT, false);
     if (this.instrumentationEnabled) {
       this.metricContext = Instrumented.getMetricContext(state, getClass());
       this.getIssuesFailedMeter = this.metricContext.contextAwareMeter(MetricRegistry.name(ServiceMetricNames.GOBBLIN_SERVICE_PREFIX,
@@ -123,7 +128,11 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
 
   public void emitObservabilityEvent(final State jobState) {
     GaaSJobObservabilityEvent event = createGaaSObservabilityEvent(jobState);
-    sendUnderlyingEvent(event);
+    if (jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD).equals(JobStatusRetriever.NA_KEY)) {
+      sendFlowLevelEvent(convertJobEventToFlowEvent(event));
+    } else {
+      sendJobLevelEvent(event);
+    }
     this.eventCollector.add(event);
   }
 
@@ -142,7 +151,9 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
    * Emits the GaaSJobObservabilityEvent with the mechanism that the child class is built upon e.g. Kafka
    * @param event
    */
-  abstract protected void sendUnderlyingEvent(GaaSJobObservabilityEvent event);
+  abstract protected void sendJobLevelEvent(GaaSJobObservabilityEvent event);
+
+  abstract protected void sendFlowLevelEvent(GaaSFlowObservabilityEvent event);
 
   /**
    * Creates a GaaSJobObservabilityEvent which is derived from a final GaaS job pipeline state, which is combination of GTE job states in an ordered fashion
@@ -242,6 +253,22 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
             issue.getDetails(),
             issue.getProperties()
         )).collect(Collectors.toList());
+  }
+
+  private GaaSFlowObservabilityEvent convertJobEventToFlowEvent(GaaSJobObservabilityEvent jobEvent) {
+    GaaSFlowObservabilityEvent.Builder builder = GaaSFlowObservabilityEvent.newBuilder();
+    builder.setEventTimestamp(jobEvent.getEventTimestamp())
+        .setGaasId(jobEvent.getGaasId())
+        .setFlowName(jobEvent.getFlowName())
+        .setFlowGroup(jobEvent.getFlowGroup())
+        .setFlowExecutionId(jobEvent.getFlowExecutionId())
+        .setLastFlowModificationTimestamp(jobEvent.getLastFlowModificationTimestamp())
+        .setSourceNode(jobEvent.getSourceNode())
+        .setDestinationNode(jobEvent.getDestinationNode())
+        .setFlowEdgeId(jobEvent.getFlowEdgeId())
+        .setEffectiveUserUrn(jobEvent.getEffectiveUserUrn())
+        .setFlowStatus(FlowStatus.valueOf(jobEvent.getJobStatus().toString()));
+    return builder.build();
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -265,7 +265,6 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
         .setLastFlowModificationTimestamp(jobEvent.getLastFlowModificationTimestamp())
         .setSourceNode(jobEvent.getSourceNode())
         .setDestinationNode(jobEvent.getDestinationNode())
-        .setFlowEdgeId(jobEvent.getFlowEdgeId())
         .setEffectiveUserUrn(jobEvent.getEffectiveUserUrn())
         .setFlowStatus(FlowStatus.valueOf(jobEvent.getJobStatus().toString()));
     return builder.build();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/NoopGaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/NoopGaaSJobObservabilityEventProducer.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.service.monitoring;
 
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metrics.GaaSFlowObservabilityEvent;
 import org.apache.gobblin.metrics.GaaSJobObservabilityEvent;
 import org.apache.gobblin.runtime.troubleshooter.MultiContextIssueRepository;
 
@@ -33,12 +34,15 @@ public class NoopGaaSJobObservabilityEventProducer extends GaaSJobObservabilityE
   }
 
   public NoopGaaSJobObservabilityEventProducer() {
-    super(null, null, false);
+    super(new State(), null, false);
   }
 
   @Override
   public void emitObservabilityEvent(State jobState) {}
 
   @Override
-  protected void sendUnderlyingEvent(GaaSJobObservabilityEvent event) {}
+  protected void sendJobLevelEvent(GaaSJobObservabilityEvent event) {}
+
+  @Override
+  protected void sendFlowLevelEvent(GaaSFlowObservabilityEvent event) {}
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
@@ -215,7 +215,6 @@ public class GaaSJobObservabilityProducerTest {
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, "1");
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobName);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, flowName);
-    gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, "flowEdge");
     gteEventMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, "specExecutor");
     gteEventMetadata.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
 
@@ -232,7 +231,6 @@ public class GaaSJobObservabilityProducerTest {
     Assert.assertEquals(event.getFlowName(), flowName);
     Assert.assertEquals(event.getFlowExecutionId(), Long.valueOf(flowExecutionId));
     Assert.assertEquals(event.getFlowStatus(), FlowStatus.SUCCEEDED);
-    Assert.assertEquals(event.getFlowEdgeId(), "flowEdge");
     Assert.assertEquals(event.getEffectiveUserUrn(), null);
 
     AvroSerializer<GaaSFlowObservabilityEvent> serializer = new AvroBinarySerializer<>(

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
@@ -57,6 +57,7 @@ import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.orchestration.AzkabanProjectConfig;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.modules.spec.SerializationConstants;
 import org.apache.gobblin.util.PropertiesUtils;
 
 
@@ -210,7 +211,7 @@ public class GaaSJobObservabilityProducerTest {
     State producerState = new State();
     producerState.setProp(GaaSJobObservabilityEventProducer.EMIT_FLOW_OBSERVABILITY_EVENT, "true");
     MockGaaSJobObservabilityEventProducer
-        producer = new MockGaaSJobObservabilityEventProducer(new State(), this.issueRepository, false);
+        producer = new MockGaaSJobObservabilityEventProducer(producerState, this.issueRepository, false);
     Map<String, String> gteEventMetadata = Maps.newHashMap();
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, flowGroup);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, flowName);
@@ -219,6 +220,7 @@ public class GaaSJobObservabilityProducerTest {
     gteEventMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, flowName);
     gteEventMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, "specExecutor");
     gteEventMetadata.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
+    gteEventMetadata.put(SerializationConstants.FLOW_START_TIME_KEY, "1");
 
     Properties jobStatusProps = new Properties();
     jobStatusProps.putAll(gteEventMetadata);
@@ -233,7 +235,8 @@ public class GaaSJobObservabilityProducerTest {
     Assert.assertEquals(event.getFlowName(), flowName);
     Assert.assertEquals(event.getFlowExecutionId(), Long.valueOf(flowExecutionId));
     Assert.assertEquals(event.getFlowStatus(), FlowStatus.SUCCEEDED);
-    Assert.assertEquals(event.getEffectiveUserUrn(), null);
+    Assert.assertNull(event.getEffectiveUserUrn());
+    Assert.assertEquals(event.getFlowStartTimestamp(), Long.valueOf(1));
 
     AvroSerializer<GaaSFlowObservabilityEvent> serializer = new AvroBinarySerializer<>(
         GaaSFlowObservabilityEvent.SCHEMA$, new NoopSchemaVersionWriter()

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityProducerTest.java
@@ -207,6 +207,8 @@ public class GaaSJobObservabilityProducerTest {
         TroubleshooterUtils.getContextIdForJob(flowGroup, flowName, flowExecutionId, jobName),
         createTestIssue("issueSummary", "issueCode", IssueSeverity.INFO)
     );
+    State producerState = new State();
+    producerState.setProp(GaaSJobObservabilityEventProducer.EMIT_FLOW_OBSERVABILITY_EVENT, "true");
     MockGaaSJobObservabilityEventProducer
         producer = new MockGaaSJobObservabilityEventProducer(new State(), this.issueRepository, false);
     Map<String, String> gteEventMetadata = Maps.newHashMap();

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MockGaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MockGaaSJobObservabilityEventProducer.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metrics.GaaSFlowObservabilityEvent;
 import org.apache.gobblin.metrics.GaaSJobObservabilityEvent;
 import org.apache.gobblin.metrics.InMemoryOpenTelemetryMetrics;
 import org.apache.gobblin.metrics.OpenTelemetryMetricsBase;
@@ -33,7 +34,9 @@ import org.apache.gobblin.runtime.troubleshooter.MultiContextIssueRepository;
  * Tests can use a getter to fetch a read-only version of the events that were emitted
  */
 public class MockGaaSJobObservabilityEventProducer extends GaaSJobObservabilityEventProducer {
-  private List<GaaSJobObservabilityEvent> emittedEvents = new ArrayList<>();
+  private List<GaaSJobObservabilityEvent> emittedJobEvents = new ArrayList<>();
+
+  private List<GaaSFlowObservabilityEvent> emittedFlowEvents = new ArrayList<>();
 
   public MockGaaSJobObservabilityEventProducer(State state, MultiContextIssueRepository issueRepository, boolean instrumentationEnabled) {
     super(state, issueRepository, instrumentationEnabled);
@@ -44,18 +47,33 @@ public class MockGaaSJobObservabilityEventProducer extends GaaSJobObservabilityE
     return InMemoryOpenTelemetryMetrics.getInstance(state);
   }
   @Override
-  protected void sendUnderlyingEvent(GaaSJobObservabilityEvent event) {
-    emittedEvents.add(event);
+  protected void sendJobLevelEvent(GaaSJobObservabilityEvent event) {
+    emittedJobEvents.add(event);
+  }
+
+  @Override
+  protected void sendFlowLevelEvent(GaaSFlowObservabilityEvent event) {
+    emittedFlowEvents.add(event);
   }
 
   /**
-   * Returns the events that the mock producer has written
-   * This should only be used as a read-only object for emitted GaaSObservabilityEvents
+   * Returns the job level events that the mock producer has written
+   * This should only be used as a read-only object for emitted GaaSJobObservabilityEvents
    * @return list of events that would have been emitted
    */
-  public List<GaaSJobObservabilityEvent> getTestEmittedEvents() {
-    return Collections.unmodifiableList(this.emittedEvents);
+  public List<GaaSJobObservabilityEvent> getTestEmittedJobEvents() {
+    return Collections.unmodifiableList(this.emittedJobEvents);
   }
+
+  /**
+   * Returns the flow level events that the mock producer has written
+   * This should only be used as a read-only object for emitted GaaSFlowObservabilityEvents
+   * @return list of events that would have been emitted
+   */
+  public List<GaaSFlowObservabilityEvent> getTestEmittedFlowEvents() {
+    return Collections.unmodifiableList(this.emittedFlowEvents);
+  }
+
 
   public InMemoryOpenTelemetryMetrics getOpentelemetryMetrics() {
     return (InMemoryOpenTelemetryMetrics) this.opentelemetryMetrics;


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2079


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
`GaaSJobObservabilityEvents` currently encapsulate both jobs and flows in GaaS.
This is fine for single hop flows, but flows with multiple jobs encapsulated in them now have a mix of job level events with the majority of metadata, and flow level events which provide a better view to users when their flow fails at any given point.

Since the data in both events differs vastly with most metadata only having contextual sense in the job level event, we should separate job and flow level events to their own respective event types.

This PR creates a new type of event, called `GaaSFlowObservabilityEvent`, which contains the following metadata defined in this file: gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

