### PR TITLE
[GOBBLIN-2154] bring back the old toString method for DagId

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -317,6 +318,11 @@ public class Dag<T> {
     private final String flowGroup;
     private final String flowName;
     private final long flowExecutionId;
+
+    @Override
+    public String toString() {
+      return Joiner.on("_").join(flowGroup, flowName, flowExecutionId);
+    }
 
     public FlowId getFlowId() {
       return new FlowId().setFlowGroup(this.flowGroup).setFlowName(this.flowName);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2154


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In https://github.com/apache/gobblin/commit/45ad13e07ebe212002b279132e1fa4d121a9294f while moving DagId from DagManager to Dag class, we changed toString method to lombok's generated method. This has in impact, and in DMSS, where it stores this id, it cannot find the old entries.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
verified the change through existing test cases

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

