### PR TITLE
[GOBBLIN-2089] Fix /flowexecutions KILL and RESUME action to return HTTP 404 when flow execution doesn't exist

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandlerWithWarmStandby.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandlerWithWarmStandby.java
@@ -56,13 +56,13 @@ public class GobblinServiceFlowExecutionResourceHandlerWithWarmStandby extends G
 
   @Override
   public void resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
-    FlowStatusId id = key.getKey();
+    FlowStatusId id = this.get(key).getId(); // pre-check to throw `HttpStatus.S_404_NOT_FOUND`, in case FlowExecution doesn't exist
     addDagAction(id.getFlowGroup(), id.getFlowName(), id.getFlowExecutionId(), DagActionStore.DagActionType.RESUME);
   }
 
   @Override
   public UpdateResponse delete(ComplexResourceKey<org.apache.gobblin.service.FlowStatusId, EmptyRecord> key) {
-    FlowStatusId id = key.getKey();
+    FlowStatusId id = this.get(key).getId();  // pre-check to throw `HttpStatus.S_404_NOT_FOUND`, in case FlowExecution doesn't exist
     addDagAction(id.getFlowGroup(), id.getFlowName(), id.getFlowExecutionId(), DagActionStore.DagActionType.KILL);
     return new UpdateResponse(HttpStatus.S_200_OK);
   }


### PR DESCRIPTION
…ution doesn't exist

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2089) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-2089


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The current implementation doesn't check for FlowExecution existence before accepting a KILL or RESUME.
Updated the functions to call GET api first to get the FlowExecution. This GET api throws a 404 if a FlowExecution doesn't exist.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Tested kill and resumse commands in dev fabric by adding the changed line to `GobblinServiceFlowExecutionResourceHandler` class resume and kill functions. Tested with flow executions which were present and did not exist in the `shared_gaas_job_status` table.
    - Resume test screenshot:
![image](https://github.com/apache/gobblin/assets/16535454/9e11d680-8b45-42ec-baa1-f93c0578810b)

    - Kill test screenshot:
![image](https://github.com/apache/gobblin/assets/16535454/84966454-880e-4ece-8297-610f6d4b0d2a)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

