### PR TITLE
[GOBBLIN-2167] Allow filtering of Hive datasets by underlying HDFS folder location

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -271,7 +271,7 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
             Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
             if ((tableFilter.isPresent() && !tableFilter.get().apply(table))
                 || !shouldAllowTableLocation(tableFolderAllowlistRegex, table)) {
-              log.info("Ignoring table {} as its underlying location {} does not part of allowlist regex {}", dbAndTable,
+              log.info("Ignoring table {} as its underlying location {} does not pass allowlist regex {}", dbAndTable,
                   table.getSd().getLocation(), tableFolderAllowlistRegex);
               continue;
             }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -269,7 +269,8 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
 
           try (AutoReturnableObject<IMetaStoreClient> client = HiveDatasetFinder.this.clientPool.getClient()) {
             Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
-            if ((tableFilter.isPresent() && !tableFilter.get().apply(table)) || !shouldAllowTableLocation(tableFolderAllowlistRegex, table)) {
+            if ((tableFilter.isPresent() && !tableFilter.get().apply(table))
+                || !shouldAllowTableLocation(tableFolderAllowlistRegex, table)) {
               continue;
             }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -271,6 +271,7 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
             Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
             if ((tableFilter.isPresent() && !tableFilter.get().apply(table))
                 || !shouldAllowTableLocation(tableFolderAllowlistRegex, table)) {
+              log.info("Ignoring table {} as its underlying location does not part of allowlist regex {}", dbAndTable, tableFolderAllowlistRegex);
               continue;
             }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -271,7 +271,8 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
             Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
             if ((tableFilter.isPresent() && !tableFilter.get().apply(table))
                 || !shouldAllowTableLocation(tableFolderAllowlistRegex, table)) {
-              log.info("Ignoring table {} as its underlying location does not part of allowlist regex {}", dbAndTable, tableFolderAllowlistRegex);
+              log.info("Ignoring table {} as its underlying location {} does not part of allowlist regex {}", dbAndTable,
+                  table.getSd().getLocation(), tableFolderAllowlistRegex);
               continue;
             }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
@@ -216,38 +216,29 @@ public class HiveDatasetFinderTest {
   }
 
   @Test
-  public void testDatasetConfig() throws Exception {
-
+  public void testHiveTableFolderFilter() throws Exception {
     List<HiveDatasetFinder.DbAndTable> dbAndTables = Lists.newArrayList();
     dbAndTables.add(new HiveDatasetFinder.DbAndTable("db1", "table1"));
     HiveMetastoreClientPool pool = getTestPool(dbAndTables);
 
     Properties properties = new Properties();
     properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
-
-    properties.put("hive.dataset.test.conf1", "conf1-val1");
-    properties.put("hive.dataset.test.conf2", "conf2-val2");
+    // Try a regex with multiple groups
+    properties.put(HiveDatasetFinder.TABLE_FOLDER_ALLOWLIST_FILTER, "(/tmp/|a).*");
 
     HiveDatasetFinder finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
     List<HiveDataset> datasets = Lists.newArrayList(finder.getDatasetsIterator());
 
     Assert.assertEquals(datasets.size(), 1);
-    HiveDataset hiveDataset = datasets.get(0);
 
-    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("hive.dataset.test.conf1"), "conf1-val1");
-    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("hive.dataset.test.conf2"), "conf2-val2");
-
-    // Test scoped configs with prefix
-    properties.put(HiveDatasetFinder.HIVE_DATASET_CONFIG_PREFIX_KEY, "hive.dataset.test");
+    properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
+    // The table located at /tmp/test should be filtered
+    properties.put(HiveDatasetFinder.TABLE_FOLDER_ALLOWLIST_FILTER, "/a/b");
 
     finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
     datasets = Lists.newArrayList(finder.getDatasetsIterator());
 
-    Assert.assertEquals(datasets.size(), 1);
-    hiveDataset = datasets.get(0);
-    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("conf1"), "conf1-val1");
-    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("conf2"), "conf2-val2");
-
+    Assert.assertEquals(datasets.size(), 0);
   }
 
   private HiveMetastoreClientPool getTestPool(List<HiveDatasetFinder.DbAndTable> dbAndTables) throws Exception {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
@@ -216,9 +216,10 @@ public class HiveDatasetFinderTest {
   }
 
   @Test
-  public void testHiveTableFolderFilter() throws Exception {
+  public void testHiveTableFolderAllowlistFilter() throws Exception {
     List<HiveDatasetFinder.DbAndTable> dbAndTables = Lists.newArrayList();
     dbAndTables.add(new HiveDatasetFinder.DbAndTable("db1", "table1"));
+    // This table is created on /tmp/test
     HiveMetastoreClientPool pool = getTestPool(dbAndTables);
 
     Properties properties = new Properties();
@@ -234,6 +235,24 @@ public class HiveDatasetFinderTest {
     properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
     // The table located at /tmp/test should be filtered
     properties.put(HiveDatasetFinder.TABLE_FOLDER_ALLOWLIST_FILTER, "/a/b");
+
+    finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
+    datasets = Lists.newArrayList(finder.getDatasetsIterator());
+
+    Assert.assertEquals(datasets.size(), 0);
+
+    // Test empty filter
+    properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
+    // The table located at /tmp/test should be filtered
+    properties.put(HiveDatasetFinder.TABLE_FOLDER_ALLOWLIST_FILTER, "");
+
+    finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
+    datasets = Lists.newArrayList(finder.getDatasetsIterator());
+
+    Assert.assertEquals(datasets.size(), 0);
+
+    // Test no regex config
+    properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
 
     finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
     datasets = Lists.newArrayList(finder.getDatasetsIterator());

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinderTest.java
@@ -215,6 +215,41 @@ public class HiveDatasetFinderTest {
 
   }
 
+  @Test
+  public void testDatasetConfig() throws Exception {
+
+    List<HiveDatasetFinder.DbAndTable> dbAndTables = Lists.newArrayList();
+    dbAndTables.add(new HiveDatasetFinder.DbAndTable("db1", "table1"));
+    HiveMetastoreClientPool pool = getTestPool(dbAndTables);
+
+    Properties properties = new Properties();
+    properties.put(HiveDatasetFinder.HIVE_DATASET_PREFIX + "." + WhitelistBlacklist.WHITELIST, "");
+
+    properties.put("hive.dataset.test.conf1", "conf1-val1");
+    properties.put("hive.dataset.test.conf2", "conf2-val2");
+
+    HiveDatasetFinder finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
+    List<HiveDataset> datasets = Lists.newArrayList(finder.getDatasetsIterator());
+
+    Assert.assertEquals(datasets.size(), 1);
+    HiveDataset hiveDataset = datasets.get(0);
+
+    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("hive.dataset.test.conf1"), "conf1-val1");
+    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("hive.dataset.test.conf2"), "conf2-val2");
+
+    // Test scoped configs with prefix
+    properties.put(HiveDatasetFinder.HIVE_DATASET_CONFIG_PREFIX_KEY, "hive.dataset.test");
+
+    finder = new TestHiveDatasetFinder(FileSystem.getLocal(new Configuration()), properties, pool);
+    datasets = Lists.newArrayList(finder.getDatasetsIterator());
+
+    Assert.assertEquals(datasets.size(), 1);
+    hiveDataset = datasets.get(0);
+    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("conf1"), "conf1-val1");
+    Assert.assertEquals(hiveDataset.getDatasetConfig().getString("conf2"), "conf2-val2");
+
+  }
+
   private HiveMetastoreClientPool getTestPool(List<HiveDatasetFinder.DbAndTable> dbAndTables) throws Exception {
 
     SetMultimap<String, String> entities = HashMultimap.create();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2167


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Hive tables can be located in different folders in HDFS even if they belong to the same database.
This becomes tricky to manage within a single Gobblin job especially when there are different permissions and handling based on underlying files for viewFS.

This PR adds a configuration to have a regex to filter tables based on their table location:
```
hive.dataset.tableFolderAllowlistFilter=<regex>
```
where tables with paths matching this filter will be selected, otherwise ignore

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

