### PR TITLE
[GOBBLIN-2122] serialize/deserialize currentAttemps and currentGeneration in dag node

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/InMemorySpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/InMemorySpecExecutor.java
@@ -44,7 +44,7 @@ import org.apache.gobblin.util.CompletedFuture;
 public class InMemorySpecExecutor extends AbstractSpecExecutor {
   // Communication mechanism components.
   // Not specifying final for further extension based on this implementation.
-  private SpecProducer<Spec> inMemorySpecProducer;
+  private final SpecProducer<Spec> inMemorySpecProducer;
 
   public InMemorySpecExecutor(Config config){
     this(config, Optional.absent());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListDeserializer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListDeserializer.java
@@ -110,6 +110,8 @@ public class JobExecutionPlanListDeserializer implements JsonDeserializer<List<J
 
       JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(jobSpec, specExecutor);
       jobExecutionPlan.setExecutionStatus(executionStatus);
+      jobExecutionPlan.setCurrentGeneration(serializedJobExecutionPlan.get(SerializationConstants.CURRENT_GENERATION_KEY).getAsInt());
+      jobExecutionPlan.setCurrentAttempts(serializedJobExecutionPlan.get(SerializationConstants.CURRENT_ATTEMPTS_KEY).getAsInt());
 
       JsonElement flowStartTime = serializedJobExecutionPlan.get(SerializationConstants.FLOW_START_TIME_KEY);
       if (flowStartTime != null) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListSerializer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListSerializer.java
@@ -82,6 +82,8 @@ public class JobExecutionPlanListSerializer implements JsonSerializer<List<JobEx
 
       String executionStatus = jobExecutionPlan.getExecutionStatus().name();
       jobExecutionPlanJson.addProperty(SerializationConstants.EXECUTION_STATUS_KEY, executionStatus);
+      jobExecutionPlanJson.addProperty(SerializationConstants.CURRENT_GENERATION_KEY, jobExecutionPlan.getCurrentGeneration());
+      jobExecutionPlanJson.addProperty(SerializationConstants.CURRENT_ATTEMPTS_KEY, jobExecutionPlan.getCurrentAttempts());
 
       jobExecutionPlanJson.addProperty(SerializationConstants.FLOW_START_TIME_KEY, jobExecutionPlan.getFlowStartTime());
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/SerializationConstants.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/SerializationConstants.java
@@ -31,6 +31,8 @@ public class SerializationConstants {
   public static final String SPEC_EXECUTOR_URI_KEY = "uri";
 
   public static final String EXECUTION_STATUS_KEY = "executionStatus";
+  public static final String CURRENT_GENERATION_KEY = "currentGeneration";
+  public static final String CURRENT_ATTEMPTS_KEY = "currentAttempts";
   public static final String JOB_EXECUTION_FUTURE = "jobExecutionFuture";
   public static final String FLOW_START_TIME_KEY = "flowStartTime";
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreWithDagNodesTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreWithDagNodesTest.java
@@ -79,6 +79,8 @@ public class MysqlDagStateStoreWithDagNodesTest {
     Dag<JobExecutionPlan> originalDag2 = DagTestUtils.buildDag("random_2", 456L);
     DagManager.DagId dagId1 = DagManagerUtils.generateDagId(originalDag1);
     DagManager.DagId dagId2 = DagManagerUtils.generateDagId(originalDag2);
+    originalDag1.getStartNodes().get(0).getValue().setCurrentGeneration(2);
+    originalDag1.getStartNodes().get(0).getValue().setCurrentAttempts(3);
     this.dagStateStore.writeCheckpoint(originalDag1);
     this.dagStateStore.writeCheckpoint(originalDag2);
 
@@ -97,6 +99,8 @@ public class MysqlDagStateStoreWithDagNodesTest {
     Dag.DagNode<JobExecutionPlan> parent = dagDeserialized.getStartNodes().get(0);
     Assert.assertEquals(dagDeserialized.getParentChildMap().size(), 1);
     Assert.assertTrue(dagDeserialized.getParentChildMap().get(parent).contains(child));
+    Assert.assertEquals(dagDeserialized.getStartNodes().get(0).getValue().getCurrentGeneration(), 2);
+    Assert.assertEquals(dagDeserialized.getStartNodes().get(0).getValue().getCurrentAttempts(), 3);
 
     for (int i = 0; i < 2; i++) {
       JobExecutionPlan plan = dagDeserialized.getNodes().get(i).getValue();

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -49,6 +48,7 @@ import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.DagManagerTest;
 import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
+import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.ReevaluateDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.monitoring.JobStatus;
@@ -187,7 +187,6 @@ public class ReevaluateDagProcTest {
   @Test
   public void testCurrentJobToRun() throws Exception {
     String flowName = "fn3";
-    DagManager.DagId dagId = new DagManager.DagId(flowGroup, flowName, flowExecutionId);
     Dag<JobExecutionPlan> dag = DagManagerTest.buildDag("1", flowExecutionId, DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(),
         2, "user5", ConfigFactory.empty()
             .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2122


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
serialize/deserialize currentAttemptNumber and currentGenerationNumber in JEP


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added tests in MysqlDagStateStoreWithDagNodesTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

