### PR TITLE
[GOBBLIN-2133] provide job future before calling SpecProducer::cancelJob

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
@@ -42,13 +42,14 @@ import static org.mockito.Mockito.when;
 public class MockedSpecExecutor extends InMemorySpecExecutor {
   private final SpecProducer<Spec> mockedSpecProducer;
   private final Config config;
+  public static final String dummySerializedFuture = "12345";
 
   public MockedSpecExecutor(Config config) {
     super(config);
     this.config = config;
     this.mockedSpecProducer = Mockito.mock(SpecProducer.class);
     when(mockedSpecProducer.addSpec(any())).thenReturn(new CompletedFuture(Boolean.TRUE, null));
-    when(mockedSpecProducer.serializeAddSpecResponse(any())).thenReturn("");
+    when(mockedSpecProducer.serializeAddSpecResponse(any())).thenReturn(dummySerializedFuture);
     when(mockedSpecProducer.deserializeAddSpecResponse(any())).thenReturn(new CompletedFuture(Boolean.TRUE, null));
     when(mockedSpecProducer.cancelJob(any(), any())).thenReturn(new CompletedFuture(Boolean.TRUE, null));
     }

--- a/gobblin-service/build.gradle
+++ b/gobblin-service/build.gradle
@@ -91,6 +91,8 @@ dependencies {
   testCompile externalDependency.hamcrest
   testCompile externalDependency.jhyde
   testCompile externalDependency.mockitoInline
+  testCompile externalDependency.powerMockApi
+  testCompile externalDependency.powerMockModule
   testCompile externalDependency.testContainers
   testCompile externalDependency.testContainersMysql
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -345,7 +345,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       NewState newState = newState(jobStatus, states);
       String newStatus = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
       if (newState == NewState.FINISHED) {
-        log.info("Flow {}:{}:{}:{} reached a terminal state {}", flowGroup, flowName, flowExecutionId, jobName, newStatus);
+        log.info("Flow/Job {}:{}:{}:{} reached a terminal state {}", flowGroup, flowName, flowExecutionId, jobName, newStatus);
       }
       return ImmutablePair.of(jobStatus, newState);
     } catch (Exception e) {

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -204,6 +204,8 @@ ext.externalDependency = [
     'parquetAvro': 'org.apache.parquet:parquet-avro:1.11.0',
     'parquetProto': 'org.apache.parquet:parquet-protobuf:1.11.0',
     'parquetHadoop': 'org.apache.parquet:parquet-hadoop-bundle:1.11.0',
+    'powerMockApi' : 'org.powermock:powermock-api-mockito2:2.0.9',
+    'powerMockModule' : 'org.powermock:powermock-module-junit4:2.0.9',
     'reactivex': 'io.reactivex.rxjava2:rxjava:2.1.0',
     "slf4j": [
         "org.slf4j:slf4j-api:" + slf4jVersion,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2133


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
https://github.com/apache/gobblin/pull/4021/files had introduced a bug where i was calling SpecProducer::cancelJob without filling in the job future required to cancel the job

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
difficult to test ordering of events

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

