### PR TITLE
[GOBBLIN-2171] Streamline log messages for easier debugging of GaaS multi-active DAG processing

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigLoggedException.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigLoggedException.java
@@ -24,7 +24,7 @@ import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.RestLiServiceException;
 
 /**
- * Exception thrown by {@link FlowConfigsResourceHandler} when it cannot handle Restli gracefully.
+ * Exception thrown by {@link FlowConfigsResourceHandlerInterface} when it cannot handle Restli gracefully.
  */
 public class FlowConfigLoggedException extends RestLiServiceException {
   private static final Logger log = LoggerFactory.getLogger(FlowConfigLoggedException.class);

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
@@ -106,7 +106,7 @@ public class FlowConfigsV2Resource extends ComplexKeyResourceTemplate<FlowId, Fl
 
   /**
    * Get all {@link FlowConfig}s that matches the provided parameters. All the parameters are optional.
-   * If a parameter is null, it is ignored. {@see FlowConfigV2Resource#getFilteredFlows}
+   * If a parameter is null, it is ignored.
    */
   @Finder("filterFlows")
   public List<FlowConfig> getFilteredFlows(@Context PagingContext context,

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/FlowUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/FlowUtils.java
@@ -17,10 +17,11 @@
 package org.apache.gobblin.service.modules.flow;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.FlowSpec;
+
 public class FlowUtils {
   /**
    * A FlowSpec contains a FlowExecutionId if it is a runOnce flow.
-   * Refer {@link FlowConfigResourceLocalHandler#createFlowSpecForConfig} for details.
+   * Refer {@link org.apache.gobblin.service.modules.restli.FlowConfigsV2ResourceHandler#createFlowSpecForConfig} for details.
    * @param spec flow spec
    * @return flow execution id
    */

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
@@ -96,15 +96,13 @@ public class DagActionReminderScheduler {
       boolean isDeadlineReminder) throws SchedulerException {
     DagActionStore.DagAction dagAction = leaseParams.getDagAction();
     JobDetail jobDetail = createReminderJobDetail(leaseParams, isDeadlineReminder);
-    Trigger trigger = createReminderJobTrigger(leaseParams, reminderDurationMillis,
-        System::currentTimeMillis, isDeadlineReminder);
-    log.info("Going to set reminder for dagAction {} to fire after {} ms, isDeadlineTrigger: {}",
-        dagAction, reminderDurationMillis, isDeadlineReminder);
+    Trigger trigger = createReminderJobTrigger(leaseParams, reminderDurationMillis, System::currentTimeMillis, isDeadlineReminder);
+    log.info("Setting reminder for {} in {} ms, isDeadlineTrigger: {}", dagAction, reminderDurationMillis, isDeadlineReminder);
     quartzScheduler.scheduleJob(jobDetail, trigger);
   }
 
   public void unscheduleReminderJob(DagActionStore.LeaseParams leaseParams, boolean isDeadlineTrigger) throws SchedulerException {
-    log.info("Reminder unset for LeaseParams {}, isDeadlineTrigger: {}", leaseParams, isDeadlineTrigger);
+    log.info("Unsetting reminder for {}, isDeadlineTrigger: {}", leaseParams, isDeadlineTrigger);
     if (!quartzScheduler.deleteJob(createJobKey(leaseParams, isDeadlineTrigger))) {
       log.warn("Reminder not found for {}. Possibly the event is received out-of-order.", leaseParams);
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagementTaskStreamImpl.java
@@ -99,7 +99,7 @@ public class DagManagementTaskStreamImpl implements DagManagement, DagTaskStream
 
   @Override
   public synchronized void addDagAction(DagActionStore.LeaseParams leaseParams) {
-    log.info("Adding {} to queue...", leaseParams);
+    log.info("Enqueuing {}", leaseParams);
     if (!this.leaseParamsQueue.offer(leaseParams)) {
       throw new RuntimeException(String.format("Could not add %s to the queue", leaseParams));
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
@@ -140,16 +140,16 @@ public class DagProcessingEngine extends AbstractIdleService {
         DagTask dagTask = dagTaskStream.next(); // blocking call
         if (dagTask == null) {
           //todo - add a metrics to count the times dagTask was null
-          log.warn("Received a null dag task, ignoring.");
+          log.warn("Ignoring null dag task!");
           continue;
         }
         DagProc<?> dagProc = dagTask.host(dagProcFactory);
         try {
           dagProc.process(dagManagementStateStore, dagProcEngineMetrics);
           dagTask.conclude();
-          log.info("Concluded dagTask : {}", dagTask);
+          log.info(dagProc.contextualizeStatus("concluded dagTask"));
         } catch (Exception e) {
-          log.error("DagProcEngineThread encountered exception while processing dag " + dagProc.getDagId(), e);
+          log.error("DagProcEngineThread: " + dagProc.contextualizeStatus("error"), e);
           dagManagementStateStore.getDagManagerMetrics().dagProcessingExceptionMeter.mark();
         }
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -117,6 +117,7 @@ public class FlowLaunchHandler {
 
   private void handleFlowTriggerEvent(Properties jobProps, DagActionStore.LeaseParams leaseParams, boolean adoptConsensusFlowExecutionId)
       throws IOException {
+    log.info("Handling trigger {} (adoptConsensusTimestamp: {})", leaseParams, adoptConsensusFlowExecutionId);
     long origEventTimeMillis = leaseParams.getEventTimeMillis();
     LeaseAttemptStatus leaseAttempt = this.multiActiveLeaseArbiter.tryAcquireLease(leaseParams, adoptConsensusFlowExecutionId);
     if (leaseAttempt instanceof LeaseAttemptStatus.LeaseObtainedStatus

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FlowLaunchHandler.java
@@ -117,15 +117,14 @@ public class FlowLaunchHandler {
 
   private void handleFlowTriggerEvent(Properties jobProps, DagActionStore.LeaseParams leaseParams, boolean adoptConsensusFlowExecutionId)
       throws IOException {
-    long previousEventTimeMillis = leaseParams.getEventTimeMillis();
+    long origEventTimeMillis = leaseParams.getEventTimeMillis();
     LeaseAttemptStatus leaseAttempt = this.multiActiveLeaseArbiter.tryAcquireLease(leaseParams, adoptConsensusFlowExecutionId);
     if (leaseAttempt instanceof LeaseAttemptStatus.LeaseObtainedStatus
         && persistDagAction((LeaseAttemptStatus.LeaseObtainedStatus) leaseAttempt)) {
-      log.info("Successfully persisted: [{}, eventTimestamp: {}] ", leaseAttempt.getConsensusDagAction(),
-          previousEventTimeMillis);
+      log.info("Successfully persisted (origEventTimestamp: {}) {}", origEventTimeMillis, leaseAttempt.getConsensusLeaseParams());
     } else { // when NOT successfully `persistDagAction`, set a reminder to re-attempt handling (unless leasing finished)
       calcLeasedToAnotherStatusForReminder(leaseAttempt).ifPresent(leasedToAnother ->
-          scheduleReminderForEvent(jobProps, leasedToAnother, previousEventTimeMillis));
+          scheduleReminderForEvent(jobProps, leasedToAnother, origEventTimeMillis));
     }
   }
 
@@ -150,7 +149,7 @@ public class FlowLaunchHandler {
    * Presently used for both `LAUNCH` and `KILL` `DagAction`s
    */
   private boolean persistDagAction(LeaseAttemptStatus.LeaseObtainedStatus leaseStatus) {
-    DagActionStore.DagAction dagAction = leaseStatus.getConsensusDagAction();
+    DagActionStore.DagAction dagAction = leaseStatus.getConsensusLeaseParams().getDagAction();
     try {
       this.dagManagementStateStore.addDagAction(dagAction);
       this.numFlowsSubmitted.mark();
@@ -167,25 +166,24 @@ public class FlowLaunchHandler {
    * @param jobProps
    * @param status used to extract event to be reminded for (stored in `consensusDagAction`) and the minimum time after
    *               which reminder should occur
-   * @param triggerEventTimeMillis the event timestamp we were originally handling (only used for logging purposes)
+   * @param origEventTimeMillis the event timestamp we were originally handling (only used for logging)
    */
-  private void scheduleReminderForEvent(Properties jobProps, LeaseAttemptStatus.LeasedToAnotherStatus status,
-      long triggerEventTimeMillis) {
-    DagActionStore.DagAction consensusDagAction = status.getConsensusDagAction();
+  private void scheduleReminderForEvent(Properties jobProps, LeaseAttemptStatus.LeasedToAnotherStatus status, long origEventTimeMillis) {
+    DagActionStore.LeaseParams consensusLeaseParams = status.getConsensusLeaseParams();
     JobKey origJobKey = new JobKey(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY, "<<no job name>>"),
         jobProps.getProperty(ConfigurationKeys.JOB_GROUP_KEY, "<<no job group>>"));
     try {
       if (!this.schedulerService.getScheduler().checkExists(origJobKey)) {
-        log.warn("Skipping setting a reminder for a job that does not exist in the scheduler. Key: {}", origJobKey);
+        log.warn("Skipping flow launch reminder for unknown job ({}; origEventTimestamp: {}) {}", origJobKey, origEventTimeMillis, consensusLeaseParams);
         this.jobDoesNotExistInSchedulerCount.inc();
         return;
       }
-      Trigger reminderTrigger = createAndScheduleReminder(origJobKey, status, status.getEventTimeMillis());
-      log.info("Flow Launch Handler - [{}, eventTimestamp: {}] - SCHEDULED REMINDER for event {} in {} millis",
-          consensusDagAction, triggerEventTimeMillis, status.getEventTimeMillis(), reminderTrigger.getNextFireTime());
+      Trigger reminderTrigger = createAndScheduleReminder(origJobKey, status);
+      log.info("Scheduled flow launch reminder for job ({}; origEventTimestamp: {}) {} at {}", origJobKey, origEventTimeMillis, consensusLeaseParams,
+          reminderTrigger.getNextFireTime());
     } catch (SchedulerException e) {
-      log.warn("Failed to add job reminder due to SchedulerException for job {} trigger event {}. Exception: {}",
-          origJobKey, status.getEventTimeMillis(), e);
+      log.warn(String.format("Failed to schedule flow launch reminder for job (%s; origEventTimestamp %s) %s", origJobKey, origEventTimeMillis,
+          consensusLeaseParams), e);
       this.failedToSetEventReminderCount.inc();
     }
   }
@@ -196,12 +194,11 @@ public class FlowLaunchHandler {
    * triggerEventTimeMillis to revisit upon firing.
    * @param origJobKey
    * @param status
-   * @param triggerEventTimeMillis
    * @return Trigger for reminder
    * @throws SchedulerException
    */
-  protected Trigger createAndScheduleReminder(JobKey origJobKey, LeaseAttemptStatus.LeasedToAnotherStatus status,
-      long triggerEventTimeMillis) throws SchedulerException {
+  protected Trigger createAndScheduleReminder(JobKey origJobKey, LeaseAttemptStatus.LeasedToAnotherStatus status)
+      throws SchedulerException {
     // Generate a suffix to differentiate the reminder Job and Trigger from the original JobKey and Trigger, so we can
     // allow us to keep track of additional properties needed for reminder events (all triggers associated with one job
     // refer to the same set of jobProperties)
@@ -211,9 +208,7 @@ public class FlowLaunchHandler {
     jobDetail.setKey(reminderJobKey);
     Trigger reminderTrigger = JobScheduler.createTriggerForJob(reminderJobKey, getJobPropertiesFromJobDetail(jobDetail),
         Optional.of(reminderSuffix));
-    log.debug("Flow Launch Handler - [{}, eventTimestamp: {}] -  attempting to schedule reminder for event {} with "
-            + "reminderJobKey {} and reminderTriggerKey {}", status.getConsensusDagAction(), triggerEventTimeMillis,
-        status.getEventTimeMillis(), reminderJobKey, reminderTrigger.getKey());
+    log.debug("Scheduling flow launch reminder for job ({}; renamed: {}) {}", origJobKey, reminderJobKey, status.getConsensusLeaseParams());
     this.schedulerService.getScheduler().scheduleJob(jobDetail, reminderTrigger);
     return reminderTrigger;
   }
@@ -226,7 +221,7 @@ public class FlowLaunchHandler {
    */
   @VisibleForTesting
   public static String createSuffixForJobTrigger(LeaseAttemptStatus.LeasedToAnotherStatus leasedToAnotherStatus) {
-    return "reminder_for_" + leasedToAnotherStatus.getEventTimeMillis();
+    return "reminder_for_" + leasedToAnotherStatus.getConsensusLeaseParams().getEventTimeMillis();
   }
 
   /**
@@ -281,7 +276,7 @@ public class FlowLaunchHandler {
     // can differ between participants and be interpreted as a reminder for a distinct flow trigger which will cause
     // excess flows to be triggered by the reminder functionality.
     newJobProperties.put(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY,
-        String.valueOf(leasedToAnotherStatus.getEventTimeMillis()));
+        String.valueOf(leasedToAnotherStatus.getConsensusLeaseParams().getEventTimeMillis()));
     // Use this boolean to indicate whether this is a reminder event
     newJobProperties.put(ConfigurationKeys.FLOW_IS_REMINDER_EVENT_KEY, String.valueOf(true));
     // Replace reference to old Properties map with new cloned Properties

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
@@ -73,9 +73,7 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
 
   @Override
   public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseParams leaseParams, boolean skipFlowExecutionIdReplacement) throws IOException {
-    LeaseAttemptStatus leaseAttemptStatus =
-        decoratedMultiActiveLeaseArbiter.tryAcquireLease(leaseParams, skipFlowExecutionIdReplacement);
-    log.info("Multi-active lease status [{}] for: {}", leaseAttemptStatus.getClass().getSimpleName(), leaseParams);
+    LeaseAttemptStatus leaseAttemptStatus = decoratedMultiActiveLeaseArbiter.tryAcquireLease(leaseParams, skipFlowExecutionIdReplacement);
     if (leaseAttemptStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
       if (leaseParams.isReminder()) {
         this.leasesObtainedDueToReminderCount.mark();
@@ -89,8 +87,7 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
       this.noLongerLeasingStatusCount.inc();
       return leaseAttemptStatus;
     }
-    throw new RuntimeException(String.format("Received type of leaseAttemptStatus: %s not handled by this method",
-        leaseAttemptStatus.getClass().getName()));
+    throw new RuntimeException(String.format("Unexpected LeaseAttemptStatus (%s) for %s", leaseAttemptStatus.getClass().getName(), leaseParams));
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/InstrumentedLeaseArbiter.java
@@ -75,9 +75,7 @@ public class InstrumentedLeaseArbiter implements MultiActiveLeaseArbiter {
   public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseParams leaseParams, boolean skipFlowExecutionIdReplacement) throws IOException {
     LeaseAttemptStatus leaseAttemptStatus =
         decoratedMultiActiveLeaseArbiter.tryAcquireLease(leaseParams, skipFlowExecutionIdReplacement);
-    log.info("Multi-active arbiter attempt for: {} received type of leaseAttemptStatus: [{}, "
-            + "eventTimestamp: {}] ", leaseParams, leaseAttemptStatus.getClass().getName(),
-        leaseParams.getEventTimeMillis());
+    log.info("Multi-active lease status [{}] for: {}", leaseAttemptStatus.getClass().getSimpleName(), leaseParams);
     if (leaseAttemptStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus) {
       if (leaseParams.isReminder()) {
         this.leasesObtainedDueToReminderCount.mark();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/LeaseAttemptStatus.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -29,23 +30,16 @@ import lombok.Getter;
  * Hierarchy to convey the specific outcome of attempted lease acquisition via the {@link MultiActiveLeaseArbiter},
  * with each derived type carrying outcome-specific status info.
  *
- * IMPL. NOTE: {@link LeaseAttemptStatus#getConsensusDagAction} and {@link LeaseAttemptStatus#getMinimumLingerDurationMillis}
+ * IMPL. NOTE: {@link LeaseAttemptStatus#getConsensusLeaseParams()} and {@link LeaseAttemptStatus#getMinimumLingerDurationMillis}
  * intended for `@Override`.
  */
 public abstract class LeaseAttemptStatus {
   /**
-   * @return the {@link DagActionStore.LeaseParams}, containing the dagAction, eventTimeMillis of the event, and boolean
-   * indicating if it's a reminder event; {@see MultiActiveLeaseArbiter#tryAcquireLease}
+   * @return the {@link DagActionStore.LeaseParams} containing the {@link DagActionStore.DagAction}, which may now have an updated
+   * flowExecutionId that MUST henceforth be used
+   * @see MultiActiveLeaseArbiter#tryAcquireLease
    */
   public DagActionStore.LeaseParams getConsensusLeaseParams() {
-    return null;
-  }
-
-  /**
-   * @return the {@link DagActionStore.DagAction}, which may now have an updated flowExecutionId that MUST henceforth be
-   * used; {@see MultiActiveLeaseArbiter#tryAcquireLease}
-   */
-  public DagActionStore.DagAction getConsensusDagAction() {
     return null;
   }
 
@@ -79,11 +73,6 @@ public abstract class LeaseAttemptStatus {
     @Getter(AccessLevel.NONE)
     private final MultiActiveLeaseArbiter multiActiveLeaseArbiter;
 
-    @Override
-    public DagActionStore.DagAction getConsensusDagAction() {
-      return consensusLeaseParams.getDagAction();
-    }
-
     /**
      * Completes the lease referenced by this status object if it has not expired.
      * @return true if able to complete lease, false otherwise.
@@ -93,7 +82,8 @@ public abstract class LeaseAttemptStatus {
       return multiActiveLeaseArbiter.recordLeaseSuccess(this);
     }
 
-    public long getEventTimeMillis() {
+    @VisibleForTesting
+    protected long getEventTimeMillis() {
       return consensusLeaseParams.getEventTimeMillis();
     }
   }
@@ -112,12 +102,8 @@ public abstract class LeaseAttemptStatus {
     private final DagActionStore.LeaseParams consensusLeaseParams;
     private final long minimumLingerDurationMillis;
 
-    @Override
-    public DagActionStore.DagAction getConsensusDagAction() {
-      return consensusLeaseParams.getDagAction();
-    }
-
-    public long getEventTimeMillis() {
+    @VisibleForTesting
+    protected long getEventTimeMillis() {
       return consensusLeaseParams.getEventTimeMillis();
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MultiActiveLeaseArbiter.java
@@ -51,9 +51,9 @@ public interface MultiActiveLeaseArbiter {
    *
    * @param leaseParams                   uniquely identifies the flow, the present action upon it, the time the action
    *                                      was triggered, and if the dag action event we're checking on is a reminder event
-   * @param adoptConsensusFlowExecutionId if true then replaces the dagAction flowExecutionId returned in
-   *                                      LeaseAttemptStatuses with the consensus eventTime, accessed via
-   *                                      {@link LeaseAttemptStatus#getConsensusDagAction()}
+   * @param adoptConsensusFlowExecutionId if true then replaces the dagAction flowExecutionId returned as a {@link LeaseAttemptStatus}
+   *                                      with the consensus flowExecutionId (also the eventTime) accessible via
+   *                                      {@link LeaseAttemptStatus#getConsensusLeaseParams()}
    * @return {@link LeaseAttemptStatus}, containing, when `adoptConsensusFlowExecutionId`, a universally-agreed-upon
    * {@link DagActionStore.DagAction} with a possibly updated ("laundered") flow execution id that MUST be used thereafter
    * @throws IOException

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MySqlDagManagementStateStore.java
@@ -240,7 +240,7 @@ public class MySqlDagManagementStateStore implements DagManagementStateStore {
 
   @Override
   public boolean deleteDagAction(DagActionStore.DagAction dagAction) throws IOException {
-    log.info("Deleting Dag Action {}", dagAction);
+    log.info("Deleting {}", dagAction);
     return this.dagActionStore.deleteDagAction(dagAction);
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -250,7 +250,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
   @Override
   public LeaseAttemptStatus tryAcquireLease(DagActionStore.LeaseParams leaseParams,
       boolean adoptConsensusFlowExecutionId) throws IOException {
-    log.info("Multi-active arbiter about to handle trigger event: {}", leaseParams);
+    log.info("Multi-active arbitration for {}", leaseParams);
     // Query lease arbiter table about this dag action
     Optional<GetEventInfoResult> getResult = getExistingEventInfo(leaseParams);
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -302,8 +302,7 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
 
       // TODO: check whether reminder event before replacing flowExecutionId
       if (adoptConsensusFlowExecutionId) {
-        log.info("NOTE: Multi-active arbiter will use current DB epoch millis ({}) to launder {}", dbCurrentTimestamp.getTime(),
-            contextualizeLeasing(leaseParams));
+        log.info("Multi-active will use DB time ({}) to launder {}", dbCurrentTimestamp.getTime(), contextualizeLeasing(leaseParams));
       }
       /* Note that we use `adoptConsensusFlowExecutionId` parameter's value to determine whether we should use the db
       laundered event timestamp as the flowExecutionId or maintain the original one

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -187,9 +187,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       sharedFlowMetricsSingleton.addFlowGauge(spec, flowConfig, flowGroup, flowName);
       DagActionStore.DagAction launchDagAction = DagActionStore.DagAction.forFlow(flowGroup, flowName,
           FlowUtils.getOrCreateFlowExecutionId(flowSpec), DagActionStore.DagActionType.LAUNCH);
-      DagActionStore.LeaseParams leaseObject = new DagActionStore.LeaseParams(launchDagAction, isReminderEvent, triggerTimestampMillis);
+      DagActionStore.LeaseParams leaseParams = new DagActionStore.LeaseParams(launchDagAction, isReminderEvent, triggerTimestampMillis);
       // `flowSpec.isScheduled()` ==> adopt consensus `flowExecutionId` as clock drift safeguard, yet w/o disrupting API-layer's ad hoc ID assignment
-      flowLaunchHandler.handleFlowLaunchTriggerEvent(jobProps, leaseObject, flowSpec.isScheduled());
+      flowLaunchHandler.handleFlowLaunchTriggerEvent(jobProps, leaseParams, flowSpec.isScheduled());
       _log.info("Multi-active scheduler finished handling trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
           launchDagAction, isReminderEvent ? "reminder" : "original", triggerTimestampMillis);
     } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -122,11 +122,13 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
   @Override
   public AddSpecResponse onAddSpec(Spec addedSpec) {
     if (addedSpec instanceof TopologySpec) {
-      _log.info("New Spec detected of type TopologySpec: " + addedSpec);
+      _log.info("Orchestrator - onAdd[Topology]Spec: " + addedSpec);
       this.specCompiler.onAddSpec(addedSpec);
     } else if (addedSpec instanceof FlowSpec) {
-      _log.info("New Spec detected of type FlowSpec: " + addedSpec);
+      _log.info("Orchestrator - onAdd[Flow]Spec: " + addedSpec);
       return this.specCompiler.onAddSpec(addedSpec);
+    } else {
+      _log.info("Orchestrator - onAdd[<<Unrecognized>>]Spec (" + addedSpec.getClass() + ") - ignoring!: " + addedSpec);
     }
     return new AddSpecResponse<>(null);
   }
@@ -178,7 +180,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     long startTime = System.nanoTime();
     if (spec instanceof FlowSpec) {
       FlowSpec flowSpec = (FlowSpec) spec;
-      Config flowConfig = (flowSpec).getConfig();
+      Config flowConfig = flowSpec.getConfig();
       String flowGroup = flowConfig.getString(ConfigurationKeys.FLOW_GROUP_KEY);
       String flowName = flowConfig.getString(ConfigurationKeys.FLOW_NAME_KEY);
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -190,8 +190,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
       DagActionStore.LeaseParams leaseParams = new DagActionStore.LeaseParams(launchDagAction, isReminderEvent, triggerTimestampMillis);
       // `flowSpec.isScheduled()` ==> adopt consensus `flowExecutionId` as clock drift safeguard, yet w/o disrupting API-layer's ad hoc ID assignment
       flowLaunchHandler.handleFlowLaunchTriggerEvent(jobProps, leaseParams, flowSpec.isScheduled());
-      _log.info("Multi-active scheduler finished handling trigger event: [{}, is: {}, triggerEventTimestamp: {}]",
-          launchDagAction, isReminderEvent ? "reminder" : "original", triggerTimestampMillis);
+      _log.info("Multi-active scheduler finished handling {}", leaseParams);
     } else {
       Instrumented.markMeter(this.flowOrchestrationFailedMeter);
       throw new RuntimeException("Spec not of type FlowSpec, cannot orchestrate: " + spec);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
@@ -122,7 +122,7 @@ public abstract class DagProc<T> {
     return String.format("{} - {} - dagId : {}", getClass().getSimpleName(), message, this.dagId);
   }
 
-  /** INFO-level logging of `message` with class name and {@link #getDagId()} */
+  /** INFO-level logging for `message` with class name and {@link #getDagId()} */
   public void logContextualizedInfo(String message) {
     log.info(contextualizeStatus(message));
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
@@ -119,7 +119,7 @@ public abstract class DagProc<T> {
 
   /** @return `message` formatted with class name and {@link #getDagId()} */
   public String contextualizeStatus(String message) {
-    return String.format("{} - {} - dagId : {}", getClass().getSimpleName(), message, this.dagId);
+    return String.format("%s - %s - dagId : %s", getClass().getSimpleName(), message, this.dagId);
   }
 
   /** INFO-level logging for `message` with class name and {@link #getDagId()} */

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProc.java
@@ -85,6 +85,7 @@ public abstract class DagProc<T> {
       DagProcessingEngineMetrics dagProcEngineMetrics) throws IOException {
     T state;
     try {
+      logContextualizedInfo("initializing");
       state = initialize(dagManagementStateStore);
       dagProcEngineMetrics.markDagActionsInitialize(getDagActionType(), true);
     } catch (Exception e) {
@@ -92,8 +93,9 @@ public abstract class DagProc<T> {
       throw e;
     }
     try {
+      logContextualizedInfo("ready to process");
       act(dagManagementStateStore, state, dagProcEngineMetrics);
-      log.info("{} processed dagId : {}", getClass().getSimpleName(), this.dagId);
+      logContextualizedInfo("processed");
     } catch (Exception e) {
       if (isNonTransientException(e)) {
         log.error("Ignoring non transient exception. DagTask {} will conclude and will not be retried. Exception - {} ",
@@ -113,6 +115,16 @@ public abstract class DagProc<T> {
 
   public DagActionStore.DagActionType getDagActionType() {
     return this.dagTask.getDagAction().getDagActionType();
+  }
+
+  /** @return `message` formatted with class name and {@link #getDagId()} */
+  public String contextualizeStatus(String message) {
+    return String.format("{} - {} - dagId : {}", getClass().getSimpleName(), message, this.dagId);
+  }
+
+  /** INFO-level logging of `message` with class name and {@link #getDagId()} */
+  public void logContextualizedInfo(String message) {
+    log.info(contextualizeStatus(message));
   }
 
   protected boolean isNonTransientException(Exception e) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -264,13 +264,13 @@ public class DagProcUtils {
       String flowName, long flowExecutionId, String jobName) {
     DagActionStore.DagAction enforceJobStartDeadlineDagAction = new DagActionStore.DagAction(flowGroup, flowName,
         flowExecutionId, jobName, DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE);
-    log.info("Deleting dag action {}", enforceJobStartDeadlineDagAction);
+    log.info("Deleting (job start) deadline: {}", enforceJobStartDeadlineDagAction);
     // todo - add metrics
 
     try {
       dagManagementStateStore.deleteDagAction(enforceJobStartDeadlineDagAction);
     } catch (IOException e) {
-      log.warn("Failed to delete dag action {}", enforceJobStartDeadlineDagAction);
+      log.warn("Failed to delete (job start) deadline: {}", enforceJobStartDeadlineDagAction);
     }
   }
 
@@ -278,13 +278,13 @@ public class DagProcUtils {
     DagActionStore.DagAction enforceFlowFinishDeadlineDagAction = DagActionStore.DagAction.forFlow(dagId.getFlowGroup(),
         dagId.getFlowName(), dagId.getFlowExecutionId(),
         DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE);
-    log.info("Deleting dag action {}", enforceFlowFinishDeadlineDagAction);
+    log.info("Deleting (flow finish) deadline: {}", enforceFlowFinishDeadlineDagAction);
     // todo - add metrics
 
     try {
       dagManagementStateStore.deleteDagAction(enforceFlowFinishDeadlineDagAction);
     } catch (IOException e) {
-      log.warn("Failed to delete dag action {}", enforceFlowFinishDeadlineDagAction);
+      log.warn("Failed to delete (flow finish) deadline: {}", enforceFlowFinishDeadlineDagAction);
     }
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
@@ -102,8 +102,7 @@ public class DagManagementDagActionStoreChangeMonitor extends DagActionStoreChan
    */
   @Override
   protected void handleDagAction(DagActionStore.DagAction dagAction, boolean isStartup) {
-    log.info("(" + (isStartup ? "on-startup" : "post-startup") + ") DagAction change ({}) received for flow: {}",
-        dagAction.getDagActionType(), dagAction);
+    log.info("(" + (isStartup ? "on-startup" : "post-startup") + ") Handling {}", dagAction);
     try {
       switch (dagAction.getDagActionType()) {
         case ENFORCE_FLOW_FINISH_DEADLINE:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
@@ -102,7 +102,7 @@ public class DagManagementDagActionStoreChangeMonitor extends DagActionStoreChan
    */
   @Override
   protected void handleDagAction(DagActionStore.DagAction dagAction, boolean isStartup) {
-    log.info("(" + (isStartup ? "on-startup" : "post-startup") + ") Handling {}", dagAction);
+    log.info("(" + (isStartup ? "on-startup" : "post-startup") + ") Handling {} for {}", dagAction.getDagActionType(), dagAction);
     try {
       switch (dagAction.getDagActionType()) {
         case ENFORCE_FLOW_FINISH_DEADLINE:


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2171


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Some logs from GaaS flow/DAG processing, e.g. by the `MysqlMultiActiveLeaseArbiter`, the `FlowLaunchHandler`, the `DagProcessingEngine`, etc., are challenging to skim, especially when only the first characters on the line are shown (as the remaining content of long lines flows beyond view).

Improve consistency, brevity, and the placement of the most-vital info.  Also contextualize when it's not otherwise clear where in the processing a message originates (e.g. which `MultiActiveLeaseArbiter` instance).

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

existing tests still pass

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

