### PR TITLE
[GOBBLIN-2176] Set default authenticator in Yarn Temporal containers

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
@@ -70,6 +70,7 @@ import org.apache.gobblin.metrics.RootMetricContext;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 import org.apache.gobblin.metrics.reporter.util.MetricReportUtils;
+import org.apache.gobblin.runtime.AbstractJobLauncher;
 import org.apache.gobblin.runtime.api.TaskEventMetadataGenerator;
 import org.apache.gobblin.temporal.GobblinTemporalConfigurationKeys;
 import org.apache.gobblin.temporal.workflows.client.TemporalWorkflowClientFactory;
@@ -223,6 +224,9 @@ public class GobblinTemporalTaskRunner implements StandardMetricsBridge {
 
     // Add a shutdown hook so the task scheduler gets properly shutdown
     addShutdownHook();
+
+    // Update authenticator if set
+    AbstractJobLauncher.setDefaultAuthenticator(ConfigUtils.configToProperties(this.clusterConfig));
 
     try {
       for (int i = 0; i < this.numTemporalWorkers; i++) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2176) issues and references them in the PR title. For example, "[GOBBLIN-2176] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2176


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Set default authenticator in Yarn containers if the property is set.

The default authenticator is set in MR world through [TaskRunner of MRJobLauncher](https://github.com/apache/gobblin/blob/e5d897edaee391d05a55e6ac8a420e3416fef6d9/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java#L833).

It gets set in Temporal AM through GobblinTemporalJobLauncher which extends GobblinJobLauncher which extends AbstractJobLauncher. AbstractJobLauncher's [constructor](https://github.com/apache/gobblin/blob/e5d897edaee391d05a55e6ac8a420e3416fef6d9/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java#L222C7-L222C30) sets the default authenticator.

The only missing place is `GobblinTemporalTaskRunner` which is added in this PR.

`AbstractJobLauncher.setDefaultAuthenticator()` only performs any action when the property `job.default.authenticator.class` is set, or else it is a no-op.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Performed testing in a local Azkaban project.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

