### PR TITLE
[GOBBLIN-2143] handle concurrent ReevaluateDagProc for cancelled dag nodes correctly

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
@@ -101,7 +101,7 @@ public interface DagManagementStateStore {
    * @param dagNode dag node to be added
    * @param dagId dag id of the dag this dag node belongs to
    */
-  void addDagNodeState(Dag.DagNode<JobExecutionPlan> dagNode, DagManager.DagId dagId) throws IOException;
+  void updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
   /**
    * Returns the requested {@link  org.apache.gobblin.service.modules.flowgraph.Dag.DagNode} and its {@link JobStatus}.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
@@ -38,7 +38,7 @@ public interface DagStateStoreWithDagNodes extends DagStateStore {
    * Updates the {@link Dag.DagNode} with the provided value.
    * Returns 1 if the dag node is updated successfully, 0 otherwise
    */
-  int updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
+  boolean updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
   /**
    * Returns all the {@link org.apache.gobblin.service.modules.flowgraph.Dag.DagNode}s for the given

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
@@ -36,7 +36,7 @@ public interface DagStateStoreWithDagNodes extends DagStateStore {
 
   /**
    * Updates the {@link Dag.DagNode} with the provided value.
-   * Returns 1 if the dag node is updated successfully, 0 otherwise
+   * Returns true if the dag node is updated successfully, false otherwise
    */
   boolean updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagStateStoreWithDagNodes.java
@@ -35,12 +35,10 @@ import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 public interface DagStateStoreWithDagNodes extends DagStateStore {
 
   /**
-   * Updates a dag node identified by the provided {@link DagManager.DagId}
-   * with the given {@link Dag.DagNode}.
-   * Returns 1 if the dag node is inserted as a new one, 2 if is updated, and 0 if new dag node is same as the existing one
-   * <a href="https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html">Refer</a>
+   * Updates the {@link Dag.DagNode} with the provided value.
+   * Returns 1 if the dag node is updated successfully, 0 otherwise
    */
-  int updateDagNode(DagManager.DagId dagId, Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
+  int updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException;
 
   /**
    * Returns all the {@link org.apache.gobblin.service.modules.flowgraph.Dag.DagNode}s for the given

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
@@ -142,8 +142,11 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
 
   @Override
   public void deleteDag(DagManager.DagId dagId) throws IOException {
-    this.dagStateStore.cleanUp(dagId);
-    log.info("Deleted dag {}", dagId);
+    if (this.dagStateStore.cleanUp(dagId)) {
+      log.info("Deleted dag {}", dagId);
+    } else {
+      log.info("Dag deletion was tried but did not happen {}", dagId);
+    }
   }
 
   @Override
@@ -158,9 +161,9 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
   }
 
   @Override
-  public synchronized void addDagNodeState(Dag.DagNode<JobExecutionPlan> dagNode, DagManager.DagId dagId)
+  public synchronized void updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode)
       throws IOException {
-    this.dagStateStore.updateDagNode(dagId, dagNode);
+    this.dagStateStore.updateDagNode(dagNode);
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreWithDagNodes.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlDagStateStoreWithDagNodes.java
@@ -87,8 +87,8 @@ public class MysqlDagStateStoreWithDagNodes implements DagStateStoreWithDagNodes
       + "UNIQUE INDEX dag_node_index (dag_node_id), "
       + "INDEX dag_index (parent_dag_id))";
 
-  protected static final String INSERT_STATEMENT = "INSERT INTO %s (dag_node_id, parent_dag_id, dag_node) "
-      + "VALUES (?, ?, ?) AS new ON DUPLICATE KEY UPDATE dag_node = new.dag_node";
+  protected static final String INSERT_DAG_NODE_STATEMENT = "INSERT INTO %s (dag_node_id, parent_dag_id, dag_node) VALUES (?, ?, ?)";
+  protected static final String UPDATE_DAG_NODE_STATEMENT = "UPDATE %s SET dag_node = ? WHERE dag_node_id = ?";
   protected static final String GET_DAG_NODES_STATEMENT = "SELECT dag_node FROM %s WHERE parent_dag_id = ?";
   protected static final String GET_DAG_NODE_STATEMENT = "SELECT dag_node FROM %s WHERE dag_node_id = ?";
   protected static final String DELETE_DAG_STATEMENT = "DELETE FROM %s WHERE parent_dag_id = ?";
@@ -126,18 +126,32 @@ public class MysqlDagStateStoreWithDagNodes implements DagStateStoreWithDagNodes
   }
 
   @Override
-  public void writeCheckpoint(Dag<JobExecutionPlan> dag)
-      throws IOException {
-    DagManager.DagId dagId = DagManagerUtils.generateDagId(dag);
-    boolean newDag = false;
-    for (Dag.DagNode<JobExecutionPlan> dagNode : dag.getNodes()) {
-      if (updateDagNode(dagId, dagNode) == 1) {
-        newDag = true;
+  public void writeCheckpoint(Dag<JobExecutionPlan> dag) throws IOException {
+    String dagId = DagManagerUtils.generateDagId(dag).toString();
+    dbStatementExecutor.withPreparedStatement(String.format(INSERT_DAG_NODE_STATEMENT, tableName), insertStatement -> {
+      int dagSize = dag.getNodes().size();
+      Object[][] data = new Object[dagSize][3];
+
+      for (int i=0; i<dagSize; i++) {
+        Dag.DagNode<JobExecutionPlan> dagNode = dag.getNodes().get(i);
+        data[i][0] = dagNode.getValue().getId().toString();
+        data[i][1] = dagId;
+        data[i][2] =this.serDe.serialize(Collections.singletonList(dagNode.getValue()));
       }
-    }
-    if (newDag) {
-      this.totalDagCount.inc();
-    }
+
+      for (Object[] row : data) {
+        insertStatement.setObject(1, row[0]);
+        insertStatement.setObject(2, row[1]);
+        insertStatement.setObject(3, row[2]);
+        insertStatement.addBatch();
+      }
+      try {
+        return insertStatement.executeBatch();
+      } catch (SQLException e) {
+        throw new IOException(String.format("Failure adding dag for %s", dagId), e);
+      }}, true);
+
+    this.totalDagCount.inc();
   }
 
   @Override
@@ -147,15 +161,18 @@ public class MysqlDagStateStoreWithDagNodes implements DagStateStoreWithDagNodes
 
   @Override
   public boolean cleanUp(DagManager.DagId dagId) throws IOException {
-    dbStatementExecutor.withPreparedStatement(String.format(DELETE_DAG_STATEMENT, tableName), deleteStatement -> {
+    if (dbStatementExecutor.withPreparedStatement(String.format(DELETE_DAG_STATEMENT, tableName), deleteStatement -> {
       try {
         deleteStatement.setString(1, dagId.toString());
         return deleteStatement.executeUpdate() != 0;
       } catch (SQLException e) {
         throw new IOException(String.format("Failure deleting dag for %s", dagId), e);
-      }}, true);
-    this.totalDagCount.dec();
-    return true;
+      }}, true)) {
+      this.totalDagCount.dec();
+      return true;
+    } else {
+      return false;
+    }
   }
 
   @Override
@@ -195,16 +212,15 @@ public class MysqlDagStateStoreWithDagNodes implements DagStateStoreWithDagNodes
   }
 
   @Override
-  public int updateDagNode(DagManager.DagId parentDagId, Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
+  public int updateDagNode(Dag.DagNode<JobExecutionPlan> dagNode) throws IOException {
     String dagNodeId = dagNode.getValue().getId().toString();
-    return dbStatementExecutor.withPreparedStatement(String.format(INSERT_STATEMENT, tableName), insertStatement -> {
+    return dbStatementExecutor.withPreparedStatement(String.format(UPDATE_DAG_NODE_STATEMENT, tableName), updateStatement -> {
       try {
-        insertStatement.setString(1, dagNodeId);
-        insertStatement.setString(2, parentDagId.toString());
-        insertStatement.setString(3, this.serDe.serialize(Collections.singletonList(dagNode.getValue())));
-        return insertStatement.executeUpdate();
+        updateStatement.setString(1, this.serDe.serialize(Collections.singletonList(dagNode.getValue())));
+        updateStatement.setString(2, dagNodeId);
+        return updateStatement.executeUpdate();
       } catch (SQLException e) {
-        throw new IOException(String.format("Failure adding dag node for %s", dagNodeId), e);
+        throw new IOException(String.format("Failure updating dag node for %s", dagNodeId), e);
       }}, true);
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -81,6 +81,11 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
 
     JobStatus jobStatus = dagNodeWithJobStatus.getRight().get();
     ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatus.getEventName());
+    // get the dag before updating dag node's status because after updating status, dag may be considered "complete" and
+    // may get cleaned up by other Reevaluate DagProc
+    Dag<JobExecutionPlan> dag = dagManagementStateStore.getDag(getDagId()).get();
+    dag.getNodes().stream().filter(node -> node.getValue().getId().equals(getDagNodeId())).findFirst().get().getValue()
+        .setExecutionStatus(executionStatus);
     updateDagNodeStatus(dagManagementStateStore, dagNode, executionStatus);
     boolean isRetry = jobStatus.isShouldRetry();
 
@@ -92,8 +97,6 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
           FlowStatusGenerator.FINISHED_STATUSES));
     }
 
-    // get the dag after updating dag node status
-    Dag<JobExecutionPlan> dag = dagManagementStateStore.getDag(getDagId()).get();
     onJobFinish(dagManagementStateStore, dagNode, dag);
 
     if (jobStatus.isShouldRetry()) {
@@ -132,7 +135,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
   private void updateDagNodeStatus(DagManagementStateStore dagManagementStateStore,
       Dag.DagNode<JobExecutionPlan> dagNode, ExecutionStatus executionStatus) throws IOException {
     dagNode.getValue().setExecutionStatus(executionStatus);
-    dagManagementStateStore.addDagNodeState(dagNode, getDagId());
+    dagManagementStateStore.updateDagNode(dagNode);
   }
 
   /**

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStoreTest.java
@@ -100,14 +100,13 @@ public class MySqlDagManagementStateStoreTest {
     Dag.DagNode<JobExecutionPlan> dagNode2 = dag.getNodes().get(1);
     Dag.DagNode<JobExecutionPlan> dagNode3 = dag2.getNodes().get(0);
     DagManager.DagId dagId = DagManagerUtils.generateDagId(dag);
-    DagManager.DagId dagId2 = DagManagerUtils.generateDagId(dag2);
     DagNodeId dagNodeId = DagManagerUtils.calcJobId(dagNode.getValue().getJobSpec().getConfig());
 
     this.dagManagementStateStore.addDag(dag);
     this.dagManagementStateStore.addDag(dag2);
-    this.dagManagementStateStore.addDagNodeState(dagNode, dagId);
-    this.dagManagementStateStore.addDagNodeState(dagNode2, dagId);
-    this.dagManagementStateStore.addDagNodeState(dagNode3, dagId2);
+    this.dagManagementStateStore.updateDagNode(dagNode);
+    this.dagManagementStateStore.updateDagNode(dagNode2);
+    this.dagManagementStateStore.updateDagNode(dagNode3);
 
     Assert.assertTrue(compareLists(dag.getNodes(), this.dagManagementStateStore.getDag(dagId).get().getNodes()));
     Assert.assertEquals(dagNode, this.dagManagementStateStore.getDagNodeWithJobStatus(dagNodeId).getLeft().get());
@@ -126,7 +125,7 @@ public class MySqlDagManagementStateStoreTest {
     jobExecutionPlan.setJobFuture(Optional.of(future));
 
     Dag.DagNode<JobExecutionPlan> duplicateDagNode = new Dag.DagNode<>(jobExecutionPlan);
-    this.dagManagementStateStore.addDagNodeState(duplicateDagNode, dagId);
+    this.dagManagementStateStore.updateDagNode(duplicateDagNode);
     Assert.assertEquals(this.dagManagementStateStore.getDagNodes(dagId).size(), 2);
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
@@ -123,7 +123,7 @@ public class ReevaluateDagProcTest {
     // next job is sent to spec producer
     Mockito.verify(specProducers.get(1), Mockito.times(1)).addSpec(any());
     // there are two invocations, one after setting status and other after sending new job to specProducer
-    Mockito.verify(this.dagManagementStateStore, Mockito.times(2)).addDagNodeState(any(), any());
+    Mockito.verify(this.dagManagementStateStore, Mockito.times(2)).updateDagNode(any());
 
     // assert that the first job is completed
     Assert.assertEquals(ExecutionStatus.COMPLETE,

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProcTest.java
@@ -109,7 +109,7 @@ public class ResumeDagProcTest {
      buildNaiveTopologySpec().getSpecExecutor() respectively.
      the result will be that after serializing/deserializing the test dag, the spec executor (and producer) type may change */
 
-    Mockito.verify(this.dagManagementStateStore, Mockito.times(expectedNumOfResumedJobs)).addDagNodeState(any(), any());
+    Mockito.verify(this.dagManagementStateStore, Mockito.times(expectedNumOfResumedJobs)).updateDagNode(any());
 
     Assert.assertFalse(DagProcUtils.isDagFinished(this.dagManagementStateStore.getDag(dagId).get()));
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2143


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When a dag is cancelled and multiple ReevaluateDagProcs are being processed for kill dag nodes, all of them will try to delete the dag and insert the dag node state too. this "insert" and "delete" may create inconsistency in the dag state store.
To safe guard against this, let only ReevaluateDagProc update the status of a dag node; and it should only UPDATE the status, NOT try to INSERT the dag node.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

