### PR TITLE
[GOBBLIN-2117] Initialize metrics map for DagProcEngineMetrics

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -101,6 +101,5 @@ public class ServiceMetricNames {
   public static final String DAG_ACTIONS_CONCLUDE_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsConcludeSucceeded.";
   public static final String DAG_ACTIONS_DELETE_SUCCEEDED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsDeleteSucceeded.";
   public static final String DAG_ACTIONS_DELETE_FAILED = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsDeleteFailed.";
-  // TODO: implement this one
   public static final String DAG_ACTIONS_AVERAGE_PROCESSING_DELAY_MILLIS = DAG_PROCESSING_ENGINE_PREFIX + "dagActionsAvgProcessingDelayMillis.";
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagActionStore.java
@@ -133,8 +133,10 @@ public class MysqlDagActionStore implements DagActionStore {
     try {
       fillPreparedStatement(dagAction.getFlowGroup(), dagAction.getFlowName(), dagAction.getFlowExecutionId(),
           dagAction.getJobName(), dagAction.getDagActionType(), deleteStatement);
+      this.dagProcessingEngineMetrics.markDagActionsDeleted(dagAction.getDagActionType(), true);
       return deleteStatement.executeUpdate() != 0;
     } catch (SQLException e) {
+      this.dagProcessingEngineMetrics.markDagActionsDeleted(dagAction.getDagActionType(), false);
       throw new IOException(String.format("Failure deleting action for DagAction: %s in table %s", dagAction,
           tableName), e);
     }}, true);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
@@ -47,22 +47,23 @@ public class DagProcessingEngineMetrics {
    handle concurrent mark requests correctly. ConcurrentMap is not needed since no updates are made to the mappings,
    only get calls.
   */
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsStoredMeterByDagActionType = new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsObservedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeasesObtainedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsNoLongerLeasingMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeaseReminderScheduledMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsReminderProcessedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsExceededMaxRetryMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeFailedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeSucceededMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActFailedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActSucceededMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeFailedMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeSucceededMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsRemovedFromStoreMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsFailingRemovalMeterByDagActionType =  new HashMap();
-  private HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionAverageProcessingDelayMillisMeterByDagActionType =  new HashMap();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsStoredMeterByDagActionType = new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsObservedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeasesObtainedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsNoLongerLeasingMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsLeaseReminderScheduledMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsReminderProcessedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsExceededMaxRetryMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeFailedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsInitializeSucceededMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActFailedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActSucceededMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeFailedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeSucceededMeterByDagActionType =  new HashMap<>();
+  // TODO: mark these metrics
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsDeleteFailedMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsDeleteSucceededMeterByDagActionType =  new HashMap<>();
+  private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsAverageProcessingDelayMillisMeterByDagActionType =  new HashMap<>();
 
   public DagProcessingEngineMetrics(MetricContext metricContext) {
     this.metricContext = metricContext;
@@ -92,6 +93,9 @@ public class DagProcessingEngineMetrics {
     registerMetricForEachDagActionType(this.dagActionsActSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_ACT_SUCCEEDED);
     registerMetricForEachDagActionType(this.dagActionsConcludeFailedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_CONCLUDE_FAILED);
     registerMetricForEachDagActionType(this.dagActionsConcludeSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_CONCLUDE_SUCCEEDED);
+    registerMetricForEachDagActionType(this.dagActionsDeleteFailedMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_DELETE_FAILED);
+    registerMetricForEachDagActionType(this.dagActionsDeleteSucceededMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_DELETE_SUCCEEDED);
+    registerMetricForEachDagActionType(this.dagActionsAverageProcessingDelayMillisMeterByDagActionType, ServiceMetricNames.DAG_ACTIONS_AVERAGE_PROCESSING_DELAY_MILLIS);
   }
 
   /**
@@ -163,6 +167,19 @@ public class DagProcessingEngineMetrics {
     }
   }
 
+  // TODO: mark this metric when deleted
+  public void markDagActionsDeleted(DagActionStore.DagActionType dagActionType, boolean succeeded) {
+    if (succeeded) {
+      updateMetricForDagActionType(this.dagActionsDeleteSucceededMeterByDagActionType, dagActionType);
+    } else {
+      updateMetricForDagActionType(this.dagActionsDeleteFailedMeterByDagActionType, dagActionType);
+    }
+  }
+
+  // TODO: measure processing time
+  public void mark(DagActionStore.DagActionType dagActionType) {
+    updateMetricForDagActionType(this.dagActionsAverageProcessingDelayMillisMeterByDagActionType, dagActionType);
+  }
 
   /**
    * Generic helper used to increment a metric corresponding to the dagActionType in the provided map. It assumes the

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
@@ -75,6 +75,7 @@ public class DagProcessingEngineMetrics {
     List<Tag<?>> tags = new ArrayList<>();
     tags.add(new Tag<>(MetricTagNames.METRIC_BACKEND_REPRESENTATION, GobblinMetrics.MetricType.COUNTER));
     this.metricContext = Instrumented.getMetricContext(new State(), this.getClass(), tags);
+    registerAllMetrics();
   }
 
   public void registerAllMetrics() {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
@@ -59,7 +59,6 @@ public class DagProcessingEngineMetrics {
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsActSucceededMeterByDagActionType =  new HashMap<>();
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeFailedMeterByDagActionType =  new HashMap<>();
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsConcludeSucceededMeterByDagActionType =  new HashMap<>();
-  // TODO: mark these metrics
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsDeleteFailedMeterByDagActionType =  new HashMap<>();
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsDeleteSucceededMeterByDagActionType =  new HashMap<>();
   private final HashMap<DagActionStore.DagActionType, ContextAwareMeter> dagActionsAverageProcessingDelayMillisMeterByDagActionType =  new HashMap<>();
@@ -163,8 +162,7 @@ public class DagProcessingEngineMetrics {
       updateMetricForDagActionType(this.dagActionsConcludeFailedMeterByDagActionType, dagActionType);
     }
   }
-
-  // TODO: mark this metric when deleted
+  
   public void markDagActionsDeleted(DagActionStore.DagActionType dagActionType, boolean succeeded) {
     if (succeeded) {
       updateMetricForDagActionType(this.dagActionsDeleteSucceededMeterByDagActionType, dagActionType);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagProcessingEngineMetrics.java
@@ -17,9 +17,8 @@
 
 package org.apache.gobblin.service.modules.orchestration.task;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -72,11 +71,9 @@ public class DagProcessingEngineMetrics {
 
   @Inject
   public DagProcessingEngineMetrics() {
-    // Create a new metric context for the DagProcessingEngineMetrics tagged appropriately
-    List<Tag<?>> tags = new ArrayList<>();
-    tags.add(new Tag<>(MetricTagNames.METRIC_BACKEND_REPRESENTATION, GobblinMetrics.MetricType.COUNTER));
-    this.metricContext = Instrumented.getMetricContext(new State(), this.getClass(), tags);
-    registerAllMetrics();
+    this(Instrumented.getMetricContext(new State(),
+        DagProcessingEngineMetrics.class,
+        Collections.singleton(new Tag<>(MetricTagNames.METRIC_BACKEND_REPRESENTATION, GobblinMetrics.MetricType.COUNTER))));
   }
 
   public void registerAllMetrics() {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngineMetricsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngineMetricsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.orchestration;
+
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class DagProcessingEngineMetricsTest {
+  DagProcessingEngineMetrics dagProcessingEngineMetrics;
+
+  @BeforeClass
+  public void setup() {
+    dagProcessingEngineMetrics = new DagProcessingEngineMetrics();
+  }
+
+  /*
+  Checks that the dagActionsStored metric can be incremented for every DagActionType. It ensures that the default
+  constructor of the DagProcessingEngine initializes a meter for each DagActionType.
+   */
+  @Test
+  public void testMarkDagActionsStored() {
+    for (DagActionStore.DagActionType dagActionType : DagActionStore.DagActionType.values()) {
+      dagProcessingEngineMetrics.markDagActionsStored(dagActionType);
+    }
+  }
+
+  /*
+  Checks that the dagActionsObserved metric can be incremented for every DagActionType. It ensures that the default
+  constructor of the DagProcessingEngine initializes a meter for each DagActionType.
+   */
+  @Test
+  public void testMarkDagActionsObserved() {
+    for (DagActionStore.DagActionType dagActionType : DagActionStore.DagActionType.values()) {
+      dagProcessingEngineMetrics.markDagActionsStored(dagActionType);
+    }
+  }
+}


### PR DESCRIPTION
	* adds unit test to verify initialization

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2117


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
` No meter exists for dagActionType ENFORCE_JOB_START_DEADLINE in metricsMap {}`
Initialize metrics map for each `dagActionType` in default constructor of `DagProcessingEngineMetrics`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adds two unit tests that use this default constructor and tries to mark every dagAction for the two metrics, dagActionsStored and dagActionsObserved (the other tests are trivial). 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

