### PR TITLE
[GOBBLIN-2116] Update Hive retention to add table location to retention dataset root…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/finder/CleanableHiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/dataset/finder/CleanableHiveDatasetFinder.java
@@ -28,6 +28,7 @@ import org.apache.gobblin.config.client.ConfigClient;
 import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
 import org.apache.gobblin.data.management.retention.dataset.CleanableHiveDataset;
 import org.apache.gobblin.data.management.retention.dataset.ConfigurableCleanableDataset;
+import org.apache.gobblin.data.management.retention.dataset.FsCleanableHelper;
 
 
 public class CleanableHiveDatasetFinder extends HiveDatasetFinder {
@@ -41,7 +42,10 @@ public class CleanableHiveDatasetFinder extends HiveDatasetFinder {
   }
 
   protected CleanableHiveDataset createHiveDataset(Table table, Config datasetConfig) throws IOException {
-    return new CleanableHiveDataset(super.fs, super.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table), super.properties, datasetConfig);
+    Properties datasetProperties = new Properties();
+    datasetProperties.putAll(this.properties);
+    datasetProperties.put(FsCleanableHelper.RETENTION_DATASET_ROOT, table.getSd().getLocation());
+    return new CleanableHiveDataset(super.fs, super.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table), datasetProperties, datasetConfig);
   }
 
   private static Properties setConfigPrefix(Properties props) {


### PR DESCRIPTION
… property

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In Iceberg and File retention, the field `FsCleanableHelper.RETENTION_DATASET_ROOT` is added in order to send metadata about the table to the retention job to compute trash locations. We want to maintain this behavior for Hive retention.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adding property only

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

