### PR TITLE
[GOBBLIN-2108] fix quartz not able to create non static inner class, create a separa…

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/SchedulerService.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/SchedulerService.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.SchedulerFactory;
 import org.quartz.impl.StdSchedulerFactory;
 
 import com.google.common.base.Optional;
@@ -44,52 +43,35 @@ import org.apache.gobblin.util.PropertiesUtils;
 @Singleton
 public class SchedulerService extends AbstractIdleService {
 
-  private SchedulerFactory schedulerFactory;
-  // Refers to traditional job scheduler
   @Getter
   private Scheduler scheduler;
   private final boolean waitForJobCompletion;
   private final Optional<Properties> quartzProps;
 
-  public SchedulerService(boolean waitForJobCompletion, Optional<Properties> quartzConfig,
-      StdSchedulerFactory schedulerFactory) {
+  public SchedulerService(boolean waitForJobCompletion, Optional<Properties> quartzConfig) {
     this.waitForJobCompletion = waitForJobCompletion;
     this.quartzProps = quartzConfig;
-    if (this.schedulerFactory == null) {
-      this.schedulerFactory = new StdSchedulerFactory();
-    }
-    else {
-      this.schedulerFactory = schedulerFactory;
-    }
-  }
-
-  public SchedulerService(Properties props, StdSchedulerFactory schedulerFactory) {
-    this(Boolean.parseBoolean(
-            props.getProperty(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY,
-                              ConfigurationKeys.DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION)),
-        Optional.of(PropertiesUtils.extractPropertiesWithPrefix(props, Optional.of("org.quartz."))), schedulerFactory);
   }
 
   public SchedulerService(Properties props) {
-    this(props, null);
-  }
-
-  public SchedulerService(Config cfg) {
-    this(cfg, null);
+    this(Boolean.parseBoolean(
+            props.getProperty(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY,
+                ConfigurationKeys.DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION)),
+        Optional.of(PropertiesUtils.extractPropertiesWithPrefix(props, Optional.of("org.quartz."))));
   }
 
   @Inject
-  public SchedulerService(Config cfg, StdSchedulerFactory schedulerFactory) {
+  public SchedulerService(Config cfg) {
     this(cfg.hasPath(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY) ?
             cfg.getBoolean(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY) :
             Boolean.parseBoolean(ConfigurationKeys.DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION),
-        Optional.of(ConfigUtils.configToProperties(cfg, "org.quartz.")), schedulerFactory);
+        Optional.of(ConfigUtils.configToProperties(cfg, "org.quartz.")));
   }
 
   @Override protected void startUp() throws SchedulerException  {
-    if (this.quartzProps.isPresent() && this.quartzProps.get().size() > 0) {
-      // Cast to StdSchedulerFactory to reference initialization method that generic interface does not provide
-      ((StdSchedulerFactory) schedulerFactory).initialize(this.quartzProps.get());
+    StdSchedulerFactory schedulerFactory = new StdSchedulerFactory();
+    if (this.quartzProps.isPresent() && !this.quartzProps.get().isEmpty()) {
+      schedulerFactory.initialize(this.quartzProps.get());
     }
     this.scheduler = schedulerFactory.getScheduler();
     this.scheduler.start();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -20,7 +20,6 @@ package org.apache.gobblin.service.modules.core;
 import java.util.Objects;
 
 import org.apache.helix.HelixManager;
-import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +77,7 @@ import org.apache.gobblin.service.modules.orchestration.DagTaskStream;
 import org.apache.gobblin.service.modules.orchestration.FlowLaunchHandler;
 import org.apache.gobblin.service.modules.orchestration.FlowLaunchMultiActiveLeaseArbiterFactory;
 import org.apache.gobblin.service.modules.orchestration.MultiActiveLeaseArbiter;
-import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
+import org.apache.gobblin.service.modules.orchestration.MostlyMySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MysqlDagActionStore;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
@@ -178,7 +177,7 @@ public class GobblinServiceGuiceModule implements Module {
     OptionalBinder.newOptionalBinder(binder, DagActionStore.class);
     if (serviceConfig.isWarmStandbyEnabled()) {
       binder.bind(DagActionStore.class).to(MysqlDagActionStore.class);
-      binder.bind(DagManagementStateStore.class).to(MySqlDagManagementStateStore.class);
+      binder.bind(DagManagementStateStore.class).to(MostlyMySqlDagManagementStateStore.class);
       binder.bind(FlowConfigsResourceHandler.class).to(GobblinServiceFlowConfigResourceHandler.class);
       binder.bind(FlowConfigsV2ResourceHandler.class).to(GobblinServiceFlowConfigV2ResourceHandlerWithWarmStandby.class);
       binder.bind(FlowExecutionResourceHandler.class).to(GobblinServiceFlowExecutionResourceHandlerWithWarmStandby.class);
@@ -199,8 +198,6 @@ public class GobblinServiceGuiceModule implements Module {
     if (serviceConfig.isMultiActiveSchedulerEnabled()) {
       binder.bind(FlowLaunchHandler.class);
     }
-
-    binder.bind(StdSchedulerFactory.class);
 
     OptionalBinder.newOptionalBinder(binder, DagManagement.class);
     OptionalBinder.newOptionalBinder(binder, DagTaskStream.class);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -20,7 +20,6 @@ package org.apache.gobblin.service.modules.core;
 import java.util.Objects;
 
 import org.apache.helix.HelixManager;
-import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,9 +198,6 @@ public class GobblinServiceGuiceModule implements Module {
     if (serviceConfig.isMultiActiveSchedulerEnabled()) {
       binder.bind(FlowLaunchHandler.class);
     }
-
-    // Note: only one SchedulerFactory instance should exist per JVM
-    binder.bind(StdSchedulerFactory.class).in(Singleton.class);
 
     OptionalBinder.newOptionalBinder(binder, DagManagement.class);
     OptionalBinder.newOptionalBinder(binder, DagTaskStream.class);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.service.modules.core;
 import java.util.Objects;
 
 import org.apache.helix.HelixManager;
+import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +77,8 @@ import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
 import org.apache.gobblin.service.modules.orchestration.DagTaskStream;
 import org.apache.gobblin.service.modules.orchestration.FlowLaunchHandler;
 import org.apache.gobblin.service.modules.orchestration.FlowLaunchMultiActiveLeaseArbiterFactory;
-import org.apache.gobblin.service.modules.orchestration.MostlyMySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MultiActiveLeaseArbiter;
+import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MysqlDagActionStore;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
@@ -177,7 +178,7 @@ public class GobblinServiceGuiceModule implements Module {
     OptionalBinder.newOptionalBinder(binder, DagActionStore.class);
     if (serviceConfig.isWarmStandbyEnabled()) {
       binder.bind(DagActionStore.class).to(MysqlDagActionStore.class);
-      binder.bind(DagManagementStateStore.class).to(MostlyMySqlDagManagementStateStore.class);
+      binder.bind(DagManagementStateStore.class).to(MySqlDagManagementStateStore.class);
       binder.bind(FlowConfigsResourceHandler.class).to(GobblinServiceFlowConfigResourceHandler.class);
       binder.bind(FlowConfigsV2ResourceHandler.class).to(GobblinServiceFlowConfigV2ResourceHandlerWithWarmStandby.class);
       binder.bind(FlowExecutionResourceHandler.class).to(GobblinServiceFlowExecutionResourceHandlerWithWarmStandby.class);
@@ -198,6 +199,8 @@ public class GobblinServiceGuiceModule implements Module {
     if (serviceConfig.isMultiActiveSchedulerEnabled()) {
       binder.bind(FlowLaunchHandler.class);
     }
+
+    binder.bind(StdSchedulerFactory.class);
 
     OptionalBinder.newOptionalBinder(binder, DagManagement.class);
     OptionalBinder.newOptionalBinder(binder, DagTaskStream.class);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
@@ -116,8 +116,9 @@ public class DagActionReminderSchedulerTest {
     this.dagActionReminderScheduler.unscheduleReminderJob(launchLeaseParams2, true);
   }
 
+  // Test multiple schedulers can co-exist and run their jobs of different types
   @Test
-  public void testScheduleReminder() throws SchedulerException, InterruptedException, IOException {
+  public void testMultipleSchedules() throws SchedulerException, InterruptedException, IOException {
     JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(launchLeaseParams, false);
     Scheduler scheduler1 = this.dagActionReminderScheduler.quartzScheduler;
     Scheduler scheduler2 = new StdSchedulerFactory().getScheduler();


### PR DESCRIPTION
…te scheduler for reminder jobs

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2108


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
QuartzSchduler cannot instantiate ReminderJob because in the last commit, I changed it from static to non-static inner class (to achieve something). This is not allowed in java without creating the outer class.
In order to create ReminderJob without creating the outer DagActionReminderScheduler class, I am adding a ReminderJobFactory.
Because we do not want FlowSpec scheduler to use this factory, we want to do this in a different scheduler, so creating a different one for DagActionReminderScheduler.
revert changes in SchedulerService made in PR#3890 because i think those were unnecessary
### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
add a unit test to verify normal scheuler and the one in DagActionReminderScheduler create different schedulers and they both run and complete their jobs.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

