### PR TITLE
[GOBBLIN-2147] Added lookback time fetch in partitioned filesource

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK 1.8
@@ -47,7 +47,7 @@ jobs:
           java-version: 1.8
       # Stores external dependencies, can be further improved with Gradle 6.1
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -70,14 +70,14 @@ jobs:
     needs: build
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       # Stores external dependencies, can be further improved with Gradle 6.1
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -112,7 +112,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK 1.8
@@ -137,7 +137,7 @@ jobs:
             mysql --host 127.0.0.1 --port 3306 -uroot -ptestPassword -e "SHOW DATABASES"
             mysql --host 127.0.0.1 --port 3306 -uroot -ptestPassword -e "SET GLOBAL max_connections=2000"
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -351,6 +351,11 @@ public class ConfigurationKeys {
   public static final String WATERMARK_INTERVAL_VALUE_KEY = "watermark.interval.value";
 
   /**
+   * DEFAULT LOOKBACK TIME KEY property
+   */
+  public static final String DEFAULT_COPY_LOOKBACK_TIME_KEY = "copy.lookbackTime";
+
+  /**
    * Extract related configuration properties.
    */
   public static final String EXTRACT_TABLE_TYPE_KEY = "extract.table.type";

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -54,9 +55,9 @@ import static org.apache.gobblin.source.PartitionedFileSourceBase.DATE_PARTITION
  *
  * For example, if {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} is set to /my/data/, then the class assumes
  * folders following the pattern /my/data/daily/[year]/[month]/[day] are present. It will iterate through all the data
- * under these folders starting from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until
- * either {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data
- * to process. For example, if {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} is set to 2015/01/01, then the job
+ * under these folders starting from the date specified by {@link PartitionedFileSourceBase#DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until
+ * either {@link PartitionedFileSourceBase#DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data
+ * to process. For example, if {@link PartitionedFileSourceBase#DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} is set to 2015/01/01, then the job
  * will read from the folder /my/data/daily/2015/01/01/, /my/data/daily/2015/01/02/, /my/data/2015/01/03/ etc.
  *
  */
@@ -114,6 +115,10 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
       throw new IOException("Error initializing FileSystem", e);
     }
 
+    GrowthMilestoneTracker growthTracker = new GrowthMilestoneTracker();
+    Long iteration = 0L;
+    LOG.info("Starting processing files from {} to {}", lowWaterMarkDate, currentDay);
+
     for (DateTime date = lowWaterMarkDate; !date.isAfter(currentDay) && filesToProcess.size() < maxFilesToReturn;
         date = date.withFieldAdded(incrementalUnit, 1)) {
 
@@ -129,7 +134,14 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
               new FileInfo(fileStatus.getPath().toString(), fileStatus.getLen(), date.getMillis(), partitionPath));
         }
       }
+
+      if (growthTracker.isAnotherMilestone(iteration++)) {
+        LOG.info("~{}~ collected files to process", filesToProcess.size());
+        LOG.info("Last Source Path processed : ~{}~", sourcePath);
+      }
     }
+
+    LOG.info("Finished processing files");
 
     return filesToProcess;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -45,6 +44,7 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.source.extractor.filebased.FileBasedHelperException;
 import org.apache.gobblin.source.extractor.hadoop.HadoopFsHelper;
 import org.apache.gobblin.util.DatePartitionType;
+import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
 
 import static org.apache.gobblin.source.PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_PATTERN;
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
@@ -117,7 +117,7 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
 
     GrowthMilestoneTracker growthTracker = new GrowthMilestoneTracker();
     Long iteration = 0L;
-    LOG.info("Starting processing files from {} to {}", lowWaterMarkDate, currentDay);
+    LOG.info("~{}~ Starting collecting files to process from {} to {}", sourceDir, lowWaterMarkDate, currentDay);
 
     for (DateTime date = lowWaterMarkDate; !date.isAfter(currentDay) && filesToProcess.size() < maxFilesToReturn;
         date = date.withFieldAdded(incrementalUnit, 1)) {
@@ -136,12 +136,11 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
       }
 
       if (growthTracker.isAnotherMilestone(iteration++)) {
-        LOG.info("~{}~ collected files to process", filesToProcess.size());
-        LOG.info("Last Source Path processed : ~{}~", sourcePath);
+        LOG.info("~{}~ collected {} files to process; most-recent source path: ~{}~", sourceDir, filesToProcess.size(), sourcePath);
       }
     }
 
-    LOG.info("Finished processing files");
+    LOG.info("~{}~ Finished collecting {} files to process", sourceDir, filesToProcess.size());
 
     return filesToProcess;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
@@ -77,13 +77,10 @@ public class PartitionAwareFileRetrieverUtils {
         long lookBack = Long.parseLong(lookBackTime.substring(0, lookBackTime.length() - 1));
         return new Duration(lookBack * lookBackTimeGranularityInMillis);
       } catch(NumberFormatException ex) {
-        log.error("Exception Caught while parsing lookback time", ex);
         throw new IOException("Invalid lookback time: " + lookBackTime, ex);
       }
     } else {
-      String errMsg = String.format("There is no valid time granularity for lookback time: %s", lookBackTime);
-      log.error(errMsg);
-      throw new IOException(errMsg);
+      throw new IOException("There is no valid time granularity in lookback time: " + lookBackTime);
     }
   }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
@@ -16,14 +16,13 @@
  */
 package org.apache.gobblin.source;
 
-import java.util.Optional;
+import java.io.IOException;
 
 import org.joda.time.DateTimeFieldType;
 import org.joda.time.Duration;
 import org.joda.time.chrono.ISOChronology;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.util.DatePartitionType;
@@ -38,8 +37,8 @@ import static org.apache.gobblin.source.PartitionedFileSourceBase.DEFAULT_PARTIT
  * Utility functions for parsing configuration parameters commonly used by {@link PartitionAwareFileRetriever}
  * objects.
  */
+@Slf4j
 public class PartitionAwareFileRetrieverUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(PartitionAwareFileRetrieverUtils.class);
   /**
    * Retrieve the lead time duration from the LEAD_TIME and LEAD_TIME granularity config settings.
    */
@@ -65,24 +64,26 @@ public class PartitionAwareFileRetrieverUtils {
    * Calculates the lookback time duration based on the provided lookback time string.
    *
    * @param lookBackTime the lookback time string, which should include a numeric value followed by a time unit character.
-   *                     For example, "5d" for 5 days or "10h" for 10 hours.
-   * @return an {@link Optional} containing the {@link Duration} if the lookback time is valid, or
-   *         an empty {@link Optional} if the lookback time is invalid or cannot be parsed.
+   *                     For example, "5d" for 5 days or "10h" for 10 hours. See {@link DatePartitionType#lookupByPattern}
+   * @return an {@link Duration} of lookBackTime if the lookback time is valid
+   * @throws IOException if the lookback time is invalid
    */
-  public static Optional<Duration> getLookbackTimeDuration(String lookBackTime) {
-    try {
-      DateTimeFieldType lookBackTimeGranularity = DatePartitionType.getLowestIntervalUnit(lookBackTime);
-      if (lookBackTimeGranularity != null) {
-        long lookBackTimeGranularityInMillis =
-            lookBackTimeGranularity.getDurationType().getField(ISOChronology.getInstance()).getUnitMillis();
+  public static Duration getLookbackTimeDuration(String lookBackTime) throws IOException {
+    DateTimeFieldType lookBackTimeGranularity = DatePartitionType.getLowestIntervalUnit(lookBackTime);
+    if (lookBackTimeGranularity != null) {
+      long lookBackTimeGranularityInMillis =
+          lookBackTimeGranularity.getDurationType().getField(ISOChronology.getInstance()).getUnitMillis();
+      try {
         long lookBack = Long.parseLong(lookBackTime.substring(0, lookBackTime.length() - 1));
-        return Optional.of(new Duration(lookBack * lookBackTimeGranularityInMillis));
+        return new Duration(lookBack * lookBackTimeGranularityInMillis);
+      } catch(NumberFormatException ex) {
+        log.error("Exception Caught while parsing lookback time", ex);
+        throw new IOException("Invalid lookback time: " + lookBackTime, ex);
       }
-      LOG.warn("There is no valid time granularity for lookback time: {}", lookBackTime);
-      return Optional.empty();
-    } catch(NumberFormatException ex) {
-      LOG.warn("Exception Caught while parsing lookback time", ex);
-      return Optional.empty();
+    } else {
+      String errMsg = String.format("There is no valid time granularity for lookback time: %s", lookBackTime);
+      log.error(errMsg);
+      throw new IOException(errMsg);
     }
   }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtils.java
@@ -17,14 +17,16 @@
 package org.apache.gobblin.source;
 
 import java.util.Optional;
+
 import org.joda.time.DateTimeFieldType;
 import org.joda.time.Duration;
 import org.joda.time.chrono.ISOChronology;
 
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.util.DatePartitionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.util.DatePartitionType;
 
 import static org.apache.gobblin.source.PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME;
 import static org.apache.gobblin.source.PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -390,7 +390,7 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
       Duration lookBackDuration = PartitionAwareFileRetrieverUtils.getLookbackTimeDuration(lookBackTime);
       return new DateTime().minus(lookBackDuration).getMillis();
     } catch (IOException e) {
-      log.warn("Failed to parse lookback time: {} , Returning 0 as low watermark value, ", lookBackTime, e);
+      log.error("Failed to parse lookback time: {} , Returning 0 as low watermark value, {}", lookBackTime, e.getMessage());
     }
     return 0;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -390,7 +390,7 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
       Duration lookBackDuration = PartitionAwareFileRetrieverUtils.getLookbackTimeDuration(lookBackTime);
       return new DateTime().minus(lookBackDuration).getMillis();
     } catch (IOException e) {
-      Throwables.propagate(e);
+      log.warn("Failed to parse lookback time: {} , Returning 0 as low watermark value, ", lookBackTime, e);
     }
     return 0;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.source;
 
-import com.google.common.base.Throwables;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -25,8 +24,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.State;
@@ -45,14 +57,6 @@ import org.apache.gobblin.source.workunit.MultiWorkUnitWeightedQueue;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.DatePartitionType;
 import org.apache.gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -390,7 +390,7 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
       Duration lookBackDuration = PartitionAwareFileRetrieverUtils.getLookbackTimeDuration(lookBackTime);
       return new DateTime().minus(lookBackDuration).getMillis();
     } catch (IOException e) {
-      log.error("Failed to parse lookback time: {} , Returning 0 as low watermark value, {}", lookBackTime, e.getMessage());
+      log.error("Failed to parse lookback time: {} , Returning 0 as low watermark value, {}", lookBackTime, e);
     }
     return 0;
   }

--- a/gobblin-core/src/test/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtilsTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/source/PartitionAwareFileRetrieverUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.source;
+
+import java.io.IOException;
+
+import org.joda.time.Duration;
+import org.joda.time.chrono.ISOChronology;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** Tests for {@link PartitionAwareFileRetrieverUtils}*/
+public class PartitionAwareFileRetrieverUtilsTest {
+
+  @Test(dataProvider = "validLookbackTimes")
+  public void testValidLookbackTime(String lookBackTime, long expectedMillis) throws IOException {
+    Duration expectedDuration = new Duration(expectedMillis);
+    Duration actualDuration = PartitionAwareFileRetrieverUtils.getLookbackTimeDuration(lookBackTime);
+    Assert.assertEquals(expectedDuration, actualDuration);
+  }
+
+  @Test(dataProvider = "invalidLookbackTimes", expectedExceptions = IOException.class)
+  public void testInvalidLookbackTime(String lookBackTime) throws IOException {
+    PartitionAwareFileRetrieverUtils.getLookbackTimeDuration(lookBackTime);
+  }
+
+  @DataProvider(name = "validLookbackTimes")
+  public Object[][] validLookbackTimes() {
+    return new Object[][] {
+        {"5d", 5 * ISOChronology.getInstance().days().getUnitMillis()},
+        {"10h", 10 * ISOChronology.getInstance().hours().getUnitMillis()},
+        {"30m", 30 * ISOChronology.getInstance().minutes().getUnitMillis()}
+    };
+  }
+
+  @DataProvider(name = "invalidLookbackTimes")
+  public String[][] invalidLookbackTimes() {
+    return new String[][] {
+        {"5x"}, // Invalid format
+        {"30z"}, // Invalid format
+        {"xd"}, // Invalid number
+        {"yh"}, // Invalid number
+        {"zm"}  // Invalid number
+    };
+  }
+
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [✅] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2147 


### Description
- [✅] Here are some details about my PR, including screenshots (if applicable):
   - In partitioned file source based copy even if copy.lookbackTime property was passed in config it wasn't used and files from lowest watermark (if passed, otherwise default value was used) were being processed  which can lead to too much processing of files in case granularity isn't configured properly.
   - With this change user can pass "copy.lookbackTime" or "date.partitioned.source.lookback.time"
   - If in case user doesn't passed values or values are not proper or there is any exception while parsing the property value then it will fallback to watermark values.


### Tests
- [✅] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - `PartitionAwareFileRetrieverUtilsTest` 


### Commits
- [✅] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

