### PR TITLE
[GOBBLIN-2129] do not throw exception only to be swallowed by the only caller, becas…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -115,6 +115,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
   protected final Boolean isWarmStandbyEnabled;
   protected final Optional<UserQuotaManager> quotaManager;
   protected final Optional<FlowLaunchHandler> flowTriggerHandler;
+  // todo - consider using JobScheduler::scheduledJobs in place of scheduledFlowSpecs
   @Getter
   protected final Map<String, FlowSpec> scheduledFlowSpecs;
   @Getter
@@ -617,7 +618,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
    * @param specURI
    * @param specVersion
    */
-  private void unscheduleSpec(URI specURI, String specVersion) throws JobException {
+  private boolean unscheduleSpec(URI specURI, String specVersion) throws JobException {
     if (this.scheduledFlowSpecs.containsKey(specURI.toString())) {
       _log.info("Unscheduling flowSpec " + specURI + "/" + specVersion);
       this.scheduledFlowSpecs.remove(specURI.toString());
@@ -630,10 +631,12 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         } catch (SpecNotFoundException e) {
           _log.warn("Unable to retrieve spec for URI {}", specURI);
         }
+      return true;
     } else {
-      throw new JobException(String.format(
-          "Spec with URI: %s was not found in cache. May be it was cleaned, if not please clean it manually",
+      _log.info(String.format(
+          "Spec with URI: %s was not found in cache. Maybe it was cleaned, if not please clean it manually",
           specURI));
+      return false;
     }
   }
 
@@ -659,8 +662,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
 
     try {
       Spec deletedSpec = this.scheduledFlowSpecs.get(deletedSpecURI.toString());
-      unscheduleSpec(deletedSpecURI, deletedSpecVersion);
-      this.orchestrator.remove(deletedSpec, headers);
+      if (unscheduleSpec(deletedSpecURI, deletedSpecVersion)) {
+        this.orchestrator.remove(deletedSpec, headers);
+      }
     } catch (JobException | IOException e) {
       _log.warn(String.format("Spec with URI: %s was not unscheduled cleaning", deletedSpecURI), e);
     }


### PR DESCRIPTION
…ue it pollutes log analyzer data

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2129


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The only caller of GobblinServiceJobScheduler::unscheduleSpec was ignoring the exception it throws, so lets throw it. It pollutes log analyzer result that hides real exceptions

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

