### PR TITLE
[GOBBLIN-2096] Retry Transient SQL Exception for MALA 

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -441,10 +441,10 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
               if (exponentialBackoff.awaitNextRetryIfAvailable()) {
                 return attemptLeaseIfNewRow(dagAction, exponentialBackoff);
               }
-            } catch (InterruptedException | IOException e2) {
+            } catch (InterruptedException e2) {
               throw new IOException(e2);
             }
-            return 0;
+            throw e; 
           }
           catch (SQLIntegrityConstraintViolationException e) {
             if (!e.getMessage().contains("Duplicate entry")) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -23,6 +23,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLTransientException;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Optional;
@@ -41,6 +42,7 @@ import org.apache.gobblin.metastore.MysqlDataSourceFactory;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.DBStatementExecutor;
+import org.apache.gobblin.util.ExponentialBackoff;
 
 
 /**
@@ -254,7 +256,8 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         log.debug("tryAcquireLease for [{}, is; {}, eventTimestamp: {}] - CASE 1: no existing row for this dag action,"
             + " then go ahead and insert", dagActionLeaseObject.getDagAction(),
             dagActionLeaseObject.isReminder() ? "reminder" : "original", dagActionLeaseObject.getEventTimeMillis());
-        int numRowsUpdated = attemptLeaseIfNewRow(dagActionLeaseObject.getDagAction());
+        int numRowsUpdated = attemptLeaseIfNewRow(dagActionLeaseObject.getDagAction(),
+            ExponentialBackoff.builder().maxRetries(3).initialDelay(10L).build());
        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, dagActionLeaseObject.getDagAction(),
            Optional.empty(), dagActionLeaseObject.isReminder(), adoptConsensusFlowExecutionId);
       }
@@ -420,7 +423,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
    * near past for it.
    * @return int corresponding to number of rows updated by INSERT statement to acquire lease
    */
-  protected int attemptLeaseIfNewRow(DagActionStore.DagAction dagAction) throws IOException {
+  protected int attemptLeaseIfNewRow(DagActionStore.DagAction dagAction, ExponentialBackoff exponentialBackoff) throws IOException {
     String formattedAcquireLeaseNewRowStatement =
         String.format(ACQUIRE_LEASE_IF_NEW_ROW_STATEMENT, this.leaseArbiterTableName);
     return dbStatementExecutor.withPreparedStatement(formattedAcquireLeaseNewRowStatement,
@@ -428,7 +431,17 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
           completeInsertPreparedStatement(insertStatement, dagAction);
           try {
             return insertStatement.executeUpdate();
-          } catch (SQLIntegrityConstraintViolationException e) {
+          } catch (SQLTransientException e) {
+            try {
+              if (exponentialBackoff.awaitNextRetryIfAvailable()) {
+                return attemptLeaseIfNewRow(dagAction, exponentialBackoff);
+              }
+            } catch (InterruptedException | IOException e2) {
+              throw new IOException(e2);
+            }
+            return 0;
+          }
+          catch (SQLIntegrityConstraintViolationException e) {
             if (!e.getMessage().contains("Duplicate entry")) {
               throw e;
             }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -18,11 +18,16 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.SQLTransientException;
 import java.sql.Timestamp;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.commons.math3.analysis.function.Exp;
+import org.apache.gobblin.util.ExponentialBackoff;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -201,9 +206,11 @@ public class MysqlMultiActiveLeaseArbiterTest {
   @Test
   public void testAcquireLeaseIfNewRow() throws IOException {
     // Inserting the first time should update 1 row
-    Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction), 1);
+    Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
+        ExponentialBackoff.builder().maxRetries(3).initialDelay(10L).build()), 1);
     // Inserting the second time should not update any rows
-    Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction), 0);
+    Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
+        ExponentialBackoff.builder().maxRetries(3).initialDelay(10L).build()), 0);
   }
 
     /*

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -204,11 +204,11 @@ public class MysqlMultiActiveLeaseArbiterTest {
     // Inserting the first time should update 1 row
     Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
         ExponentialBackoff.builder().maxRetries(MysqlMultiActiveLeaseArbiter.MAX_RETRIES)
-            .initialDelay(MysqlMultiActiveLeaseArbiter.INITIAL_DELAY_FOR_RETRY_MILLIS).build()), 1);
+            .initialDelay(MysqlMultiActiveLeaseArbiter.MIN_INITIAL_DELAY_MILLIS).build()), 1);
     // Inserting the second time should not update any rows
     Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
         ExponentialBackoff.builder().maxRetries(MysqlMultiActiveLeaseArbiter.MAX_RETRIES)
-            .initialDelay(MysqlMultiActiveLeaseArbiter.INITIAL_DELAY_FOR_RETRY_MILLIS).build()), 0);
+            .initialDelay(MysqlMultiActiveLeaseArbiter.MIN_INITIAL_DELAY_MILLIS).build()), 0);
   }
 
     /*

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -18,16 +18,12 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLTransientException;
 import java.sql.Timestamp;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.math3.analysis.function.Exp;
 import org.apache.gobblin.util.ExponentialBackoff;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -207,10 +203,12 @@ public class MysqlMultiActiveLeaseArbiterTest {
   public void testAcquireLeaseIfNewRow() throws IOException {
     // Inserting the first time should update 1 row
     Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
-        ExponentialBackoff.builder().maxRetries(3).initialDelay(10L).build()), 1);
+        ExponentialBackoff.builder().maxRetries(MysqlMultiActiveLeaseArbiter.MAX_RETRIES)
+            .initialDelay(MysqlMultiActiveLeaseArbiter.INITIAL_DELAY_FOR_RETRY_MILLIS).build()), 1);
     // Inserting the second time should not update any rows
     Assert.assertEquals(mysqlMultiActiveLeaseArbiter.attemptLeaseIfNewRow(resumeDagAction,
-        ExponentialBackoff.builder().maxRetries(3).initialDelay(10L).build()), 0);
+        ExponentialBackoff.builder().maxRetries(MysqlMultiActiveLeaseArbiter.MAX_RETRIES)
+            .initialDelay(MysqlMultiActiveLeaseArbiter.INITIAL_DELAY_FOR_RETRY_MILLIS).build()), 0);
   }
 
     /*


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2096


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We're seeing a `MySQLTransactionRollbackException`: Deadlock found when trying to get lock when calling `MysqlMultiActiveLeaseArbiter. attemptLeaseIfNewRow() `in the rare case when two hosts check the lease arbiter table at the same time, see there's no entry matching the current primary key and try to insert it at the exact same time (both wait for lock on the same row). Normally, there's slight discrepancy that results in an `IntegrityConstraintViolationException` if one insert succeeds before the other OR  one finishes the write early and the other sees the entry when reading the `getResult` of the arbiter table. This PR adds retries with exponential backoff for transient SQL exceptions to the insert statement. Note, it's not needed for other cases when the INSERT/UPDATE statements are conditional on a read value. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Exponential backoff is tested by other functions, no other major updates here 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

