### PR TITLE
[GOBBLIN-2107] Delete adhoc flowSpecs from flowCatalog bug fix

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -289,6 +289,18 @@ public class DagManager extends AbstractIdleService {
   }
 
   /**
+   * Method to submit a {@link Dag} to the {@link DagManager} and delete adhoc flowSpecs from the FlowCatalog after
+   * persisting it in the other addDag method called. The DagManager's failure recovery method ensures the flow will be
+   * executed in the event of downtime.
+   * @throws IOException
+   */
+  public synchronized void addDagAndRemoveAdhocFlowSpec(FlowSpec flowSpec, Dag<JobExecutionPlan> dag, boolean persist,
+      boolean setStatus) throws IOException {
+    addDag(dag, persist, setStatus);
+    removeFlowSpecIfAdhoc(flowSpec);
+  }
+
+  /**
    * Method to submit a {@link Dag} to the {@link DagManager}. The {@link DagManager} optionally persists the
    * submitted dag to the {@link DagStateStore} and then adds the dag to a {@link BlockingQueue} to be picked up
    * by one of the {@link DagManagerThread}s.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -289,18 +289,6 @@ public class DagManager extends AbstractIdleService {
   }
 
   /**
-   * Method to submit a {@link Dag} to the {@link DagManager} and delete adhoc flowSpecs from the FlowCatalog after
-   * persisting it in the other addDag method called. The DagManager's failure recovery method ensures the flow will be
-   * executed in the event of downtime.
-   * @throws IOException
-   */
-  public synchronized void addDagAndRemoveAdhocFlowSpec(FlowSpec flowSpec, Dag<JobExecutionPlan> dag, boolean persist,
-      boolean setStatus) throws IOException {
-    addDag(dag, persist, setStatus);
-    removeFlowSpecIfAdhoc(flowSpec);
-  }
-
-  /**
    * Method to submit a {@link Dag} to the {@link DagManager}. The {@link DagManager} optionally persists the
    * submitted dag to the {@link DagStateStore} and then adds the dag to a {@link BlockingQueue} to be picked up
    * by one of the {@link DagManagerThread}s.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -261,10 +261,10 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
           // Depending on if DagManager is present, handle execution
           submitFlowToDagManager(flowSpec, compiledDag);
         } finally {
-        /* Remove adhoc flow spec from the flow catalog, regardless of whether the flow was successfully validated
-        and permitted to exec (concurrently)
-         */
-        this.dagManager.removeFlowSpecIfAdhoc(flowSpec);
+          /* Remove adhoc flow spec from the flow catalog, regardless of whether the flow was successfully validated
+          and permitted to exec (concurrently)
+           */
+          this.dagManager.removeFlowSpecIfAdhoc(flowSpec);
         }
       }
     } else {
@@ -276,11 +276,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
   }
 
   /**
-   * Method that accepts a flowSpec that it compiles before forwarding to the DagManagerfor execution. It's meant to be
-   * called by {@link org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor}
-   * @param flowSpec
-   * @throws IOException
-   * @throws InterruptedException
+   * Compiles the provided {@link FlowSpec} into a {@link Dag<JobExecutionPlan>} and forwards that to the
+   * {@link DagManager} for execution. It's meant to be called by
+   * {@link org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor}
    */
   public void compileAndSubmitFlowToDagManager(FlowSpec flowSpec) throws IOException, InterruptedException {
     try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -140,31 +140,39 @@ public class FlowCompilationValidationHelper {
         ConfigurationKeys.FLOW_ALLOW_CONCURRENT_EXECUTION, String.valueOf(this.isFlowConcurrencyEnabled)));
 
     Dag<JobExecutionPlan> jobExecutionPlanDag = specCompiler.compileFlow(flowSpec);
-    if (jobExecutionPlanDag == null || jobExecutionPlanDag.isEmpty()) {
-      return Optional.absent();
-    }
-    addFlowExecutionIdIfAbsent(flowMetadata, jobExecutionPlanDag);
+    Optional<Dag<JobExecutionPlan>> optionalJobExecutionPlan = null;
 
-    if (isExecutionPermitted(flowStatusGenerator, flowGroup, flowName, allowConcurrentExecution,
-        Long.parseLong(flowMetadata.get(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD)))) {
-      return Optional.fromNullable(jobExecutionPlanDag);
-    } else {
-      log.warn("Another instance of flowGroup: {}, flowName: {} running; Skipping flow execution since "
-          + "concurrent executions are disabled for this flow.", flowGroup, flowName);
-      sharedFlowMetricsSingleton.conditionallyUpdateFlowGaugeSpecState(flowSpec,
-          SharedFlowMetricsSingleton.CompiledState.SKIPPED);
-      Instrumented.markMeter(sharedFlowMetricsSingleton.getSkippedFlowsMeter());
-      if (!flowSpec.isScheduled()) {
-        // For ad-hoc flow, we might already increase quota, we need to decrease here
-        for (Dag.DagNode dagNode : jobExecutionPlanDag.getStartNodes()) {
-          quotaManager.releaseQuota(dagNode);
-        }
+    try {
+      if (jobExecutionPlanDag == null || jobExecutionPlanDag.isEmpty()) {
+        optionalJobExecutionPlan = Optional.absent();
       }
-      // Send FLOW_FAILED event
-      flowMetadata.put(TimingEvent.METADATA_MESSAGE, "Flow failed because another instance is running and concurrent "
-          + "executions are disabled. Set flow.allowConcurrentExecution to true in the flowSpec to change this behaviour.");
-      new TimingEvent(eventSubmitter, TimingEvent.FlowTimings.FLOW_FAILED).stop(flowMetadata);
-      return Optional.absent();
+      addFlowExecutionIdIfAbsent(flowMetadata, jobExecutionPlanDag);
+
+      if (isExecutionPermitted(flowStatusGenerator, flowGroup, flowName, allowConcurrentExecution,
+          Long.parseLong(flowMetadata.get(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD)))) {
+        optionalJobExecutionPlan = Optional.fromNullable(jobExecutionPlanDag);
+      } else {
+        log.warn("Another instance of flowGroup: {}, flowName: {} running; Skipping flow execution since "
+            + "concurrent executions are disabled for this flow.", flowGroup, flowName);
+        optionalJobExecutionPlan = Optional.absent();
+      }
+    } finally {
+      if (optionalJobExecutionPlan == null || !optionalJobExecutionPlan.isPresent()) {
+        sharedFlowMetricsSingleton.conditionallyUpdateFlowGaugeSpecState(flowSpec,
+            SharedFlowMetricsSingleton.CompiledState.SKIPPED);
+        Instrumented.markMeter(sharedFlowMetricsSingleton.getSkippedFlowsMeter());
+        if (!flowSpec.isScheduled()) {
+          // For ad-hoc flow, we might already increase quota, we need to decrease here
+          for (Dag.DagNode dagNode : jobExecutionPlanDag.getStartNodes()) {
+            quotaManager.releaseQuota(dagNode);
+          }
+        }
+        // Send FLOW_FAILED event
+        flowMetadata.put(TimingEvent.METADATA_MESSAGE, "Flow failed because another instance is running and concurrent "
+            + "executions are disabled. Set flow.allowConcurrentExecution to true in the flowSpec to change this behaviour.");
+        new TimingEvent(eventSubmitter, TimingEvent.FlowTimings.FLOW_FAILED).stop(flowMetadata);
+      }
+      return optionalJobExecutionPlan;
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -315,7 +315,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagAc
       change. It's crucial to adopt the consensus flowExecutionId here to prevent creating a new one during compilation.
       */
       spec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, dagAction.getFlowExecutionId());
-      this.orchestrator.submitFlowToDagManager(spec);
+      this.orchestrator.compileAndSubmitFlowToDagManager(spec);
     } catch (URISyntaxException e) {
       log.warn("Could not create URI object for flowId {}. Exception {}", flowId, e.getMessage());
       launchSubmissionMetricProxy.markFailure();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -321,8 +321,10 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagAc
       launchSubmissionMetricProxy.markFailure();
       return;
     } catch (SpecNotFoundException e) {
-      log.warn("Spec not found for flowId {} due to exception {}", flowId, e.getMessage());
-      launchSubmissionMetricProxy.markFailure();
+      log.info("Spec not found for flowId {} due to deletion by active dagManager host due to exception {}",
+          flowId, e.getMessage());
+      // TODO: mark this failure if there are other valid cases of this exception
+      // launchSubmissionMetricProxy.markFailure();
       return;
     } catch (IOException e) {
       log.warn("Failed to add Job Execution Plan for flowId {} due to exception {}", flowId, e.getMessage());


### PR DESCRIPTION
	* if job compilation fails then ensure quota is released and flow compilation event sent in all cases
	* fix bug where adhoc flows are not deleted in multi-active scheduler case by re-adding deletion to DagManager.addDag()

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2107


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Delete adhoc `flowSpecs` from `flowCatalog` to avoid build up of adhoc flowSpecs in catalog even when job compilation fails by adding the deletion in a finally block in non-MA scheduler case. 

1. Previous PR: https://github.com/apache/gobblin/pull/3944/files causes a bug where adhoc flows are not deleted when multi-active scheduler is enabled. This PR re-adds deletion of `flowSpec` to the `dagManager` to be called by the active host for the MA scheduler case (there will only be one active host if `dagManager` is enabled otherwise code will use `dagProcessingEngine`). 
2. It also ensures quota is released and failed flow compilation event sent by the `FlowCompilationValidationHelper` in all compilation failure cases. This was being incorrectly handled before. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- added a unit test `testDeleteFlowSpecCalledForMultiActivePath` that validates that the `compileAndSubmitFlowToDagManager` used by the `DagActionStoreChangeMonitor` attempts deleting adhoc flowSpecs from the catalog. Note that this test does not definitively ensure that this method is called by the `DagActionStoreChangeMonitor` which proves more complex but verifies if that method is used then the flow will be deleted after compilation. 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    3. Subject is limited to 50 characters
    4. Subject does not end with a period
    5. Subject uses the imperative mood ("add", not "adding")
    6. Body wraps at 72 characters
    7. Body explains "what" and "why", not "how"

