### PR TITLE
[GOBBLIN-2142] fix bug in determining if a dag is finished or not

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
@@ -144,12 +144,6 @@ public interface DagManagementStateStore {
   Optional<JobStatus> getJobStatus(DagNodeId dagNodeId);
 
   /**
-   * Returns true if the {@link Dag} identified by the given {@link org.apache.gobblin.service.modules.orchestration.DagManager.DagId}
-   * has any running job, false otherwise.
-   */
-  boolean hasRunningJobs(DagManager.DagId dagId) throws IOException;
-
-  /**
    * Check if an action exists in dagAction store by flow group, flow name, flow execution id, and job name.
    * @param flowGroup flow group for the dag action
    * @param flowName flow name for the dag action

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -219,6 +219,7 @@ public class DagManagerUtils {
         switch (failureOption) {
           case FINISH_RUNNING:
             return new HashSet<>();
+          // todo - FINISH_ALL_POSSIBLE should probably `continue` not `break`
           case FINISH_ALL_POSSIBLE:
           default:
             break;
@@ -228,7 +229,7 @@ public class DagManagerUtils {
     return nextNodesToExecute;
   }
 
-  static FailureOption getFailureOption(Dag<JobExecutionPlan> dag) {
+  public static FailureOption getFailureOption(Dag<JobExecutionPlan> dag) {
     if (dag.isEmpty()) {
       return null;
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
@@ -43,7 +43,6 @@ import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.DagNodeId;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
-import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.JobStatus;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.util.ConfigUtils;
@@ -207,13 +206,6 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
     } else {
       return java.util.Optional.empty();
     }
-  }
-
-
-  @Override
-  public boolean hasRunningJobs(DagManager.DagId dagId) throws IOException {
-    return getDagNodes(dagId).stream()
-        .anyMatch(node -> !FlowStatusGenerator.FINISHED_STATUSES.contains(node.getValue().getExecutionStatus().name()));
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -311,7 +311,6 @@ public class DagProcUtils {
     List<Dag.DagNode<JobExecutionPlan>> nodes = dag.getNodes();
     Set<Dag.DagNode<JobExecutionPlan>> canRun = new HashSet<>(nodes);
     Set<Dag.DagNode<JobExecutionPlan>> completed = new HashSet<>();
-    DagManager.FailureOption failureOption = DagManagerUtils.getFailureOption(dag);
     boolean anyFailure = false;
 
     for (Dag.DagNode<JobExecutionPlan> node : nodes) {
@@ -339,6 +338,8 @@ public class DagProcUtils {
 
     assert canRun.size() >= completed.size();
 
+    DagManager.FailureOption failureOption = DagManagerUtils.getFailureOption(dag);
+
     if (!anyFailure || failureOption == DagManager.FailureOption.FINISH_ALL_POSSIBLE) {
       // In the end, check if there are more nodes in canRun than completed
       return canRun.size() == completed.size();
@@ -361,14 +362,6 @@ public class DagProcUtils {
 
   private static boolean areAllParentsInCanRun(Dag.DagNode<JobExecutionPlan> node,
       Set<Dag.DagNode<JobExecutionPlan>> canRun) {
-    if (node.getParentNodes() == null) {
-      return true;
-    }
-    for (Dag.DagNode<JobExecutionPlan> parent : node.getParentNodes()) {
-      if (!canRun.contains(parent)) {
-        return false; // If any parent is not in canRun, return false
-      }
-    }
-    return true; // All parents are in canRun
+    return node.getParentNodes() == null || canRun.containsAll(node.getParentNodes());
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -17,12 +17,33 @@
 
 package org.apache.gobblin.service.modules.orchestration;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.config.ConfigBuilder;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.spec_executorInstance.MockedSpecExecutor;
+import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.orchestration.proc.DagProcUtils;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
+import org.apache.gobblin.util.ConfigUtils;
+
+import static org.apache.gobblin.service.ExecutionStatus.*;
 
 
 public class DagManagerUtilsTest {
@@ -37,5 +58,300 @@ public class DagManagerUtilsTest {
       // Assume each key is a string because all job configs are currently strings
       Assert.assertEquals(jobSpec.getConfigAsProperties().get(key), jobSpec.getConfig().getString(key));
     }
+  }
+
+  @Test
+  public void testIsDagFinished() throws URISyntaxException {
+    long flowExecutionId = 12345L;
+    String flowGroup = "fg";
+    String flowName = "fn";
+
+    Dag<JobExecutionPlan> dag = DagManagerTest.buildDag("1", flowExecutionId, DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(),
+        1, "user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI))
+    );
+
+    setJobStatuses(dag, Collections.singletonList(COMPLETE));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(FAILED));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(CANCELLED));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(PENDING_RETRY));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(PENDING_RESUME));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Collections.singletonList(RUNNING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    dag = DagManagerTest.buildDag("1", flowExecutionId, DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(),
+        2, "user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI))
+    );
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    dag = buildComplexDag2("1", flowExecutionId, DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(), "user5",
+        ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(FAILED, PENDING, PENDING, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING, PENDING, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(PENDING, PENDING, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    dag = buildComplexDag3("1", flowExecutionId, DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(), "user5",
+        ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    dag = buildComplexDag1("1", flowExecutionId,
+        DagManager.FailureOption.FINISH_ALL_POSSIBLE.name(),"user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY,  ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(FAILED, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, COMPLETE, PENDING, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RESUME, COMPLETE, COMPLETE, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RETRY, COMPLETE, COMPLETE, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, RUNNING, COMPLETE, COMPLETE, PENDING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, FAILED, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING, COMPLETE));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+  }
+
+  @Test
+  public void testIsDagFinishedWithFinishRunningFailureOption() throws URISyntaxException {
+    long flowExecutionId = 12345L;
+    String flowGroup = "fg";
+    String flowName = "fn";
+    Dag<JobExecutionPlan> dag = buildComplexDag4("1", flowExecutionId, DagManager.FailureOption.FINISH_RUNNING.name(), "user5",
+        ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, RUNNING, PENDING));
+    Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+  }
+
+  private void setJobStatuses(Dag<JobExecutionPlan> dag, List<ExecutionStatus> statuses) {
+    int i=0;
+    for (ExecutionStatus status : statuses) {
+      dag.getNodes().get(i++).getValue().setExecutionStatus(status);
+    }
+  }
+
+  // This creates a dag like this
+  //  D0  D1  D2  D3
+  //  |   |   | \ |
+  //  D4  D5  |  D6
+  //  |   |  \|
+  //  D7  |   D8
+  //    \ |  /
+  //      D9
+
+  public static Dag<JobExecutionPlan> buildComplexDag1(String id, long flowExecutionId,
+      String flowFailureOption, String proxyUser, Config additionalConfig) throws URISyntaxException {
+    List<JobExecutionPlan> jobExecutionPlans = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      String suffix = Integer.toString(i);
+      Config jobConfig = ConfigBuilder.create().
+          addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, "flow" + id).
+          addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId).
+          addPrimitive(ConfigurationKeys.JOB_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.JOB_NAME_KEY, "job" + suffix).
+          addPrimitive(ConfigurationKeys.FLOW_FAILURE_OPTION, flowFailureOption).
+          addPrimitive(AzkabanProjectConfig.USER_TO_PROXY, proxyUser).build();
+      jobConfig = additionalConfig.withFallback(jobConfig);
+      if (i == 4) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job0"));
+      } else if (i == 5) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job1"));
+      } if (i == 6) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job2,job3"));
+      } else if (i == 7) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job4"));
+      } else if (i == 8) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job5,job2"));
+      } else if (i == 9) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job7,job5,job8"));
+      }
+      JobSpec js = JobSpec.builder("test_job" + suffix).withVersion(suffix).withConfig(jobConfig).
+          withTemplate(new URI("job" + suffix)).build();
+      SpecExecutor specExecutor = MockedSpecExecutor.createDummySpecExecutor(new URI(
+          ConfigUtils.getString(additionalConfig, ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY,"job" + i)));
+      JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(js, specExecutor);
+      jobExecutionPlans.add(jobExecutionPlan);
+    }
+    return new JobExecutionPlanDagFactory().createDag(jobExecutionPlans);
+  }
+
+  public static Dag<JobExecutionPlan> buildComplexDag2(String id, long flowExecutionId,
+      String flowFailureOption, String proxyUser, Config additionalConfig) throws URISyntaxException {
+    List<JobExecutionPlan> jobExecutionPlans = new ArrayList<>();
+
+    for (int i = 0; i < 4; i++) {
+      String suffix = Integer.toString(i);
+      Config jobConfig = ConfigBuilder.create().
+          addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, "flow" + id).
+          addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId).
+          addPrimitive(ConfigurationKeys.JOB_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.JOB_NAME_KEY, "job" + suffix).
+          addPrimitive(ConfigurationKeys.FLOW_FAILURE_OPTION, flowFailureOption).
+          addPrimitive(AzkabanProjectConfig.USER_TO_PROXY, proxyUser).build();
+      jobConfig = additionalConfig.withFallback(jobConfig);
+      if (i == 1) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job0"));
+      } else if (i == 2) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job1"));
+      } if (i == 3) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job2"));
+      }
+      JobSpec js = JobSpec.builder("test_job" + suffix).withVersion(suffix).withConfig(jobConfig).
+          withTemplate(new URI("job" + suffix)).build();
+      SpecExecutor specExecutor = MockedSpecExecutor.createDummySpecExecutor(new URI(
+          ConfigUtils.getString(additionalConfig, ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY,"job" + i)));
+      JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(js, specExecutor);
+      jobExecutionPlans.add(jobExecutionPlan);
+    }
+    return new JobExecutionPlanDagFactory().createDag(jobExecutionPlans);
+  }
+
+  public static Dag<JobExecutionPlan> buildComplexDag3(String id, long flowExecutionId,
+      String flowFailureOption, String proxyUser, Config additionalConfig) throws URISyntaxException {
+    List<JobExecutionPlan> jobExecutionPlans = new ArrayList<>();
+
+    for (int i = 0; i < 3; i++) {
+      String suffix = Integer.toString(i);
+      Config jobConfig = ConfigBuilder.create().
+          addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, "flow" + id).
+          addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId).
+          addPrimitive(ConfigurationKeys.JOB_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.JOB_NAME_KEY, "job" + suffix).
+          addPrimitive(ConfigurationKeys.FLOW_FAILURE_OPTION, flowFailureOption).
+          addPrimitive(AzkabanProjectConfig.USER_TO_PROXY, proxyUser).build();
+      jobConfig = additionalConfig.withFallback(jobConfig);
+      if (i == 2) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job0,job1"));
+      }
+      JobSpec js = JobSpec.builder("test_job" + suffix).withVersion(suffix).withConfig(jobConfig).
+          withTemplate(new URI("job" + suffix)).build();
+      SpecExecutor specExecutor = MockedSpecExecutor.createDummySpecExecutor(new URI(
+          ConfigUtils.getString(additionalConfig, ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY,"job" + i)));
+      JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(js, specExecutor);
+      jobExecutionPlans.add(jobExecutionPlan);
+    }
+    return new JobExecutionPlanDagFactory().createDag(jobExecutionPlans);
+  }
+
+  public static Dag<JobExecutionPlan> buildComplexDag4(String id, long flowExecutionId,
+      String flowFailureOption, String proxyUser, Config additionalConfig) throws URISyntaxException {
+    List<JobExecutionPlan> jobExecutionPlans = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      String suffix = Integer.toString(i);
+      Config jobConfig = ConfigBuilder.create().
+          addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, "flow" + id).
+          addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId).
+          addPrimitive(ConfigurationKeys.JOB_GROUP_KEY, "group" + id).
+          addPrimitive(ConfigurationKeys.JOB_NAME_KEY, "job" + suffix).
+          addPrimitive(ConfigurationKeys.FLOW_FAILURE_OPTION, flowFailureOption).
+          addPrimitive(AzkabanProjectConfig.USER_TO_PROXY, proxyUser).build();
+      jobConfig = additionalConfig.withFallback(jobConfig);
+      if (i == 1) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job0"));
+      } else if (i == 2) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job0"));
+      } else if (i == 3 || i == 4) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job2"));
+      }
+      JobSpec js = JobSpec.builder("test_job" + suffix).withVersion(suffix).withConfig(jobConfig).
+          withTemplate(new URI("job" + suffix)).build();
+      SpecExecutor specExecutor = MockedSpecExecutor.createDummySpecExecutor(new URI(
+          ConfigUtils.getString(additionalConfig, ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY,"job" + i)));
+      JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(js, specExecutor);
+      jobExecutionPlans.add(jobExecutionPlan);
+    }
+    return new JobExecutionPlanDagFactory().createDag(jobExecutionPlans);
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -209,7 +209,19 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedWithFinishRunningFailureOption() throws URISyntaxException {
+  public void testIsDagFinishedWithFinishRunningFailureOptionTwoNodes() throws URISyntaxException {
+    Dag<JobExecutionPlan> dag =
+        DagManagerTest.buildDag(id, flowExecutionId, flowFailureOption, 2, proxyUser, additionalConfig);
+
+    setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+
+    setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
+    Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+  }
+
+  @Test
+  public void testIsDagFinishedWithFinishRunningFailureOptionMultiNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag = buildComplexDagWithFinishRunningFailureOption();
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
@@ -180,6 +180,7 @@ public class KillDagProcTest {
             .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef("fg"))
             .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
                 MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    DagManager.DagId dagId = DagManagerUtils.generateDagId(dag);
     FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
     JobStatus
         jobStatus = JobStatus.builder().flowName("job0").flowGroup("fg").jobGroup("fg").jobName("job0").flowExecutionId(flowExecutionId).

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -29,6 +29,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -59,6 +60,7 @@ import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.DagManagerTest;
+import org.apache.gobblin.service.modules.orchestration.DagManagerUtils;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
 import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
@@ -121,6 +123,7 @@ public class LaunchDagProcTest {
             .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
             .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
             MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    DagManager.DagId dagId = DagManagerUtils.generateDagId(dag);
     FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
     List<SpecProducer<Spec>> specProducers = ReevaluateDagProcTest.getDagSpecProducers(dag);
@@ -144,6 +147,8 @@ public class LaunchDagProcTest {
     // FLOW_RUNNING is emitted exactly once per flow during the execution of LaunchDagProc
     Mockito.verify(this.mockedEventSubmitter, Mockito.times(1))
         .submit(eq(TimingEvent.FlowTimings.FLOW_RUNNING), anyMap());
+
+    Assert.assertFalse(DagProcUtils.isDagFinished(this.dagManagementStateStore.getDag(dagId).get()));
   }
 
   @Test
@@ -157,6 +162,7 @@ public class LaunchDagProcTest {
             .withValue(ConfigurationKeys.FLOW_NAME_KEY,  ConfigValueFactory.fromAnyRef(flowName))
             .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
                 MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    DagManager.DagId dagId = DagManagerUtils.generateDagId(dag);
     FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
     LaunchDagProc launchDagProc = new LaunchDagProc(
@@ -174,6 +180,8 @@ public class LaunchDagProcTest {
     // FLOW_RUNNING is emitted exactly once per flow during the execution of LaunchDagProc
     Mockito.verify(this.mockedEventSubmitter, Mockito.times(1))
         .submit(eq(TimingEvent.FlowTimings.FLOW_RUNNING), anyMap());
+
+    Assert.assertFalse(DagProcUtils.isDagFinished(this.dagManagementStateStore.getDag(dagId).get()));
   }
 
   // This creates a dag like this

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -109,5 +110,7 @@ public class ResumeDagProcTest {
      the result will be that after serializing/deserializing the test dag, the spec executor (and producer) type may change */
 
     Mockito.verify(this.dagManagementStateStore, Mockito.times(expectedNumOfResumedJobs)).addDagNodeState(any(), any());
+
+    Assert.assertFalse(DagProcUtils.isDagFinished(this.dagManagementStateStore.getDag(dagId).get()));
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2142


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
There is an apparent bug in DMSS::hasRunningJobs()
If in a dag with two sequential jobs, first failed, this method returns true, while it should return false because the second job just cannot run. Because of this bug, ReevaluateDagProc fails to remove dag (or mark it as failed)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added tests in DagManagerUtilTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

