### PR TITLE
[GOBBLIN-2104] Initialize dagProcessingEngine metrics

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -80,4 +80,27 @@ public class ServiceMetricNames {
   public static final String DAG_COUNT_FS_DAG_STATE_COUNT = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "FsDagStateStore" + ".totalDagCount";
 
   public static final String DAG_PROCESSING_EXCEPTION_METER = "DagProcessingException";
+  /* DagProcessingEngine & Multi-active Execution Related Metrics
+  * Note: metrics ending with the delimiter '.' will be suffixed by the specific {@link DagActionType} type for finer
+  * grained monitoring of each dagAction type in addition to the aggregation of all types.
+   */
+  public static final String DAG_PROCESSING_ENGINE_PREFIX = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "DagProcEngine.";
+  public static final String DAG_ACTIONS_STORED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsStored.";
+  public static final String DAG_ACTIONS_OBSERVED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsObserved.";
+  public static final String DAG_ACTIONS_LEASES_OBTAINED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsLeasesObtained.";
+  public static final String DAG_ACTIONS_NO_LONGER_LEASING = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsNoLongerLeasing.";
+  public static final String DAG_ACTIONS_LEASE_REMINDER_SCHEDULED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsLeaseReminderScheduled.";
+  public static final String DAG_ACTIONS_REMINDER_PROCESSED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsRemindersProcessed.";
+  // TODO: implement dropping reminder event after exceed some time
+  public static final String DAG_ACTIONS_EXCEEDED_MAX_RETRY = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsExceededMaxRetry.";
+  public static final String DAG_ACTIONS_INITIALIZE_FAILED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsInitializeFailed.";
+  public static final String DAG_ACTIONS_INITIALIZE_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsInitializeSucceeded.";
+  public static final String DAG_ACTIONS_ACT_FAILED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsActFailed.";
+  public static final String DAG_ACTIONS_ACT_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsActSucceeded.";
+  public static final String DAG_ACTIONS_CONCLUDE_FAILED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsConcludeFailed.";
+  public static final String DAG_ACTIONS_CONCLUDE_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsConcludeSucceeded.";
+  public static final String DAG_ACTIONS_DELETE_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsDeleteSucceeded.";
+  public static final String DAG_ACTIONS_DELETE_FAILED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsDeleteFailed.";
+  // TODO: implement this one
+  public static final String DAG_ACTIONS_AVERAGE_PROCESSING_DELAY_MILLIS = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsAvgProcessingDelayMillis.";
 }

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime;
 
 import java.net.URI;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -90,7 +91,7 @@ public class DagActionStoreChangeMonitorTest {
     public MockDagActionStoreChangeMonitor(String topic, Config config, int numThreads, boolean isMultiActiveSchedulerEnabled,
         DagManagementStateStore dagManagementStateStore, DagManager dagManager, FlowCatalog flowCatalog, Orchestrator orchestrator) {
       super(topic, config, dagManager, numThreads, flowCatalog, orchestrator,
-          dagManagementStateStore, isMultiActiveSchedulerEnabled);
+          dagManagementStateStore, isMultiActiveSchedulerEnabled, mock(DagProcessingEngineMetrics.class));
     }
 
     protected void processMessageForTest(DecodeableKafkaRecord record) {

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.runtime;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.quartz.SchedulerException;
 import org.testng.annotations.BeforeClass;
@@ -75,7 +76,8 @@ public class DagManagementDagActionStoreChangeMonitorTest {
 
     public MockDagManagementDagActionStoreChangeMonitor(Config config, int numThreads, boolean isMultiActiveSchedulerEnabled) {
       super(config, numThreads, mock(FlowCatalog.class), mock(Orchestrator.class), mock(DagManagementStateStore.class),
-          isMultiActiveSchedulerEnabled, mock(DagManagement.class), dagActionReminderScheduler);
+          isMultiActiveSchedulerEnabled, mock(DagManagement.class), dagActionReminderScheduler,
+          mock(DagProcessingEngineMetrics.class));
     }
     protected void processMessageForTest(DecodeableKafkaRecord<String, DagActionStoreChangeEvent> record) {
       super.processMessage(record);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -82,6 +82,7 @@ import org.apache.gobblin.service.modules.orchestration.MysqlDagActionStore;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
 import org.apache.gobblin.service.modules.orchestration.proc.DagProcUtils;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigResourceHandler;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigV2ResourceHandler;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigV2ResourceHandlerWithWarmStandby;
@@ -186,6 +187,8 @@ public class GobblinServiceGuiceModule implements Module {
       binder.bind(FlowConfigsV2ResourceHandler.class).to(GobblinServiceFlowConfigV2ResourceHandler.class);
       binder.bind(FlowExecutionResourceHandler.class).to(GobblinServiceFlowExecutionResourceHandler.class);
     }
+
+    binder.bind(DagProcessingEngineMetrics.class);
 
     /* Note that two instances of the same class can only be differentiated with an `annotatedWith` marker provided at
     binding time (optionally bound classes cannot have names associated with them), so both arbiters need to be

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
@@ -183,8 +183,7 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
 
   @Override
   public Set<Dag.DagNode<JobExecutionPlan>> getDagNodes(DagManager.DagId dagId) throws IOException {
-    return this.dagStateStore.getDagNodes(dagId);
-  }
+    return this.dagStateStore.getDagNodes(dagId);}
 
   @Override
   public void tryAcquireQuota(Collection<Dag.DagNode<JobExecutionPlan>> dagNodes) throws IOException {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
@@ -26,6 +26,7 @@ import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.EnforceFlowFinishDeadlineDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
@@ -41,8 +42,8 @@ public class EnforceFlowFinishDeadlineDagProc extends DeadlineEnforcementDagProc
     super(enforceFlowFinishDeadlineDagTask);
   }
 
-  protected void enforceDeadline(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag)
-      throws IOException {
+  protected void enforceDeadline(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag,
+      DagProcessingEngineMetrics dagProcEngineMetrics) throws IOException {
     Dag.DagNode<JobExecutionPlan> dagNode = dag.getNodes().get(0);
     long flowFinishDeadline = DagManagerUtils.getFlowSLA(dagNode);
     long flowStartTime = DagManagerUtils.getFlowStartTime(dagNode);
@@ -58,7 +59,9 @@ public class EnforceFlowFinishDeadlineDagProc extends DeadlineEnforcementDagProc
 
       dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED);
       dag.setMessage("Flow killed due to exceeding SLA of " + flowFinishDeadline + " ms");
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
     } else {
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
       log.error("EnforceFlowFinishDeadline dagAction received before due time. flowStartTime {}, flowFinishDeadline {} ", flowStartTime, flowFinishDeadline);
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -28,6 +28,7 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.LaunchDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
@@ -66,14 +67,15 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
   }
 
   @Override
-  protected void act(DagManagementStateStore dagManagementStateStore, Optional<Dag<JobExecutionPlan>> dag)
-      throws IOException {
+  protected void act(DagManagementStateStore dagManagementStateStore, Optional<Dag<JobExecutionPlan>> dag,
+      DagProcessingEngineMetrics dagProcEngineMetrics) throws IOException {
     if (!dag.isPresent()) {
       log.warn("Dag with id " + getDagId() + " could not be compiled.");
-      // todo - add metrics
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), false);
     } else {
       DagProcUtils.submitNextNodes(dagManagementStateStore, dag.get(), getDagId());
       DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
     }
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -29,6 +29,7 @@ import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.ReevaluateDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
@@ -48,19 +49,19 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
   }
 
   @Override
-  protected Pair<Optional<Dag.DagNode<JobExecutionPlan>>, Optional<JobStatus>> initialize(DagManagementStateStore dagManagementStateStore)
-      throws IOException {
-    return dagManagementStateStore.getDagNodeWithJobStatus(this.dagNodeId);
+  protected Pair<Optional<Dag.DagNode<JobExecutionPlan>>, Optional<JobStatus>> initialize(
+      DagManagementStateStore dagManagementStateStore) throws IOException {
+      return dagManagementStateStore.getDagNodeWithJobStatus(this.dagNodeId);
   }
 
   @Override
   protected void act(DagManagementStateStore dagManagementStateStore, Pair<Optional<Dag.DagNode<JobExecutionPlan>>,
-      Optional<JobStatus>> dagNodeWithJobStatus) throws IOException {
+      Optional<JobStatus>> dagNodeWithJobStatus, DagProcessingEngineMetrics dagProcEngineMetrics) throws IOException {
     if (!dagNodeWithJobStatus.getLeft().isPresent()) {
       // one of the reason this could arise is when the MALA leasing doesn't work cleanly and another DagProc::process
       // has cleaned up the Dag, yet did not complete the lease before this current one acquired its own
       log.error("DagNode or its job status not found for a Reevaluate DagAction with dag node id {}", this.dagNodeId);
-      // todo - add metrics to count such occurrences
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), false);
       return;
     }
 
@@ -72,6 +73,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
       // dag actions for each of those parallel job and in this scenario there is no job status available.
       // If the job status is not present, this job was never launched, submit it now.
       DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
+      dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
       return;
     }
 
@@ -118,6 +120,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
 
       DagProcUtils.removeFlowFinishDeadlineDagAction(dagManagementStateStore, getDagId());
     }
+    dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration.task;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.metrics.ContextAwareMeter;
+import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.MetricTagNames;
+import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.service.modules.orchestration.DagActionStore;
+import org.apache.gobblin.metrics.ServiceMetricNames;
+
+/**
+ * Used to track all metrics relating to processing dagActions when DagProcessingEngine is enabled. The metrics can be
+ * used to trace the number of dagActions (which can be further broken down by type) at various points of the system,
+ * starting from addition to the DagActionStore to observation in the DagActionChangeMonitor through the
+ * DagProcessingEngine pipeline (DagManagement -> DagTaskStreamImpl -> MySqlMultiActiveLeaseArbiter -> DagProc).
+ */
+@Slf4j
+public class DagProcessingEngineMetrics {
+  MetricContext metricContext;
+  /*
+   Declare map of dagActionType to a ContextAwareMeter for each metric. ContextAwareMeters are thread safe, so it will
+   handle concurrent mark requests correctly. ConcurrentMap is not needed since no updates are made to the mappings,
+   only get calls.
+  */
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsStoredMeterByDagActionType = new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsObservedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeasesObtainedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsNoLongerLeasingMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeaseReminderScheduledMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsReminderProcessedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsExceededMaxRetryMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeFailedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeSucceededMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActFailedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActSucceededMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeFailedMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeSucceededMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsRemovedFromStoreMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsFailingRemovalMeterByDagActionType =  new HashMap();
+  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionAverageProcessingDelayMillisMeterByDagActionType =  new HashMap();
+
+  public DagProcessingEngineMetrics(MetricContext metricContext) {
+    this.metricContext = metricContext;
+    registerAllMetrics();
+  }
+
+  @Inject
+  public DagProcessingEngineMetrics() {
+    // Create a new metric context for the DagProcessingEngineMetrics tagged appropriately
+    List<Tag<?>> tags = new ArrayList<>();
+    tags.add(new Tag<>(MetricTagNames.METRIC_BACKEND_REPRESENTATION, GobblinMetrics.MetricType.COUNTER));
+    this.metricContext = Instrumented.getMetricContext(new State(), this.getClass(), tags);
+  }
+
+  public void registerAllMetrics() {
+    registerMetricForEachDagActionType(this.dagActionsStoredMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_STORED);
+    registerMetricForEachDagActionType(this.dagActionsObservedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_OBSERVED);
+    registerMetricForEachDagActionType(this.dagActionsLeasesObtainedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_LEASES_OBTAINED);
+    registerMetricForEachDagActionType(this.dagActionsNoLongerLeasingMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_NO_LONGER_LEASING);
+    registerMetricForEachDagActionType(this.dagActionsLeaseReminderScheduledMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_LEASE_REMINDER_SCHEDULED);
+    registerMetricForEachDagActionType(this.dagActionsReminderProcessedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_REMINDER_PROCESSED);
+    registerMetricForEachDagActionType(this.dagActionsExceededMaxRetryMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_EXCEEDED_MAX_RETRY);
+    registerMetricForEachDagActionType(this.dagActionsInitializeFailedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_INITIALIZE_FAILED);
+    registerMetricForEachDagActionType(this.dagActionsInitializeSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_INITIALIZE_SUCCEEDED);
+    registerMetricForEachDagActionType(this.dagActionsActFailedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_ACT_FAILED);
+    registerMetricForEachDagActionType(this.dagActionsActSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_ACT_SUCCEEDED);
+    registerMetricForEachDagActionType(this.dagActionsConcludeFailedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_CONCLUDE_FAILED);
+    registerMetricForEachDagActionType(this.dagActionsConcludeSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_CONCLUDE_SUCCEEDED);
+  }
+
+  /**
+   * Create a meter of each dagActionType for the given metric, register it with the metric context, and store it in a
+   * concurrent map.
+   * @param metricMap
+   * @param metricName
+   */
+  private void registerMetricForEachDagActionType(HashMap<DagActionStore.DagActionType, ContextAwareMeter> metricMap, String metricName) {
+    for (DagActionStore.DagActionType dagActionType : DagActionStore.DagActionType.values()) {
+      metricMap.put(dagActionType, this.metricContext.contextAwareMeter(metricName + dagActionType));
+    }
+  }
+
+  public void markDagActionsStored(DagActionStore.DagActionType dagActionType) {
+    updateMetricForDagActionType(this.dagActionsStoredMeterByDagActionType, dagActionType);
+  }
+
+  public void markDagActionsObserved(DagActionStore.DagActionType dagActionType) {
+    updateMetricForDagActionType(this.dagActionsObservedMeterByDagActionType, dagActionType);
+  }
+
+  public void markDagActionsLeasedObtained(DagActionStore.LeaseParams leaseParams) {
+    updateMetricForDagActionType(this.dagActionsLeasesObtainedMeterByDagActionType,
+        leaseParams.getDagAction().getDagActionType());
+  }
+
+  public void markDagActionsNoLongerLeasing(DagActionStore.LeaseParams leaseParams) {
+    updateMetricForDagActionType(this.dagActionsNoLongerLeasingMeterByDagActionType,
+        leaseParams.getDagAction().getDagActionType());
+  }
+
+  public void markDagActionsLeaseReminderScheduled(DagActionStore.LeaseParams leaseParams) {
+    updateMetricForDagActionType(this.dagActionsLeaseReminderScheduledMeterByDagActionType,
+        leaseParams.getDagAction().getDagActionType());
+  }
+
+  public void markDagActionsRemindersProcessed(DagActionStore.LeaseParams leaseParams) {
+    updateMetricForDagActionType(this.dagActionsReminderProcessedMeterByDagActionType,
+        leaseParams.getDagAction().getDagActionType());
+  }
+
+  // TODO: implement evaluating max retries later
+  public void markDagActionsExceedingMaxRetry(DagActionStore.DagActionType dagActionType) {
+    updateMetricForDagActionType(this.dagActionsExceededMaxRetryMeterByDagActionType, dagActionType);
+  }
+
+  public void markDagActionsInitialize(DagActionStore.DagActionType dagActionType, boolean succeeded) {
+    if (succeeded) {
+      updateMetricForDagActionType(this.dagActionsInitializeSucceededMeterByDagActionType, dagActionType);
+    } else {
+      updateMetricForDagActionType(this.dagActionsInitializeFailedMeterByDagActionType, dagActionType);
+    }
+  }
+
+  public void markDagActionsAct(DagActionStore.DagActionType dagActionType, boolean succeeded) {
+    if (succeeded) {
+      updateMetricForDagActionType(this.dagActionsActSucceededMeterByDagActionType, dagActionType);
+    } else {
+      updateMetricForDagActionType(this.dagActionsActFailedMeterByDagActionType, dagActionType);
+    }
+  }
+
+  public void markDagActionsConclude(DagActionStore.DagActionType dagActionType, boolean succeeded) {
+    if (succeeded) {
+      updateMetricForDagActionType(this.dagActionsConcludeSucceededMeterByDagActionType, dagActionType);
+    } else {
+      updateMetricForDagActionType(this.dagActionsConcludeFailedMeterByDagActionType, dagActionType);
+    }
+  }
+
+
+  /**
+   * Generic helper used to increment a metric corresponding to the dagActionType in the provided map. It assumes the
+   * meter for each dagActionType can be identified by its name.
+   */
+  private void updateMetricForDagActionType(HashMap<DagActionStore.DagActionType, ContextAwareMeter> metricMap,
+      DagActionStore.DagActionType dagActionType) {
+      if (metricMap.containsKey(dagActionType)) {
+        metricMap.get(dagActionType).mark();
+      } else {
+        throw new RuntimeException(String.format("No meter exists for dagActionType %s in metricsMap %s",
+            dagActionType, metricMap));
+      }
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/EnforceFlowFinishDeadlineDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/EnforceFlowFinishDeadlineDagTask.java
@@ -30,8 +30,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 
 public class EnforceFlowFinishDeadlineDagTask extends DagTask {
   public EnforceFlowFinishDeadlineDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/EnforceJobStartDeadlineDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/EnforceJobStartDeadlineDagTask.java
@@ -30,8 +30,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 
 public class EnforceJobStartDeadlineDagTask extends DagTask {
   public EnforceJobStartDeadlineDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/KillDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/KillDagTask.java
@@ -29,8 +29,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 
 public class KillDagTask extends DagTask {
   public KillDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/LaunchDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/LaunchDagTask.java
@@ -36,8 +36,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 @Slf4j
 public class LaunchDagTask extends DagTask {
   public LaunchDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/ReevaluateDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/ReevaluateDagTask.java
@@ -29,8 +29,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 
 public class ReevaluateDagTask extends DagTask {
   public ReevaluateDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/ResumeDagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/ResumeDagTask.java
@@ -28,8 +28,8 @@ import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
  */
 public class ResumeDagTask extends DagTask {
   public ResumeDagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
-      DagManagementStateStore dagManagementStateStore) {
-    super(dagAction, leaseObtainedStatus, dagManagementStateStore);
+      DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
+    super(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   public <T> T host(DagTaskVisitor<T> visitor) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitorFactory.java
@@ -31,6 +31,7 @@ import org.apache.gobblin.runtime.util.InjectionNames;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.util.ConfigUtils;
 
 
@@ -47,17 +48,20 @@ public class DagActionStoreChangeMonitorFactory implements Provider<DagActionSto
   private Orchestrator orchestrator;
   private DagManagementStateStore dagManagementStateStore;
   private boolean isMultiActiveSchedulerEnabled;
+  private DagProcessingEngineMetrics dagProcEngineMetrics;
 
   @Inject
   public DagActionStoreChangeMonitorFactory(Config config, DagManager dagManager, FlowCatalog flowCatalog,
       Orchestrator orchestrator, DagManagementStateStore dagManagementStateStore,
-      @Named(InjectionNames.MULTI_ACTIVE_SCHEDULER_ENABLED) boolean isMultiActiveSchedulerEnabled) {
+      @Named(InjectionNames.MULTI_ACTIVE_SCHEDULER_ENABLED) boolean isMultiActiveSchedulerEnabled,
+      DagProcessingEngineMetrics dagProcEngineMetrics) {
     this.config = Objects.requireNonNull(config);
     this.dagManager = dagManager;
     this.flowCatalog = flowCatalog;
     this.orchestrator = orchestrator;
     this.dagManagementStateStore = dagManagementStateStore;
     this.isMultiActiveSchedulerEnabled = isMultiActiveSchedulerEnabled;
+    this.dagProcEngineMetrics = dagProcEngineMetrics;
   }
 
   private DagActionStoreChangeMonitor createDagActionStoreMonitor() {
@@ -68,7 +72,7 @@ public class DagActionStoreChangeMonitorFactory implements Provider<DagActionSto
     int numThreads = ConfigUtils.getInt(dagActionStoreChangeConfig, DAG_ACTION_STORE_CHANGE_MONITOR_NUM_THREADS_KEY, 5);
 
     return new DagActionStoreChangeMonitor(topic, dagActionStoreChangeConfig, this.dagManager, numThreads, flowCatalog,
-        orchestrator, dagManagementStateStore, isMultiActiveSchedulerEnabled);
+        orchestrator, dagManagementStateStore, isMultiActiveSchedulerEnabled, dagProcEngineMetrics);
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
@@ -31,6 +31,7 @@ import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagement;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 
 
 /**
@@ -47,10 +48,12 @@ public class DagManagementDagActionStoreChangeMonitor extends DagActionStoreChan
   // client itself to determine all Kafka related information dynamically rather than through the config.
   public DagManagementDagActionStoreChangeMonitor(Config config, int numThreads,
       FlowCatalog flowCatalog, Orchestrator orchestrator, DagManagementStateStore dagManagementStateStore,
-      boolean isMultiActiveSchedulerEnabled, DagManagement dagManagement, DagActionReminderScheduler dagActionReminderScheduler) {
+      boolean isMultiActiveSchedulerEnabled, DagManagement dagManagement,
+      DagActionReminderScheduler dagActionReminderScheduler, DagProcessingEngineMetrics dagProcEngineMetrics) {
     // DagManager is only needed in the `handleDagAction` method of its parent class and not needed in this class,
     // so we are passing a null value for DagManager to its parent class.
-    super("", config, null, numThreads, flowCatalog, orchestrator, dagManagementStateStore, isMultiActiveSchedulerEnabled);
+    super("", config, null, numThreads, flowCatalog, orchestrator, dagManagementStateStore,
+        isMultiActiveSchedulerEnabled, dagProcEngineMetrics);
     this.dagManagement = dagManagement;
     this.dagActionReminderScheduler = dagActionReminderScheduler;
   }
@@ -64,6 +67,7 @@ public class DagManagementDagActionStoreChangeMonitor extends DagActionStoreChan
       switch (operation) {
         case "INSERT":
           handleDagAction(dagAction, false);
+          this.dagProcEngineMetrics.markDagActionsObserved(dagActionType);
           break;
         case "UPDATE":
           log.warn("Received an UPDATE action to the DagActionStore when values in this store are never supposed to be "

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
@@ -33,6 +33,7 @@ import org.apache.gobblin.service.modules.orchestration.DagManagement;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.util.ConfigUtils;
 
 
@@ -50,12 +51,13 @@ public class DagManagementDagActionStoreChangeMonitorFactory implements Provider
   private final boolean isMultiActiveSchedulerEnabled;
   private final DagManagement dagManagement;
   private final DagActionReminderScheduler dagActionReminderScheduler;
+  private final DagProcessingEngineMetrics dagProcEngineMetrics;
 
   @Inject
   public DagManagementDagActionStoreChangeMonitorFactory(Config config, DagManager dagManager, FlowCatalog flowCatalog,
       Orchestrator orchestrator, DagManagementStateStore dagManagementStateStore, DagManagement dagManagement,
       @Named(InjectionNames.MULTI_ACTIVE_SCHEDULER_ENABLED) boolean isMultiActiveSchedulerEnabled,
-      DagActionReminderScheduler dagActionReminderScheduler) {
+      DagActionReminderScheduler dagActionReminderScheduler, DagProcessingEngineMetrics dagProcEngineMetrics) {
     this.config = Objects.requireNonNull(config);
     this.flowCatalog = flowCatalog;
     this.orchestrator = orchestrator;
@@ -63,6 +65,7 @@ public class DagManagementDagActionStoreChangeMonitorFactory implements Provider
     this.isMultiActiveSchedulerEnabled = isMultiActiveSchedulerEnabled;
     this.dagManagement = dagManagement;
     this.dagActionReminderScheduler = dagActionReminderScheduler;
+    this.dagProcEngineMetrics = dagProcEngineMetrics;
   }
 
   private DagManagementDagActionStoreChangeMonitor createDagActionStoreMonitor() {
@@ -73,7 +76,7 @@ public class DagManagementDagActionStoreChangeMonitorFactory implements Provider
 
     return new DagManagementDagActionStoreChangeMonitor(dagActionStoreChangeConfig,
         numThreads, flowCatalog, orchestrator, dagManagementStateStore, isMultiActiveSchedulerEnabled, this.dagManagement,
-        this.dagActionReminderScheduler);
+        this.dagActionReminderScheduler, dagProcEngineMetrics);
   }
 
   @Override

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImplTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.service.modules.orchestration;
 import java.io.IOException;
 import java.util.Optional;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -68,10 +69,10 @@ public class DagManagementTaskStreamImplTest {
     this.dagManagementTaskStream =
         new DagManagementTaskStreamImpl(config, Optional.of(mock(DagActionStore.class)),
             mock(MultiActiveLeaseArbiter.class), Optional.of(mock(DagActionReminderScheduler.class)),
-            false, mock(DagManagementStateStore.class));
+            false, mock(DagManagementStateStore.class), mock(DagProcessingEngineMetrics.class));
     this.dagProcFactory = new DagProcFactory(null);
     this.dagProcEngineThread = new DagProcessingEngine.DagProcEngineThread(
-        this.dagManagementTaskStream, this.dagProcFactory, dagManagementStateStore, 0);
+        this.dagManagementTaskStream, this.dagProcFactory, dagManagementStateStore, mock(DagProcessingEngineMetrics.class), 0);
   }
 
   @AfterClass(alwaysRun = true)

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -89,7 +90,7 @@ public class DagManagerFlowTest {
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
         .build();
 
-    dagActionStore = new MysqlDagActionStore(config);
+    dagActionStore = new MysqlDagActionStore(config, Mockito.mock(DagProcessingEngineMetrics.class));
     dagActionStore.addFlowDagAction(flowGroup, flowName, flowExecutionId, DagActionStore.DagActionType.KILL);
     dagActionStore.addFlowDagAction(flowGroup, flowName, flowExecutionId_2, DagActionStore.DagActionType.RESUME);
     dagManager = new MockedDagManager(ConfigUtils.propertiesToConfig(props));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngineTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngineTest.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -56,6 +57,7 @@ public class DagProcessingEngineTest {
   private DagProcFactory dagProcFactory;
   // Field is static because it's used to instantiate every MockedDagTask
   private static MySqlDagManagementStateStore dagManagementStateStore;
+  private static DagProcessingEngineMetrics mockedDagProcEngineMetrics;
   private ITestMetastoreDatabase testMetastoreDatabase;
   static LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus;
 
@@ -81,18 +83,19 @@ public class DagProcessingEngineTest {
     doReturn(true).when(dagActionStore).deleteDagAction(any());
     dagManagementTaskStream =
         new DagManagementTaskStreamImpl(config, Optional.of(mock(DagActionStore.class)),
-            mock(MultiActiveLeaseArbiter.class), Optional.of(mock(DagActionReminderScheduler.class)), false,
-            dagManagementStateStore);
+            mock(MultiActiveLeaseArbiter.class), Optional.of(mock(DagActionReminderScheduler.class)),
+            false, dagManagementStateStore, Mockito.mock(DagProcessingEngineMetrics.class));
     this.dagProcFactory = new DagProcFactory(null);
 
     DagProcessingEngine.DagProcEngineThread dagProcEngineThread =
         new DagProcessingEngine.DagProcEngineThread(dagManagementTaskStream, this.dagProcFactory,
-            dagManagementStateStore, 0);
+            dagManagementStateStore, mock(DagProcessingEngineMetrics.class), 0);
     this.dagTaskStream = spy(new MockedDagTaskStream());
     DagProcessingEngine dagProcessingEngine =
         new DagProcessingEngine(config, Optional.ofNullable(dagTaskStream), Optional.ofNullable(this.dagProcFactory),
-            Optional.ofNullable(dagManagementStateStore), 100000L);
+            Optional.ofNullable(dagManagementStateStore), 100000L, mock(DagProcessingEngineMetrics.class));
     dagProcessingEngine.startAsync();
+    this.mockedDagProcEngineMetrics = mock(DagProcessingEngineMetrics.class);
   }
 
   @AfterClass(alwaysRun = true)
@@ -129,7 +132,7 @@ public class DagProcessingEngineTest {
     private final boolean isBad;
 
     public MockedDagTask(DagActionStore.DagAction dagAction, boolean isBad) {
-      super(dagAction, leaseObtainedStatus, DagProcessingEngineTest.dagManagementStateStore);
+      super(dagAction, leaseObtainedStatus, DagProcessingEngineTest.dagManagementStateStore, mockedDagProcEngineMetrics);
       this.isBad = isBad;
     }
 
@@ -158,7 +161,8 @@ public class DagProcessingEngineTest {
     }
 
     @Override
-    protected void act(DagManagementStateStore dagManagementStateStore, Void state) {
+    protected void act(DagManagementStateStore dagManagementStateStore, Void state,
+        DagProcessingEngineMetrics dagProcEngineMetrics) {
       if (this.isBad) {
         throw new RuntimeException("Simulating an exception!");
       }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStoreTest.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -66,7 +68,7 @@ public class MysqlDagActionStoreTest {
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
         .addPrimitive("MysqlDagActionStore." + ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
         .build();
-    return new MysqlDagActionStore(config);
+    return new MysqlDagActionStore(config, Mockito.mock(DagProcessingEngineMetrics.class));
   }
 
   @Test

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceDeadlineDagProcsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceDeadlineDagProcsTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
@@ -57,10 +58,12 @@ import static org.mockito.Mockito.spy;
 public class EnforceDeadlineDagProcsTest {
   private ITestMetastoreDatabase testMetastoreDatabase;
   private final MockedStatic<GobblinServiceManager> mockedGobblinServiceManager = Mockito.mockStatic(GobblinServiceManager.class);
+  private DagProcessingEngineMetrics mockedDagProcEngineMetrics;
 
   @BeforeClass
   public void setUp() throws Exception {
     this.testMetastoreDatabase = TestMetastoreDatabaseFactory.get();
+    this.mockedDagProcEngineMetrics = Mockito.mock(DagProcessingEngineMetrics.class);
   }
 
   @AfterClass(alwaysRun = true)
@@ -103,8 +106,9 @@ public class EnforceDeadlineDagProcsTest {
 
     EnforceJobStartDeadlineDagProc enforceJobStartDeadlineDagProc = new EnforceJobStartDeadlineDagProc(
         new EnforceJobStartDeadlineDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId,
-            "job0", DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE), null, dagManagementStateStore));
-    enforceJobStartDeadlineDagProc.process(dagManagementStateStore);
+            "job0", DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE), null,
+            dagManagementStateStore, mockedDagProcEngineMetrics));
+    enforceJobStartDeadlineDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     int expectedNumOfDeleteDagNodeStates = 1; // the one dag node corresponding to the EnforceStartDeadlineDagProc
     Mockito.verify(specProducers.get(0), Mockito.times(1)).cancelJob(any(), any());
@@ -145,8 +149,9 @@ public class EnforceDeadlineDagProcsTest {
 
     EnforceJobStartDeadlineDagProc enforceJobStartDeadlineDagProc = new EnforceJobStartDeadlineDagProc(
         new EnforceJobStartDeadlineDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId,
-            "job0", DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE), null, dagManagementStateStore));
-    enforceJobStartDeadlineDagProc.process(dagManagementStateStore);
+            "job0", DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE), null,
+            dagManagementStateStore, mockedDagProcEngineMetrics));
+    enforceJobStartDeadlineDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     // no job cancelled because we simulated (by not adding) missing dag action
     specProducers.forEach(sp -> Mockito.verify(sp, Mockito.never()).cancelJob(any(), any()));
@@ -186,8 +191,9 @@ public class EnforceDeadlineDagProcsTest {
 
     EnforceFlowFinishDeadlineDagProc enforceFlowFinishDeadlineDagProc = new EnforceFlowFinishDeadlineDagProc(
         new EnforceFlowFinishDeadlineDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId,
-            "job0", DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE), null, dagManagementStateStore));
-    enforceFlowFinishDeadlineDagProc.process(dagManagementStateStore);
+            "job0", DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE), null,
+            dagManagementStateStore, mockedDagProcEngineMetrics));
+    enforceFlowFinishDeadlineDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     specProducers.forEach(sp -> Mockito.verify(sp, Mockito.times(1)).cancelJob(any(), any()));
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.service.modules.orchestration.proc;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -50,12 +51,14 @@ import static org.mockito.Mockito.spy;
 public class ResumeDagProcTest {
   private MySqlDagManagementStateStore dagManagementStateStore;
   private ITestMetastoreDatabase testDb;
+  private DagProcessingEngineMetrics mockedDagProcEngineMetrics;
 
   @BeforeClass
   public void setUp() throws Exception {
     testDb = TestMetastoreDatabaseFactory.get();
     this.dagManagementStateStore = spy(MySqlDagManagementStateStoreTest.getDummyDMSS(testDb));
     LaunchDagProcTest.mockDMSSCommonBehavior(this.dagManagementStateStore);
+    this.mockedDagProcEngineMetrics = Mockito.mock(DagProcessingEngineMetrics.class);
   }
 
   @AfterClass(alwaysRun = true)
@@ -91,8 +94,8 @@ public class ResumeDagProcTest {
 
     ResumeDagProc resumeDagProc = new ResumeDagProc(new ResumeDagTask(new DagActionStore.DagAction(flowGroup, flowName,
         flowExecutionId, MysqlDagActionStore.NO_JOB_NAME_DEFAULT, DagActionStore.DagActionType.RESUME),
-        null, this.dagManagementStateStore));
-    resumeDagProc.process(this.dagManagementStateStore);
+        null, this.dagManagementStateStore, mockedDagProcEngineMetrics));
+    resumeDagProc.process(this.dagManagementStateStore, mockedDagProcEngineMetrics);
 
     int expectedNumOfResumedJobs = 1; // = number of resumed nodes
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/task/LaunchDagTaskTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/task/LaunchDagTaskTest.java
@@ -65,7 +65,8 @@ public class LaunchDagTaskTest {
    */
   @Test
   public void concludeRemovesAdhocFlowSpec() throws IOException {
-    LaunchDagTask dagTask = new LaunchDagTask(dagAction, leaseObtainedStatus, dagManagementStateStore);
+    LaunchDagTask dagTask = new LaunchDagTask(dagAction, leaseObtainedStatus, dagManagementStateStore,
+        Mockito.mock(DagProcessingEngineMetrics.class));
     dagTask.conclude();
     Mockito.verify(dagManagementStateStore, Mockito.times(1)).deleteDagAction(any());
     Mockito.verify(dagManagementStateStore, Mockito.times(1)).removeFlowSpec(any(), any(), anyBoolean());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2104

### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
This PR adds a common metrics utility class `DagProcessingEngineMetrics`  that is used to trace life cycle of a request from moment it’s received through completion. 

 `DagActionChangeMonitor -> DagManagement -> DagTaskStreamImpl -> MySqlMultiActiveLeaseArbiter -> DagProc`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

