### PR TITLE
[GOBBLIN-2157] Copy table properties in iceberg distcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,6 +40,7 @@ import org.apache.iceberg.io.FileIO;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import lombok.AllArgsConstructor;
@@ -213,7 +215,10 @@ public class IcebergTable {
   protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {
     if (dstMetadata != null) {
       // use current destination metadata as 'base metadata' and source as 'updated metadata' while committing
-      this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(dstMetadata.properties()));
+      Map<String, String> combinedMetadataProperties = Maps.newHashMap();
+      combinedMetadataProperties.putAll(dstMetadata.properties());
+      combinedMetadataProperties.putAll(srcMetadata.properties());
+      this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(combinedMetadataProperties));
     }
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -217,6 +217,8 @@ public class IcebergTable {
       // use current destination metadata as 'base metadata' and source as 'updated metadata' while committing
       Map<String, String> combinedMetadataProperties = Maps.newHashMap();
       combinedMetadataProperties.putAll(dstMetadata.properties());
+      // Presume that the source metadata properties are more up-to-date than the destination metadata properties
+      // but maintain any dest properties that are not in the src table
       combinedMetadataProperties.putAll(srcMetadata.properties());
       this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(combinedMetadataProperties));
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,7 +39,6 @@ import org.apache.iceberg.io.FileIO;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import lombok.AllArgsConstructor;
@@ -214,13 +212,9 @@ public class IcebergTable {
    * @param dstMetadata is null if destination {@link IcebergTable} is absent, in which case registration is skipped */
   protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {
     if (dstMetadata != null) {
-      // use current destination metadata as 'base metadata' and source as 'updated metadata' while committing
-      Map<String, String> combinedMetadataProperties = Maps.newHashMap();
-      combinedMetadataProperties.putAll(dstMetadata.properties());
-      // Presume that the source metadata properties are more up-to-date than the destination metadata properties
-      // but maintain any dest properties that are not in the src table
-      combinedMetadataProperties.putAll(srcMetadata.properties());
-      this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(combinedMetadataProperties));
+      // Use current destination metadata as 'base metadata' and but update to source metadata when committing
+      // If any of the source table properties are deleted, they will be reflected in the destination table
+      this.tableOps.commit(dstMetadata, srcMetadata);
     }
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -212,8 +212,8 @@ public class IcebergTable {
    * @param dstMetadata is null if destination {@link IcebergTable} is absent, in which case registration is skipped */
   protected void registerIcebergTable(TableMetadata srcMetadata, TableMetadata dstMetadata) {
     if (dstMetadata != null) {
-      // Use current destination metadata as 'base metadata' and but update to source metadata when committing
-      // If any of the source table properties are deleted, they will be reflected in the destination table
+      // Use current destination metadata as 'base metadata', but commit the source-side metadata
+      // to synchronize source-side property deletion over to the destination
       this.tableOps.commit(dstMetadata, srcMetadata);
     }
   }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
@@ -249,11 +249,6 @@ public class IcebergTableTest extends HiveMetastoreTest {
     System.err.println("calculated metadata base path: '" + basePath + "'");
     return basePath;
   }
-  protected String calcMetadataBasePathNew(String theDbName, String theTableName) {
-    String basePath = String.format("%s/%s/new/metadata", metastore.getDatabasePath(theDbName), theTableName);
-    System.err.println("calculated metadata base path: '" + basePath + "'");
-    return basePath;
-  }
 
   /** Add one snapshot per sub-list of `perSnapshotFilesets`, in order, with the sub-list contents as the data files */
   protected static void initializeSnapshots(Table table, List<List<String>> perSnapshotFilesets) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
@@ -195,7 +195,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     srcTableProperties.put("testKey", "testValueNew");
     destTableProperties.put("testKey", "testValueOld");
     // Expect existing property values to be maintained if it does not exist on the source
-    destTableProperties.put("existingTableProperty", "existingTablePropertyValue");
+    destTableProperties.put("deletedTableProperty", "deletedTablePropertyValue");
 
     TableIdentifier destTableId = TableIdentifier.of(dbName, "destTable");
     catalog.createTable(destTableId, icebergSchema, null, destTableProperties);
@@ -205,10 +205,10 @@ public class IcebergTableTest extends HiveMetastoreTest {
     TableMetadata newSourceTableProperties = destIcebergTable.accessTableMetadata().replaceProperties(srcTableProperties);
 
     destIcebergTable.registerIcebergTable(newSourceTableProperties, destIcebergTable.accessTableMetadata());
-    Assert.assertEquals(destIcebergTable.accessTableMetadata().properties().size(), 3);
+    Assert.assertEquals(destIcebergTable.accessTableMetadata().properties().size(), 2);
     Assert.assertEquals(destIcebergTable.accessTableMetadata().properties().get("newKey"), "newValue");
     Assert.assertEquals(destIcebergTable.accessTableMetadata().properties().get("testKey"), "testValueNew");
-    Assert.assertEquals(destIcebergTable.accessTableMetadata().properties().get("existingTableProperty"), "existingTablePropertyValue");
+    Assert.assertNull(destIcebergTable.accessTableMetadata().properties().get("deletedTableProperty"));
   }
 
   /** full validation for a particular {@link IcebergSnapshotInfo} */

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTableTest.java
@@ -194,7 +194,7 @@ public class IcebergTableTest extends HiveMetastoreTest {
     // Expect the old value to be overwritten by the new value
     srcTableProperties.put("testKey", "testValueNew");
     destTableProperties.put("testKey", "testValueOld");
-    // Expect existing property values to be maintained if it does not exist on the source
+    // Expect existing property values to be deleted if it does not exist on the source
     destTableProperties.put("deletedTableProperty", "deletedTablePropertyValue");
 
     TableIdentifier destTableId = TableIdentifier.of(dbName, "destTable");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2157


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
The existing iceberg registration step has the following snippet:
```
    if (dstMetadata != null) {
      // use current destination metadata as 'base metadata' and source as 'updated metadata' while committing
      this.tableOps.commit(dstMetadata, srcMetadata.replaceProperties(dstMetadata.properties())); <<<<<------- BUG
    }
```
Since Iceberg's `replaceProperties` https://github.com/apache/iceberg/blob/e449d3405cfdb304c94835845bd8f34a73b4a517/core/src/main/java/org/apache/iceberg/TableMetadata.java#L583 just replaces the full set of properties, not just any existing properties, the result is that all of the properties are equivalent to the destination table metadata properties. Which effectively copies no properties.

This PR modifies this behavior so that the destination table properties can be overwritten by the source table properties if the source table updates existing properties, as well as maintaining any existing properties in the destination that is not defined on the source.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

