### PR TITLE
[GOBBLIN-2094] verify dag action exist in deadline dag procs

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -106,7 +106,7 @@ public interface DagActionStore {
    * @param dagActionType the value of the dag action
    * @throws IOException
    */
-  boolean exists(String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionType dagActionType) throws IOException, SQLException;
+  boolean exists(String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionType dagActionType) throws IOException;
 
   /**
    * Check if an action exists in dagAction store by flow group, flow name, and flow execution id, it assumes jobName is

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
@@ -207,7 +207,7 @@ public interface DagManagementStateStore {
    * @throws IOException
    */
   boolean existsJobDagAction(String flowGroup, String flowName, long flowExecutionId, String jobName,
-      DagActionStore.DagActionType dagActionType) throws IOException, SQLException;
+      DagActionStore.DagActionType dagActionType) throws IOException;
 
   /**
    * Check if an action exists in dagAction store by flow group, flow name, and flow execution id, it assumes jobName is

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcFactory.java
@@ -46,7 +46,7 @@ import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 
 @Alpha
 @Singleton
-public class DagProcFactory implements DagTaskVisitor<DagProc> {
+public class DagProcFactory implements DagTaskVisitor<DagProc<?>> {
 
   private final FlowCompilationValidationHelper flowCompilationValidationHelper;
 
@@ -56,15 +56,14 @@ public class DagProcFactory implements DagTaskVisitor<DagProc> {
   }
 
   @Override
-  public DagProc meet(EnforceFlowFinishDeadlineDagTask enforceFlowFinishDeadlineDagTask) {
+  public EnforceFlowFinishDeadlineDagProc meet(EnforceFlowFinishDeadlineDagTask enforceFlowFinishDeadlineDagTask) {
     return new EnforceFlowFinishDeadlineDagProc(enforceFlowFinishDeadlineDagTask);
   }
 
   @Override
-  public DagProc meet(EnforceJobStartDeadlineDagTask enforceJobStartDeadlineDagTask) {
+  public EnforceJobStartDeadlineDagProc meet(EnforceJobStartDeadlineDagTask enforceJobStartDeadlineDagTask) {
     return new EnforceJobStartDeadlineDagProc(enforceJobStartDeadlineDagTask);
   }
-
 
   @Override
   public LaunchDagProc meet(LaunchDagTask launchDagTask) {
@@ -85,6 +84,5 @@ public class DagProcFactory implements DagTaskVisitor<DagProc> {
   public ResumeDagProc meet(ResumeDagTask resumeDagTask) {
     return new ResumeDagProc(resumeDagTask);
   }
-  //todo - overload meet method for other dag tasks
 }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStore.java
@@ -277,7 +277,7 @@ public class MostlyMySqlDagManagementStateStore implements DagManagementStateSto
 
   @Override
   public boolean existsJobDagAction(String flowGroup, String flowName, long flowExecutionId, String jobName,
-      DagActionStore.DagActionType dagActionType) throws IOException, SQLException {
+      DagActionStore.DagActionType dagActionType) throws IOException {
     return this.dagActionStore.exists(flowGroup, flowName, flowExecutionId, jobName, dagActionType);
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
@@ -97,7 +97,7 @@ public class MysqlDagActionStore implements DagActionStore {
   }
 
   @Override
-  public boolean exists(String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionType dagActionType) throws IOException, SQLException {
+  public boolean exists(String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionType dagActionType) throws IOException {
     return dbStatementExecutor.withPreparedStatement(String.format(EXISTS_STATEMENT, tableName), existStatement -> {
       int i = 0;
       existStatement.setString(++i, flowGroup);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
@@ -99,24 +99,13 @@ public class MysqlDagActionStore implements DagActionStore {
   @Override
   public boolean exists(String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionType dagActionType) throws IOException {
     return dbStatementExecutor.withPreparedStatement(String.format(EXISTS_STATEMENT, tableName), existStatement -> {
-      int i = 0;
-      existStatement.setString(++i, flowGroup);
-      existStatement.setString(++i, flowName);
-      existStatement.setString(++i, String.valueOf(flowExecutionId));
-      existStatement.setString(++i, jobName);
-      existStatement.setString(++i, dagActionType.toString());
-      ResultSet rs = null;
-      try {
-        rs = existStatement.executeQuery();
+      fillPreparedStatement(flowGroup, flowName, flowExecutionId, jobName, dagActionType, existStatement);
+      try (ResultSet rs = existStatement.executeQuery()) {
         rs.next();
         return rs.getBoolean(1);
       } catch (SQLException e) {
         throw new IOException(String.format("Failure checking existence of DagAction: %s in table %s",
             new DagAction(flowGroup, flowName, flowExecutionId, jobName, dagActionType), tableName), e);
-      } finally {
-        if (rs != null) {
-          rs.close();
-        }
       }
     }, true);
   }
@@ -131,12 +120,7 @@ public class MysqlDagActionStore implements DagActionStore {
       throws IOException {
     dbStatementExecutor.withPreparedStatement(String.format(INSERT_STATEMENT, tableName), insertStatement -> {
     try {
-      int i = 0;
-      insertStatement.setString(++i, flowGroup);
-      insertStatement.setString(++i, flowName);
-      insertStatement.setString(++i, String.valueOf(flowExecutionId));
-      insertStatement.setString(++i, jobName);
-      insertStatement.setString(++i, dagActionType.toString());
+      fillPreparedStatement(flowGroup, flowName, flowExecutionId, jobName, dagActionType, insertStatement);
       return insertStatement.executeUpdate();
     } catch (SQLException e) {
       throw new IOException(String.format("Failure adding action for DagAction: %s in table %s",
@@ -148,14 +132,9 @@ public class MysqlDagActionStore implements DagActionStore {
   public boolean deleteDagAction(DagAction dagAction) throws IOException {
     return dbStatementExecutor.withPreparedStatement(String.format(DELETE_STATEMENT, tableName), deleteStatement -> {
     try {
-      int i = 0;
-      deleteStatement.setString(++i, dagAction.getFlowGroup());
-      deleteStatement.setString(++i, dagAction.getFlowName());
-      deleteStatement.setString(++i, String.valueOf(dagAction.getFlowExecutionId()));
-      deleteStatement.setString(++i, dagAction.getJobName());
-      deleteStatement.setString(++i, dagAction.getDagActionType().toString());
-      int result = deleteStatement.executeUpdate();
-      return result != 0;
+      fillPreparedStatement(dagAction.getFlowGroup(), dagAction.getFlowName(), dagAction.getFlowExecutionId(),
+          dagAction.getJobName(), dagAction.getDagActionType(), deleteStatement);
+      return deleteStatement.executeUpdate() != 0;
     } catch (SQLException e) {
       throw new IOException(String.format("Failure deleting action for DagAction: %s in table %s", dagAction,
           tableName), e);
@@ -201,5 +180,16 @@ public class MysqlDagActionStore implements DagActionStore {
         throw new IOException(String.format("Failure get dag actions from table %s ", tableName), e);
       }
     }, true);
+  }
+
+  private static void fillPreparedStatement(String flowGroup, String flowName, long flowExecutionId, String jobName,
+      DagActionType dagActionType, PreparedStatement statement)
+      throws SQLException {
+    int i = 0;
+    statement.setString(++i, flowGroup);
+    statement.setString(++i, flowName);
+    statement.setString(++i, String.valueOf(flowExecutionId));
+    statement.setString(++i, jobName);
+    statement.setString(++i, dagActionType.toString());
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
@@ -54,15 +54,15 @@ abstract public class DeadlineEnforcementDagProc extends DagProc<Optional<Dag<Jo
 
   private boolean validate(Optional<Dag<JobExecutionPlan>> dag, DagManagementStateStore dagManagementStateStore) throws IOException {
     log.info("Request to enforce deadlines for dag {}", getDagId());
+    DagActionStore.DagAction dagAction = getDagTask().getDagAction();
 
     if (!dag.isPresent()) {
       // todo - add a metric here
-      log.error("Did not find Dag with id {}, it might be already cancelled/finished and thus cleaned up from the store.",
-          getDagId());
+      log.error("Dag not present when validating {}. It may already have cancelled/finished. Dag {}",
+          getDagId(), dagAction);
       return false;
     }
 
-    DagActionStore.DagAction dagAction = getDagTask().getDagAction();
     if (!dagManagementStateStore.existsJobDagAction(dagAction.getFlowGroup(), dagAction.getFlowName(),
         dagAction.getFlowExecutionId(), dagAction.getJobName(), dagAction.getDagActionType())) {
       log.warn("Dag action {} is cleaned up from DMSS. No further action is required.", dagAction);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
@@ -28,7 +28,9 @@ import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.task.DagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
-
+/**
+ * An abstract implementation for {@link DagProc} that enforces deadline for jobs.
+ */
 @Slf4j
 abstract public class DeadlineEnforcementDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
 
@@ -63,8 +65,7 @@ abstract public class DeadlineEnforcementDagProc extends DagProc<Optional<Dag<Jo
     DagActionStore.DagAction dagAction = getDagTask().getDagAction();
     if (!dagManagementStateStore.existsJobDagAction(dagAction.getFlowGroup(), dagAction.getFlowName(),
         dagAction.getFlowExecutionId(), dagAction.getJobName(), dagAction.getDagActionType())) {
-      log.warn("{} not found in the store. Was the flow finished and dag action cleaned up right before the dag action act?",
-          dagAction);
+      log.warn("Dag action {} is cleaned up from DMSS. No further action is required.", dagAction);
       return false;
     }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DeadlineEnforcementDagProc.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration.proc;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.orchestration.DagActionStore;
+import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
+import org.apache.gobblin.service.modules.orchestration.task.DagTask;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+
+
+@Slf4j
+abstract public class DeadlineEnforcementDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
+
+  public DeadlineEnforcementDagProc(DagTask dagTask) {
+    super(dagTask);
+  }
+
+  @Override
+  protected Optional<Dag<JobExecutionPlan>> initialize(DagManagementStateStore dagManagementStateStore)
+      throws IOException {
+    return dagManagementStateStore.getDag(getDagId());
+  }
+
+  @Override
+  protected void act(DagManagementStateStore dagManagementStateStore, Optional<Dag<JobExecutionPlan>> dag)
+      throws IOException {
+    if (validate(dag, dagManagementStateStore)) {
+      enforceDeadline(dagManagementStateStore, dag.get());
+    }
+  }
+
+  private boolean validate(Optional<Dag<JobExecutionPlan>> dag, DagManagementStateStore dagManagementStateStore) throws IOException {
+    log.info("Request to enforce deadlines for dag {}", getDagId());
+
+    if (!dag.isPresent()) {
+      // todo - add a metric here
+      log.error("Did not find Dag with id {}, it might be already cancelled/finished and thus cleaned up from the store.",
+          getDagId());
+      return false;
+    }
+
+    DagActionStore.DagAction dagAction = getDagTask().getDagAction();
+    if (!dagManagementStateStore.existsJobDagAction(dagAction.getFlowGroup(), dagAction.getFlowName(),
+        dagAction.getFlowExecutionId(), dagAction.getJobName(), dagAction.getDagActionType())) {
+      log.warn("{} not found in the store. Was the flow finished and dag action cleaned up right before the dag action act?",
+          dagAction);
+      return false;
+    }
+
+    return true;
+  }
+
+  abstract void enforceDeadline(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag) throws IOException;
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.service.modules.orchestration.proc;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,51 +35,30 @@ import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
  * {@link org.apache.gobblin.configuration.ConfigurationKeys#GOBBLIN_FLOW_SLA_TIME} time.
  */
 @Slf4j
-public class EnforceFlowFinishDeadlineDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
+public class EnforceFlowFinishDeadlineDagProc extends DeadlineEnforcementDagProc {
 
   public EnforceFlowFinishDeadlineDagProc(EnforceFlowFinishDeadlineDagTask enforceFlowFinishDeadlineDagTask) {
     super(enforceFlowFinishDeadlineDagTask);
   }
 
-  @Override
-  protected Optional<Dag<JobExecutionPlan>> initialize(DagManagementStateStore dagManagementStateStore)
+  protected void enforceDeadline(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag)
       throws IOException {
-   return dagManagementStateStore.getDag(getDagId());
-  }
-
-  @Override
-  protected void act(DagManagementStateStore dagManagementStateStore, Optional<Dag<JobExecutionPlan>> dag)
-      throws IOException {
-    log.info("Request to enforce deadlines for dag {}", getDagId());
-
-    if (!dag.isPresent()) {
-      // todo - add a metric here
-      log.error("Did not find Dag with id {}, it might be already cancelled/finished and thus cleaned up from the store.",
-          getDagId());
-      return;
-    }
-
-    enforceFlowFinishDeadline(dagManagementStateStore, dag);
-  }
-
-  private void enforceFlowFinishDeadline(DagManagementStateStore dagManagementStateStore, Optional<Dag<JobExecutionPlan>> dag)
-      throws IOException {
-    Dag.DagNode<JobExecutionPlan> dagNode = dag.get().getNodes().get(0);
+    Dag.DagNode<JobExecutionPlan> dagNode = dag.getNodes().get(0);
     long flowFinishDeadline = DagManagerUtils.getFlowSLA(dagNode);
     long flowStartTime = DagManagerUtils.getFlowStartTime(dagNode);
 
     // note that this condition should be true because the triggered dag action has waited enough before reaching here
     if (System.currentTimeMillis() > flowStartTime + flowFinishDeadline) {
-      List<Dag.DagNode<JobExecutionPlan>> dagNodesToCancel = dag.get().getNodes();
+      List<Dag.DagNode<JobExecutionPlan>> dagNodesToCancel = dag.getNodes();
       log.info("Found {} DagNodes to cancel (DagId {}).", dagNodesToCancel.size(), getDagId());
 
       for (Dag.DagNode<JobExecutionPlan> dagNodeToCancel : dagNodesToCancel) {
         DagProcUtils.cancelDagNode(dagNodeToCancel, dagManagementStateStore);
       }
 
-      dag.get().setFlowEvent(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED);
-      dag.get().setMessage("Flow killed due to exceeding SLA of " + flowFinishDeadline + " ms");
-      dagManagementStateStore.checkpointDag(dag.get());
+      dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED);
+      dag.setMessage("Flow killed due to exceeding SLA of " + flowFinishDeadline + " ms");
+      dagManagementStateStore.checkpointDag(dag);
     } else {
       log.error("EnforceFlowFinishDeadline dagAction received before due time. flowStartTime {}, flowFinishDeadline {} ", flowStartTime, flowFinishDeadline);
     }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MostlyMySqlDagManagementStateStoreTest.java
@@ -135,7 +135,8 @@ public class MostlyMySqlDagManagementStateStoreTest {
     URI specExecURI = new URI(TEST_SPEC_EXECUTOR_URI);
     topologySpecMap.put(specExecURI, topologySpec);
     MostlyMySqlDagManagementStateStore dagManagementStateStore =
-        new MostlyMySqlDagManagementStateStore(config, null, null, jobStatusRetriever, mock(DagActionStore.class));
+        new MostlyMySqlDagManagementStateStore(config, null, null, jobStatusRetriever,
+            MysqlDagActionStoreTest.getTestDagActionStore(testMetastoreDatabase));
     dagManagementStateStore.setTopologySpecMap(topologySpecMap);
     return dagManagementStateStore;
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
@@ -46,25 +46,28 @@ public class MysqlDagActionStoreTest {
   private static final long flowExecutionId_2 = 12345678L;
   private static final long flowExecutionId_3 = 12345679L;
   private ITestMetastoreDatabase testDb;
-  private MysqlDagActionStore mysqlDagActionStore;
+  private DagActionStore mysqlDagActionStore;
 
   @BeforeClass
   public void setUp() throws Exception {
     this.testDb = TestMetastoreDatabaseFactory.get();
-    Config config = ConfigBuilder.create()
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, this.testDb.getJdbcUrl())
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
-        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
-        .build();
-
-    this.mysqlDagActionStore = new MysqlDagActionStore(config);
+    this.mysqlDagActionStore = getTestDagActionStore(this.testDb);
   }
 
   @AfterClass(alwaysRun = true)
   public void tearDown() throws IOException {
     // `.close()` to avoid (in the aggregate, across multiple suites) - java.sql.SQLNonTransientConnectionException: Too many connections
     this.testDb.close();
+  }
+
+  public static DagActionStore getTestDagActionStore(ITestMetastoreDatabase testDb) throws Exception {
+    Config config = ConfigBuilder.create()
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
+        .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
+        .build();
+    return new MysqlDagActionStore(config);
   }
 
   @Test

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceDeadlineDagProcsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceDeadlineDagProcsTest.java
@@ -107,6 +107,11 @@ public class EnforceDeadlineDagProcsTest {
             .filter(a -> a.getMethod().getName().equals("deleteDagNodeState")).count());
   }
 
+  /*
+  This test simulate deletion of a dag action (by not adding it into DMSS).
+  Absence of dag action signals that deadline enforcement is not required and hence the test verifies no further action
+  is taken by deadline dag proc.
+   */
   @Test
   public void enforceJobStartDeadlineTestWithMissingDagAction() throws Exception {
     String flowGroup = "fg";

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -119,7 +119,7 @@ public class LaunchDagProcTest {
   @Test
   public void launchDagWithMultipleParallelJobs() throws IOException, InterruptedException, URISyntaxException {
     String flowGroup = "fg";
-    String flowName = "fn";
+    String flowName = "fn2";
     long flowExecutionId = 12345L;
     Dag<JobExecutionPlan> dag = buildDagWithMultipleNodesAtDifferentLevels("1", flowExecutionId,
         DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(),"user5", ConfigFactory.empty()


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2094


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
deadline dag procs may have been pulled out of dagActionQueue for processing right before the corresponding dag actions are deleted by job status monitor (singnaling flow start) or reevaluate dag proc (signaling flow finish).
deadline dag procs should stop if these things happened by checking the dag action one more time.

also did some code refactoring to avoid duplicate code

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test in EnforceDeadlineDagProcsTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

