### PR TITLE
[GOBBLIN-2113] Process Heartbeat DagAction CDC messages with empty FlowExecutionId str

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagActionStoreChangeMonitorTest.java
@@ -150,7 +150,7 @@ public class DagActionStoreChangeMonitorTest {
   @Test (dependsOnMethods = "testProcessMessageWithHeartbeatAndNullDagAction")
   public void testProcessMessageWithHeartbeatAndFlowInfo() throws SpecNotFoundException {
     Kafka09ConsumerClient.Kafka09ConsumerRecord consumerRecord =
-        wrapDagActionStoreChangeEvent(OperationType.HEARTBEAT, "", "", "", DagActionValue.RESUME);
+        wrapDagActionStoreChangeEvent(OperationType.HEARTBEAT, FLOW_GROUP, "", "", DagActionValue.RESUME);
     mockDagActionStoreChangeMonitor.processMessageForTest(consumerRecord);
     verify(mockDagActionStoreChangeMonitor.getDagManager(), times(0)).handleResumeFlowRequest(anyString(), anyString(), anyLong());
     verify(mockDagActionStoreChangeMonitor.getDagManager(), times(0)).handleKillFlowRequest(anyString(), anyString(), anyLong());

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
@@ -60,7 +60,7 @@ public class DagManagementDagActionStoreChangeMonitorTest {
   private final int OFFSET = 1;
   private final String FLOW_GROUP = "flowGroup";
   private final String FLOW_NAME = "flowName";
-  private final long FLOW_EXECUTION_ID = 123L;
+  private final String FLOW_EXECUTION_ID = "987654321";
   private final String JOB_NAME = "jobName";
   private MockDagManagementDagActionStoreChangeMonitor mockDagManagementDagActionStoreChangeMonitor;
   private int txidCounter = 0;
@@ -109,7 +109,7 @@ public class DagManagementDagActionStoreChangeMonitorTest {
   public void testProcessMessageWithDelete() throws SchedulerException {
     Kafka09ConsumerClient.Kafka09ConsumerRecord<String, DagActionStoreChangeEvent> consumerRecord =
         wrapDagActionStoreChangeEvent(OperationType.DELETE, FLOW_GROUP, FLOW_NAME, FLOW_EXECUTION_ID, JOB_NAME, DagActionValue.ENFORCE_JOB_START_DEADLINE);
-    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(FLOW_GROUP, FLOW_NAME, FLOW_EXECUTION_ID, JOB_NAME,
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(FLOW_GROUP, FLOW_NAME, Long.parseLong(FLOW_EXECUTION_ID), JOB_NAME,
         DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE);
     mockDagManagementDagActionStoreChangeMonitor.processMessageForTest(consumerRecord);
     /* TODO: skip deadline removal for now and let them fire
@@ -124,7 +124,7 @@ public class DagManagementDagActionStoreChangeMonitorTest {
    * Util to create a general DagActionStoreChange type event
    */
   private DagActionStoreChangeEvent createDagActionStoreChangeEvent(OperationType operationType,
-      String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionValue dagAction) {
+      String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionValue dagAction) {
     String key = DagActionStoreChangeMonitorTest.getKeyForFlow(flowGroup, flowName, flowExecutionId);
     GenericStoreChangeEvent genericStoreChangeEvent =
         new GenericStoreChangeEvent(key, String.valueOf(txidCounter), System.currentTimeMillis(), operationType);
@@ -137,7 +137,7 @@ public class DagManagementDagActionStoreChangeMonitorTest {
    * Util to create wrapper around DagActionStoreChangeEvent
    */
   private Kafka09ConsumerClient.Kafka09ConsumerRecord<String, DagActionStoreChangeEvent> wrapDagActionStoreChangeEvent(
-      OperationType operationType, String flowGroup, String flowName, long flowExecutionId, String jobName, DagActionValue dagAction) {
+      OperationType operationType, String flowGroup, String flowName, String flowExecutionId, String jobName, DagActionValue dagAction) {
     DagActionStoreChangeEvent eventToProcess = null;
     try {
       eventToProcess =

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -290,6 +290,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
         _log.warn("Flow: {} submitted to dagManager failed to compile and produce a job execution plan dag", flowSpec);
         Instrumented.markMeter(this.flowOrchestrationFailedMeter);
       }
+    } catch (IOException | InterruptedException e) {
+      Instrumented.markMeter(this.flowOrchestrationFailedMeter);
+      throw e;
     } finally {
       this.dagManager.removeFlowSpecIfAdhoc(flowSpec);
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -129,7 +129,8 @@ public class FlowCompilationValidationHelper {
       flowCompilationTimer.stop(flowMetadata);
       return jobExecutionPlanDagOptional;
     } catch (IOException e) {
-      log.error("Encountered exception when attempting to compile and perform checks for flow: {}", flowSpec);
+      log.error("Encountered exception when attempting to compile and perform checks for flowGroup: {} flowName: {}",
+          flowGroup, flowName);
       throw e;
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -112,20 +112,26 @@ public class FlowCompilationValidationHelper {
 
     TimingEvent flowCompilationTimer = new TimingEvent(this.eventSubmitter, TimingEvent.FlowTimings.FLOW_COMPILED);
     Map<String, String> flowMetadata = TimingEventUtils.getFlowMetadata(flowSpec);
-    Optional<Dag<JobExecutionPlan>> jobExecutionPlanDagOptional =
-        validateAndHandleConcurrentExecution(flowConfig, flowSpec, flowGroup, flowName, flowMetadata);
 
-    if (!jobExecutionPlanDagOptional.isPresent()) {
-      return Optional.absent();
+    try {
+      Optional<Dag<JobExecutionPlan>> jobExecutionPlanDagOptional =
+          validateAndHandleConcurrentExecution(flowConfig, flowSpec, flowGroup, flowName, flowMetadata);
+
+      if (!jobExecutionPlanDagOptional.isPresent()) {
+        return Optional.absent();
+      }
+
+      if (jobExecutionPlanDagOptional.get().isEmpty()) {
+        populateFlowCompilationFailedEventMessage(eventSubmitter, flowSpec, flowMetadata);
+        return Optional.absent();
+      }
+
+      flowCompilationTimer.stop(flowMetadata);
+      return jobExecutionPlanDagOptional;
+    } catch (IOException e) {
+      log.error("Encountered exception when attempting to compile and perform checks for flow: {}", flowSpec);
+      throw e;
     }
-
-    if (jobExecutionPlanDagOptional.get().isEmpty()) {
-      populateFlowCompilationFailedEventMessage(eventSubmitter, flowSpec, flowMetadata);
-      return Optional.absent();
-    }
-
-    flowCompilationTimer.stop(flowMetadata);
-    return jobExecutionPlanDagOptional;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -199,7 +199,7 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagAc
     String operation = value.getChangeEventIdentifier().getOperationType().name();
     String flowGroup = value.getFlowGroup();
     String flowName = value.getFlowName();
-    long flowExecutionId = Long.parseLong(value.getFlowExecutionId());
+    String flowExecutionId = value.getFlowExecutionId();
     String jobName = value.getJobName();
 
     produceToConsumeDelayValue = calcMillisSince(produceTimestamp);
@@ -219,12 +219,14 @@ public class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagAc
     }
 
     DagActionStore.DagActionType dagActionType = DagActionStore.DagActionType.valueOf(value.getDagAction().toString());
+    // Parse flowExecutionIds after filtering out HB messages to prevent exception from parsing empty strings
+    long flowExecutionIdLong = Long.parseLong(flowExecutionId);
 
     // Used to easily log information to identify the dag action
-    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName,
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(flowGroup, flowName, flowExecutionIdLong, jobName,
         dagActionType);
 
-    handleDagAction(operation, dagAction, flowGroup, flowName, flowExecutionId, dagActionType);
+    handleDagAction(operation, dagAction, flowGroup, flowName, flowExecutionIdLong, dagActionType);
 
     dagActionsSeenCache.put(changeIdentifier, changeIdentifier);
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2113


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
After changing `flowExecutionId` from a Str to a long in a previous PR, we encounter `NumberFormatException` in the `DagActionStoreChangeMonitor` when processing HB events. This ends up killing the `HighLevelConsumer` queues for the hosts that receive the HB events in their partition. 
```
{{Encountered exception while processing record so stopping queue processing. Record: LiKafka10ConsumerRecord(consumerRecord=ConsumerRecord(topic = ds_mysql_makto-db-152_prod_SHARED_GOBBLIN_DAG_ACTION_STORE_20221208211255, partition = 0, leaderEpoch = null, offset = 905733, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = RecordHeaders(headers = [], isReadOnly = false), key = , value = {"changeEventIdentifier":
{"key": "", "txId": "", "produceTimestampMillis": 1721078158347, "operationType": "HEARTBEAT"}
, "flowGroup": "", "flowName": "", "flowExecutionId": "", "jobName": "", "dagAction": null})) Exception: java.lang.NumberFormatException: For input string: ""}}
```

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updates the following unit test for Heartbeat (HB) events which was using valid flow names, groups, and flowExecutionId for HB event that did not accurately reflect a HB event received from CDC. After updating its values the test failed locally 

```
Gradle suite > Gradle test > org.apache.gobblin.runtime.DagActionStoreChangeMonitorTest > testProcessMessageWithHeartbeatAndNullDagAction FAILED
    java.lang.NumberFormatException: For input string: ""
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:601)
        at java.lang.Long.parseLong(Long.java:631)
        at org.apache.gobblin.service.monitoring.DagActionStoreChangeMonitor.processMessage(DagActionStoreChangeMonitor.java:203)
        at org.apache.gobblin.runtime.DagActionStoreChangeMonitorTest$MockDagActionStoreChangeMonitor.processMessageForTest(DagActionStoreChangeMonitorTest.java:97)
        at org.apache.gobblin.runtime.DagActionStoreChangeMonitorTest.testProcessMessageWithHeartbeatAndNullDagAction(DagActionStoreChangeMonitorTest.java:139)
Failed tests:
[org.apache.gobblin.runtime.DagActionStoreChangeMonitorTest::testProcessMessageWithHeartbeatAndNullDagAction
```

It passes after the update. 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

