### PR TITLE
[GOBBLIN-2151] ignore flows that are running beyond job start and flow finish deadli…

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigsV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigsV2Test.java
@@ -132,8 +132,7 @@ public class FlowConfigsV2Test {
       binder.bind(GroupOwnershipService.class).toInstance(groupOwnershipService);
     });
 
-    _server = EmbeddedRestliServer.builder().resources(
-        Lists.newArrayList(FlowConfigsV2Resource.class)).injector(injector).build();
+    _server = EmbeddedRestliServer.builder().resources(Lists.newArrayList(FlowConfigsV2Resource.class)).injector(injector).build();
 
     _server.startAsync();
     _server.awaitRunning();

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/service/monitoring/FlowStatusGeneratorTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/service/monitoring/FlowStatusGeneratorTest.java
@@ -58,7 +58,7 @@ public class FlowStatusGeneratorTest {
     JobStatus jobStatus = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
         .jobName(JobStatusRetriever.NA_KEY).jobGroup(JobStatusRetriever.NA_KEY).eventName(ExecutionStatus.COMPILED.name()).build();
     Iterator<JobStatus> jobStatusIterator = Lists.newArrayList(jobStatus).iterator();
-    FlowStatus flowStatus = new FlowStatus(flowName,flowGroup,flowExecutionId,jobStatusIterator,ExecutionStatus.COMPILED);
+    FlowStatus flowStatus = new FlowStatus(flowName, flowGroup, flowExecutionId, jobStatusIterator, ExecutionStatus.COMPILED);
     when(jobStatusRetriever.getAllFlowStatusesForFlowExecutionsOrdered(flowGroup, flowName)).thenReturn(
         Lists.newArrayList(flowStatus));
     FlowStatusGenerator flowStatusGenerator = new FlowStatusGenerator(jobStatusRetriever);
@@ -77,7 +77,7 @@ public class FlowStatusGeneratorTest {
     JobStatus jobStatus = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
         .jobName(JobStatusRetriever.NA_KEY).jobGroup(JobStatusRetriever.NA_KEY).eventName(ExecutionStatus.COMPILED.name()).build();
     Iterator<JobStatus> jobStatusIterator = Lists.newArrayList(jobStatus).iterator();
-    FlowStatus flowStatus = new FlowStatus(flowName,flowGroup,flowExecutionId,jobStatusIterator,ExecutionStatus.COMPILED);
+    FlowStatus flowStatus = new FlowStatus(flowName, flowGroup, flowExecutionId, jobStatusIterator, ExecutionStatus.COMPILED);
     when(jobStatusRetriever.getAllFlowStatusesForFlowExecutionsOrdered(flowGroup, flowName)).thenReturn(
         Lists.newArrayList(flowStatus));
     FlowStatusGenerator flowStatusGenerator = new FlowStatusGenerator(jobStatusRetriever);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementStateStore.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -141,6 +142,11 @@ public interface DagManagementStateStore {
    * @return {@link JobStatus} or {@link Optional#empty} if not present in the Job-Status Store
    */
   Optional<JobStatus> getJobStatus(DagNodeId dagNodeId);
+
+  /**
+   * @return list of {@link org.apache.gobblin.service.monitoring.FlowStatus} for the provided flow group and flow name.
+   */
+  List<org.apache.gobblin.service.monitoring.FlowStatus> getAllFlowStatusesForFlow(String flowGroup, String flowName);
 
   /**
    * Check if an action exists in dagAction store by flow group, flow name, flow execution id, and job name.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -43,6 +44,7 @@ import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.DagNodeId;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.monitoring.FlowStatus;
 import org.apache.gobblin.service.monitoring.JobStatus;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.util.ConfigUtils;
@@ -209,6 +211,11 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
     } else {
       return java.util.Optional.empty();
     }
+  }
+
+  @Override
+  public List<FlowStatus> getAllFlowStatusesForFlow(String flowGroup, String flowName) {
+    return this.jobStatusRetriever.getAllFlowStatusesForFlowExecutionsOrdered(flowGroup, flowName);
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -204,6 +204,7 @@ public class FlowCompilationValidationHelper {
    * Returns true if any previous execution for the flow determined by the provided flowGroup, flowName is running.
    * We ignore the execution that has the provided flowExecutionId. We also ignore the flows that are running beyond
    * the job start deadline and flow finish deadline.
+   * If this method returns `false`, callers may start a flow and subsequent calls to this method may return `true`.
    */
   @VisibleForTesting
   static boolean isFlowRunning(String flowGroup, String flowName, DagManagementStateStore dagManagementStateStore)

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -19,10 +19,12 @@ package org.apache.gobblin.service.modules.utils;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -38,15 +40,21 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.service.ExecutionStatus;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flow.SpecCompiler;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
+import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
+import org.apache.gobblin.service.modules.orchestration.DagUtils;
 import org.apache.gobblin.service.modules.orchestration.TimingEventUtils;
 import org.apache.gobblin.service.modules.orchestration.UserQuotaManager;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
-import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
+import org.apache.gobblin.service.monitoring.FlowStatus;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
+
+import static org.apache.gobblin.service.ExecutionStatus.*;
 
 
 /**
@@ -69,12 +77,12 @@ public class FlowCompilationValidationHelper {
   private final SpecCompiler specCompiler;
   private final UserQuotaManager quotaManager;
   private final EventSubmitter eventSubmitter;
-  private final FlowStatusGenerator flowStatusGenerator;
+  private final DagManagementStateStore dagManagementStateStore;
   private final boolean isFlowConcurrencyEnabled;
 
   @Inject
   public FlowCompilationValidationHelper(Config config, SharedFlowMetricsSingleton sharedFlowMetricsSingleton,
-      UserQuotaManager userQuotaManager, FlowStatusGenerator flowStatusGenerator) {
+      UserQuotaManager userQuotaManager, DagManagementStateStore dagManagementStateStore) {
     try {
       String specCompilerClassName = ConfigUtils.getString(config, ServiceConfigKeys.GOBBLIN_SERVICE_FLOWCOMPILER_CLASS_KEY,
           ServiceConfigKeys.DEFAULT_GOBBLIN_SERVICE_FLOWCOMPILER_CLASS);
@@ -88,7 +96,7 @@ public class FlowCompilationValidationHelper {
     this.quotaManager = userQuotaManager;
     MetricContext metricContext = Instrumented.getMetricContext(ConfigUtils.configToState(config), this.specCompiler.getClass());
     this.eventSubmitter = new EventSubmitter.Builder(metricContext, "org.apache.gobblin.service").build();
-    this.flowStatusGenerator = flowStatusGenerator;
+    this.dagManagementStateStore = dagManagementStateStore;
     this.isFlowConcurrencyEnabled = ConfigUtils.getBoolean(config, ServiceConfigKeys.FLOW_CONCURRENCY_ALLOWED,
         ServiceConfigKeys.DEFAULT_FLOW_CONCURRENCY_ALLOWED);
   }
@@ -156,9 +164,8 @@ public class FlowCompilationValidationHelper {
     }
     addFlowExecutionIdIfAbsent(flowMetadata, jobExecutionPlanDag);
 
-    if (isExecutionPermitted(flowStatusGenerator, flowGroup, flowName, allowConcurrentExecution,
-        Long.parseLong(flowMetadata.get(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD)))) {
-      return Optional.fromNullable(jobExecutionPlanDag);
+    if (isExecutionPermitted(flowGroup, flowName, allowConcurrentExecution)) {
+      return Optional.of(jobExecutionPlanDag);
     } else {
       log.warn("Another instance of flowGroup: {}, flowName: {} running; Skipping flow execution since "
           + "concurrent executions are disabled for this flow.", flowGroup, flowName);
@@ -167,7 +174,7 @@ public class FlowCompilationValidationHelper {
       Instrumented.markMeter(sharedFlowMetricsSingleton.getSkippedFlowsMeter());
       if (!flowSpec.isScheduled()) {
         // For ad-hoc flow, we might already increase quota, we need to decrease here
-        for (Dag.DagNode dagNode : jobExecutionPlanDag.getStartNodes()) {
+        for (Dag.DagNode<JobExecutionPlan> dagNode : jobExecutionPlanDag.getStartNodes()) {
           quotaManager.releaseQuota(dagNode);
         }
       }
@@ -187,9 +194,59 @@ public class FlowCompilationValidationHelper {
    * @param allowConcurrentExecution
    * @return true if the {@link FlowSpec} allows concurrent executions or if no other instance of the flow is currently RUNNING.
    */
-  private boolean isExecutionPermitted(FlowStatusGenerator flowStatusGenerator, String flowGroup, String flowName,
-      boolean allowConcurrentExecution, long flowExecutionId) {
-    return allowConcurrentExecution || !flowStatusGenerator.isFlowRunning(flowName, flowGroup, flowExecutionId);
+  private boolean isExecutionPermitted(String flowGroup, String flowName, boolean allowConcurrentExecution)
+      throws IOException {
+    return allowConcurrentExecution || !isFlowRunning(flowGroup, flowName, dagManagementStateStore);
+  }
+
+  /**
+   * Returns true if any previous execution for the flow determined by the provided flowGroup, flowName is running.
+   * We ignore the execution that has the provided flowExecutionId. We also ignore the flows that are running beyond
+   * the job start deadline and flow finish deadline.
+   */
+  @VisibleForTesting
+  static boolean isFlowRunning(String flowGroup, String flowName, DagManagementStateStore dagManagementStateStore)
+      throws IOException {
+    List<FlowStatus> flowStatusList = dagManagementStateStore.getAllFlowStatusesForFlow(flowGroup, flowName);
+
+    if (flowStatusList == null || flowStatusList.isEmpty()) {
+      return false;
+    }
+
+    for (FlowStatus flowStatus : flowStatusList) {
+      ExecutionStatus flowExecutionStatus = flowStatus.getFlowExecutionStatus();
+      log.info("Verifying if {} is running...", flowStatus);
+
+      if (flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING
+          || flowExecutionStatus == PENDING_RESUME || flowExecutionStatus == RUNNING) {
+        Dag.DagId dagIdOfOldExecution = new Dag.DagId(flowGroup, flowName, flowStatus.getFlowExecutionId());
+        java.util.Optional<Dag<JobExecutionPlan>> dag = dagManagementStateStore.getDag(dagIdOfOldExecution);
+
+        if (!dag.isPresent()) {
+          // dag is finished and cleaned up, job status monitor somehow did not receive/update the flow status; just ignore it...
+          continue;
+        }
+
+        Dag.DagNode<JobExecutionPlan> dagNode = dag.get().getNodes().get(0);
+        long flowStartTime = DagUtils.getFlowStartTime(dagNode);
+        long jobStartDeadline =
+            DagUtils.getJobStartDeadline(dagNode, DagProcessingEngine.getDefaultJobStartDeadlineTimeMillis());
+        long flowFinishDeadline = DagUtils.getFlowFinishDeadline(dagNode);
+        if (((flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING)
+                && (System.currentTimeMillis() < flowStartTime + jobStartDeadline)) ||
+            ((flowExecutionStatus == RUNNING || flowExecutionStatus == ORCHESTRATED || flowExecutionStatus == PENDING_RESUME)
+                && System.currentTimeMillis() < flowStartTime + flowFinishDeadline)) {
+          log.info("{} is still running. Found a dag for this, flowStartTime {}, jobStartDeadline {}, flowFinishDeadline {}",
+              flowStatus, flowStartTime, jobStartDeadline, flowFinishDeadline);
+          return true;
+        } else {
+          log.warn("Dag {} is still running beyond deadline! flowStartTime {}, jobStartDeadline {}, flowFinishDeadline {}",
+              dag, flowStartTime, jobStartDeadline, flowFinishDeadline);
+        }
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -228,7 +228,7 @@ public class FlowCompilationValidationHelper {
           log.info("A previous execution with the same flowExecutionId found {}. Previous execution may not be "
               + "successfully submitted.", flowStatus);
         } else if (flowExecutionStatus == RUNNING) {
-          log.error("A previous execution with the same flowExecutionId found {}. This is a rare case of previous "
+          log.warn("A previous execution with the same flowExecutionId found {}. This is a rare case of previous "
               + "execution getting submitted but then LaunchDagProc failed to complete the lease", flowStatus);
         }
         continue;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -218,8 +218,9 @@ public class FlowCompilationValidationHelper {
       ExecutionStatus flowExecutionStatus = flowStatus.getFlowExecutionStatus();
       log.debug("Verifying if {} is running...", flowStatus);
 
-      if (FlowStatusGenerator.FINISHED_STATUSES.contains(flowExecutionStatus.name())) {
+      if (FlowStatusGenerator.FINISHED_STATUSES.contains(flowExecutionStatus.name()) || flowExecutionStatus == $UNKNOWN) {
         // ignore finished entries
+        // todo - make changes so `getAllFlowStatusesForFlow` never returns $UNKNOWN flow status
       } else if (flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING
           || flowExecutionStatus == PENDING_RESUME || flowExecutionStatus == RUNNING) {
         // these are the only four non-terminal statuses that a flow can have. jobs have two more non-terminal statuses

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -228,8 +228,10 @@ public class FlowCompilationValidationHelper {
           log.info("A previous execution with the same flowExecutionId found {}. Previous execution may not be "
               + "successfully submitted.", flowStatus);
         } else if (flowExecutionStatus == RUNNING) {
-          log.warn("A previous execution with the same flowExecutionId found {}. This is a rare case of previous "
+          log.error("A previous execution with the same flowExecutionId found {}. This is a rare case of previous "
               + "execution getting submitted but then LaunchDagProc failed to complete the lease", flowStatus);
+        } else {
+          log.warn("A previous execution with the same flowExecutionId and an unexpected status is found {}.", flowStatus);
         }
         continue;
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelper.java
@@ -217,6 +217,8 @@ public class FlowCompilationValidationHelper {
       ExecutionStatus flowExecutionStatus = flowStatus.getFlowExecutionStatus();
       log.info("Verifying if {} is running...", flowStatus);
 
+      // these are the only four non-terminal statuses that a flow can have. jobs have two more non-terminal statuses
+      // ORCHESTRATED and PENDING_RETRY
       if (flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING
           || flowExecutionStatus == PENDING_RESUME || flowExecutionStatus == RUNNING) {
         Dag.DagId dagIdOfOldExecution = new Dag.DagId(flowGroup, flowName, flowStatus.getFlowExecutionId());
@@ -232,10 +234,10 @@ public class FlowCompilationValidationHelper {
         long jobStartDeadline =
             DagUtils.getJobStartDeadline(dagNode, DagProcessingEngine.getDefaultJobStartDeadlineTimeMillis());
         long flowFinishDeadline = DagUtils.getFlowFinishDeadline(dagNode);
-        if (((flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING)
-                && (System.currentTimeMillis() < flowStartTime + jobStartDeadline)) ||
-            ((flowExecutionStatus == RUNNING || flowExecutionStatus == ORCHESTRATED || flowExecutionStatus == PENDING_RESUME)
-                && System.currentTimeMillis() < flowStartTime + flowFinishDeadline)) {
+        if ((flowExecutionStatus == COMPILED || flowExecutionStatus == PENDING)
+              && System.currentTimeMillis() < flowStartTime + jobStartDeadline
+            || (flowExecutionStatus == RUNNING || flowExecutionStatus == PENDING_RESUME)
+              && System.currentTimeMillis() < flowStartTime + flowFinishDeadline) {
           log.info("{} is still running. Found a dag for this, flowStartTime {}, jobStartDeadline {}, flowFinishDeadline {}",
               flowStatus, flowStartTime, jobStartDeadline, flowFinishDeadline);
           return true;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetriever.java
@@ -98,7 +98,7 @@ public class MysqlJobStatusRetriever extends JobStatusRetriever {
   @Override
   public List<FlowStatus> getAllFlowStatusesForFlowExecutionsOrdered(String flowGroup, String flowName) {
     String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-    List<State> jobStatusStates = timeOpAndWrapIOException(() -> this.stateStore.getAllWithPrefix(storeName),
+    List<State> jobStatusStates = timeOpAndWrapIOException(() -> this.stateStore.getAll(storeName),
         GET_LATEST_FLOW_GROUP_STATUS_METRIC);
     return asFlowStatuses(groupByFlowExecutionAndRetainLatest(flowGroup, jobStatusStates,null));
   }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -124,7 +124,7 @@ public class OrchestratorTest {
     SharedFlowMetricsSingleton sharedFlowMetricsSingleton = new SharedFlowMetricsSingleton(ConfigUtils.propertiesToConfig(orchestratorProperties));
 
     FlowCompilationValidationHelper flowCompilationValidationHelper = new FlowCompilationValidationHelper(ConfigFactory.empty(),
-        sharedFlowMetricsSingleton, mock(UserQuotaManager.class), mock(FlowStatusGenerator.class));
+        sharedFlowMetricsSingleton, mock(UserQuotaManager.class), dagManagementStateStore);
     this.dagMgrNotFlowLaunchHandlerBasedOrchestrator = new Orchestrator(ConfigUtils.propertiesToConfig(orchestratorProperties),
         this.topologyCatalog, Optional.of(logger), mock(FlowLaunchHandler.class), sharedFlowMetricsSingleton, dagManagementStateStore,
         flowCompilationValidationHelper, mock(JobStatusRetriever.class));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/OrchestratorTest.java
@@ -59,7 +59,6 @@ import org.apache.gobblin.service.GobblinServiceManagerTest;
 import org.apache.gobblin.service.modules.flow.IdentityFlowToJobSpecCompiler;
 import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 import org.apache.gobblin.service.modules.utils.SharedFlowMetricsSingleton;
-import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelperTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/utils/FlowCompilationValidationHelperTest.java
@@ -114,7 +114,7 @@ public class FlowCompilationValidationHelperTest {
     list.add(new FlowStatus(flowName, flowGroup, previousFlowExecutionId, jobStatusIterator, ExecutionStatus.COMPILED));
     when(this.dagManagementStateStore.getAllFlowStatusesForFlow(anyString(), anyString())).thenReturn(list);
 
-    Assert.assertFalse(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertFalse(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         previousFlowExecutionId, this.dagManagementStateStore));
   }
 
@@ -133,7 +133,7 @@ public class FlowCompilationValidationHelperTest {
         .withValue(ConfigurationKeys.GOBBLIN_JOB_START_DEADLINE_TIME_UNIT, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.name()))
         .withValue(ConfigurationKeys.GOBBLIN_JOB_START_DEADLINE_TIME, ConfigValueFactory.fromAnyRef(jobStartDeadline)));
 
-    Assert.assertFalse(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertFalse(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         currentFlowExecutionId, this.dagManagementStateStore));
   }
 
@@ -151,7 +151,7 @@ public class FlowCompilationValidationHelperTest {
             .withValue(ConfigurationKeys.GOBBLIN_FLOW_FINISH_DEADLINE_TIME_UNIT, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.name()))
             .withValue(ConfigurationKeys.GOBBLIN_FLOW_FINISH_DEADLINE_TIME, ConfigValueFactory.fromAnyRef(flowFinishDeadline)));
 
-    Assert.assertFalse(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertFalse(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         currentFlowExecutionId, this.dagManagementStateStore));
   }
 
@@ -169,7 +169,7 @@ public class FlowCompilationValidationHelperTest {
             .withValue(ConfigurationKeys.GOBBLIN_FLOW_FINISH_DEADLINE_TIME_UNIT, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.name()))
             .withValue(ConfigurationKeys.GOBBLIN_FLOW_FINISH_DEADLINE_TIME, ConfigValueFactory.fromAnyRef(flowFinishDeadline)));
 
-    Assert.assertTrue(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertTrue(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         currentFlowExecutionId, this.dagManagementStateStore));
   }
 
@@ -186,24 +186,24 @@ public class FlowCompilationValidationHelperTest {
     // change the mock to not return any previous flow status
     when(this.dagManagementStateStore.getAllFlowStatusesForFlow(anyString(), anyString())).thenReturn(Collections.emptyList());
 
-    Assert.assertFalse(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertFalse(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         flowStartTime, this.dagManagementStateStore));
   }
 
   @Test
-  public void testConcurrentFlowCurrentExecutionWithNonTerminalStatusRunningWithinJobStartDeadline() throws IOException, URISyntaxException {
+  public void testSameFlowExecAlreadyCompiledWithinJobStartDeadline() throws IOException, URISyntaxException {
     String flowGroup = "fg";
     String flowName = "fn";
     long jobStartDeadline = 10000L;
     long flowStartTime = System.currentTimeMillis();
 
-    insertFlowIntoDMSSMock(flowGroup, flowName, flowStartTime, ExecutionStatus.PENDING,
+    insertFlowIntoDMSSMock(flowGroup, flowName, flowStartTime, ExecutionStatus.COMPILED,
         ConfigFactory.empty()
             .withValue(ConfigurationKeys.GOBBLIN_JOB_START_DEADLINE_TIME_UNIT, ConfigValueFactory.fromAnyRef(TimeUnit.MILLISECONDS.name()))
             .withValue(ConfigurationKeys.GOBBLIN_JOB_START_DEADLINE_TIME, ConfigValueFactory.fromAnyRef(jobStartDeadline)));
 
     // flowStartTime = currentFlowExecutionId
-    Assert.assertFalse(FlowCompilationValidationHelper.isFlowBeforeThisExecutionRunning(flowGroup, flowName,
+    Assert.assertFalse(FlowCompilationValidationHelper.isPriorFlowExecutionRunning(flowGroup, flowName,
         flowStartTime, this.dagManagementStateStore));
   }
 


### PR DESCRIPTION
…nes when doing the concurrency check

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2151


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
We are trying to ignore flows that are running beyond job start and flow finish deadlines.
We first get all the flow statuses from job status store; then for each of them get the dag from DMSS. if dag is not present, that means the flow is not running.
if dag is found in DMSS, we check the running time and get the job.start and flow.finish deadlines from the dag and use them to ignore flows that are running beyond job start and flow finish deadlines.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated FlowCompilationValidationHelperTest

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

