### PR TITLE
[GOBBLIN-2150] calculate flow status correctly

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -42,7 +42,6 @@ import org.apache.gobblin.service.ExecutionStatus;
 public class FlowStatusGenerator {
   public static final List<String> FINISHED_STATUSES = Lists.newArrayList(ExecutionStatus.FAILED.name(),
       ExecutionStatus.COMPLETE.name(), ExecutionStatus.CANCELLED.name());
-
   public static final int MAX_LOOKBACK = 100;
 
   private final JobStatusRetriever jobStatusRetriever;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -20,21 +20,18 @@ package org.apache.gobblin.service.monitoring;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.service.ExecutionStatus;
 
 
@@ -45,14 +42,6 @@ import org.apache.gobblin.service.ExecutionStatus;
 public class FlowStatusGenerator {
   public static final List<String> FINISHED_STATUSES = Lists.newArrayList(ExecutionStatus.FAILED.name(),
       ExecutionStatus.COMPLETE.name(), ExecutionStatus.CANCELLED.name());
-  public static final Map<ExecutionStatus, String> FLOW_STATUS_TO_FLOW_EVENT_MAPPING = ImmutableMap.<ExecutionStatus, String>builder()
-      .put(ExecutionStatus.COMPILED, TimingEvent.FlowTimings.FLOW_COMPILED)
-      .put(ExecutionStatus.RUNNING, TimingEvent.FlowTimings.FLOW_RUNNING)
-      .put(ExecutionStatus.PENDING_RESUME, TimingEvent.FlowTimings.FLOW_PENDING_RESUME)
-      .put(ExecutionStatus.COMPLETE, TimingEvent.FlowTimings.FLOW_SUCCEEDED)
-      .put(ExecutionStatus.FAILED, TimingEvent.FlowTimings.FLOW_FAILED)
-      .put(ExecutionStatus.CANCELLED, TimingEvent.FlowTimings.FLOW_CANCELLED)
-      .build();
 
   public static final int MAX_LOOKBACK = 100;
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -20,18 +20,21 @@ package org.apache.gobblin.service.monitoring;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.service.ExecutionStatus;
 
 
@@ -42,6 +45,15 @@ import org.apache.gobblin.service.ExecutionStatus;
 public class FlowStatusGenerator {
   public static final List<String> FINISHED_STATUSES = Lists.newArrayList(ExecutionStatus.FAILED.name(),
       ExecutionStatus.COMPLETE.name(), ExecutionStatus.CANCELLED.name());
+  public static final Map<ExecutionStatus, String> FLOW_STATUS_TO_FLOW_EVENT_MAPPING = ImmutableMap.<ExecutionStatus, String>builder()
+      .put(ExecutionStatus.COMPILED, TimingEvent.FlowTimings.FLOW_COMPILED)
+      .put(ExecutionStatus.RUNNING, TimingEvent.FlowTimings.FLOW_RUNNING)
+      .put(ExecutionStatus.PENDING_RESUME, TimingEvent.FlowTimings.FLOW_PENDING_RESUME)
+      .put(ExecutionStatus.COMPLETE, TimingEvent.FlowTimings.FLOW_SUCCEEDED)
+      .put(ExecutionStatus.FAILED, TimingEvent.FlowTimings.FLOW_FAILED)
+      .put(ExecutionStatus.CANCELLED, TimingEvent.FlowTimings.FLOW_CANCELLED)
+      .build();
+
   public static final int MAX_LOOKBACK = 100;
 
   private final JobStatusRetriever jobStatusRetriever;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -359,24 +359,20 @@ public class DagProcUtils {
     return node.getParentNodes() == null || canRun.containsAll(node.getParentNodes());
   }
 
-  public static ExecutionStatus calcFlowStatus(Dag<JobExecutionPlan> dag) {
+  public static String calcFlowStatus(Dag<JobExecutionPlan> dag) {
     Set<ExecutionStatus> jobsStatuses = dag.getNodes().stream().map(node -> node.getValue().getExecutionStatus())
         .collect(Collectors.toSet());
 
     if (jobsStatuses.contains(FAILED)) {
-      return FAILED;
+      return TimingEvent.FlowTimings.FLOW_FAILED;
     } else if (jobsStatuses.contains(CANCELLED)) {
-      return CANCELLED;
+      return TimingEvent.FlowTimings.FLOW_CANCELLED;
     } else if (jobsStatuses.contains(PENDING_RESUME)) {
-      return PENDING_RESUME;
-    } else if (jobsStatuses.contains(PENDING_RETRY)) {
-      return PENDING_RETRY;
+      return TimingEvent.FlowTimings.FLOW_PENDING_RESUME;
     } else if (jobsStatuses.stream().allMatch(jobStatus -> jobStatus == COMPLETE)) {
-      return COMPLETE;
-    } else if (jobsStatuses.stream().allMatch(jobStatus -> jobStatus == PENDING)) {
-      return PENDING;
+      return TimingEvent.FlowTimings.FLOW_SUCCEEDED;
     } else {
-      return RUNNING;
+      return TimingEvent.FlowTimings.FLOW_RUNNING;
     }
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -115,11 +115,10 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
       dag.setFlowEvent(null);
       DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
     } else if (DagProcUtils.isDagFinished(dag)) {
-      ExecutionStatus flowExecutionStatus = DagProcUtils.calcFlowStatus(dag);
-      String flowEvent = FlowStatusGenerator.FLOW_STATUS_TO_FLOW_EVENT_MAPPING.get(flowExecutionStatus);
+      String flowEvent = DagProcUtils.calcFlowStatus(dag);
       dag.setFlowEvent(flowEvent);
-      DagProcUtils.setAndEmitFlowEvent(eventSubmitter, dag, flowExecutionStatus.name());
-      if (flowExecutionStatus == ExecutionStatus.COMPLETE) {
+      DagProcUtils.setAndEmitFlowEvent(eventSubmitter, dag, flowEvent);
+      if (flowEvent.equals(TimingEvent.FlowTimings.FLOW_SUCCEEDED)) {
         // todo - verify if work from PR#3641 is required
         dagManagementStateStore.deleteDag(getDagId());
       } else {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -74,7 +74,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedSingleNode() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedSingleNode() throws URISyntaxException {
     Dag<JobExecutionPlan> dag =
         DagManagerTest.buildDag(id, flowExecutionId, flowFailureOption, 1, proxyUser, additionalConfig);
 
@@ -112,7 +112,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedTwoNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedTwoNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag =
         DagManagerTest.buildDag(id, flowExecutionId, flowFailureOption, 2, proxyUser, additionalConfig);
 
@@ -134,7 +134,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedThreeNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedThreeNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag = buildComplexDag3();
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING));
@@ -151,7 +151,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedFourNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedFourNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag = buildLinearDagOf4Nodes();
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING, PENDING));
@@ -172,7 +172,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedMultiNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedMultiNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag = buildComplexDag1();
     setJobStatuses(dag, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
@@ -238,7 +238,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedWithFinishRunningFailureOptionTwoNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedWithFinishRunningFailureOptionTwoNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag =
         DagManagerTest.buildDag(id, flowExecutionId, flowFailureOption, 2, proxyUser, additionalConfig);
 
@@ -252,7 +252,7 @@ public class DagManagerUtilsTest {
   }
 
   @Test
-  public void testIsDagFinishedWithFinishRunningFailureOptionMultiNodes() throws URISyntaxException {
+  public void testFlowStatusAndIsDagFinishedWithFinishRunningFailureOptionMultiNodes() throws URISyntaxException {
     Dag<JobExecutionPlan> dag = buildComplexDagWithFinishRunningFailureOption();
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -33,6 +33,7 @@ import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.spec_executorInstance.MockedSpecExecutor;
@@ -79,35 +80,35 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Collections.singletonList(COMPLETE));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(COMPLETE, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_SUCCEEDED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(FAILED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(CANCELLED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(PENDING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING_RETRY));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(PENDING_RETRY, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING_RESUME));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(PENDING_RESUME, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_PENDING_RESUME, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(ORCHESTRATED));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(RUNNING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -117,19 +118,19 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -138,15 +139,15 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -155,19 +156,19 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(PENDING, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(PENDING, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -177,63 +178,63 @@ public class DagManagerUtilsTest {
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
     Collections.shuffle(dag.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(COMPLETE, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_SUCCEEDED, DagProcUtils.calcFlowStatus(dag));
 
     Dag<JobExecutionPlan> dag2 = buildComplexDag1();
     setJobStatuses(dag2, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
     Collections.shuffle(dag2.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag2));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag2));
 
     Dag<JobExecutionPlan> dag3 = buildComplexDag1();
     setJobStatuses(dag3, Arrays.asList(FAILED, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag3));
     Collections.shuffle(dag3.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag3));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag3));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag3));
 
     Dag<JobExecutionPlan> dag4 = buildComplexDag1();
     setJobStatuses(dag4, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag4));
     Collections.shuffle(dag4.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag4));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag4));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag4));
 
     Dag<JobExecutionPlan> dag5 = buildComplexDag1();
     setJobStatuses(dag5, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag5));
     Collections.shuffle(dag5.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag5));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag5));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag5));
 
     Dag<JobExecutionPlan> dag6 = buildComplexDag1();
     setJobStatuses(dag6, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RESUME, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag6));
     Collections.shuffle(dag6.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag6));
-    Assert.assertEquals(PENDING_RESUME, DagProcUtils.calcFlowStatus(dag6));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_PENDING_RESUME, DagProcUtils.calcFlowStatus(dag6));
 
     Dag<JobExecutionPlan> dag7 = buildComplexDag1();
     setJobStatuses(dag7, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RETRY, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag7));
     Collections.shuffle(dag7.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag7));
-    Assert.assertEquals(PENDING_RETRY, DagProcUtils.calcFlowStatus(dag7));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag7));
 
     Dag<JobExecutionPlan> dag8 = buildComplexDag1();
     setJobStatuses(dag8, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, RUNNING, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag8));
     Collections.shuffle(dag8.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag8));
-    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag8));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_RUNNING, DagProcUtils.calcFlowStatus(dag8));
 
     Dag<JobExecutionPlan> dag9 = buildComplexDag1();
     setJobStatuses(dag9, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, FAILED, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING, COMPLETE));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag9));
     Collections.shuffle(dag9.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag9));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag9));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag9));
   }
 
   @Test
@@ -243,11 +244,11 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -256,11 +257,11 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, RUNNING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
-    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
+    Assert.assertEquals(TimingEvent.FlowTimings.FLOW_CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   private void setJobStatuses(Dag<JobExecutionPlan> dag, List<ExecutionStatus> statuses) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -182,7 +182,7 @@ public class DagManagerUtilsTest {
     Dag<JobExecutionPlan> dag2 = buildComplexDag1();
     setJobStatuses(dag2, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
-//    Collections.shuffle(dag2.getNodes());
+    Collections.shuffle(dag2.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
     Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag2));
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtilsTest.java
@@ -79,27 +79,35 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Collections.singletonList(COMPLETE));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(COMPLETE, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(FAILED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(CANCELLED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(PENDING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING_RETRY));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(PENDING_RETRY, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(PENDING_RESUME));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(PENDING_RESUME, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(ORCHESTRATED));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Collections.singletonList(RUNNING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -109,15 +117,19 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -126,12 +138,15 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -140,15 +155,19 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(PENDING, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(PENDING, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -158,54 +177,63 @@ public class DagManagerUtilsTest {
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
     Collections.shuffle(dag.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(COMPLETE, DagProcUtils.calcFlowStatus(dag));
 
     Dag<JobExecutionPlan> dag2 = buildComplexDag1();
     setJobStatuses(dag2, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
-    Collections.shuffle(dag2.getNodes());
+//    Collections.shuffle(dag2.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag2));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag2));
 
     Dag<JobExecutionPlan> dag3 = buildComplexDag1();
     setJobStatuses(dag3, Arrays.asList(FAILED, COMPLETE, COMPLETE, COMPLETE, PENDING, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag3));
     Collections.shuffle(dag3.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag3));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag3));
 
     Dag<JobExecutionPlan> dag4 = buildComplexDag1();
     setJobStatuses(dag4, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag4));
     Collections.shuffle(dag4.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag4));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag4));
 
     Dag<JobExecutionPlan> dag5 = buildComplexDag1();
     setJobStatuses(dag5, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, CANCELLED, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag5));
     Collections.shuffle(dag5.getNodes());
     Assert.assertTrue(DagProcUtils.isDagFinished(dag5));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag5));
 
     Dag<JobExecutionPlan> dag6 = buildComplexDag1();
     setJobStatuses(dag6, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RESUME, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag6));
     Collections.shuffle(dag6.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag6));
+    Assert.assertEquals(PENDING_RESUME, DagProcUtils.calcFlowStatus(dag6));
 
     Dag<JobExecutionPlan> dag7 = buildComplexDag1();
     setJobStatuses(dag7, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, PENDING_RETRY, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag7));
     Collections.shuffle(dag7.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag7));
+    Assert.assertEquals(PENDING_RETRY, DagProcUtils.calcFlowStatus(dag7));
 
     Dag<JobExecutionPlan> dag8 = buildComplexDag1();
     setJobStatuses(dag8, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, COMPLETE, COMPLETE, RUNNING, COMPLETE, COMPLETE, PENDING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag8));
     Collections.shuffle(dag8.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag8));
+    Assert.assertEquals(RUNNING, DagProcUtils.calcFlowStatus(dag8));
 
     Dag<JobExecutionPlan> dag9 = buildComplexDag1();
     setJobStatuses(dag9, Arrays.asList(COMPLETE, COMPLETE, COMPLETE, FAILED, COMPLETE, COMPLETE, PENDING, COMPLETE, PENDING, COMPLETE));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag9));
     Collections.shuffle(dag9.getNodes());
     Assert.assertFalse(DagProcUtils.isDagFinished(dag9));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag9));
   }
 
   @Test
@@ -215,9 +243,11 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(FAILED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(FAILED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(CANCELLED, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   @Test
@@ -226,9 +256,11 @@ public class DagManagerUtilsTest {
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, PENDING, PENDING));
     Assert.assertTrue(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
 
     setJobStatuses(dag, Arrays.asList(COMPLETE, CANCELLED, COMPLETE, RUNNING, PENDING));
     Assert.assertFalse(DagProcUtils.isDagFinished(dag));
+    Assert.assertEquals(CANCELLED, DagProcUtils.calcFlowStatus(dag));
   }
 
   private void setJobStatuses(Dag<JobExecutionPlan> dag, List<ExecutionStatus> statuses) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2150


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If a dag has multiple jobs; and a job failed, the Dag's status should be FAILED. Imagine, another job that was running in parallel passed. This passing job should not emit a FLOW_SUCCEEDED event. Right now, we decide it based on Dag's `flowEvent` field which is not persisted in state store and is also set by the **last finished job** and is also deprecated. In this PR, I am calculating the flow status based on **all the job statuses** of the dag. Individual job statuses are persisted.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

