### PR TITLE
[GOBBLIN-2168] Compare with the current time in UTC

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/trash/TimeBasedSnapshotCleanupPolicy.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/trash/TimeBasedSnapshotCleanupPolicy.java
@@ -21,6 +21,8 @@ import java.util.Properties;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 
 
 /**
@@ -41,6 +43,20 @@ public class TimeBasedSnapshotCleanupPolicy implements SnapshotCleanupPolicy {
   @Override
   public boolean shouldDeleteSnapshot(FileStatus snapshot, Trash trash) {
     DateTime snapshotTime = Trash.TRASH_SNAPSHOT_NAME_FORMATTER.parseDateTime(snapshot.getPath().getName());
+    System.out.println("Parsed time is " + snapshotTime + " and the timezone is " + snapshotTime.getZone());
+    System.out.println("Target clean up time is " + snapshotTime.plusMinutes(this.retentionMinutes));
+    System.out.println("Current time is  " + new DateTime() + " and the timezone is " + new DateTime().getZone());
+
+    DateTime now = new DateTime().withZone(DateTimeZone.UTC).minusHours(7); // mimic the time in azkaban 
+    DateTime targetCleanupTime = snapshotTime.plusMinutes(this.retentionMinutes);
+    DateTime delta = targetCleanupTime.minus(now.getMillis());
+
+    Duration duration = new Duration(now, targetCleanupTime);
+    duration.toStandardHours();
+    duration.toStandardMinutes();
+    System.out.println("Time delta is " +  duration.toStandardHours() + " hours and " + duration.toStandardMinutes() + " minutes");
+
+
     return snapshotTime.plusMinutes(this.retentionMinutes).isBeforeNow();
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/trash/TimeBasedSnapshotCleanupPolicyTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/trash/TimeBasedSnapshotCleanupPolicyTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.trash;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class TimeBasedSnapshotCleanupPolicyTest {
+
+    private MockTimeBasedSnapshotCleanupPolicy cleanupPolicy;
+
+    @BeforeMethod
+    public void setUp()  {
+        // Initialize the cleanup policy with a retention period (e.g., 1 day)
+        Properties properties = new Properties();
+        properties.setProperty(MockTimeBasedSnapshotCleanupPolicy.SNAPSHOT_RETENTION_POLICY_MINUTES_KEY, "1440"); // 1440 minutes = 1 day
+        // Mock the cutoff time to be 2024-10-30 01:01:00 UTC
+        cleanupPolicy = new MockTimeBasedSnapshotCleanupPolicy(properties, new DateTime(2024, 10, 30, 1, 1, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void testShouldDeleteSnapshot() throws IOException {
+
+        // Create a Trash
+        TrashTestBase trashTestBase = new TrashTestBase(new Properties());
+        Trash trash = trashTestBase.trash;
+
+        // Create dummy paths
+        FileStatus fs1 = new FileStatus(0, true, 0, 0, 0, 
+                                        new Path(trash.getTrashLocation(), new DateTime(2024, 10, 29, 1, 0, DateTimeZone.UTC).toString(Trash.TRASH_SNAPSHOT_NAME_FORMATTER)));
+        FileStatus fs2 = new FileStatus(0, true, 0, 0, 0, 
+                                        new Path(trash.getTrashLocation(), new DateTime(2024, 10, 29, 2, 0, DateTimeZone.UTC).toString(Trash.TRASH_SNAPSHOT_NAME_FORMATTER)));
+
+        // Test old snapshot (should be deleted)
+        // 2024-10-29 01:00:00 UTC + 1440 minutes = 2024-10-30 01:00:00 UTC < Cutoff time a.k.a system current_time (2024-10-30 01:01:00 UTC)
+        Assert.assertTrue(cleanupPolicy.shouldDeleteSnapshot(fs1, trash), "Old snapshot should be deleted");
+
+        // Test snapshot (should not be deleted)
+        // 2024-10-29 02:00:00 UTC + 1440 minutes = 2024-10-30 02:00:00 UTC > Cutoff time a.k.a system current_time (2024-10-30 01:01:00 UTC)
+        Assert.assertFalse(cleanupPolicy.shouldDeleteSnapshot(fs2, trash), "snapshot should not be deleted");
+    }
+
+    /**
+     * Mock the TimeBasedSnapshotCleanupPolicy for testing purposes
+     * 
+     * In this class, the current time used in the comparison method isBefore() can be mocked 
+     * Why? The current time is used to determine if a snapshot is older than the retention period, 
+     * and given that the current time is always changing, it is difficult to test the method shouldDeleteSnapshot()
+     */
+    public class MockTimeBasedSnapshotCleanupPolicy implements SnapshotCleanupPolicy {
+
+        public static final String SNAPSHOT_RETENTION_POLICY_MINUTES_KEY = "gobblin.trash.snapshot.retention.minutes";
+        public static final int SNAPSHOT_RETENTION_POLICY_MINUTES_DEFAULT = 1440; // one day
+
+        private final int retentionMinutes;
+        private final DateTime MOCK_CURRENT_TIME; 
+
+        public MockTimeBasedSnapshotCleanupPolicy(Properties props, DateTime mockCurrentTime) {
+            this.retentionMinutes = Integer.parseInt(props.getProperty(SNAPSHOT_RETENTION_POLICY_MINUTES_KEY,
+                Integer.toString(SNAPSHOT_RETENTION_POLICY_MINUTES_DEFAULT)));
+            this.MOCK_CURRENT_TIME = mockCurrentTime;
+        }
+
+        @Override
+        public boolean shouldDeleteSnapshot(FileStatus snapshot, Trash trash) {
+            DateTime snapshotTime = Trash.TRASH_SNAPSHOT_NAME_FORMATTER.parseDateTime(snapshot.getPath().getName());
+            return snapshotTime.plusMinutes(this.retentionMinutes).isBefore(this.MOCK_CURRENT_TIME);
+        }
+    }
+
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [GOBBLIN-2168](https://issues.apache.org/jira/browse/GOBBLIN-2168) 

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

In existing trash cleaner, the comparison between snapshotTime and the current time is NOT done in the same time zone, this leads to longer hard deletion time due to time zone difference.

the fix ensure that the comparison between snapshotTime and the current time is done in the same time zone



### Tests
- [x] My PR adds the following unit tests :

Implement a unit test class `[TimeBasedSnapshotCleanupPolicyTest.java](https://github.com/apache/gobblin/compare/master...linweihs:incubator-gobblin:welin/trash?expand=1#diff-59e30e386f99115a2511854af4f01812ea1cf832430c696bb48182af91713f77)` ensuring the comparison are asserted expectedly.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

