### PR TITLE
Add support for sending proxy jvm args to Yarn AM and Containers

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
@@ -32,6 +32,7 @@ import com.typesafe.config.ConfigValueFactory;
 import azkaban.jobExecutor.AbstractJob;
 import lombok.Getter;
 
+import org.apache.gobblin.util.AzkabanLauncherUtils;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.yarn.GobblinYarnAppLauncher;
 import org.apache.gobblin.yarn.GobblinYarnConfigurationKeys;
@@ -63,7 +64,7 @@ public class AzkabanGobblinYarnAppLauncher extends AbstractJob {
   public AzkabanGobblinYarnAppLauncher(String jobId, Properties gobblinProps)
       throws IOException {
     super(jobId, LOGGER);
-
+    gobblinProps = AzkabanLauncherUtils.undoPlaceholderConversion(gobblinProps);
     addRuntimeProperties(gobblinProps);
 
     Config gobblinConfig = ConfigUtils.propertiesToConfig(gobblinProps);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -242,12 +242,8 @@ class YarnService extends AbstractIdleService {
         Optional.of(config.getString(GobblinYarnConfigurationKeys.CONTAINER_JVM_ARGS_KEY)) :
         Optional.<String>absent();
 
-    String proxyConfigValue = config.hasPath(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) ?
+    this.proxyJvmArgs = config.hasPath(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) ?
         config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) : StringUtils.EMPTY;
-
-    //We get config value as emptyStringPlaceholder when the string is actually supposed to be empty
-    this.proxyJvmArgs = proxyConfigValue.contains(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
-        ? StringUtils.EMPTY : proxyConfigValue;
 
     int numContainerLaunchThreads =
         ConfigUtils.getInt(config, GobblinYarnConfigurationKeys.MAX_CONTAINER_LAUNCH_THREADS_KEY,

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -246,7 +246,7 @@ class YarnService extends AbstractIdleService {
         config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) : StringUtils.EMPTY;
 
     //We get config value as emptyStringPlaceholder when the string is actually supposed to be empty
-    this.proxyJvmArgs = proxyConfigValue.equals(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
+    this.proxyJvmArgs = proxyConfigValue.contains(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
         ? StringUtils.EMPTY : proxyConfigValue;
 
     int numContainerLaunchThreads =

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AzkabanLauncherUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AzkabanLauncherUtils.java
@@ -19,6 +19,8 @@ package org.apache.gobblin.util;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableBiMap;
 
@@ -28,7 +30,19 @@ import com.google.common.collect.ImmutableBiMap;
 public class AzkabanLauncherUtils {
   public static final String PLACEHOLDER_MAP_KEY = "placeholderMap";
 
+  /**
+   * Reverts properties that were converted to placeholders back to their original values.
+   * It checks if the properties contain placeholderMap key and, if so, uses it as an inverse map
+   * to replace placeholder values with their original values.
+   *
+   * @param appProperties the properties object containing the application properties alongwith the inverse map
+   * @return a new Properties object with placeholders reverted to their original values, or the original properties if no placeholderMap
+   */
   public static Properties undoPlaceholderConversion(Properties appProperties) {
+    if (StringUtils.EMPTY.equals(appProperties.getProperty(PLACEHOLDER_MAP_KEY, StringUtils.EMPTY))) {
+      return appProperties;
+    }
+
     Properties convertedProperties = new Properties();
     convertedProperties.putAll(appProperties);
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AzkabanLauncherUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AzkabanLauncherUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.util;
+
+import java.util.Map;
+import java.util.Properties;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableBiMap;
+
+/**
+ * Utility class for Azkaban App Launcher.
+ */
+public class AzkabanLauncherUtils {
+  public static final String PLACEHOLDER_MAP_KEY = "placeholderMap";
+
+  public static Properties undoPlaceholderConversion(Properties appProperties) {
+    Properties convertedProperties = new Properties();
+    convertedProperties.putAll(appProperties);
+
+    // Undo properties converted to placeholders
+    Map<String, String> inversePlaceholderMap = ImmutableBiMap.copyOf(Splitter.on(",").withKeyValueSeparator(":")
+        .split(convertedProperties.get(PLACEHOLDER_MAP_KEY).toString())).inverse();
+    for (Map.Entry<Object, Object> entry : convertedProperties.entrySet()) {
+      if (inversePlaceholderMap.containsKey(entry.getValue().toString())) {
+        convertedProperties.put(entry.getKey(), inversePlaceholderMap.get(entry.getValue().toString()));
+      }
+    }
+    return convertedProperties;
+  }
+}

--- a/gobblin-utility/src/test/java/org/apache/gobblin/AzkabanLauncherUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/AzkabanLauncherUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.util.AzkabanLauncherUtils;
+
+
+@Test
+public class AzkabanLauncherUtilsTest {
+
+  @Test
+  public void testPropertyPlaceholderReplacement() {
+    Properties props = new Properties();
+
+    props.setProperty("placeholderMap", ":emptyStringPlaceholder, :spacePlaceholder,\\t:tabPlaceholder");
+    props.setProperty("key1", "emptyStringPlaceholder");
+    props.setProperty("key2", "spacePlaceholder");
+    props.setProperty("key3", "tabPlaceholder");
+    props.setProperty("key4", "someOtherValue");
+    props.setProperty("key5", "123emptyStringPlaceholder");
+
+    props = AzkabanLauncherUtils.undoPlaceholderConversion(props);
+    Assert.assertEquals("", props.get("key1").toString());
+    Assert.assertEquals(" ", props.get("key2").toString());
+    Assert.assertEquals("\\t", props.get("key3").toString());
+    Assert.assertEquals("someOtherValue", props.get("key4").toString());
+
+    // should replace exact matches only
+    Assert.assertEquals("123emptyStringPlaceholder", props.get("key5").toString());
+  }
+}

--- a/gobblin-utility/src/test/java/org/apache/gobblin/AzkabanLauncherUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/AzkabanLauncherUtilsTest.java
@@ -40,12 +40,31 @@ public class AzkabanLauncherUtilsTest {
     props.setProperty("key5", "123emptyStringPlaceholder");
 
     props = AzkabanLauncherUtils.undoPlaceholderConversion(props);
-    Assert.assertEquals("", props.get("key1").toString());
-    Assert.assertEquals(" ", props.get("key2").toString());
-    Assert.assertEquals("\\t", props.get("key3").toString());
-    Assert.assertEquals("someOtherValue", props.get("key4").toString());
+    Assert.assertEquals(props.get("key1").toString(), "");
+    Assert.assertEquals(props.get("key2").toString(), " ");
+    Assert.assertEquals(props.get("key3").toString(), "\\t");
+    Assert.assertEquals(props.get("key4").toString(), "someOtherValue");
 
     // should replace exact matches only
-    Assert.assertEquals("123emptyStringPlaceholder", props.get("key5").toString());
+    Assert.assertEquals(props.get("key5").toString(), "123emptyStringPlaceholder");
+  }
+
+  @Test
+  public void testPlaceholderMapMissing() {
+    Properties props = new Properties();
+    props.setProperty("key1", "emptyStringPlaceholder");
+
+    props = AzkabanLauncherUtils.undoPlaceholderConversion(props);
+    Assert.assertEquals(props.get("key1").toString(), "emptyStringPlaceholder");
+  }
+
+  @Test
+  public void testEmptyPlaceholderMap() {
+    Properties props = new Properties();
+    props.setProperty("placeholderMap", "");
+    props.setProperty("key1", "emptyStringPlaceholder");
+
+    props = AzkabanLauncherUtils.undoPlaceholderConversion(props);
+    Assert.assertEquals(props.get("key1").toString(), "emptyStringPlaceholder");
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -286,7 +286,7 @@ public class GobblinYarnAppLauncher {
         config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) : StringUtils.EMPTY;
 
     //We get config value as emptyStringPlaceholder when the string is actually supposed to be empty
-    this.proxyJvmArgs = proxyConfigValue.equals(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
+    this.proxyJvmArgs = proxyConfigValue.contains(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
         ? StringUtils.EMPTY : proxyConfigValue;
 
     this.sinkLogRootDir = ConfigUtils.getString(config, GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY, null);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -282,12 +282,8 @@ public class GobblinYarnAppLauncher {
         Optional.of(config.getString(GobblinYarnConfigurationKeys.APP_MASTER_JVM_ARGS_KEY)) :
         Optional.<String>absent();
 
-    String proxyConfigValue = config.hasPath(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) ?
+    this.proxyJvmArgs = config.hasPath(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) ?
         config.getString(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS) : StringUtils.EMPTY;
-
-    //We get config value as emptyStringPlaceholder when the string is actually supposed to be empty
-    this.proxyJvmArgs = proxyConfigValue.contains(GobblinYarnConfigurationKeys.EMPTY_STRING_PLACEHOLDER)
-        ? StringUtils.EMPTY : proxyConfigValue;
 
     this.sinkLogRootDir = ConfigUtils.getString(config, GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY, null);
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -57,6 +57,10 @@ public class GobblinYarnConfigurationKeys {
 
   public static final String YARN_APPLICATION_LIB_JAR_LIST = GOBBLIN_YARN_PREFIX + "lib.jar.list";
 
+  /**
+   * Config for setting http/https proxy host and port.
+   * The value for this property is expected in format -DproxySet=true -Dhttps.proxyHost=[hostname] -Dhttps.proxyPort=[port]
+   */
   public static final String YARN_APPLICATION_PROXY_JVM_ARGS = GOBBLIN_YARN_PREFIX + "proxy.jvm.args";
 
   // Used to store the start time of the app launcher to propagate to workers and appmaster

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -59,9 +59,6 @@ public class GobblinYarnConfigurationKeys {
 
   public static final String YARN_APPLICATION_PROXY_JVM_ARGS = GOBBLIN_YARN_PREFIX + "proxy.jvm.args";
 
-  //Config value for proxy jvm args when absent
-  public static final String EMPTY_STRING_PLACEHOLDER = "emptyStringPlaceholder";
-
   // Used to store the start time of the app launcher to propagate to workers and appmaster
   public static final String YARN_APPLICATION_LAUNCHER_START_TIME_KEY = GOBBLIN_YARN_PREFIX + "application.start.time";
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -57,6 +57,11 @@ public class GobblinYarnConfigurationKeys {
 
   public static final String YARN_APPLICATION_LIB_JAR_LIST = GOBBLIN_YARN_PREFIX + "lib.jar.list";
 
+  public static final String YARN_APPLICATION_PROXY_JVM_ARGS = GOBBLIN_YARN_PREFIX + "proxy.jvm.args";
+
+  //Config value for proxy jvm args when absent
+  public static final String EMPTY_STRING_PLACEHOLDER = "emptyStringPlaceholder";
+
   // Used to store the start time of the app launcher to propagate to workers and appmaster
   public static final String YARN_APPLICATION_LAUNCHER_START_TIME_KEY = GOBBLIN_YARN_PREFIX + "application.start.time";
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -363,13 +363,6 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
 
     String command = this.gobblinYarnAppLauncher.buildApplicationMasterCommand("application_1234_3456", 64);
     Assert.assertTrue(command.contains("-Dhttp.proxyHost=foo-bar.baz.org -Dhttp.proxyPort=1234"));
-
-    this.config = this.config.withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS,
-        ConfigValueFactory.fromAnyRef("emptyStringPlaceholder"));
-    this.gobblinYarnAppLauncher = new GobblinYarnAppLauncher(this.config, clusterConf);
-
-    command = this.gobblinYarnAppLauncher.buildApplicationMasterCommand("application_1234_3456", 64);
-    Assert.assertFalse(command.contains("emptyStringPlaceholder"));
   }
 
   @AfterClass

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -129,7 +129,9 @@ public class YarnServiceTest {
 
     Config modifiedConfig = this.config
         .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, ConfigValueFactory.fromAnyRef("10"))
-        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef("0.8"));
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef("0.8"))
+        .withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS,
+        ConfigValueFactory.fromAnyRef("-Dhttp.proxyHost=foo-bar.baz.org -Dhttp.proxyPort=1234"));
     TestYarnService yarnService = new TestYarnService(modifiedConfig, "testApp2", "appId2",
             this.clusterConf, FileSystem.getLocal(new Configuration()), this.eventBus);
 
@@ -147,6 +149,7 @@ public class YarnServiceTest {
     Assert.assertTrue(command.contains(String.format("--%s %s", HELIX_INSTANCE_NAME_OPTION_NAME, helixInstance)));
     Assert.assertTrue(command.contains(String.format("--%s %s", HELIX_INSTANCE_TAGS_OPTION_NAME, helixTag)));
     Assert.assertTrue(command.endsWith("1><LOG_DIR>/GobblinYarnTaskRunner.stdout 2><LOG_DIR>/GobblinYarnTaskRunner.stderr"));
+    Assert.assertFalse(command.contains("-Dhttp.proxyHost=foo-bar.baz.org -Dhttp.proxyPort=1234"));
   }
 
   static class TestYarnService extends YarnService {

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -129,9 +129,7 @@ public class YarnServiceTest {
 
     Config modifiedConfig = this.config
         .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, ConfigValueFactory.fromAnyRef("10"))
-        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef("0.8"))
-        .withValue(GobblinYarnConfigurationKeys.YARN_APPLICATION_PROXY_JVM_ARGS,
-        ConfigValueFactory.fromAnyRef("-Dhttp.proxyHost=foo-bar.baz.org -Dhttp.proxyPort=1234"));
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef("0.8"));
     TestYarnService yarnService = new TestYarnService(modifiedConfig, "testApp2", "appId2",
             this.clusterConf, FileSystem.getLocal(new Configuration()), this.eventBus);
 
@@ -149,7 +147,6 @@ public class YarnServiceTest {
     Assert.assertTrue(command.contains(String.format("--%s %s", HELIX_INSTANCE_NAME_OPTION_NAME, helixInstance)));
     Assert.assertTrue(command.contains(String.format("--%s %s", HELIX_INSTANCE_TAGS_OPTION_NAME, helixTag)));
     Assert.assertTrue(command.endsWith("1><LOG_DIR>/GobblinYarnTaskRunner.stdout 2><LOG_DIR>/GobblinYarnTaskRunner.stderr"));
-    Assert.assertFalse(command.contains("-Dhttp.proxyHost=foo-bar.baz.org -Dhttp.proxyPort=1234"));
   }
 
   static class TestYarnService extends YarnService {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-2172] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2172


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
It allows proxy jvm args to be sent to Yarn AM and Containers which are retrieved from a new property.

Added custom handling for emptyStringPlaceholder since that's the value of config getting passed when the string is actually emtpy.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally using test Azkaban project
Added relevant unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

