### PR TITLE
[GOBBLIN-2146] Send cancellation flow events when a job is killed by the SLA cancell…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceFlowFinishDeadlineDagProc.java
@@ -60,7 +60,9 @@ public class EnforceFlowFinishDeadlineDagProc extends DeadlineEnforcementDagProc
         DagProcUtils.cancelDagNode(dagNodeToCancel, dagManagementStateStore);
       }
 
-      dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_RUN_DEADLINE_EXCEEDED);
+      DagProcUtils.setAndEmitFlowEvent(eventSubmitter, dag, TimingEvent.FlowTimings.FLOW_CANCELLED);
+
+      log.warn("Killing dag {} due to exceeding SLA of {} ms", getDagId(), flowFinishDeadline);
       dag.setMessage("Flow killed due to exceeding SLA of " + flowFinishDeadline + " ms");
       dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
     } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceJobStartDeadlineDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/EnforceJobStartDeadlineDagProc.java
@@ -79,7 +79,8 @@ public class EnforceJobStartDeadlineDagProc extends DeadlineEnforcementDagProc {
           DagManagerUtils.getJobName(dagNode), jobOrchestratedTime, timeOutForJobStart);
       dagManagementStateStore.getDagManagerMetrics().incrementCountsStartSlaExceeded(dagNode);
       DagProcUtils.cancelDagNode(dagNode, dagManagementStateStore);
-      dag.setFlowEvent(TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED);
+      DagProcUtils.setAndEmitFlowEvent(eventSubmitter, dag, TimingEvent.FlowTimings.FLOW_START_DEADLINE_EXCEEDED);
+
       dag.setMessage("Flow killed because no update received for " + timeOutForJobStart + " ms after orchestration");
     }
     dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);


### PR DESCRIPTION
…ation

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2146


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Instead of `setFlowEvent`, the proc engine needs to enforce that flow level events are always being emitted for each type of flow. In this scenario, it needs to emit flow level events for cancellation at a flow level so that jobs are properly killed, similar to the DagManager.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

