### PR TITLE
[GOBBLIN-2095] Set owner and group when pre-creating directories

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/CreateAndSetDirectoryPermissionCommitStep.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/util/commit/CreateAndSetDirectoryPermissionCommitStep.java
@@ -71,6 +71,8 @@ public class CreateAndSetDirectoryPermissionCommitStep implements CommitStep {
         if (!fs.exists(path)) {
           log.info("Creating path {} with permission {}", path, entry.getValue().getFsPermission());
           fs.mkdirs(path, entry.getValue().getFsPermission());
+          // Set owner and group since created directories will have owner set to the job runner (instead of the data owner)
+          fs.setOwner(path, entry.getValue().getOwner(), entry.getValue().getGroup());
         } else {
           log.info("Setting permission {} on existing path {}", entry.getValue().getFsPermission(), path);
           fs.setPermission(path, entry.getValue().getFsPermission());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2095


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
When a job is run by a headless account that is not the dataset owner, the `CreateAndSetPermissionCommitStep` needs to set the file owners and group appropriately to match the original dataset owner, otherwise it will lead to a mismatch for the source data.

The reason why the commit step creates folders manually instead of fully copying them via rename is to avoid the race condition where multiple files may be publishing with the same file root at the same time, in which case `fs.mkdirs` in the scenario where the folder does not exist on destination may append an extra directory level.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

