### PR TITLE
[GOBBLIN-2164] Add default value for OpenTelemetry attribute

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -76,6 +76,7 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
   public static final String ISSUES_READ_FAILED_METRIC_NAME =  GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "getIssuesFailedCount";
   public static final String GAAS_OBSERVABILITY_METRICS_GROUPNAME = GAAS_JOB_OBSERVABILITY_EVENT_PRODUCER_PREFIX + "metrics";
   public static final String GAAS_OBSERVABILITY_JOB_SUCCEEDED_METRIC_NAME = "jobSucceeded";
+  private static final String DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE = "-";
 
   protected MetricContext metricContext;
   protected State state;
@@ -138,14 +139,29 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
   }
 
   public Attributes getEventAttributes(GaaSJobObservabilityEvent event) {
-    Attributes tags = Attributes.builder().put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, event.getFlowName())
-        .put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, event.getFlowGroup())
-        .put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, event.getJobName())
+    Attributes tags = Attributes.builder().put(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD, getOrDefault(event.getFlowName(), DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE))
+        .put(TimingEvent.FlowEventConstants.FLOW_GROUP_FIELD, getOrDefault(event.getFlowGroup(), DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE))
+        .put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, getOrDefault(event.getJobName(), DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE))
         .put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, event.getFlowExecutionId())
-        .put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, event.getExecutorId())
-        .put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, event.getFlowEdgeId())
+        .put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, getOrDefault(event.getExecutorId(), DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE))
+        .put(TimingEvent.FlowEventConstants.FLOW_EDGE_FIELD, getOrDefault(event.getFlowEdgeId(), DEFAULT_OPENTELEMETRY_ATTRIBUTE_VALUE))
         .build();
     return tags;
+  }
+
+  /**
+   * Returns the given string value if it is not empty (i.e., not null and not empty).
+   * Otherwise, returns the specified default value.
+   *
+   * <p>This method utilizes {@link org.apache.commons.lang3.StringUtils#isNotEmpty(CharSequence)}
+   * to check if the string is non-empty.</p>
+   *
+   * @param value the string to check
+   * @param defaultValue the default value to return if the provided string is empty or null
+   * @return the original string if it is not empty; otherwise, the provided default value
+   */
+  private String getOrDefault(String value, String defaultValue) {
+    return StringUtils.isNotEmpty(value) ? value : defaultValue;
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2164


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    - As per the Metric Data Model (MDM) documentation, it is essential to define pre-aggregation rules for metrics to allow for effective slicing and dicing based on dimensions. When emitting metrics, if any dimension within a pre-aggregation does not have a value (i.e., it is an empty string ""), the metric will be dropped as it is treated as having no value, which prevents accurate metric reporting and analysis. 
    - Added default value to ensure that all dimensions for pre-aggregated metrics are populated with either their actual values or a default placeholder value `-` if they are empty.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"