### PR TITLE
[GOBBLIN-2118]Reduce no of network calls while fetching kafka offsets during startup

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -67,6 +67,25 @@ public interface GobblinKafkaConsumerClient extends Closeable {
   public long getEarliestOffset(KafkaPartition partition) throws KafkaOffsetRetrievalFailureException;
 
   /**
+   * Get the earliest available offset for a {@link Collection} of {@link KafkaPartition}s. NOTE: The default implementation
+   * is not efficient i.e. it will make a getEarliest() call for every {@link KafkaPartition}. Individual implementations
+   * of {@link GobblinKafkaConsumerClient} should override this method to use more advanced APIs of the underlying KafkaConsumer
+   * to retrieve the latest offsets for a collection of partitions.
+   *
+   * @param partitions for which earliest offset is retrieved
+   *
+   * @throws KafkaOffsetRetrievalFailureException - If the underlying kafka-client does not support getting the earliest offset
+   */
+  public default Map<KafkaPartition, Long> getEarliestOffsets(Collection<KafkaPartition> partitions)
+      throws KafkaOffsetRetrievalFailureException {
+    Map<KafkaPartition, Long> offsetMap = Maps.newHashMap();
+    for (KafkaPartition partition : partitions) {
+      offsetMap.put(partition, getEarliestOffset(partition));
+    }
+    return offsetMap;
+  }
+
+  /**
    * Get the latest available offset for a <code>partition</code>
    *
    * @param partition for which latest offset is retrieved

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -76,10 +76,10 @@ public interface GobblinKafkaConsumerClient extends Closeable {
    *
    * @throws KafkaOffsetRetrievalFailureException - If the underlying kafka-client does not support getting the earliest offset
    */
-  public default Map<KafkaPartition, Long> getEarliestOffsets(Collection<KafkaPartition> partitions)
+  public default Map<KafkaPartition, Long> getEarliestOffsets(final Collection<KafkaPartition> partitions)
       throws KafkaOffsetRetrievalFailureException {
-    Map<KafkaPartition, Long> offsetMap = Maps.newHashMap();
-    for (KafkaPartition partition : partitions) {
+    final Map<KafkaPartition, Long> offsetMap = Maps.newHashMap();
+    for (final KafkaPartition partition : partitions) {
       offsetMap.put(partition, getEarliestOffset(partition));
     }
     return offsetMap;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -531,9 +531,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     }
     final Map<KafkaPartition, WorkUnit> workUnitMap = Maps.newHashMap();
     for (Map.Entry<KafkaPartition, Offsets> partitionOffset : partitionOffsetMap.entrySet()) {
-      workUnitMap.put(partitionOffset.getKey(),
+      WorkUnit workUnit =
           getWorkUnitForTopicPartition(partitionOffset.getKey(), state, topicSpecificState, partitionOffset.getValue(),
-              failedOffsetsGetList.contains(partitionOffset.getKey())));
+              failedOffsetsGetList.contains(partitionOffset.getKey()));
+      if (workUnit != null) {
+        workUnitMap.put(partitionOffset.getKey(), workUnit);
+      }
     }
     return workUnitMap;
   }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -446,13 +446,13 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     boolean topicQualified = isTopicQualified(topic);
     context.close();
 
-    List<WorkUnit> workUnits = Lists.newArrayList();
-    List<KafkaPartition> topicPartitions = topic.getPartitions();
+    final List<WorkUnit> workUnits = Lists.newArrayList();
+    final List<KafkaPartition> topicPartitions = topic.getPartitions();
     Map<KafkaPartition, WorkUnit> workUnitMap;
 
     if (filteredPartitions.isPresent()) {
       LOG.info("Filtered partitions for topic {} are {}", topic.getName(), filteredPartitions.get());
-      List<KafkaPartition> filteredPartitionsToBeProcessed = topicPartitions.stream()
+      final List<KafkaPartition> filteredPartitionsToBeProcessed = topicPartitions.stream()
           .filter(partition -> filteredPartitions.get().contains(partition.getId()))
           .collect(Collectors.toList());
       workUnitMap = getWorkUnits(filteredPartitionsToBeProcessed, state, topicSpecificState);
@@ -497,12 +497,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
    */
   private Map<KafkaPartition, WorkUnit> getWorkUnits(Collection<KafkaPartition> partitions, SourceState state,
       Optional<State> topicSpecificState) {
-    Map<KafkaPartition, Offsets> partitionOffsetMap = Maps.newHashMap();
-    Set<KafkaPartition> fetchOffsetsFailedPartitions = Sets.newHashSet();
+    final Map<KafkaPartition, Offsets> partitionOffsetMap = Maps.newHashMap();
+    final Set<KafkaPartition> fetchOffsetsFailedPartitions = Sets.newHashSet();
     try (Timer.Context context = this.metricContext.timer(OFFSET_FETCH_TIMER).time()) {
       // Fetch the offsets for all the partitions at once
-      Map<KafkaPartition, Long> earliestOffsetMap = this.kafkaConsumerClient.get().getEarliestOffsets(partitions);
-      Map<KafkaPartition, Long> latestOffsetMap = this.kafkaConsumerClient.get().getLatestOffsets(partitions);
+      final Map<KafkaPartition, Long> earliestOffsetMap = this.kafkaConsumerClient.get().getEarliestOffsets(partitions);
+      final Map<KafkaPartition, Long> latestOffsetMap = this.kafkaConsumerClient.get().getLatestOffsets(partitions);
       for (KafkaPartition partition : partitions) {
         Offsets offsets = new Offsets();
         offsets.setOffsetFetchEpochTime(System.currentTimeMillis());
@@ -524,7 +524,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     if (!fetchOffsetsFailedPartitions.isEmpty()) {
       LOG.error("Failed to fetch offsets for partitions {}", fetchOffsetsFailedPartitions);
     }
-    Map<KafkaPartition, WorkUnit> workUnitMap = Maps.newHashMap();
+    final Map<KafkaPartition, WorkUnit> workUnitMap = Maps.newHashMap();
     for (Map.Entry<KafkaPartition, Offsets> partitionOffset : partitionOffsetMap.entrySet()) {
       workUnitMap.put(partitionOffset.getKey(),
           getWorkUnitForTopicPartition(partitionOffset.getKey(), state, topicSpecificState, partitionOffset.getValue(),

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -159,7 +159,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   // sharing the kafka consumer may result in contention, so support thread local consumers
   protected final ConcurrentLinkedQueue<GobblinKafkaConsumerClient> kafkaConsumerClientPool = new ConcurrentLinkedQueue();
   protected static final ThreadLocal<GobblinKafkaConsumerClient> kafkaConsumerClient =
-        new ThreadLocal<GobblinKafkaConsumerClient>();
+          new ThreadLocal<GobblinKafkaConsumerClient>();
   private GobblinKafkaConsumerClient sharedKafkaConsumerClient = null;
   private final ClassAliasResolver<GobblinKafkaConsumerClientFactory> kafkaConsumerClientResolver =
       new ClassAliasResolver<>(GobblinKafkaConsumerClientFactory.class);
@@ -235,11 +235,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
     try {
       Config config = ConfigUtils.propertiesToConfig(state.getProperties());
-      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory =
-kafkaConsumerClientResolver
+      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory = kafkaConsumerClientResolver
           .resolveClass(state.getProp(
               GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
-DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
+              DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
 
       this.kafkaConsumerClient.set(kafkaConsumerClientFactory.create(config));
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -515,7 +515,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           partitionOffsetMap.put(partition, offsets);
           // If either is not available, put it in the failed offsets list
         } else {
-          failedOffsetsGetList.contains(partition);
+          failedOffsetsGetList.add(partition);
         }
       }
       LOG.info("Time taken to fetch offset for partitions {} is {} ms", partitions,

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -440,7 +440,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   /*
    * This function need to be thread safe since it is called in the Runnable
    */
-  private List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state,
+  public List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state,
       Optional<State> topicSpecificState, Optional<Set<Integer>> filteredPartitions) {
     Timer.Context context = this.metricContext.timer("isTopicQualifiedTimer").time();
     boolean topicQualified = isTopicQualified(topic);
@@ -496,7 +496,6 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       for (KafkaPartition partition : partitions) {
         Offsets offsets = new Offsets();
         offsets.setOffsetFetchEpochTime(System.currentTimeMillis());
-        // TODO : Need to find a way to determine
         if (earliestOffsetMap.containsKey(partition) && latestOffsetMap.containsKey(partition)) {
           offsets.setEarliestOffset(earliestOffsetMap.get(partition));
           offsets.setLatestOffset(latestOffsetMap.get(partition));

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -157,9 +157,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   private final AtomicInteger offsetTooLateCount = new AtomicInteger(0);
 
   // sharing the kafka consumer may result in contention, so support thread local consumers
-  protected final ConcurrentLinkedQueue<GobblinKafkaConsumerClient> kafkaConsumerClientPool = new ConcurrentLinkedQueue();
+  protected final ConcurrentLinkedQueue<GobblinKafkaConsumerClient> kafkaConsumerClientPool =
+      new ConcurrentLinkedQueue();
   protected static final ThreadLocal<GobblinKafkaConsumerClient> kafkaConsumerClient =
-          new ThreadLocal<GobblinKafkaConsumerClient>();
+      new ThreadLocal<GobblinKafkaConsumerClient>();
   private GobblinKafkaConsumerClient sharedKafkaConsumerClient = null;
   private final ClassAliasResolver<GobblinKafkaConsumerClientFactory> kafkaConsumerClientResolver =
       new ClassAliasResolver<>(GobblinKafkaConsumerClientFactory.class);
@@ -235,16 +236,15 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
     try {
       Config config = ConfigUtils.propertiesToConfig(state.getProperties());
-      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory = kafkaConsumerClientResolver
-          .resolveClass(
-              state.getProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
-                  DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
+      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory = kafkaConsumerClientResolver.resolveClass(
+          state.getProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
+              DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
 
       this.kafkaConsumerClient.set(kafkaConsumerClientFactory.create(config));
 
       Collection<KafkaTopic> topics;
-      if(filteredTopicPartition.isPresent()) {
-        if(filteredTopicPartition.get().isEmpty()) {
+      if (filteredTopicPartition.isPresent()) {
+        if (filteredTopicPartition.get().isEmpty()) {
           // return an empty list as filteredTopicPartition is present but contains no valid entry
           return new ArrayList<>();
         } else {
@@ -292,12 +292,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
               .addAllIfNotExist(topic.getTopicSpecificState().get());
         }
         Optional<Set<Integer>> partitionIDSet = Optional.absent();
-        if(filteredTopicPartition.isPresent()) {
-          List<Integer> list = java.util.Optional.ofNullable(filteredTopicPartitionMap.get(topic.getName()))
-              .orElse(new ArrayList<>());
+        if (filteredTopicPartition.isPresent()) {
+          List<Integer> list =
+              java.util.Optional.ofNullable(filteredTopicPartitionMap.get(topic.getName())).orElse(new ArrayList<>());
           partitionIDSet = Optional.of(new HashSet<>(list));
-          LOG.info("Compute the workunit for topic {} with num of filtered partitions: {}",
-              topic.getName(), list.size());
+          LOG.info("Compute the workunit for topic {} with num of filtered partitions: {}", topic.getName(),
+              list.size());
         }
 
         threadPool.submit(
@@ -311,13 +311,14 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
       // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
       // but aren't processed). When filteredTopicPartition present, only filtered topic-partitions are needed so skip this call
-      if(!filteredTopicPartition.isPresent()) {
+      if (!filteredTopicPartition.isPresent()) {
         createEmptyWorkUnitsForSkippedPartitions(kafkaTopicWorkunitMap, topicSpecificStateMap, state);
       }
 
-      KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
+      KafkaWorkUnitPacker kafkaWorkUnitPacker =
+          KafkaWorkUnitPacker.getInstance(this, state, Optional.of(this.metricContext));
       int numOfMultiWorkunits = minContainer.or(1);
-      if(state.contains(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {
+      if (state.contains(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {
         numOfMultiWorkunits = Math.max(numOfMultiWorkunits,
             calculateNumMappersForPacker(state, kafkaWorkUnitPacker, kafkaTopicWorkunitMap));
       }
@@ -337,7 +338,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           consumerClient.close();
         }
         // cleanup clients from pool
-        for (GobblinKafkaConsumerClient client: kafkaConsumerClientPool) {
+        for (GobblinKafkaConsumerClient client : kafkaConsumerClientPool) {
           client.close();
         }
       } catch (Throwable t) {
@@ -346,11 +347,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         LOG.error("Exception {} encountered closing GobblinKafkaConsumerClient ", t);
       }
     }
-
   }
 
-  protected void populateClientPool(int count,
-      GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory,
+  protected void populateClientPool(int count, GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory,
       Config config) {
     // Clear the pool first as clients within may already be close
     kafkaConsumerClientPool.clear();
@@ -359,7 +358,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     }
   }
 
-  private void addTopicSpecificPropsToWorkUnits(Map<String, List<WorkUnit>> workUnits, Map<String, State> topicSpecificStateMap) {
+  private void addTopicSpecificPropsToWorkUnits(Map<String, List<WorkUnit>> workUnits,
+      Map<String, State> topicSpecificStateMap) {
     for (List<WorkUnit> workUnitList : workUnits.values()) {
       for (WorkUnit workUnit : workUnitList) {
         addTopicSpecificPropsToWorkUnit(workUnit, topicSpecificStateMap);
@@ -407,9 +407,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         String topicName = partition.getTopicName();
         if (!this.isDatasetStateEnabled.get() || this.topicsToProcess.contains(topicName)) {
           long previousOffset = entry.getValue();
-          WorkUnit emptyWorkUnit = createEmptyWorkUnit(partition, previousOffset,
-              this.previousOffsetFetchEpochTimes.get(partition),
-              Optional.fromNullable(topicSpecificStateMap.get(partition.getTopicName())));
+          WorkUnit emptyWorkUnit =
+              createEmptyWorkUnit(partition, previousOffset, this.previousOffsetFetchEpochTimes.get(partition),
+                  Optional.fromNullable(topicSpecificStateMap.get(partition.getTopicName())));
 
           if (workUnits.containsKey(topicName)) {
             workUnits.get(topicName).add(emptyWorkUnit);
@@ -422,12 +422,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   }
 
   //determine the number of mappers/containers for workunit packer
-  private int calculateNumMappersForPacker(SourceState state,
-      KafkaWorkUnitPacker kafkaWorkUnitPacker, Map<String, List<WorkUnit>> workUnits) {
+  private int calculateNumMappersForPacker(SourceState state, KafkaWorkUnitPacker kafkaWorkUnitPacker,
+      Map<String, List<WorkUnit>> workUnits) {
     int maxMapperNum =
         state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
     int numContainers = maxMapperNum;
-    if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
+    if (state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
       double totalEstDataSize = kafkaWorkUnitPacker.setWorkUnitEstSizes(workUnits);
       LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
       double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
@@ -440,26 +440,27 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   /*
    * This function need to be thread safe since it is called in the Runnable
    */
-  public List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state,
-      Optional<State> topicSpecificState, Optional<Set<Integer>> filteredPartitions) {
+  public List<WorkUnit> getWorkUnitsForTopic(KafkaTopic topic, SourceState state, Optional<State> topicSpecificState,
+      Optional<Set<Integer>> filteredPartitions) {
     Timer.Context context = this.metricContext.timer("isTopicQualifiedTimer").time();
     boolean topicQualified = isTopicQualified(topic);
     context.close();
 
     List<WorkUnit> workUnits = Lists.newArrayList();
     List<KafkaPartition> topicPartitions = topic.getPartitions();
-    Map<KafkaPartition, WorkUnit> workUnitMap = Maps.newHashMap();
+    Map<KafkaPartition, WorkUnit> workUnitMap;
 
-    if(filteredPartitions.isPresent()) {
-      List<KafkaPartition> partitionsToBeProcessed =
-          topicPartitions.stream().filter(partition -> filteredPartitions.get().contains(partition.getId()))
+    if (filteredPartitions.isPresent()) {
+      LOG.info("Filtered partitions for topic {} are {}", topic.getName(), filteredPartitions.get());
+      List<KafkaPartition> filteredPartitionsToBeProcessed = topicPartitions.stream()
+          .filter(partition -> filteredPartitions.get().contains(partition.getId()))
           .collect(Collectors.toList());
-      workUnitMap = getWorkUnits(partitionsToBeProcessed, state, topicSpecificState);
+      workUnitMap = getWorkUnits(filteredPartitionsToBeProcessed, state, topicSpecificState);
     } else {
       workUnitMap = getWorkUnits(topicPartitions, state, topicSpecificState);
     }
 
-    for(WorkUnit workUnit : workUnitMap.values()) {
+    for (WorkUnit workUnit : workUnitMap.values()) {
       if (!topicQualified) {
         skipWorkUnit(workUnit);
       }
@@ -486,11 +487,20 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     workUnit.setProp(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY, workUnit.getLowWaterMark());
   }
 
+  /**
+   * Get the workunits of all the partitions passed, this method fetches all the offsets for the partitions
+   * at once from kafka, and for each partiton creates a workunit.
+   * @param partitions
+   * @param state
+   * @param topicSpecificState
+   * @return
+   */
   private Map<KafkaPartition, WorkUnit> getWorkUnits(Collection<KafkaPartition> partitions, SourceState state,
       Optional<State> topicSpecificState) {
     Map<KafkaPartition, Offsets> partitionOffsetMap = Maps.newHashMap();
-    Map<KafkaPartition, Boolean> kafkaOffsetsFetchFailureMap = Maps.newConcurrentMap();
+    Set<KafkaPartition> fetchOffsetsFailedPartitions = Sets.newHashSet();
     try (Timer.Context context = this.metricContext.timer(OFFSET_FETCH_TIMER).time()) {
+      // Fetch the offsets for all the partitions at once
       Map<KafkaPartition, Long> earliestOffsetMap = this.kafkaConsumerClient.get().getEarliestOffsets(partitions);
       Map<KafkaPartition, Long> latestOffsetMap = this.kafkaConsumerClient.get().getLatestOffsets(partitions);
       for (KafkaPartition partition : partitions) {
@@ -502,26 +512,29 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           offsets.setOffsetFetchEpochTime(System.currentTimeMillis());
           partitionOffsetMap.put(partition, offsets);
         } else {
-          kafkaOffsetsFetchFailureMap.put(partition, true);
+          fetchOffsetsFailedPartitions.contains(partition);
         }
       }
+      LOG.info("Time taken to fetch offset for partitions {} is {} ms", partitions,
+          TimeUnit.NANOSECONDS.toMillis(context.stop()));
     } catch (KafkaOffsetRetrievalFailureException e) {
-      for (KafkaPartition partition : partitions) {
-        kafkaOffsetsFetchFailureMap.put(partition, true);
-      }
+      fetchOffsetsFailedPartitions.addAll(partitions);
       LOG.error("Caught error in creating work unit for {}", partitions, e);
+    }
+    if (!fetchOffsetsFailedPartitions.isEmpty()) {
+      LOG.error("Failed to fetch offsets for partitions {}", fetchOffsetsFailedPartitions);
     }
     Map<KafkaPartition, WorkUnit> workUnitMap = Maps.newHashMap();
     for (Map.Entry<KafkaPartition, Offsets> partitionOffset : partitionOffsetMap.entrySet()) {
       workUnitMap.put(partitionOffset.getKey(),
           getWorkUnitForTopicPartition(partitionOffset.getKey(), state, topicSpecificState, partitionOffset.getValue(),
-              kafkaOffsetsFetchFailureMap.getOrDefault(partitionOffset.getKey(), false)));
+              fetchOffsetsFailedPartitions.contains(partitionOffset.getKey())));
     }
     return workUnitMap;
   }
 
   private WorkUnit getWorkUnitForTopicPartition(KafkaPartition partition, SourceState state,
-      Optional<State> topicSpecificState,  Offsets offsets, boolean failedToGetKafkaOffsets) {
+      Optional<State> topicSpecificState, Offsets offsets, boolean failedToGetKafkaOffsets) {
 
     long previousOffset = 0;
     long previousOffsetFetchEpochTime = 0;
@@ -546,11 +559,11 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
       // When unable to get earliest/latest offsets from Kafka, skip the partition and create an empty workunit,
       // so that previousOffset is persisted.
-      LOG.warn(String
-          .format("Failed to retrieve earliest and/or latest offset for partition %s. This partition will be skipped.",
-              partition));
-      return previousOffsetNotFound ? null : createEmptyWorkUnit(partition, previousOffset, previousOffsetFetchEpochTime,
-          topicSpecificState);
+      LOG.warn(String.format(
+          "Failed to retrieve earliest and/or latest offset for partition %s. This partition will be skipped.",
+          partition));
+      return previousOffsetNotFound ? null
+          : createEmptyWorkUnit(partition, previousOffset, previousOffsetFetchEpochTime, topicSpecificState);
     }
 
     if (shouldMoveToLatestOffset(partition, state)) {
@@ -575,10 +588,11 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
             offsetNotFoundMsg + "This partition will start from the earliest offset: " + offsets.getEarliestOffset());
         offsets.startAtEarliestOffset();
       } else if (offsetOption.equals(OFFSET_LOOKBACK)) {
-        long lookbackOffsetRange = state.getPropAsLong(KAFKA_OFFSET_LOOKBACK , 0L);
+        long lookbackOffsetRange = state.getPropAsLong(KAFKA_OFFSET_LOOKBACK, 0L);
         long latestOffset = offsets.getLatestOffset();
         long offset = latestOffset - lookbackOffsetRange;
-        LOG.warn(offsetNotFoundMsg + "This partition will start from latest-lookback [ " + latestOffset + " - " + lookbackOffsetRange + " ]  start offset: " + offset);
+        LOG.warn(offsetNotFoundMsg + "This partition will start from latest-lookback [ " + latestOffset + " - "
+            + lookbackOffsetRange + " ]  start offset: " + offset);
         try {
           offsets.startAt(offset);
         } catch (StartOffsetOutOfRangeException e) {
@@ -592,26 +606,25 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           // When above computed offset (latest-lookback) is out of range, either start at earliest, latest or nearest offset, or skip the
           // partition. If skipping, need to create an empty workunit so that previousOffset is persisted.
           String offsetOutOfRangeMsg = String.format(
-                  "Start offset for partition %s is out of range. Start offset = %d, earliest offset = %d, latest offset = %d.",
-                  partition, offsets.getStartOffset(), offsets.getEarliestOffset(), offsets.getLatestOffset());
+              "Start offset for partition %s is out of range. Start offset = %d, earliest offset = %d, latest offset = %d.",
+              partition, offsets.getStartOffset(), offsets.getEarliestOffset(), offsets.getLatestOffset());
           offsetOption =
-                  state.getProp(RESET_ON_OFFSET_OUT_OF_RANGE, DEFAULT_RESET_ON_OFFSET_OUT_OF_RANGE).toLowerCase();
+              state.getProp(RESET_ON_OFFSET_OUT_OF_RANGE, DEFAULT_RESET_ON_OFFSET_OUT_OF_RANGE).toLowerCase();
           if (offsetOption.equals(LATEST_OFFSET) || (offsetOption.equals(NEAREST_OFFSET)
-                  && offsets.getStartOffset() >= offsets.getLatestOffset())) {
+              && offsets.getStartOffset() >= offsets.getLatestOffset())) {
             LOG.warn(
-                    offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
+                offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
             offsets.startAtLatestOffset();
           } else if (offsetOption.equals(EARLIEST_OFFSET) || offsetOption.equals(NEAREST_OFFSET)) {
-            LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: " + offsets
-                    .getEarliestOffset());
+            LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: "
+                + offsets.getEarliestOffset());
             offsets.startAtEarliestOffset();
           } else {
             LOG.warn(offsetOutOfRangeMsg + "This partition will be skipped.");
             return createEmptyWorkUnit(partition, previousOffset, previousOffsetFetchEpochTime, topicSpecificState);
           }
         }
-      }
-      else {
+      } else {
         LOG.warn(offsetNotFoundMsg + "This partition will be skipped.");
         return null;
       }
@@ -640,8 +653,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
               offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
           offsets.startAtLatestOffset();
         } else if (offsetOption.equals(EARLIEST_OFFSET) || offsetOption.equals(NEAREST_OFFSET)) {
-          LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: " + offsets
-              .getEarliestOffset());
+          LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: "
+              + offsets.getEarliestOffset());
           offsets.startAtEarliestOffset();
         } else {
           LOG.warn(offsetOutOfRangeMsg + "This partition will be skipped.");
@@ -662,18 +675,25 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   private void addSourceStatePropsToWorkUnit(WorkUnit workUnit, SourceState state) {
     //Copy the SLA config from SourceState to WorkUnitState.
     if (state.contains(KafkaSource.RECORD_LEVEL_SLA_MINUTES_KEY)) {
-      workUnit.setProp(KafkaSource.RECORD_LEVEL_SLA_MINUTES_KEY, state.getProp(KafkaSource.RECORD_LEVEL_SLA_MINUTES_KEY));
+      workUnit.setProp(KafkaSource.RECORD_LEVEL_SLA_MINUTES_KEY,
+          state.getProp(KafkaSource.RECORD_LEVEL_SLA_MINUTES_KEY));
     }
-    boolean isobservedLatencyMeasurementEnabled = state.getPropAsBoolean(KafkaSource.OBSERVED_LATENCY_MEASUREMENT_ENABLED, DEFAULT_OBSERVED_LATENCY_MEASUREMENT_ENABLED);
+    boolean isobservedLatencyMeasurementEnabled =
+        state.getPropAsBoolean(KafkaSource.OBSERVED_LATENCY_MEASUREMENT_ENABLED,
+            DEFAULT_OBSERVED_LATENCY_MEASUREMENT_ENABLED);
     if (isobservedLatencyMeasurementEnabled) {
-      Preconditions.checkArgument(state.contains(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD), "Missing config key: " + KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD);
+      Preconditions.checkArgument(state.contains(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD),
+          "Missing config key: " + KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD);
       workUnit.setProp(KafkaSource.OBSERVED_LATENCY_MEASUREMENT_ENABLED, isobservedLatencyMeasurementEnabled);
       workUnit.setProp(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS,
-          state.getPropAsInt(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS, DEFAULT_MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS));
+          state.getPropAsInt(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS,
+              DEFAULT_MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS));
       workUnit.setProp(KafkaSource.OBSERVED_LATENCY_PRECISION,
           state.getPropAsInt(KafkaSource.OBSERVED_LATENCY_PRECISION, KafkaSource.DEFAULT_OBSERVED_LATENCY_PRECISION));
-      workUnit.setProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD, state.getProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD));
-      workUnit.setProp(KafkaSource.RECORD_CREATION_TIMESTAMP_UNIT, state.getProp(KafkaSource.RECORD_CREATION_TIMESTAMP_UNIT, TimeUnit.MILLISECONDS.name()));
+      workUnit.setProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD,
+          state.getProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD));
+      workUnit.setProp(KafkaSource.RECORD_CREATION_TIMESTAMP_UNIT,
+          state.getProp(KafkaSource.RECORD_CREATION_TIMESTAMP_UNIT, TimeUnit.MILLISECONDS.name()));
     }
     if (state.contains(ConfigurationKeys.JOB_NAME_KEY)) {
       workUnit.setProp(ConfigurationKeys.JOB_NAME_KEY, state.getProp(ConfigurationKeys.JOB_NAME_KEY));
@@ -685,14 +705,14 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
   private long getPreviousStartFetchEpochTimeForPartition(KafkaPartition partition, SourceState state) {
     getAllPreviousOffsetState(state);
-    return this.previousStartFetchEpochTimes.containsKey(partition) ?
-        this.previousStartFetchEpochTimes.get(partition) : 0;
+    return this.previousStartFetchEpochTimes.containsKey(partition) ? this.previousStartFetchEpochTimes.get(partition)
+        : 0;
   }
 
   private long getPreviousStopFetchEpochTimeForPartition(KafkaPartition partition, SourceState state) {
     getAllPreviousOffsetState(state);
-    return this.previousStopFetchEpochTimes.containsKey(partition) ?
-        this.previousStopFetchEpochTimes.get(partition) : 0;
+    return this.previousStopFetchEpochTimes.containsKey(partition) ? this.previousStopFetchEpochTimes.get(partition)
+        : 0;
   }
 
   private long getPreviousOffsetFetchEpochTimeForPartition(KafkaPartition partition, SourceState state)
@@ -704,9 +724,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       return this.previousOffsetFetchEpochTimes.get(partition);
     }
 
-    throw new PreviousOffsetNotFoundException(String
-        .format("Previous offset fetch epoch time for topic %s, partition %s not found.", partition.getTopicName(),
-            partition.getId()));
+    throw new PreviousOffsetNotFoundException(
+        String.format("Previous offset fetch epoch time for topic %s, partition %s not found.",
+            partition.getTopicName(), partition.getId()));
   }
 
   private long getPreviousOffsetForPartition(KafkaPartition partition, SourceState state)
@@ -717,8 +737,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     if (this.previousOffsets.containsKey(partition)) {
       return this.previousOffsets.get(partition);
     }
-    throw new PreviousOffsetNotFoundException(String
-        .format("Previous offset for topic %s, partition %s not found.", partition.getTopicName(), partition.getId()));
+    throw new PreviousOffsetNotFoundException(
+        String.format("Previous offset for topic %s, partition %s not found.", partition.getTopicName(),
+            partition.getId()));
   }
 
   private long getPreviousExpectedHighWatermark(KafkaPartition partition, SourceState state)
@@ -729,9 +750,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     if (this.previousExpectedHighWatermarks.containsKey(partition)) {
       return this.previousExpectedHighWatermarks.get(partition);
     }
-    throw new PreviousOffsetNotFoundException(String
-        .format("Previous expected high watermark for topic %s, partition %s not found.", partition.getTopicName(),
-            partition.getId()));
+    throw new PreviousOffsetNotFoundException(
+        String.format("Previous expected high watermark for topic %s, partition %s not found.",
+            partition.getTopicName(), partition.getId()));
   }
 
   private long getPreviousLowWatermark(KafkaPartition partition, SourceState state)
@@ -742,8 +763,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     if (this.previousLowWatermarks.containsKey(partition)) {
       return this.previousLowWatermarks.get(partition);
     }
-    throw new PreviousOffsetNotFoundException(String
-        .format("Previous low watermark for topic %s, partition %s not found.", partition.getTopicName(),
+    throw new PreviousOffsetNotFoundException(
+        String.format("Previous low watermark for topic %s, partition %s not found.", partition.getTopicName(),
             partition.getId()));
   }
 
@@ -761,9 +782,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     this.previousStopFetchEpochTimes.clear();
     Map<String, Iterable<WorkUnitState>> workUnitStatesByDatasetUrns = state.getPreviousWorkUnitStatesByDatasetUrns();
 
-    if (!workUnitStatesByDatasetUrns.isEmpty() &&
-            !(workUnitStatesByDatasetUrns.size() == 1 && workUnitStatesByDatasetUrns.keySet().iterator().next()
-        .equals(""))) {
+    if (!workUnitStatesByDatasetUrns.isEmpty() && !(workUnitStatesByDatasetUrns.size() == 1
+        && workUnitStatesByDatasetUrns.keySet().iterator().next().equals(""))) {
       this.isDatasetStateEnabled.set(true);
     }
 
@@ -774,9 +794,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       MultiLongWatermark watermark = workUnitState.getActualHighWatermark(MultiLongWatermark.class);
       MultiLongWatermark previousLowWatermark = workUnit.getLowWatermark(MultiLongWatermark.class);
       MultiLongWatermark previousExpectedHighWatermark = workUnit.getExpectedHighWatermark(MultiLongWatermark.class);
-      Preconditions.checkArgument(partitions.size() == watermark.size(), String
-          .format("Num of partitions doesn't match number of watermarks: partitions=%s, watermarks=%s", partitions,
-              watermark));
+      Preconditions.checkArgument(partitions.size() == watermark.size(),
+          String.format("Num of partitions doesn't match number of watermarks: partitions=%s, watermarks=%s",
+              partitions, watermark));
 
       for (int i = 0; i < partitions.size(); i++) {
         KafkaPartition partition = partitions.get(i);
@@ -848,8 +868,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         currentTableType = Extract.TableType.valueOf(topicState.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY));
       }
       currentExtractNamespace = topicState.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, extractNamespace);
-      currentExtractTableName =
-          topicState.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partition.getTopicName());
+      currentExtractTableName = topicState.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partition.getTopicName());
       isCurrentFullExtract = topicState.getPropAsBoolean(ConfigurationKeys.EXTRACT_IS_FULL_KEY, isFullExtract);
     }
 
@@ -960,11 +979,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     @Setter
     private long previousStopFetchEpochTime = 0;
 
-    private void startAt(long offset)
-        throws StartOffsetOutOfRangeException {
+    private void startAt(long offset) throws StartOffsetOutOfRangeException {
       if (offset < this.earliestOffset || offset > this.latestOffset) {
-        throw new StartOffsetOutOfRangeException(String
-            .format("start offset = %d, earliest offset = %d, latest offset = %d", offset, this.earliestOffset,
+        throw new StartOffsetOutOfRangeException(
+            String.format("start offset = %d, earliest offset = %d, latest offset = %d", offset, this.earliestOffset,
                 this.latestOffset));
       }
       this.startOffset = offset;
@@ -1014,7 +1032,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         }
 
         this.allTopicWorkUnits.put(this.topic.getName(),
-            KafkaSource.this.getWorkUnitsForTopic(this.topic, this.state, this.topicSpecificState, this.filteredPartitionsId));
+            KafkaSource.this.getWorkUnitsForTopic(this.topic, this.state, this.topicSpecificState,
+                this.filteredPartitionsId));
       } catch (Throwable t) {
         LOG.error("Caught error in creating work unit for " + this.topic.getName(), t);
         throw new RuntimeException(t);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -236,10 +236,10 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     try {
       Config config = ConfigUtils.propertiesToConfig(state.getProperties());
       GobblinKafkaConsumerClientFactory kafkaConsumerClientFactory =
-          kafkaConsumerClientResolver
-              .resolveClass(
-                  state.getProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
-                      DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
+kafkaConsumerClientResolver
+          .resolveClass(state.getProp(
+              GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS,
+DEFAULT_GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS)).newInstance();
 
       this.kafkaConsumerClient.set(kafkaConsumerClientFactory.create(config));
 
@@ -662,7 +662,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           offsets.startAtLatestOffset();
         } else if (offsetOption.equals(EARLIEST_OFFSET) || offsetOption.equals(NEAREST_OFFSET)) {
           LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: " + offsets
-                .getEarliestOffset());
+              .getEarliestOffset());
           offsets.startAtEarliestOffset();
         } else {
           LOG.warn(offsetOutOfRangeMsg + "This partition will be skipped.");
@@ -690,8 +690,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       Preconditions.checkArgument(state.contains(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD), "Missing config key: " + KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD);
       workUnit.setProp(KafkaSource.OBSERVED_LATENCY_MEASUREMENT_ENABLED, isobservedLatencyMeasurementEnabled);
       workUnit.setProp(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS,
-          state.getPropAsInt(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS,
-              DEFAULT_MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS));
+          state.getPropAsInt(KafkaSource.MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS, DEFAULT_MAX_POSSIBLE_OBSERVED_LATENCY_IN_HOURS));
       workUnit.setProp(KafkaSource.OBSERVED_LATENCY_PRECISION,
           state.getPropAsInt(KafkaSource.OBSERVED_LATENCY_PRECISION, KafkaSource.DEFAULT_OBSERVED_LATENCY_PRECISION));
       workUnit.setProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD, state.getProp(KafkaSource.RECORD_CREATION_TIMESTAMP_FIELD));
@@ -740,8 +739,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       return this.previousOffsets.get(partition);
     }
     throw new PreviousOffsetNotFoundException(String
-        .format("Previous offset for topic %s, partition %s not found.", partition.getTopicName(),
-            partition.getId()));
+        .format("Previous offset for topic %s, partition %s not found.", partition.getTopicName(), partition.getId()));
   }
 
   private long getPreviousExpectedHighWatermark(KafkaPartition partition, SourceState state)
@@ -786,7 +784,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
     if (!workUnitStatesByDatasetUrns.isEmpty() &&
             !(workUnitStatesByDatasetUrns.size() == 1 && workUnitStatesByDatasetUrns.keySet().iterator().next()
-          .equals(""))) {
+        .equals(""))) {
       this.isDatasetStateEnabled.set(true);
     }
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
@@ -72,6 +72,24 @@ public class KafkaSourceTest {
   }
 
   @Test
+  public void testGetWorkunitsFromKafkaInSingleCall() {
+    TestKafkaClient testKafkaClient = new TestKafkaClient();
+    testKafkaClient.testTopics = testTopics;
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, "TestPath");
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_TYPE, KafkaWorkUnitPacker.PackerType.CUSTOM);
+    state.setProp(KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE, "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaTopicGroupingWorkUnitPacker");
+    state.setProp(GOBBLIN_KAFKA_CONSUMER_CLIENT_FACTORY_CLASS, "MockTestKafkaConsumerClientFactory");
+    List<KafkaTopic> kafkaTopicList = toKafkaTopicList(testTopics);
+    TestKafkaSource testKafkaSource = new TestKafkaSource(testKafkaClient);
+    for (KafkaTopic topic : kafkaTopicList) {
+      List<WorkUnit> workUnits = testKafkaSource.getWorkUnitsForTopic(topic, state, Optional.absent(),
+          Optional.absent());
+      validatePartitionNumWithinWorkUnits(workUnits, 48);
+    }
+  }
+
+  @Test
   public void testGetWorkunitsForFilteredPartitions() {
     TestKafkaClient testKafkaClient = new TestKafkaClient();
     List<String> allTopics = testTopics;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [GOBBLIN-2118](https://issues.apache.org/jira/browse/GOBBLIN-2118) issues and references them in the PR title. 


### Description
- [x] Add a default method in kafkaConsumerClient to allow fetching earliest offsets for a list of partition at a time. This needs to be overridden by the Kafka Consumer client implementation to call the actual API to fetch the parititions. 
- [x] Changes in KafkaSource to create workunits while fetching all the kafka offsets for a topic at once.


### Tests
- [x] Tested the changes by creating the flow with 2 topics (having 256 partitions) and could see the latency decreased by ~50% while fetching the parititons offset from the kafka broker. 
- [x] Added UTs to test if the new method added to fetch offsets is being invoked



### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

