### PR TITLE
[GOBBLIN-2141] Simulate directly on trash class

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/trash/TrashFactory.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/trash/TrashFactory.java
@@ -41,6 +41,9 @@ public class TrashFactory {
   public static final String SIMULATE = "gobblin.trash.simulate";
   public static final String SKIP_TRASH = "gobblin.trash.skip.trash";
 
+  // Configuration to avoid using MockTrash - as Trash implementations get more complex it's better to have the Trash class itself support simulate
+  public static final String SIMULATE_USING_ACTUAL_TRASH = "gobblin.trash.simulate.actual.trash";
+
   public static Trash createTrash(FileSystem fs) throws IOException {
     return createTrash(fs, new Properties());
   }
@@ -107,8 +110,8 @@ public class TrashFactory {
       LOG.info("Creating a test trash. Nothing will actually be deleted.");
       return new TestTrash(fs, props, user);
     }
-    if(props.containsKey(SIMULATE) && Boolean.parseBoolean(props.getProperty(SIMULATE))) {
-      LOG.info("Creating a simulate trash. Nothing will actually be deleted.");
+    if(props.containsKey(SIMULATE) && Boolean.parseBoolean(props.getProperty(SIMULATE)) && !Boolean.parseBoolean(props.getProperty(SIMULATE_USING_ACTUAL_TRASH)) ) {
+      LOG.info("Creating a mock trash. Nothing will actually be deleted.");
       return new MockTrash(fs, props, user);
     }
     if(props.containsKey(SKIP_TRASH) && Boolean.parseBoolean(props.getProperty(SKIP_TRASH))) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/trash/TrashTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/trash/TrashTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.data.management.trash;
 
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
@@ -236,6 +235,74 @@ public class TrashTest {
 
       Assert.assertEquals(deletedPaths.size(), 1);
       Assert.assertTrue(deletedPaths.get(0).equals(snapshot2));
+    } finally {
+      DateTimeUtils.setCurrentMillisSystem();
+    }
+  }
+
+  @Test
+  public void testMoveToTrashSimulate() throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty(TrashFactory.SIMULATE, "true");
+    TrashTestBase trash = new TrashTestBase(properties);
+
+    Path pathToDelete = new Path("/path/to/delete");
+
+    final List<Pair<Path, Path>> movedPaths = Lists.newArrayList();
+
+    when(trash.fs.rename(any(Path.class), any(Path.class))).thenAnswer(new Answer<Boolean>() {
+      @Override
+      public Boolean answer(InvocationOnMock invocation)
+          throws Throwable {
+        Object[] args = invocation.getArguments();
+        movedPaths.add(new Pair<Path, Path>((Path) args[0], (Path) args[1]));
+        return true;
+      }
+    });
+
+    Assert.assertTrue(trash.trash.moveToTrash(pathToDelete));
+
+    verify(trash.fs, times(0)).mkdirs(any(Path.class));
+
+    Assert.assertEquals(movedPaths.size(), 0);
+
+  }
+
+  @Test
+  public void testPurgeSnapshotsWithSimulate() throws IOException {
+
+    try {
+      Properties properties = new Properties();
+      properties.setProperty(Trash.SNAPSHOT_CLEANUP_POLICY_CLASS_KEY, TestCleanupPolicy.class.getCanonicalName());
+      properties.setProperty(TrashFactory.SIMULATE, "true");
+      TrashTestBase trash = new TrashTestBase(properties);
+
+      DateTimeUtils.setCurrentMillisFixed(new DateTime(2015, 7, 15, 10, 0).withZone(DateTimeZone.UTC).getMillis());
+
+      final List<Path> deletedPaths = Lists.newArrayList();
+
+      Path snapshot1 = new Path(trash.trash.getTrashLocation(), Trash.TRASH_SNAPSHOT_NAME_FORMATTER.print(new DateTime()));
+      Path snapshot2 = new Path(trash.trash.getTrashLocation(),
+          Trash.TRASH_SNAPSHOT_NAME_FORMATTER.print(new DateTime().minusDays(1)));
+
+      when(trash.fs.listStatus(any(Path.class), any(PathFilter.class))).
+          thenReturn(
+          Lists.newArrayList(
+                  new FileStatus(0, true, 0, 0, 0, snapshot1),
+                  new FileStatus(0, true, 0, 0, 0, snapshot2))
+              .toArray(new FileStatus[]{}));
+      when(trash.fs.delete(any(Path.class), anyBoolean())).thenAnswer(new Answer<Boolean>() {
+        @Override
+        public Boolean answer(InvocationOnMock invocation)
+            throws Throwable {
+          deletedPaths.add((Path) invocation.getArguments()[0]);
+          return true;
+        }
+      });
+
+      trash.trash.purgeTrashSnapshots();
+
+      Assert.assertEquals(deletedPaths.size(), 0);
     } finally {
       DateTimeUtils.setCurrentMillisSystem();
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2141


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Simulation mode in retention relies on the usage of MockTrash, which doesn't always reflect the details of moving trash to certain spaces that the actual Trash class implements, and some of the details of which folders it creates.
The mock trash class also makes it difficult to simulate behaviors on any classes that extend a part of Trash class since they would have to create a corresponding mock class, which makes the purpose of the simulate mode moot since it's not actually simulating the live behavior.

We want to have an opt-in configuration (to not break existing simulation jobs of retention) to have the Trash class log out which files it is moving to its trash location.

If a user has `gobblin.retention.simulate=true` and `gobblin.trash.simulate.actual.trash=true`, it will simulate without using the MockTrash class

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

