### PR TITLE
[GOBBLIN-2127] do not emit GaaSObservabilityEvent for a failed job that is going to be retried

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -41,7 +41,7 @@ import org.apache.gobblin.service.ExecutionStatus;
 @Slf4j
 public class FlowStatusGenerator {
   public static final List<String> FINISHED_STATUSES = Lists.newArrayList(ExecutionStatus.FAILED.name(),
-      ExecutionStatus.COMPLETE.name(), ExecutionStatus.CANCELLED.name(), ExecutionStatus.PENDING_RETRY.name());
+      ExecutionStatus.COMPLETE.name(), ExecutionStatus.CANCELLED.name());
   public static final int MAX_LOOKBACK = 100;
 
   private final JobStatusRetriever jobStatusRetriever;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -228,7 +228,10 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
           String tableName = jobStatusTableName(flowExecutionId, jobGroup, jobName);
           String status = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
 
-          if (updatedJobStatus.getRight() == NewState.FINISHED) {
+          boolean retryRequired = modifyStateIfRetryRequired(jobStatus);
+
+          if (updatedJobStatus.getRight() == NewState.FINISHED && !retryRequired) {
+            // do not send event if retry is required, because it can alert users to re-submit a job that is already set to be retried by GaaS
             this.eventProducer.emitObservabilityEvent(jobStatus);
           }
 
@@ -334,7 +337,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
         }
       }
 
-      modifyStateIfRetryRequired(jobStatus);
       NewState newState = newState(jobStatus, states);
       String newStatus = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
       if (newState == NewState.FINISHED) {
@@ -363,9 +365,11 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
         && currentStatus.equals(ExecutionStatus.PENDING_RESUME.name());
   }
 
-  private static void modifyStateIfRetryRequired(org.apache.gobblin.configuration.State state) {
+  // if job retry is required, it sets the job status to PENDING_RETRY and returns true
+  private static boolean modifyStateIfRetryRequired(org.apache.gobblin.configuration.State state) {
     int maxAttempts = state.getPropAsInt(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, 1);
     int currentAttempts = state.getPropAsInt(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, 1);
+    boolean retryRequired = false;
     // SHOULD_RETRY_FIELD maybe reset by JOB_COMPLETION_PERCENTAGE event
     if (state.contains(JobStatusRetriever.EVENT_NAME_FIELD) &&(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.FAILED.name())
         || state.getProp(JobStatusRetriever.EVENT_NAME_FIELD).equals(ExecutionStatus.PENDING_RETRY.name())
@@ -374,8 +378,10 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       state.setProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, true);
       state.setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.PENDING_RETRY.name());
       state.removeProp(TimingEvent.JOB_END_TIME);
+      retryRequired = true;
     }
     state.removeProp(TimingEvent.FlowEventConstants.DOES_CANCELED_FLOW_MERIT_RETRY);
+    return retryRequired;
   }
 
   static boolean isNewStateTransitionToFinal(org.apache.gobblin.configuration.State currentState, List<org.apache.gobblin.configuration.State> prevStates) {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2127


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When a job fails, it is marked as PENDING_RETRY when its currentAttempt is less than maxAttempts.
For such status, creating GaaSObservabilityEvent was producing NPE.
The approach in this PR is to not update job status to PENDING_RETRY before calculating `updatedJobStatus = recalcJobStatus()`
and then emit GaaSObservabilityEvent only if a retry is not required.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated the current tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

