### PR TITLE
[GOBBLIN-2161] Read logExporter classname from config property

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/OpenTelemetryMetrics.java
@@ -65,7 +65,8 @@ public class OpenTelemetryMetrics extends OpenTelemetryMetricsBase {
     if (state.getPropAsBoolean(ConfigurationKeys.METRICS_REPORTING_OPENTELEMETRY_LOGEXPORTER_ENABLED,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_OPENTELEMETRY_LOGEXPORTER_ENABLED)) {
       try {
-        Class<?> clazz = Class.forName(ConfigurationKeys.METRICS_REPORTING_OPENTELEMETRY_LOGEXPORTER_CLASSNAME);
+        log.info("Initializing opentelemetry LogExporter class");
+        Class<?> clazz = Class.forName(state.getProp(ConfigurationKeys.METRICS_REPORTING_OPENTELEMETRY_LOGEXPORTER_CLASSNAME));
         Method instanceMethod = clazz.getMethod("instance");
         // Invoke the method to get the singleton instance
         return metricExporter = (MetricExporter) instanceMethod.invoke(null);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2161


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    - This is a follow-up change from https://github.com/apache/gobblin/pull/4061, the change missed reading logExporter classname from the config property `metrics.reporting.opentelemetry.logexporter.className`'s value and was instead reading from config property's key. Fixed it to initialize LogExporter classname from the value in the config.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

