### PR TITLE
[GOBBLIN-2097] Use unique JobDataMaps and Properties to use for reminder events

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -292,7 +292,7 @@ public class FlowLaunchHandler {
   public static Properties deepCopyProperties(Properties original) {
     Properties copy = new Properties();
     for (String key : original.stringPropertyNames()) {
-      copy.setProperty(key, original.getProperty(key));
+      copy.setProperty(new String(key), new String(original.getProperty(key)));
     }
     return copy;
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -246,8 +246,10 @@ public class FlowLaunchHandler {
   }
 
   /**
-   * Adds the cronExpression, reminderTimestamp, originalEventTime values in the properties map of a deep copy of the
-   * jobDataMap provided and returns the new JobDataMap to the user.
+   * Adds the cronExpression, reminderTimestamp, originalEventTime values in the properties map of a new jobDataMap
+   * cloned from the one provided and returns the new JobDataMap to the user.
+   * Note: the jobDataMap and Properties field reference different objects than the original, but the keys and values
+   * themselves are not cloned.
    * @param jobDataMap
    * @param leasedToAnotherStatus
    * @param schedulerMaxBackoffMillis

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -81,6 +81,7 @@ public class FlowLaunchHandlerTest {
 
     Assert.assertNotSame(oldJobDataMap, newJobDataMap);
     Assert.assertNotSame(originalProperties, newProperties);
+    Assert.assertFalse(originalProperties.containsKey(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY));
   }
 
 
@@ -107,6 +108,7 @@ public class FlowLaunchHandlerTest {
 
     Assert.assertNotSame(oldJobDataMap, newJobDataMap);
     Assert.assertNotSame(originalProperties, newProperties);
+    Assert.assertFalse(originalProperties.containsKey(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY));
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -96,6 +96,9 @@ public class FlowLaunchHandlerTest {
     JobDataMap newJobDataMap = FlowLaunchHandler.updatePropsInJobDataMap(oldJobDataMap, leasedToAnotherStatus,
         schedulerBackOffMillis);
     Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+
+    Assert.assertNotSame(oldJobDataMap, newJobDataMap);
+    Assert.assertNotSame(originalProperties, newProperties);
     Assert.assertTrue(newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY).endsWith(cronExpressionSuffix));
     Assert.assertTrue(newProperties.containsKey(ConfigurationKeys.SCHEDULER_EXPECTED_REMINDER_TIME_MILLIS_KEY));
     Assert.assertEquals(String.valueOf(leasedToAnotherStatus.getEventTimeMillis()),

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -67,8 +67,8 @@ public class FlowLaunchHandlerTest {
     originalProperties.setProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY, "1");
     oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
 
-    JobDataMap newJobDataMap = FlowLaunchHandler.updatePropsInJobDataMap(oldJobDataMap, leasedToAnotherStatus,
-        schedulerBackOffMillis);
+    JobDataMap newJobDataMap =
+        FlowLaunchHandler.updatePropsInJobDataMap(oldJobDataMap, leasedToAnotherStatus, schedulerBackOffMillis);
     Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
     Assert.assertTrue(newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY).endsWith(cronExpressionSuffix));
     Assert.assertNotEquals("0",
@@ -76,6 +76,25 @@ public class FlowLaunchHandlerTest {
     Assert.assertEquals(String.valueOf(leasedToAnotherStatus.getEventTimeMillis()),
         newProperties.getProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY));
     Assert.assertTrue(Boolean.parseBoolean(newProperties.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY)));
+    // Note these objects refer to the same object because the original map is passed to updatePropsInJobDataMap
+    Assert.assertSame(oldJobDataMap, newJobDataMap);
+  }
+
+  /**
+   * Assert that the JobDataMap and Properties objects do not reference the same memory location if using
+   */
+  @Test
+  public void testDeepCopyJobDataMap() {
+    JobDataMap originalJobDataMap = new JobDataMap();
+    Properties properties = new Properties();
+    properties.setProperty("key", "value");
+    originalJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, properties);
+
+    JobDataMap newJobDataMap = FlowLaunchHandler.deepCopyJobDataMap(originalJobDataMap);
+
+    Assert.assertNotSame(originalJobDataMap, newJobDataMap);
+    Assert.assertNotSame(originalJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY),
+        newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY));
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -86,15 +86,15 @@ public class FlowLaunchHandlerTest {
   @Test
   public void testDeepCopyJobDataMap() {
     JobDataMap originalJobDataMap = new JobDataMap();
-    Properties properties = new Properties();
-    properties.setProperty("key", "value");
-    originalJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, properties);
+    Properties originalProperties = new Properties();
+    originalProperties.setProperty("key", "value");
+    originalJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
 
     JobDataMap newJobDataMap = FlowLaunchHandler.deepCopyJobDataMap(originalJobDataMap);
 
     Assert.assertNotSame(originalJobDataMap, newJobDataMap);
-    Assert.assertNotSame(originalJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY),
-        newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY));
+    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertNotSame(originalProperties, newProperties);
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -56,7 +56,9 @@ public class FlowLaunchHandlerTest {
 
   /**
    * Provides an input with all three values (cronExpression, reminderTimestamp, originalEventTime) set in the map
-   * Properties and checks that they are updated properly
+   * Properties and checks that they are updated properly in new jobDataMap's Properties object. It checks that the
+   * JobDataMap returned along with the Properties object it contains do not reference the same
+   * original objects.
    */
   @Test
   public void testUpdatePropsInJobDataMap() {
@@ -76,26 +78,11 @@ public class FlowLaunchHandlerTest {
     Assert.assertEquals(String.valueOf(leasedToAnotherStatus.getEventTimeMillis()),
         newProperties.getProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY));
     Assert.assertTrue(Boolean.parseBoolean(newProperties.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY)));
-    // Note these objects refer to the same object because the original map is passed to updatePropsInJobDataMap
-    Assert.assertSame(oldJobDataMap, newJobDataMap);
-  }
 
-  /**
-   * Assert that the JobDataMap and Properties objects do not reference the same memory location if using
-   */
-  @Test
-  public void testDeepCopyJobDataMap() {
-    JobDataMap originalJobDataMap = new JobDataMap();
-    Properties originalProperties = new Properties();
-    originalProperties.setProperty("key", "value");
-    originalJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
-
-    JobDataMap newJobDataMap = FlowLaunchHandler.deepCopyJobDataMap(originalJobDataMap);
-
-    Assert.assertNotSame(originalJobDataMap, newJobDataMap);
-    Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
+    Assert.assertNotSame(oldJobDataMap, newJobDataMap);
     Assert.assertNotSame(originalProperties, newProperties);
   }
+
 
   /**
    * Provides input with an empty Properties object and checks that the three values in question are set.
@@ -114,6 +101,9 @@ public class FlowLaunchHandlerTest {
     Assert.assertEquals(String.valueOf(leasedToAnotherStatus.getEventTimeMillis()),
         newProperties.getProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY));
     Assert.assertTrue(Boolean.parseBoolean(newProperties.getProperty(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY)));
+
+    Assert.assertNotSame(oldJobDataMap, newJobDataMap);
+    Assert.assertNotSame(originalProperties, newProperties);
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.service.modules.orchestration;
 import java.util.Properties;
 
 import org.junit.Assert;
+import org.mockito.Mockito;
 import org.quartz.JobDataMap;
 import org.testng.annotations.Test;
 
@@ -68,9 +69,10 @@ public class FlowLaunchHandlerTest {
     originalProperties.setProperty(ConfigurationKeys.SCHEDULER_EXPECTED_REMINDER_TIME_MILLIS_KEY, "0");
     originalProperties.setProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY, "1");
     oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+    JobDataMap spyOldJobDataMap = Mockito.spy(oldJobDataMap);
 
     JobDataMap newJobDataMap =
-        FlowLaunchHandler.updatePropsInJobDataMap(oldJobDataMap, leasedToAnotherStatus, schedulerBackOffMillis);
+        FlowLaunchHandler.cloneAndUpdateJobProperties(spyOldJobDataMap, leasedToAnotherStatus, schedulerBackOffMillis);
     Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
     Assert.assertTrue(newProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY).endsWith(cronExpressionSuffix));
     Assert.assertNotEquals("0",
@@ -82,6 +84,10 @@ public class FlowLaunchHandlerTest {
     Assert.assertNotSame(oldJobDataMap, newJobDataMap);
     Assert.assertNotSame(originalProperties, newProperties);
     Assert.assertFalse(originalProperties.containsKey(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY));
+    // Verify that only clone() and get() methods are called on the oldJobDataMap
+    Mockito.verify(spyOldJobDataMap).clone();
+    Mockito.verify(spyOldJobDataMap).get(Mockito.any());
+    Mockito.verifyNoMoreInteractions(spyOldJobDataMap);
   }
 
 
@@ -93,8 +99,9 @@ public class FlowLaunchHandlerTest {
     JobDataMap oldJobDataMap = new JobDataMap();
     Properties originalProperties = new Properties();
     oldJobDataMap.put(GobblinServiceJobScheduler.PROPERTIES_KEY, originalProperties);
+    JobDataMap spyOldJobDataMap = Mockito.spy(oldJobDataMap);
 
-    JobDataMap newJobDataMap = FlowLaunchHandler.updatePropsInJobDataMap(oldJobDataMap, leasedToAnotherStatus,
+    JobDataMap newJobDataMap = FlowLaunchHandler.cloneAndUpdateJobProperties(spyOldJobDataMap, leasedToAnotherStatus,
         schedulerBackOffMillis);
     Properties newProperties = (Properties) newJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY);
 
@@ -109,6 +116,10 @@ public class FlowLaunchHandlerTest {
     Assert.assertNotSame(oldJobDataMap, newJobDataMap);
     Assert.assertNotSame(originalProperties, newProperties);
     Assert.assertFalse(originalProperties.containsKey(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY));
+    // Verify that only clone() and get() methods are called on the oldJobDataMap
+    Mockito.verify(spyOldJobDataMap).clone();
+    Mockito.verify(spyOldJobDataMap).get(Mockito.any());
+    Mockito.verifyNoMoreInteractions(spyOldJobDataMap);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2097


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We notice that after deploying the service all subsequent scheduler triggers after the very first one are incorrectly marked as reminders even when they are for "original" events. This is a result of re-using the same `JobDetail`, `JobDataMap` and `Properties` object between the `original` and `reminder` Jobs for the `Scheduler` (all shallow copies). The following changes create deep copies of the aforementioned objects to use for the reminders so adding a reminder flag in one will not affect the other. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- adds new test to validate deep copy
- updates previous test to validate they referred to the same obj

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

