### PR TITLE
[GOBBLIN-2103] GaaS does not update flowgraph or templates if file lengths remain the same

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/util/SchedulerUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.util;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.typesafe.config.ConfigFactory;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/util/SchedulerUtilsTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.gobblin.util;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.runtime.job_spec.JobSpecResolver;
+import org.apache.gobblin.testing.AssertWithBackoff;
 import org.apache.gobblin.util.filesystem.PathAlterationListener;
 import org.apache.gobblin.util.filesystem.PathAlterationListenerAdaptor;
 import org.apache.gobblin.util.filesystem.PathAlterationObserverScheduler;
@@ -277,11 +279,10 @@ public class SchedulerUtilsTest {
       jobProps5.setProperty("k1", "b1");
       // test-job-conf-dir/test3/test31.PULL
       jobProps5.store(new FileWriter(sameContentFile), "");
-      // sleep for the observer to observe changes once
-      Thread.sleep(1500);
 
+      AssertWithBackoff.create().timeoutMs(2000).backoffFactor(2.0)
+          .assertEquals(input -> fileAltered.size(), 4, "should eventually succeed");
       semaphore.acquire(4);
-      Assert.assertEquals(fileAltered.size(), 4);
 
       Assert.assertTrue(fileAltered.contains(new Path("file:" + jobConfigFile)));
       Assert.assertTrue(fileAltered.contains(new Path("file:" + commonPropsFile)));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2103) issues and references them in the PR title."
    - https://issues.apache.org/jira/browse/GOBBLIN-2103


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Added a new field changeTime which reads from ctime of filesystem. This gets correctly saved when a file is modified and can also be seen using the stat command.
  ![image](https://github.com/apache/gobblin/assets/16535454/da4a2f5d-d98b-42f2-a163-3fa4b44e0aaf)


### Tests
- [x] My PR adds the following unit tests:
 - Updates `testPathAlterationObserver` test


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

