### PR TITLE
[GOBBLIN-2114] Add fields to show computed delta between consume and …

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -79,8 +79,8 @@ public class KafkaExtractorStatsTracker {
   private static final String FETCH_MESSAGE_BUFFER_TIME = "fetchMessageBufferTime";
   private static final String LAST_RECORD_HEADER_TIMESTAMP = "lastRecordHeaderTimestamp";
   private static final String OBSERVED_LATENCY_HISTOGRAM = "observedLatencyHistogram";
-  private static final String SLA_CREATION_TS_DURATION = "slaCreationTimeDuration";
-  private static final String SLA_APPEND_TS_DURATION = "slaAppendTimeDuration";
+  private static final String CREATION_DURATION_TIME = "creationDurationTime";
+  private static final String APPEND_DURATION_TIME = "appendDurationTime";
 
   @Getter
   private final Map<KafkaPartition, ExtractorStats> statsMap;
@@ -185,8 +185,8 @@ public class KafkaExtractorStatsTracker {
     private long minLogAppendTime = -1L;
     private long maxLogAppendTime = -1L;
     private long minRecordCreationTime = -1L;
-    private long slaCreationTimeDuration = -1L;
-    private long slaAppendTimeDuration = -1L;
+    private long creationDurationTime = -1L;
+    private long appendDurationTime = -1L;
   }
 
   /**
@@ -310,12 +310,16 @@ public class KafkaExtractorStatsTracker {
         if (logAppendTimestamp > 0 && (System.currentTimeMillis() - logAppendTimestamp > recordLevelSlaMillis)) {
           v.slaMissedRecordCount++;
         }
-        // See context in GOBBLIN-2114
+        // This experiment tracks the SLA for record creation times after migrating to Xinfra.
+        // It compares the time taken for appending records versus the time taken for creating records.
+        // The goal is to identify any potential impact on the SLA. 
+        // Here we capture the time taken from the record was appended to the time consumed by the extractor.
         if (logAppendTimestamp > 0) {
-          v.slaAppendTimeDuration = System.currentTimeMillis() - logAppendTimestamp;        
+          v.appendDurationTime = System.currentTimeMillis() - logAppendTimestamp;        
         }
+        // Here we capture the time taken from the record was created or produced to the time consumed by the extractor.
         if (recordCreationTimestamp > 0) {
-          v.slaCreationTimeDuration = System.currentTimeMillis() - recordCreationTimestamp;        
+          v.creationDurationTime = System.currentTimeMillis() - recordCreationTimestamp;        
         }
       }
       return v;
@@ -467,8 +471,8 @@ public class KafkaExtractorStatsTracker {
     tagsForPartition.put(UNDECODABLE_MESSAGE_COUNT, Long.toString(stats.getDecodingErrorCount()));
     tagsForPartition.put(NULL_RECORD_COUNT, Long.toString(stats.getNullRecordCount()));
     tagsForPartition.put(LAST_RECORD_HEADER_TIMESTAMP, Long.toString(stats.getLastSuccessfulRecordHeaderTimestamp()));
-    tagsForPartition.put(SLA_APPEND_TS_DURATION, Long.toString(stats.getSlaAppendTimeDuration()));
-    tagsForPartition.put(SLA_CREATION_TS_DURATION, Long.toString(stats.getSlaCreationTimeDuration()));
+    tagsForPartition.put(APPEND_DURATION_TIME, Long.toString(stats.getAppendDurationTime()));
+    tagsForPartition.put(CREATION_DURATION_TIME, Long.toString(stats.getCreationDurationTime()));
 
     // Commit avg time to pull a record for each partition
     double avgMillis = stats.getAvgMillisPerRecord();


### PR DESCRIPTION
…producer/append time respectively

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2114


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Add fields to show computed delta between consume and producer/append time respectively

This is the follow up https://github.com/apache/gobblin/pull/3980 to add more metrics for analysis purpose when switching to creationTimestamp

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Printed out the events and see the timestamp get set correctly.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

