### PR TITLE
Remove setpermission step for pre-existing folders

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -20,10 +20,12 @@ package org.apache.gobblin.data.management.copy;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
@@ -153,6 +155,14 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
           }
         } else if (deleteFileThatNotExistOnSource && targetFs.exists(fileToCopy)) {
           toDelete.add(targetFs.getFileStatus(fileToCopy));
+        }
+      }
+      // Only set permission for newly created folders on target
+      // To change permissions for existing dirs, expectation is to add the folder to the manifest
+      Set<String> parentFolders = new HashSet<>(flattenedAncestorPermissions.keySet());
+      for (String folder : parentFolders) {
+        if (targetFs.exists(new Path(folder))) {
+          flattenedAncestorPermissions.remove(folder);
         }
       }
       // We need both precommit step to create the directories copying to, and a postcommit step to ensure that the execute bit needed for recursive rename is reset

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/dataset/ManifestBasedDatasetFinderTest.java
@@ -130,6 +130,7 @@ public class ManifestBasedDatasetFinderTest {
       setSourceAndDestFsMocks(sourceFs, destFs, manifestPath, manifestReadFs);
       Mockito.when(destFs.exists(new Path("/tmp/dataset/test1.txt"))).thenReturn(true);
       Mockito.when(destFs.exists(new Path("/tmp/dataset/test2.txt"))).thenReturn(false);
+      Mockito.when(destFs.exists(new Path("/tmp"))).thenReturn(true);
       Mockito.when(destFs.getFileStatus(any(Path.class))).thenReturn(localFs.getFileStatus(new Path(tmpDir.toString())));
 
       List<AclEntry> aclEntrySource = AclEntry.parseAclSpec("user::rwx,group::rwx,other::rwx", true);
@@ -154,9 +155,10 @@ public class ManifestBasedDatasetFinderTest {
       CommitStep setPermissionStep = ((PostPublishStep) fileSet.getFiles().get(3)).getStep();
       Assert.assertTrue(setPermissionStep instanceof SetPermissionCommitStep);
       Map<String, OwnerAndPermission> ownerAndPermissionMap = ((SetPermissionCommitStep) setPermissionStep).getPathAndPermissions();
-      Assert.assertEquals(ownerAndPermissionMap.size(), 2);
+      // Ignore /tmp as it already exists on destination
+      Assert.assertEquals(ownerAndPermissionMap.size(), 1);
       Assert.assertTrue(ownerAndPermissionMap.containsKey("/tmp/dataset"));
-      Assert.assertTrue(ownerAndPermissionMap.containsKey("/tmp"));
+
 
     }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2125


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Although the logic was removed in https://github.com/apache/gobblin/pull/3988/files, it is still needed to ensure proper permission setting from src and dest.

The issue arises where a manifest describes a file to copy, but as the dataset is locked, the ancestor permission check will re-write the folder in destination to have the locked permissions. We only want to apply the `SetPermissionCommitStep` to newly created folders as those folders on destination may have an extra execution bit.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

