### PR TITLE
[GOBBLIN-2110]Made retry_exception_predicate configurable in RetryerFactory

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -1061,6 +1061,8 @@ public class ConfigurationKeys {
   // describes a comma separated list of non transient errors that may come in a gobblin job
   // e.g. "invalid_grant,CredentialStoreException"
   public static final String GOBBLIN_NON_TRANSIENT_ERRORS = "gobblin.errorMessages.nonTransientErrors";
+  // Key to store a comma-separated list of exception class names that should be retried
+  public static final String EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY = "EXCEPTION_LIST_FOR_RETRY";
 
   /**
    * Configuration properties related to Flows

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.gobblin.util.ConfigUtils;
 
 
 import com.github.rholder.retry.Retryer;
@@ -39,6 +38,8 @@ import com.typesafe.config.ConfigFactory;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.gobblin.exception.NonTransientException;
+import org.apache.gobblin.util.ConfigUtils;
+
 
 /**
  * Factory class that builds Retryer.

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.collections.CollectionUtils;
 
 
 import com.github.rholder.retry.Retryer;
@@ -39,6 +40,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+
 
 
 /**
@@ -58,9 +61,6 @@ public class RetryerFactory<T> {
   public static final String RETRY_TYPE = "retry_type";
   // value large or equal to 1
   public static final String RETRY_TIMES = "retry_times";
-
-  // Key to store a comma-separated list of exception class names that should be retried
-  public static final String EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY = "EXCEPTION_LIST_FOR_RETRY";
   public static final Predicate<Throwable> RETRY_EXCEPTION_PREDICATE_DEFAULT;
 
   private static final Config DEFAULTS;
@@ -98,17 +98,15 @@ public class RetryerFactory<T> {
 
     RetryerBuilder<T> builder;
 
-    Predicate<Throwable> retryPredicate = getRetryPredicateFromConfigOrDefault(config);
-
     switch (type) {
       case EXPONENTIAL:
-        builder = newExponentialRetryerBuilder(config, retryPredicate);
+        builder = newExponentialRetryerBuilder(config);
         break;
       case FIXED:
-        builder = newFixedRetryerBuilder(config, retryPredicate);
+        builder = newFixedRetryerBuilder(config);
         break;
       case FIXED_ATTEMPT:
-        builder = newFixedAttemptBoundRetryerBuilder(config, retryPredicate);
+        builder = newFixedAttemptBoundRetryerBuilder(config);
         break;
       default:
         throw new IllegalArgumentException(type + " is not supported");
@@ -127,34 +125,32 @@ public class RetryerFactory<T> {
   @VisibleForTesting
   public static Predicate<Throwable> getRetryPredicateFromConfigOrDefault(Config config) {
     // Retrieve the list of exception class names from the configuration
-    List<String> exceptionList = ConfigUtils.getStringList(config, EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY);
+    List<String> exceptionList = ConfigUtils.getStringList(config, ConfigurationKeys.EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY);
 
     // If the exception list is null or empty, return the default retry predicate
-    if (exceptionList == null || exceptionList.isEmpty()) {
+    if (CollectionUtils.isEmpty(exceptionList)) {
       return RETRY_EXCEPTION_PREDICATE_DEFAULT;
     }
 
     // Create a retry predicate by mapping each exception class name to a Predicate
-    Predicate<Throwable> retryPredicate = exceptionList.stream().map(exceptionClassName -> {
+    return exceptionList.stream().map(exceptionClassName -> {
           try {
             Class<?> clazz = Class.forName(exceptionClassName);
             if (Exception.class.isAssignableFrom(clazz)) {
               // Return a Predicate that checks if a Throwable is an instance of the class
               return (Predicate<Throwable>) clazz::isInstance;
             } else {
-              LOG.error("{} is not an exception.", exceptionClassName);
+              LOG.error("{} is not an exception,ignoring", exceptionClassName);
             }
-          } catch (ClassNotFoundException exception) {
-            LOG.error("Class not found for the given exception className {}", exceptionClassName, exception);
-          } catch (Exception exception) {
-            LOG.error("Failed to instantiate exception {}", exceptionClassName, exception);
+          } catch (ClassNotFoundException ignored) {
+            LOG.error("Class not found for the given exception className {},ignoring it", exceptionClassName, ignored);
+          } catch (Exception ignored) {
+            LOG.error("Failed to instantiate exception {},ignoring it", exceptionClassName, ignored);
           }
           return null;
         }).filter(Objects::nonNull) // Filter out any null values
         .reduce(com.google.common.base.Predicates::or) // Combine all predicates using logical OR
         .orElse(RETRY_EXCEPTION_PREDICATE_DEFAULT); // Default to retryExceptionPredicate if no valid predicates are found
-
-    return retryPredicate;
   }
 
   /**
@@ -164,28 +160,25 @@ public class RetryerFactory<T> {
     return newInstance(config, Optional.empty());
   }
 
-  private static <T> RetryerBuilder<T> newFixedRetryerBuilder(Config config,
-      Predicate<Throwable> retryExceptionPredicate) {
+  private static <T> RetryerBuilder<T> newFixedRetryerBuilder(Config config) {
     return RetryerBuilder.<T>newBuilder()
-        .retryIfException(retryExceptionPredicate)
+        .retryIfException(getRetryPredicateFromConfigOrDefault(config))
         .withWaitStrategy(WaitStrategies.fixedWait(config.getLong(RETRY_INTERVAL_MS), TimeUnit.MILLISECONDS))
         .withStopStrategy(StopStrategies.stopAfterDelay(config.getLong(RETRY_TIME_OUT_MS), TimeUnit.MILLISECONDS));
   }
 
-  private static <T> RetryerBuilder<T> newExponentialRetryerBuilder(Config config,
-      Predicate<Throwable> retryExceptionPredicate) {
+  private static <T> RetryerBuilder<T> newExponentialRetryerBuilder(Config config) {
     return RetryerBuilder.<T>newBuilder()
-        .retryIfException(retryExceptionPredicate)
+        .retryIfException(getRetryPredicateFromConfigOrDefault(config))
         .withWaitStrategy(
             WaitStrategies.exponentialWait(config.getLong(RETRY_MULTIPLIER), config.getLong(RETRY_INTERVAL_MS),
                 TimeUnit.MILLISECONDS))
         .withStopStrategy(StopStrategies.stopAfterDelay(config.getLong(RETRY_TIME_OUT_MS), TimeUnit.MILLISECONDS));
   }
 
-  private static <T> RetryerBuilder<T> newFixedAttemptBoundRetryerBuilder(Config config,
-      Predicate<Throwable> retryExceptionPredicate) {
+  private static <T> RetryerBuilder<T> newFixedAttemptBoundRetryerBuilder(Config config) {
     return RetryerBuilder.<T>newBuilder()
-        .retryIfException(retryExceptionPredicate)
+        .retryIfException(getRetryPredicateFromConfigOrDefault(config))
         .withWaitStrategy(WaitStrategies.fixedWait(config.getLong(RETRY_INTERVAL_MS), TimeUnit.MILLISECONDS))
         .withStopStrategy(StopStrategies.stopAfterAttempt(config.getInt(RETRY_TIMES)));
   }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/retry/RetryerFactoryTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/retry/RetryerFactoryTest.java
@@ -18,23 +18,24 @@ package org.apache.gobblin.util.retry;
 
 import java.util.Arrays;
 
-import org.mockito.Mockito;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Predicate;
 import com.typesafe.config.Config;
+import com.google.common.base.Predicate;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
 
 /**
  * Unit tests for the {@link org.apache.gobblin.util.retry.RetryerFactory} class.
  */
 public class RetryerFactoryTest {
-  private static final String EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY = "EXCEPTION_LIST_FOR_RETRY";
 
   @Test
   public void testGetRetryPredicateFromConfigOrDefault_withEmptyConfig() {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(false);
+    Config config = ConfigFactory.empty();
     Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
 
     Assert.assertEquals(RetryerFactory.RETRY_EXCEPTION_PREDICATE_DEFAULT, result);
@@ -42,10 +43,9 @@ public class RetryerFactoryTest {
 
   @Test
   public void testGetRetryPredicateFromConfigOrDefault_withValidException() {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
-    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
-        .thenReturn(Arrays.asList("java.lang.RuntimeException"));
+    Config config = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY,
+            ConfigValueFactory.fromAnyRef(Arrays.asList("java.lang.RuntimeException")));
 
     Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
 
@@ -55,10 +55,9 @@ public class RetryerFactoryTest {
 
   @Test
   public void testGetRetryPredicateFromConfigOrDefault_withInvalidException() {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
-    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
-        .thenReturn(Arrays.asList("non.existent.Exception"));
+    Config config = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY,
+            ConfigValueFactory.fromAnyRef(Arrays.asList("non.existent.Exception")));
 
     Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
 
@@ -67,10 +66,9 @@ public class RetryerFactoryTest {
 
   @Test
   public void testGetRetryPredicateFromConfigOrDefault_withMixedExceptions() {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
-    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
-        .thenReturn(Arrays.asList("java.lang.RuntimeException", "non.existent.Exception"));
+    Config config = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY,
+            ConfigValueFactory.fromAnyRef(Arrays.asList("java.lang.RuntimeException", "non.existent.Exception")));
 
     Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
 

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/retry/RetryerFactoryTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/retry/RetryerFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.util.retry;
+
+import java.util.Arrays;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.typesafe.config.Config;
+
+/**
+ * Unit tests for the {@link org.apache.gobblin.util.retry.RetryerFactory} class.
+ */
+public class RetryerFactoryTest {
+  private static final String EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY = "EXCEPTION_LIST_FOR_RETRY";
+
+  @Test
+  public void testGetRetryPredicateFromConfigOrDefault_withEmptyConfig() {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(false);
+    Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
+
+    Assert.assertEquals(RetryerFactory.RETRY_EXCEPTION_PREDICATE_DEFAULT, result);
+  }
+
+  @Test
+  public void testGetRetryPredicateFromConfigOrDefault_withValidException() {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
+    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
+        .thenReturn(Arrays.asList("java.lang.RuntimeException"));
+
+    Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
+
+    Assert.assertTrue(result.test(new RuntimeException()));
+    Assert.assertFalse(result.test(new Exception()));
+  }
+
+  @Test
+  public void testGetRetryPredicateFromConfigOrDefault_withInvalidException() {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
+    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
+        .thenReturn(Arrays.asList("non.existent.Exception"));
+
+    Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
+
+    Assert.assertEquals(RetryerFactory.RETRY_EXCEPTION_PREDICATE_DEFAULT, result);
+  }
+
+  @Test
+  public void testGetRetryPredicateFromConfigOrDefault_withMixedExceptions() {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.hasPath(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY)).thenReturn(true);
+    Mockito.when(config.getStringList(EXCEPTION_LIST_FOR_RETRY_CONFIG_KEY))
+        .thenReturn(Arrays.asList("java.lang.RuntimeException", "non.existent.Exception"));
+
+    Predicate<Throwable> result = RetryerFactory.getRetryPredicateFromConfigOrDefault(config);
+
+    Assert.assertTrue(result.test(new RuntimeException()));
+    Assert.assertFalse(result.test(new Exception()));
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2110


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
RetryerFactory does not give option to set retry_exception_predicate.Made it configurable



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

