### PR TITLE
[GOBBLIN-2119] ignore adding deadline dag actions if they are already present

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -260,7 +260,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
             leaseParams);
         int numRowsUpdated = attemptLeaseIfNewRow(leaseParams.getDagAction(),
             ExponentialBackoff.builder().maxRetries(MAX_RETRIES)
-                .initialDelay(MIN_INITIAL_DELAY_MILLIS + (long) Math.random() * DELAY_FOR_RETRY_RANGE_MILLIS)
+                .initialDelay(MIN_INITIAL_DELAY_MILLIS + (long) (Math.random() * DELAY_FOR_RETRY_RANGE_MILLIS))
                 .build());
        return evaluateStatusAfterLeaseAttempt(numRowsUpdated, leaseParams, Optional.empty(),
            adoptConsensusFlowExecutionId);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -201,6 +201,7 @@ public class DagProcUtils {
       dagManagementStateStore.addDagAction(dagAction);
     } catch (IOException e) {
       if (e.getCause() != null && e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+        // delete old dag action and have a new deadline dag proc with the new deadline time
         dagManagementStateStore.deleteDagAction(dagAction);
         log.warn("Duplicate ENFORCE_JOB_START_DEADLINE Dag Action is being created. Ignoring... " + e.getMessage());
         dagManagementStateStore.addDagAction(dagAction);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.service.modules.orchestration.proc;
 
 import java.io.IOException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -193,15 +194,33 @@ public class DagProcUtils {
 
   private static void sendEnforceJobStartDeadlineDagAction(DagManagementStateStore dagManagementStateStore, Dag.DagNode<JobExecutionPlan> dagNode)
       throws IOException {
-    dagManagementStateStore.addJobDagAction(dagNode.getValue().getFlowGroup(), dagNode.getValue().getFlowName(),
-        dagNode.getValue().getFlowExecutionId(), dagNode.getValue().getJobName(),
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(dagNode.getValue().getFlowGroup(),
+        dagNode.getValue().getFlowName(), dagNode.getValue().getFlowExecutionId(), dagNode.getValue().getJobName(),
         DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE);
+    try {
+      dagManagementStateStore.addDagAction(dagAction);
+    } catch (IOException e) {
+      if (e.getCause() != null && e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+        dagManagementStateStore.deleteDagAction(dagAction);
+        log.warn("Duplicate ENFORCE_JOB_START_DEADLINE Dag Action is being created. Ignoring... " + e.getMessage());
+        dagManagementStateStore.addDagAction(dagAction);
+      }
+    }
   }
 
   public static void sendEnforceFlowFinishDeadlineDagAction(DagManagementStateStore dagManagementStateStore, DagActionStore.DagAction launchDagAction)
       throws IOException {
-    dagManagementStateStore.addFlowDagAction(launchDagAction.getFlowGroup(), launchDagAction.getFlowName(),
+    DagActionStore.DagAction dagAction = DagActionStore.DagAction.forFlow(launchDagAction.getFlowGroup(), launchDagAction.getFlowName(),
         launchDagAction.getFlowExecutionId(), DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE);
+    try {
+      dagManagementStateStore.addDagAction(dagAction);
+    } catch (IOException e) {
+      if (e.getCause() != null && e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+        dagManagementStateStore.deleteDagAction(dagAction);
+        log.warn("Duplicate ENFORCE_FLOW_FINISH_DEADLINE Dag Action is being created. Ignoring... " + e.getMessage());
+        dagManagementStateStore.addDagAction(dagAction);
+      }
+    }
   }
 
   public static long getDefaultJobStartDeadline(Config config) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -82,12 +82,11 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
     updateDagNodeStatus(dagManagementStateStore, dagNode, executionStatus);
 
     if (!FlowStatusGenerator.FINISHED_STATUSES.contains(executionStatus.name())) {
-      log.warn("Job status for dagNode {} is {}. Re-evaluate dag action should have been created only for finished status - {}",
-          dagNodeId, executionStatus, FlowStatusGenerator.FINISHED_STATUSES);
-      // this may happen if adding job status in the store failed after adding a ReevaluateDagAction in KafkaJobStatusMonitor
-      throw new RuntimeException(String.format("Job status for dagNode %s is %s. Re-evaluate dag action are created for"
-              + " new jobs with no job status when there are multiple of them to run next; or when a job finishes with status - %s",
-          dagNodeId, executionStatus, FlowStatusGenerator.FINISHED_STATUSES));
+      // this may happen if adding job status in the store failed/delayed after adding a ReevaluateDagAction in KafkaJobStatusMonitor
+      throw new RuntimeException(String.format("Job status for dagNode %s is %s. Re-evaluate dag action should have been "
+              + "created only for finished status - %s. This may happen if reevaluate dag action launched reevaluate dag "
+              + "proc before job status is updated in the store in KafkaJobStatusMonitor", dagNodeId, executionStatus,
+          FlowStatusGenerator.FINISHED_STATUSES));
     }
 
     // get the dag after updating dag node status

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -235,8 +235,8 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
             if (updatedJobStatus.getRight() == NewState.FINISHED) {
               try {
                 this.dagManagementStateStore.addJobDagAction(flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.REEVALUATE);
-              } catch (Exception e) {
-                if (isExceptionInstanceOf(e, nonRetryableExceptions)) {
+              } catch (IOException e) {
+                if (e.getCause() != null && isThrowableInstanceOf(e.getCause(), nonRetryableExceptions)) {
                   // todo - add metrics
                   log.warn("Duplicate REEVALUATE Dag Action is being created. Ignoring... " + e.getMessage());
                 } else {
@@ -426,7 +426,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
 
   protected abstract org.apache.gobblin.configuration.State parseJobStatus(GobblinTrackingEvent event);
 
-  public static boolean isExceptionInstanceOf(Exception exception, List<Class<? extends Exception>> typesList) {
+  public static boolean isThrowableInstanceOf(Throwable exception, List<Class<? extends Exception>> typesList) {
     return typesList.stream().anyMatch(e -> e.isInstance(exception));
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -23,7 +23,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
@@ -55,13 +54,17 @@ import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.DagManagerTest;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.LaunchDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
 import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 import org.apache.gobblin.util.ConfigUtils;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -123,7 +126,7 @@ public class LaunchDagProcTest {
         .forEach(sp -> Mockito.verify(sp, Mockito.never()).addSpec(any()));
 
     Mockito.verify(this.dagManagementStateStore, Mockito.times(numOfLaunchedJobs))
-        .addFlowDagAction(any(), any(), anyLong(), eq(DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE));
+        .addJobDagAction(any(), any(), anyLong(), eq(DagActionStore.NO_JOB_NAME_DEFAULT), eq(DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE));
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2119


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If the service restarts before we call conclude on the lease, the deadline dag actions may get entered into the dag action store. The launch dag task (that creates deadline dag actions) will be retried on service start. It is not ideal to launch a job twice. When the job is launched again, it tries to store the deadline dag actions again and fails due to Primary Key constraint. We should ignore this exception otherwise the job submission will keep on being retried.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

