### PR TITLE
[GOBBLIN-2088] Add retry to OH replication final catalog commit

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -159,8 +159,11 @@ public class IcebergRegisterStep implements CommitStep {
       @Override
       public <V> void onRetry(Attempt<V> attempt) {
         if (attempt.hasException()) {
-          String msg = String.format("Exception caught while registering iceberg table [attempt: %d; %s after start]",
-              attempt.getAttemptNumber(), Duration.ofMillis(attempt.getDelaySinceFirstAttempt()).toString());
+          String msg = String.format("Exception caught while registering iceberg table : (src: {%s}) - (dest: {%s}) : [attempt: %d; %s after start]",
+                                      srcTableIdStr,
+                                      destTableIdStr,
+                                      attempt.getAttemptNumber(),
+                                      Duration.ofMillis(attempt.getDelaySinceFirstAttempt()).toString());
           log.warn(msg, attempt.getExceptionCause());
         }
       }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStep.java
@@ -17,11 +17,16 @@
 
 package org.apache.gobblin.data.management.copy.iceberg;
 
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import java.io.IOException;
 import java.util.Properties;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.concurrent.ExecutionException;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 
@@ -49,6 +54,7 @@ public class IcebergRegisterStep implements CommitStep {
   private final TableMetadata readTimeSrcTableMetadata;
   private final TableMetadata justPriorDestTableMetadata;
   private final Properties properties;
+  private final Integer MAX_NUMBER_OF_ATTEMPTS = 3;
 
   public IcebergRegisterStep(TableIdentifier srcTableId, TableIdentifier destTableId,
       TableMetadata readTimeSrcTableMetadata, TableMetadata justPriorDestTableMetadata,
@@ -85,11 +91,20 @@ public class IcebergRegisterStep implements CommitStep {
       if (!isJustPriorDestMetadataStillCurrent) {
         throw new IOException("error: likely concurrent writing to destination: " + determinationMsg);
       }
-      destIcebergTable.registerIcebergTable(readTimeSrcTableMetadata, currentDestMetadata);
+      Retryer<Void> registerRetryer = RetryerBuilder.<Void>newBuilder()
+          .retryIfException()
+          .withStopStrategy(StopStrategies.stopAfterAttempt(MAX_NUMBER_OF_ATTEMPTS)).build();
+      registerRetryer.call(() -> {
+        destIcebergTable.registerIcebergTable(readTimeSrcTableMetadata, currentDestMetadata);
+        return null;
+      });
     } catch (IcebergTable.TableNotFoundException tnfe) {
       String msg = "Destination table (with TableMetadata) does not exist: " + tnfe.getMessage();
       log.error(msg);
       throw new IOException(msg, tnfe);
+    } catch (ExecutionException | RetryException e) {
+      log.error("Exception Encountered while Registering Iceberg Table", e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
@@ -141,7 +141,7 @@ public class IcebergRegisterStepTest {
     return catalog;
   }
 
-    protected IcebergTable mockIcebergTableForRetryer(String tableUuid, String tableMetadataFileLocation, Boolean throwOnlyExceptionsForRegisterIcebergTable) throws IOException {
+  protected IcebergTable mockIcebergTableForRetryer(String tableUuid, String tableMetadataFileLocation, Boolean throwOnlyExceptionsForRegisterIcebergTable) throws IOException {
     TableMetadata mockMetadata = mockTableMetadata(tableUuid, tableMetadataFileLocation);
 
     IcebergTable mockTable = Mockito.mock(IcebergTable.class);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
@@ -79,7 +79,8 @@ public class IcebergRegisterStepTest {
   public void testRegisterIcebergTableWithRetryer() throws IOException {
     TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
     TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class);
-    IcebergTable mockTable = mockIcebergTableForRetryer("foo", "bar", Boolean.FALSE);
+    IcebergTable mockTable = mockIcebergTable("foo", "bar");
+    Mockito.doThrow(new RuntimeException()).doThrow(new RuntimeException()).doNothing().when(mockTable).registerIcebergTable(any(), any());
     IcebergRegisterStep regStep =
         new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
           @Override
@@ -99,7 +100,8 @@ public class IcebergRegisterStepTest {
   public void testRegisterIcebergTableWithRetryerThrowsRuntimeException() throws IOException {
     TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
     TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class);
-    IcebergTable mockTable = mockIcebergTableForRetryer("foo", "bar", Boolean.TRUE);
+    IcebergTable mockTable = mockIcebergTable("foo", "bar");
+    Mockito.doThrow(new RuntimeException()).when(mockTable).registerIcebergTable(any(), any());
     IcebergRegisterStep regStep =
         new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
           @Override
@@ -139,18 +141,5 @@ public class IcebergRegisterStepTest {
     IcebergCatalog catalog = Mockito.mock(IcebergCatalog.class);
     Mockito.when(catalog.openTable(any())).thenReturn(mockTable);
     return catalog;
-  }
-
-  protected IcebergTable mockIcebergTableForRetryer(String tableUuid, String tableMetadataFileLocation, Boolean throwOnlyExceptionsForRegisterIcebergTable) throws IOException {
-    TableMetadata mockMetadata = mockTableMetadata(tableUuid, tableMetadataFileLocation);
-
-    IcebergTable mockTable = Mockito.mock(IcebergTable.class);
-    Mockito.when(mockTable.accessTableMetadata()).thenReturn(mockMetadata);
-    if (throwOnlyExceptionsForRegisterIcebergTable) {
-      Mockito.doThrow(new RuntimeException()).when(mockTable).registerIcebergTable(any(), any());
-    } else {
-      Mockito.doThrow(new RuntimeException()).doThrow(new RuntimeException()).doNothing().when(mockTable).registerIcebergTable(any(), any());
-    }
-    return mockTable;
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
@@ -104,8 +104,7 @@ public class IcebergRegisterStepTest {
       Assert.fail("Expected Runtime Exception");
     } catch (RuntimeException re) {
       // The default number of retries is 5 so register iceberg table should fail after retrying for 5 times
-      String msg = String.format("Failed to register iceberg table : (src: {%s}) - (dest: {%s}) : (retried %d times)", srcTableId, destTableId, 5);
-      Assert.assertTrue(re.getMessage().startsWith(msg), re.getMessage());
+      assertRetryTimes(re, 5);
     }
   }
 
@@ -126,8 +125,7 @@ public class IcebergRegisterStepTest {
       Assert.fail("Expected Runtime Exception");
     } catch (RuntimeException re) {
       // register iceberg table should fail after retrying for retryCount times mentioned above
-      String msg = String.format("Failed to register iceberg table : (src: {%s}) - (dest: {%s}) : (retried %d times)", srcTableId, destTableId, Integer.parseInt(retryCount));
-      Assert.assertTrue(re.getMessage().startsWith(msg), re.getMessage());
+      assertRetryTimes(re, Integer.parseInt(retryCount));
     }
   }
 
@@ -167,5 +165,10 @@ public class IcebergRegisterStepTest {
         return mockSingleTableIcebergCatalog(mockTable);
       }
     };
+  }
+
+  private void assertRetryTimes(RuntimeException re, Integer retryTimes) {
+    String msg = String.format("Failed to register iceberg table : (src: {%s}) - (dest: {%s}) : (retried %d times)", srcTableId, destTableId, retryTimes);
+    Assert.assertTrue(re.getMessage().startsWith(msg), re.getMessage());
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergRegisterStepTest.java
@@ -29,6 +29,8 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
 
+import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TIMES;
+
 
 /** Tests for {@link org.apache.gobblin.data.management.copy.iceberg.IcebergRegisterStep} */
 public class IcebergRegisterStepTest {
@@ -41,13 +43,7 @@ public class IcebergRegisterStepTest {
     TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
     TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class); // (no mocked behavior)
     IcebergTable mockTable = mockIcebergTable("foo", "bar"); // matches!
-    IcebergRegisterStep regStep =
-        new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
-          @Override
-          protected IcebergCatalog createDestinationCatalog() throws IOException {
-            return mockSingleTableIcebergCatalog(mockTable);
-          }
-        };
+    IcebergRegisterStep regStep = createIcebergRegisterStepInstance(readTimeSrcTableMetadata, justPriorDestTableMetadata, mockTable, new Properties());
     try {
       regStep.execute();
       Mockito.verify(mockTable, Mockito.times(1)).registerIcebergTable(any(), any());
@@ -80,14 +76,13 @@ public class IcebergRegisterStepTest {
     TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
     TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class);
     IcebergTable mockTable = mockIcebergTable("foo", "bar");
-    Mockito.doThrow(new RuntimeException()).doThrow(new RuntimeException()).doNothing().when(mockTable).registerIcebergTable(any(), any());
-    IcebergRegisterStep regStep =
-        new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
-          @Override
-          protected IcebergCatalog createDestinationCatalog() throws IOException {
-            return mockSingleTableIcebergCatalog(mockTable);
-          }
-        };
+    // Mocking registerIcebergTable() call to fail for first two attempts and then succeed
+    // So total number of invocations to registerIcebergTable() should be 3 only
+    Mockito.doThrow(new RuntimeException())
+        .doThrow(new RuntimeException())
+        .doNothing()
+        .when(mockTable).registerIcebergTable(any(), any());
+    IcebergRegisterStep regStep = createIcebergRegisterStepInstance(readTimeSrcTableMetadata, justPriorDestTableMetadata, mockTable, new Properties());
     try {
       regStep.execute();
       Mockito.verify(mockTable, Mockito.times(3)).registerIcebergTable(any(), any());
@@ -97,23 +92,42 @@ public class IcebergRegisterStepTest {
   }
 
   @Test
-  public void testRegisterIcebergTableWithRetryerThrowsRuntimeException() throws IOException {
+  public void testRegisterIcebergTableWithDefaultRetryerConfig() throws IOException {
     TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
     TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class);
     IcebergTable mockTable = mockIcebergTable("foo", "bar");
+    // Mocking registerIcebergTable() call to always throw exception
     Mockito.doThrow(new RuntimeException()).when(mockTable).registerIcebergTable(any(), any());
-    IcebergRegisterStep regStep =
-        new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, new Properties()) {
-          @Override
-          protected IcebergCatalog createDestinationCatalog() throws IOException {
-            return mockSingleTableIcebergCatalog(mockTable);
-          }
-        };
+    IcebergRegisterStep regStep = createIcebergRegisterStepInstance(readTimeSrcTableMetadata, justPriorDestTableMetadata, mockTable, new Properties());
     try {
       regStep.execute();
       Assert.fail("Expected Runtime Exception");
     } catch (RuntimeException re) {
-      Assert.assertTrue(re.getMessage().startsWith("Failed to register iceberg table (retried"), re.getMessage());
+      // The default number of retries is 5 so register iceberg table should fail after retrying for 5 times
+      String msg = String.format("Failed to register iceberg table : (src: {%s}) - (dest: {%s}) : (retried %d times)", srcTableId, destTableId, 5);
+      Assert.assertTrue(re.getMessage().startsWith(msg), re.getMessage());
+    }
+  }
+
+  @Test
+  public void testRegisterIcebergTableWithOverrideRetryerConfig() throws IOException {
+    TableMetadata justPriorDestTableMetadata = mockTableMetadata("foo", "bar");
+    TableMetadata readTimeSrcTableMetadata = Mockito.mock(TableMetadata.class);
+    IcebergTable mockTable = mockIcebergTable("foo", "bar");
+    // Mocking registerIcebergTable() call to always throw exception
+    Mockito.doThrow(new RuntimeException()).when(mockTable).registerIcebergTable(any(), any());
+    Properties properties = new Properties();
+    String retryCount = "10";
+    // Changing the number of retries to 10
+    properties.setProperty(IcebergRegisterStep.RETRYER_CONFIG_PREFIX + "." + RETRY_TIMES, retryCount);
+    IcebergRegisterStep regStep = createIcebergRegisterStepInstance(readTimeSrcTableMetadata, justPriorDestTableMetadata, mockTable, properties);
+    try {
+      regStep.execute();
+      Assert.fail("Expected Runtime Exception");
+    } catch (RuntimeException re) {
+      // register iceberg table should fail after retrying for retryCount times mentioned above
+      String msg = String.format("Failed to register iceberg table : (src: {%s}) - (dest: {%s}) : (retried %d times)", srcTableId, destTableId, Integer.parseInt(retryCount));
+      Assert.assertTrue(re.getMessage().startsWith(msg), re.getMessage());
     }
   }
 
@@ -141,5 +155,17 @@ public class IcebergRegisterStepTest {
     IcebergCatalog catalog = Mockito.mock(IcebergCatalog.class);
     Mockito.when(catalog.openTable(any())).thenReturn(mockTable);
     return catalog;
+  }
+
+  private IcebergRegisterStep createIcebergRegisterStepInstance(TableMetadata readTimeSrcTableMetadata,
+                                                                TableMetadata justPriorDestTableMetadata,
+                                                                IcebergTable mockTable,
+                                                                Properties properties) {
+    return new IcebergRegisterStep(srcTableId, destTableId, readTimeSrcTableMetadata, justPriorDestTableMetadata, properties) {
+      @Override
+      protected IcebergCatalog createDestinationCatalog() throws IOException {
+        return mockSingleTableIcebergCatalog(mockTable);
+      }
+    };
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2088 


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   - Added retry with maximum number of attempts as 3 for OH replication final catalog commit

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - Added testRegisterIcebergTableWithRetryer() and testRegisterIcebergTableWithRetryerThrowsRuntimeException() 
   - In testRegisterIcebergTableWithRetryer(), I have mocked IcebergTable:registerIcebergTable() to throw runtime exception for intital two calls and then do nothing for third call so that retryer will finish after third call.
   - In testRegisterIcebergTableWithRetryerThrowsRuntimeException(), IcebergTable:registerIcebergTable() will always throw RuntimeException, so after retrying for defailt retry_times(set to 5), retryer will finish with RetryException and will throw RuntimeException


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

