### PR TITLE
[GOBBLIN-2166] Add azkaban fields in RMAppSummaryEvent for GoT jobs

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -172,6 +173,8 @@ public class GobblinYarnAppLauncher {
   private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
   private static final String GOBBLIN_YARN_APPLICATION_TYPE = "GOBBLIN_YARN";
+
+  private static final String APPLICATION_TAGS_KEY = "hadoop-inject.mapreduce.job.tags";
 
   // The set of Yarn application types this class is interested in. This is used to
   // lookup the application this class has launched previously upon restarting.
@@ -573,6 +576,11 @@ public class GobblinYarnAppLauncher {
     LOGGER.info("creating new yarn application");
     YarnClientApplication gobblinYarnApp = this.yarnClient.createApplication();
     ApplicationSubmissionContext appSubmissionContext = gobblinYarnApp.getApplicationSubmissionContext();
+    if (config.hasPath(APPLICATION_TAGS_KEY)) {
+      String tags = config.getString(APPLICATION_TAGS_KEY);
+      Set<String> tagSet = new HashSet<>(Arrays.asList(tags.split(",")));
+      appSubmissionContext.setApplicationTags(tagSet);
+    }
     appSubmissionContext.setApplicationType(GOBBLIN_YARN_APPLICATION_TYPE);
     appSubmissionContext.setMaxAppAttempts(ConfigUtils.getInt(config, GobblinYarnConfigurationKeys.APP_MASTER_MAX_ATTEMPTS_KEY, GobblinYarnConfigurationKeys.DEFAULT_APP_MASTER_MAX_ATTEMPTS_KEY));
     ApplicationId applicationId = appSubmissionContext.getApplicationId();

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -174,6 +174,8 @@ public class GobblinYarnAppLauncher {
 
   private static final String GOBBLIN_YARN_APPLICATION_TYPE = "GOBBLIN_YARN";
 
+  // The application tags are set by HadoopJavaJob on mapreduce key even though it is not a mapreduce job
+  // Reference: https://github.com/azkaban/azkaban/blob/6db750049f6fdf7842e18b8d533a3b736429bdf4/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java#L96
   private static final String APPLICATION_TAGS_KEY = "hadoop-inject.mapreduce.job.tags";
 
   // The set of Yarn application types this class is interested in. This is used to


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2166) issues and references them in the PR title. For example, "[GOBBLIN-2166] GoT must fill in info required for RMAppSummaryEvent fields"
    - https://issues.apache.org/jira/browse/GOBBLIN-2166


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
GoT doesn't send applicationTags while submitting yarn app from the launcher GobblinYarnAppLauncher. This PR adds the applicationTags to appSubmissionContext during yarn app submission.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested the change in a local azkaban project

The below query shows azkaban properties populated in RMAppSummaryEvent

```
select * from service.rmappsummaryevent
  where appid in ('application_1729067421867_143934')
    and datepartition between '2024-10-15' and '2024-10-18'
  limit 1;
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

