### PR TITLE
[GOBBLIN-2162] Only load added jars in the cache

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -559,7 +559,6 @@ class YarnService extends AbstractIdleService {
   }
 
 
-
   protected ByteBuffer getSecurityTokens() throws IOException {
     Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
     Closer closer = Closer.create();

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -547,13 +546,11 @@ class YarnService extends AbstractIdleService {
 
     FileStatus[] statuses = this.fs.listStatus(destDir);
     if (statuses != null) {
-      Set<String> libJarNames = new HashSet<>(Arrays.asList(this.config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST).split(",")));
-      String containerJars = this.config.hasPath(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY) ?
-          this.config.getString(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY) : "";
+      Set<String> appLibJars = YarnHelixUtils.getAppLibJarList(this.config);
       for (FileStatus status : statuses) {
         String fileName = status.getPath().getName();
         // Ensure that we are only adding jars that were uploaded by the YarnAppLauncher for this application
-        if (fileName.contains(".jar") && !(libJarNames.contains(fileName) || containerJars.contains(fileName))) {
+        if (fileName.contains(".jar") && !appLibJars.contains(fileName)) {
           continue;
         }
         YarnHelixUtils.addFileAsLocalResource(this.fs, status.getPath(), LocalResourceType.FILE, resourceMap);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -546,11 +547,20 @@ class YarnService extends AbstractIdleService {
 
     FileStatus[] statuses = this.fs.listStatus(destDir);
     if (statuses != null) {
+      Set<String> libJarNames = new HashSet<>(Arrays.asList(this.config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST).split(",")));
+      String containerJars = this.config.hasPath(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY) ?
+          this.config.getString(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY) : "";
       for (FileStatus status : statuses) {
+        String fileName = status.getPath().getName();
+        // Ensure that we are only adding jars that were uploaded by the YarnAppLauncher for this application
+        if (fileName.contains(".jar") && !(libJarNames.contains(fileName) || containerJars.contains(fileName))) {
+          continue;
+        }
         YarnHelixUtils.addFileAsLocalResource(this.fs, status.getPath(), LocalResourceType.FILE, resourceMap);
       }
     }
   }
+
 
 
   protected ByteBuffer getSecurityTokens() throws IOException {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -310,6 +310,7 @@ public class GobblinYarnAppLauncher {
             GobblinYarnConfigurationKeys.DEFAULT_GOBBLIN_YARN_DETACH_ON_EXIT);
     this.appLauncherMode = ConfigUtils.getString(this.config, GOBBLIN_YARN_APP_LAUNCHER_MODE, DEFAULT_GOBBLIN_YARN_APP_LAUNCHER_MODE);
     this.jarCacheEnabled = ConfigUtils.getBoolean(this.config, GobblinYarnConfigurationKeys.JAR_CACHE_ENABLED, GobblinYarnConfigurationKeys.JAR_CACHE_ENABLED_DEFAULT);
+
     try {
       config = addDynamicConfig(config);
       outputConfigToFile(config);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -243,6 +243,8 @@ public class GobblinYarnAppLauncher {
 
   private final boolean jarCacheEnabled;
 
+  private final Set<String> libJarNames = new HashSet<>(); // List of jars that are shared between appMaster and containers
+
   public GobblinYarnAppLauncher(Config config, YarnConfiguration yarnConfiguration) throws IOException {
     this.config = config.withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_LAUNCHER_START_TIME_KEY,
         ConfigValueFactory.fromAnyRef(System.currentTimeMillis()));
@@ -308,7 +310,6 @@ public class GobblinYarnAppLauncher {
             GobblinYarnConfigurationKeys.DEFAULT_GOBBLIN_YARN_DETACH_ON_EXIT);
     this.appLauncherMode = ConfigUtils.getString(this.config, GOBBLIN_YARN_APP_LAUNCHER_MODE, DEFAULT_GOBBLIN_YARN_APP_LAUNCHER_MODE);
     this.jarCacheEnabled = ConfigUtils.getBoolean(this.config, GobblinYarnConfigurationKeys.JAR_CACHE_ENABLED, GobblinYarnConfigurationKeys.JAR_CACHE_ENABLED_DEFAULT);
-
     try {
       config = addDynamicConfig(config);
       outputConfigToFile(config);
@@ -668,6 +669,7 @@ public class GobblinYarnAppLauncher {
       Path unsharedJarsDestDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.LIB_JARS_DIR_NAME);
       addLibJars(new Path(this.config.getString(GobblinYarnConfigurationKeys.LIB_JARS_DIR_KEY)),
           Optional.of(appMasterResources), libJarsDestDir, unsharedJarsDestDir, localFs);
+      this.libJarNames.addAll(appMasterResources.keySet());
       LOGGER.info("Added lib jars to directory: {} and execution-private directory: {}", libJarsDestDir, unsharedJarsDestDir);
     }
     if (this.config.hasPath(GobblinYarnConfigurationKeys.APP_MASTER_JARS_KEY)) {
@@ -814,6 +816,7 @@ public class GobblinYarnAppLauncher {
         .append(" -D").append(GobblinYarnConfigurationKeys.GOBBLIN_YARN_CONTAINER_LOG_DIR_NAME).append("=").append(ApplicationConstants.LOG_DIR_EXPANSION_VAR)
         .append(" -D").append(GobblinYarnConfigurationKeys.GOBBLIN_YARN_CONTAINER_LOG_FILE_NAME).append("=").append(logFileName).append(".").append(ApplicationConstants.STDOUT)
         .append(" -D").append(GobblinYarnConfigurationKeys.YARN_APPLICATION_LAUNCHER_START_TIME_KEY).append("=").append(config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_LAUNCHER_START_TIME_KEY))
+        .append(" -D").append(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST).append("=").append(String.join(",", this.libJarNames))
         .append(" ").append(JvmUtils.formatJvmArguments(this.appMasterJvmArgs))
         .append(" ").append(appMasterClass.getName())
         .append(" --").append(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME)

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -55,6 +55,9 @@ public class GobblinYarnConfigurationKeys {
 
   public static final String JAR_CACHE_DIR = GOBBLIN_YARN_PREFIX + "jar.cache.dir";
 
+  public static final String YARN_APPLICATION_LIB_JAR_LIST = GOBBLIN_YARN_PREFIX + "lib.jar.list";
+
+
   // Used to store the start time of the app launcher to propagate to workers and appmaster
   public static final String YARN_APPLICATION_LAUNCHER_START_TIME_KEY = GOBBLIN_YARN_PREFIX + "application.start.time";
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -57,7 +57,6 @@ public class GobblinYarnConfigurationKeys {
 
   public static final String YARN_APPLICATION_LIB_JAR_LIST = GOBBLIN_YARN_PREFIX + "lib.jar.list";
 
-
   // Used to store the start time of the app launcher to propagate to workers and appmaster
   public static final String YARN_APPLICATION_LAUNCHER_START_TIME_KEY = GOBBLIN_YARN_PREFIX + "application.start.time";
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnHelixUtils.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnHelixUtils.java
@@ -23,9 +23,11 @@ import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -52,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.typesafe.config.Config;
 
 import org.apache.gobblin.util.ConfigUtils;
@@ -235,6 +238,16 @@ public class YarnHelixUtils {
       deletesSuccessful &= fs.delete(jarDirs.get(i).getPath(), true);
     }
     return deletesSuccessful;
+  }
+
+
+  public static Set<String> getAppLibJarList(Config config) {
+    Set<String> libAppJars = new HashSet<>(Arrays.asList(
+        ConfigUtils.getString(config, GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST, "").split(",")));
+    Set<String> containerJars = new HashSet<>(Arrays.asList(
+        ConfigUtils.getString(config, GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY, "").split(",")));
+    libAppJars.addAll(containerJars);
+    return Sets.filter(libAppJars, s -> !s.isEmpty());
   }
 
   public static void addRemoteFilesToLocalResources(String hdfsFileList, Map<String, LocalResource> resourceMap, Configuration yarnConfiguration) throws IOException {

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnHelixUtilsTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnHelixUtilsTest.java
@@ -17,6 +17,7 @@
 package org.apache.gobblin.yarn;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -97,6 +98,40 @@ public class YarnHelixUtilsTest {
     // Should be cleaned up
     Assert.assertFalse(fs.exists(new Path(this.tempDir, "tmp/2024-07")));
     Assert.assertFalse(fs.exists(new Path(this.tempDir, "tmp/2024-06")));
+  }
+
+  @Test
+  public void testGetJarListFromConfigs() {
+    // Test when container jars is empty
+    Config emptyContainerJarsList = ConfigFactory.empty()
+        .withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST, ConfigValueFactory.fromAnyRef("a.jar,b.jar"))
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY, ConfigValueFactory.fromAnyRef(""));
+
+    Set<String> jars = YarnHelixUtils.getAppLibJarList(emptyContainerJarsList);
+    Assert.assertEquals(2, jars.size());
+    Assert.assertTrue(jars.contains("a.jar"));
+    Assert.assertTrue(jars.contains("b.jar"));
+
+    // Test when yarn application lib jars is empty
+    Config emptyYarnAppLibJarsConfig = ConfigFactory.empty()
+        .withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST, ConfigValueFactory.fromAnyRef(""))
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY, ConfigValueFactory.fromAnyRef("c.jar,d.jar"));
+
+    jars = YarnHelixUtils.getAppLibJarList(emptyYarnAppLibJarsConfig);
+    Assert.assertEquals(2, jars.size());
+    Assert.assertTrue(jars.contains("c.jar"));
+    Assert.assertTrue(jars.contains("d.jar"));
+
+    // Test when both yarn application lib jars and container jars are not empty
+    Config config = ConfigFactory.empty()
+        .withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_LIB_JAR_LIST, ConfigValueFactory.fromAnyRef("a.jar,b.jar"))
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JARS_KEY, ConfigValueFactory.fromAnyRef("c.jar,d.jar"));
+    jars = YarnHelixUtils.getAppLibJarList(config);
+    Assert.assertEquals(4, jars.size());
+    Assert.assertTrue(jars.contains("a.jar"));
+    Assert.assertTrue(jars.contains("b.jar"));
+    Assert.assertTrue(jars.contains("c.jar"));
+    Assert.assertTrue(jars.contains("d.jar"));
 
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnHelixUtilsTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnHelixUtilsTest.java
@@ -132,6 +132,5 @@ public class YarnHelixUtilsTest {
     Assert.assertTrue(jars.contains("b.jar"));
     Assert.assertTrue(jars.contains("c.jar"));
     Assert.assertTrue(jars.contains("d.jar"));
-
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2162


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

When Gobblin launches a YARN app, if the cache is enabled it will load all the jars stored in the cache into the classpath.

This can be problematic as jars that persisted from older versions of jars or other executions may clobber the classpath, adding jars that are not needed or jars that interfere with the current jars.

This PR ensures that only the jars that were intended to be uploaded by the GobblinYarnAppLauncher are the only jars that are loaded into the classpath from the shared cache.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

