### PR TITLE
reevaluate dag proc should accept pending_retry status if it is a retry

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -82,8 +82,9 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
     JobStatus jobStatus = dagNodeWithJobStatus.getRight().get();
     ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatus.getEventName());
     updateDagNodeStatus(dagManagementStateStore, dagNode, executionStatus);
+    boolean isRetry = jobStatus.isShouldRetry();
 
-    if (!FlowStatusGenerator.FINISHED_STATUSES.contains(executionStatus.name())) {
+    if (!isRetry && !FlowStatusGenerator.FINISHED_STATUSES.contains(executionStatus.name())) {
       // this may happen if adding job status in the store failed/delayed after adding a ReevaluateDagAction in KafkaJobStatusMonitor
       throw new RuntimeException(String.format("Job status for dagNode %s is %s. Re-evaluate dag action should have been "
               + "created only for finished status - %s. This may happen if reevaluate dag action launched reevaluate dag "

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
@@ -275,9 +275,9 @@ public class ReevaluateDagProcTest {
     );
     List<SpecProducer<Spec>> specProducers = getDagSpecProducers(dag);
     dagManagementStateStore.addDag(dag);
-    // a job status with shouldRetry=true
+    // a job status with shouldRetry=true, it should have execution status = PENDING_RETRY
     JobStatus jobStatus = JobStatus.builder().flowName(flowName).flowGroup(flowGroup).jobGroup(flowGroup)
-        .jobName("job0").flowExecutionId(flowExecutionId).message("Test message").eventName(ExecutionStatus.FAILED.name())
+        .jobName("job0").flowExecutionId(flowExecutionId).message("Test message").eventName(ExecutionStatus.PENDING_RETRY.name())
         .startTime(flowExecutionId).shouldRetry(true).orchestratedTime(flowExecutionId).build();
     doReturn(new ImmutablePair<>(Optional.of(dag.getNodes().get(0)), Optional.of(jobStatus)))
         .when(dagManagementStateStore).getDagNodeWithJobStatus(any());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2127


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
missed doing it in https://github.com/apache/gobblin/pull/4018 
a reevaluate dag proc should accept pending_retry status if it is a retry

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
corrected the unit test that should have caught this

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

