### PR TITLE
[GOBBLIN-2083] set max connections to 2000 in mysql started through the docker image to avoid "too many connections" error

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -134,6 +134,7 @@ jobs:
             sudo dpkg -l | grep -i mysql
             sudo apt-get clean
             sudo apt-get install -y mysql-client
+            mysql --host 127.0.0.1 --port 3306 -uroot -ppassword -e "SET GLOBAL max_connections=2000"
             mysql --host 127.0.0.1 --port 3306 -uroot -ppassword -e "SHOW DATABASES"
       - name: Cache Gradle Dependencies
         uses: actions/cache@v2

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/materializer/HiveMaterializerTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/materializer/HiveMaterializerTest.java
@@ -27,6 +27,19 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.data.management.conversion.hive.LocalHiveMetastoreTestUtils;
@@ -40,18 +53,6 @@ import org.apache.gobblin.runtime.TaskContext;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.AutoReturnableObject;
 import org.apache.gobblin.util.HiveJdbcConnector;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.ql.metadata.Table;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 
 
 @Test (groups = {"disabledOnCI"})
@@ -234,10 +235,10 @@ public class HiveMaterializerTest {
   }
 
   private List<List<String>> executeStatementAndGetResults(HiveJdbcConnector connector, String query, int columns) throws SQLException {
-    Connection conn = connector.getConnection();
     List<List<String>> result = new ArrayList<>();
 
-    try (Statement stmt = conn.createStatement()) {
+    try (Connection conn = connector.getConnection();
+        Statement stmt = conn.createStatement()) {
       stmt.execute(query);
       ResultSet rs = stmt.getResultSet();
       while (rs.next()) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/sql/SqlBasedRetentionPoc.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/retention/sql/SqlBasedRetentionPoc.java
@@ -22,8 +22,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 
-import com.zaxxer.hikari.HikariDataSource;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
@@ -32,6 +30,8 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.zaxxer.hikari.HikariDataSource;
 
 
 /**
@@ -71,8 +71,11 @@ public class SqlBasedRetentionPoc {
     execute("CREATE FUNCTION TIMESTAMP_DIFF(timestamp1 TIMESTAMP, timestamp2 TIMESTAMP, unitString VARCHAR(50)) RETURNS BIGINT PARAMETER STYLE JAVA NO SQL LANGUAGE JAVA EXTERNAL NAME 'org.apache.gobblin.data.management.retention.sql.SqlUdfs.timestamp_diff'");
   }
 
-  @AfterClass
+  @AfterClass (alwaysRun = true)
   public void cleanUp() throws Exception {
+    if (connection != null) {
+      connection.close();
+    }
     dataSource.close();
   }
 
@@ -89,17 +92,17 @@ public class SqlBasedRetentionPoc {
     insertSnapshot(new Path("/data/databases/Forum/Comments/1453889323804-PT-440936752"));
 
     // Derby does not support LIMIT keyword. The suggested workaround is to setMaxRows in the PreparedStatement
-    PreparedStatement statement = connection.prepareStatement("SELECT name FROM Snapshots ORDER BY ts desc");
-    statement.setMaxRows(2);
+    try (PreparedStatement statement = connection.prepareStatement("SELECT name FROM Snapshots ORDER BY ts desc")) {
+      statement.setMaxRows(2);
 
-    ResultSet rs = statement.executeQuery();
-
-    // Snapshots to be retained
-    rs.next();
-    Assert.assertEquals(rs.getString(1), "1453889323804-PT-440936752");
-    rs.next();
-    Assert.assertEquals(rs.getString(1), "1453860526464-PT-440847244");
-
+      try (ResultSet rs = statement.executeQuery()) {
+        // Snapshots to be retained
+        rs.next();
+        Assert.assertEquals(rs.getString(1), "1453889323804-PT-440936752");
+        rs.next();
+        Assert.assertEquals(rs.getString(1), "1453860526464-PT-440847244");
+      }
+    }
   }
 
   /**
@@ -119,18 +122,19 @@ public class SqlBasedRetentionPoc {
     Timestamp currentTimestamp =
         new Timestamp(DateTimeFormat.forPattern(DAILY_PARTITION_PATTERN).parseDateTime("2016/01/25").getMillis());
 
-    PreparedStatement statement =
-        connection.prepareStatement("SELECT path FROM Daily_Partitions WHERE TIMESTAMP_DIFF(?, ts, 'Days') > ?");
-    statement.setTimestamp(1, currentTimestamp);
-    statement.setLong(2, TWO_YEARS_IN_DAYS);
-    ResultSet rs = statement.executeQuery();
+    try (PreparedStatement statement =
+        connection.prepareStatement("SELECT path FROM Daily_Partitions WHERE TIMESTAMP_DIFF(?, ts, 'Days') > ?")) {
+      statement.setTimestamp(1, currentTimestamp);
+      statement.setLong(2, TWO_YEARS_IN_DAYS);
+      try (ResultSet rs = statement.executeQuery()) {
 
-    // Daily partitions to be cleaned
-    rs.next();
-    Assert.assertEquals(rs.getString(1), "/data/tracking/MetricEvent/daily/2014/01/22");
-    rs.next();
-    Assert.assertEquals(rs.getString(1), "/data/tracking/MetricEvent/daily/2013/01/25");
-
+        // Daily partitions to be cleaned
+        rs.next();
+        Assert.assertEquals(rs.getString(1), "/data/tracking/MetricEvent/daily/2014/01/22");
+        rs.next();
+        Assert.assertEquals(rs.getString(1), "/data/tracking/MetricEvent/daily/2013/01/25");
+      }
+    }
   }
 
   private void insertSnapshot(Path snapshotPath) throws Exception {
@@ -140,15 +144,15 @@ public class SqlBasedRetentionPoc {
     long ts = Long.parseLong(StringUtils.substringBefore(snapshotName, "-PT-"));
     long recordCount = Long.parseLong(StringUtils.substringAfter(snapshotName, "-PT-"));
 
-    PreparedStatement insert = connection.prepareStatement("INSERT INTO Snapshots VALUES (?, ?, ?, ?, ?)");
-    insert.setString(1, datasetPath);
-    insert.setString(2, snapshotName);
-    insert.setString(3, snapshotPath.toString());
-    insert.setTimestamp(4, new Timestamp(ts));
-    insert.setLong(5, recordCount);
+    try (PreparedStatement insert = connection.prepareStatement("INSERT INTO Snapshots VALUES (?, ?, ?, ?, ?)")) {
+      insert.setString(1, datasetPath);
+      insert.setString(2, snapshotName);
+      insert.setString(3, snapshotPath.toString());
+      insert.setTimestamp(4, new Timestamp(ts));
+      insert.setLong(5, recordCount);
 
-    insert.executeUpdate();
-
+      insert.executeUpdate();
+    }
   }
 
   private void insertDailyPartition(Path dailyPartitionPath) throws Exception {
@@ -159,17 +163,18 @@ public class SqlBasedRetentionPoc {
         DateTimeFormat.forPattern(DAILY_PARTITION_PATTERN).parseDateTime(
             StringUtils.substringAfter(dailyPartitionPath.toString(), "daily" + Path.SEPARATOR));
 
-    PreparedStatement insert = connection.prepareStatement("INSERT INTO Daily_Partitions VALUES (?, ?, ?)");
-    insert.setString(1, datasetPath);
-    insert.setString(2, dailyPartitionPath.toString());
-    insert.setTimestamp(3, new Timestamp(partition.getMillis()));
+    try (PreparedStatement insert = connection.prepareStatement("INSERT INTO Daily_Partitions VALUES (?, ?, ?)")) {
+      insert.setString(1, datasetPath);
+      insert.setString(2, dailyPartitionPath.toString());
+      insert.setTimestamp(3, new Timestamp(partition.getMillis()));
 
-    insert.executeUpdate();
-
+      insert.executeUpdate();
+    }
   }
 
   private void execute(String query) throws SQLException {
-    PreparedStatement insertStatement = connection.prepareStatement(query);
-    insertStatement.executeUpdate();
+    try (PreparedStatement insertStatement = connection.prepareStatement(query)) {
+      insertStatement.executeUpdate();
+    }
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/runtime/embedded/EmbeddedGobblinDistcpTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/runtime/embedded/EmbeddedGobblinDistcpTest.java
@@ -151,10 +151,12 @@ public class EmbeddedGobblinDistcpTest {
     metaStoreClient.tableExists(TARGET_DB, TEST_TABLE);
     FileSystem fs = FileSystem.getLocal(new Configuration());
     fs.exists(new Path(TARGET_PATH));
+
+    statement.close();
   }
 
   // Tearing down the Hive components from derby driver if there's anything generated through the test.
-  @AfterClass
+  @AfterClass (alwaysRun = true)
   public void hiveTearDown() throws Exception {
     FileSystem fs = FileSystem.getLocal(new Configuration());
     Path targetPath = new Path(TARGET_PATH);

--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseFactory.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseFactory.java
@@ -56,7 +56,7 @@ public class TestMetastoreDatabaseFactory {
     public static ITestMetastoreDatabase get(String version, Config dbConfig) throws Exception {
         try {
             synchronized (syncObject) {
-                ensureDatabaseExists(dbConfig);
+                ensureDatabaseServerExists(dbConfig);
                 TestMetadataDatabase instance = new TestMetadataDatabase(testMetastoreDatabaseServer, version);
                 instances.add(instance);
                 return instance;
@@ -72,14 +72,14 @@ public class TestMetastoreDatabaseFactory {
 
     static void release(ITestMetastoreDatabase instance) throws IOException {
         synchronized (syncObject) {
-            if (instances.remove(instance) && instances.size() == 0) {
+            if (instances.remove(instance) && instances.isEmpty()) {
                 testMetastoreDatabaseServer.close();
                 testMetastoreDatabaseServer = null;
             }
         }
     }
 
-    private static void ensureDatabaseExists(Config dbConfig) throws Exception {
+    private static void ensureDatabaseServerExists(Config dbConfig) throws Exception {
         if (testMetastoreDatabaseServer == null) {
             try (Mutex ignored = new Mutex()) {
                 if (testMetastoreDatabaseServer == null) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -30,8 +30,8 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import javax.inject.Inject;
-
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.service.ExecutionStatus;
 
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/GobblinServiceManagerTest.java
@@ -242,7 +242,7 @@ public class GobblinServiceManagerTest {
     }
   }
 
-  @AfterClass
+  @AfterClass (alwaysRun = true)
   public void cleanUp() throws Exception {
     // Shutdown Service
     try {
@@ -405,7 +405,7 @@ public class GobblinServiceManagerTest {
     }
   }
 
-  @Test (dependsOnMethods = "testUncompilableJob")
+  @Test (dependsOnMethods = "testRunQuotaExceeds")
   public void testExplainJob() throws Exception {
     int sizeBeforeTest = this.gobblinServiceManager.getFlowCatalog().getSpecs().size();
     FlowId flowId = createFlowIdWithUniqueName(TEST_GROUP_NAME);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
@@ -333,7 +333,6 @@ public class GobblinServiceJobSchedulerTest {
     FlowCatalog flowCatalog = new FlowCatalog(ConfigUtils.propertiesToConfig(properties));
     ServiceBasedAppLauncher serviceLauncher = new ServiceBasedAppLauncher(properties, "GaaSJobSchedulerTest");
 
-
     serviceLauncher.addService(flowCatalog);
     serviceLauncher.start();
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
@@ -383,7 +383,8 @@ public class GobblinServiceJobSchedulerTest {
     Assert.assertEquals(schedulerWithWarmStandbyEnabled.scheduledFlowSpecs.size(), 1);
     schedulerWithWarmStandbyEnabled.onAddSpec(flowSpec1);
     // Second flow should be added to scheduled flows since no quota check in this case
-    Assert.assertEquals(schedulerWithWarmStandbyEnabled.scheduledFlowSpecs.size(), 2);
+    AssertWithBackoff.create().maxSleepMs(200L).timeoutMs(5000L).backoffFactor(1)
+        .assertTrue(input -> schedulerWithWarmStandbyEnabled.scheduledFlowSpecs.size() == 2, "Waiting for add spec to complete");
     // set scheduler to be inactive and unschedule flows
     schedulerWithWarmStandbyEnabled.setActive(false);
     Assert.assertEquals(schedulerWithWarmStandbyEnabled.scheduledFlowSpecs.size(), 0);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2083


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

increase max_connection to 2000 to mysql from docker image to overcome SQLException too many connections
close some jdbc connections, result set and prepared connections as a good practice.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

