### PR TITLE
[GOBBLIN-2177] Avoid shutting down QueueProcessor on non-InterruptedException

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/HighLevelConsumerTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/HighLevelConsumerTest.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.kafka.KafkaTestBase;
 import org.apache.gobblin.kafka.client.AbstractBaseKafkaConsumerClient;
+import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.kafka.client.Kafka09ConsumerClient;
 import org.apache.gobblin.kafka.writer.Kafka09DataWriter;
 import org.apache.gobblin.kafka.writer.KafkaWriterConfigurationKeys;
@@ -174,6 +175,33 @@ public class HighLevelConsumerTest extends KafkaTestBase {
     };
     Long produceTimestamp = 1000L;
     Assert.assertTrue(consumer.calcMillisSince(produceTimestamp).equals(234L));
+  }
+
+  @Test
+  public void testQueueProcessorRuntimeExceptionEncountered() throws Exception {
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty(ConfigurationKeys.KAFKA_BROKERS, _kafkaBrokers);
+    consumerProps.setProperty(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    consumerProps.setProperty(SOURCE_KAFKA_CONSUMERCONFIG_KEY_WITH_DOT + KAFKA_AUTO_OFFSET_RESET_KEY, "earliest");
+    //Generate a brand new consumer group id to ensure there are no previously committed offsets for this group id
+    String consumerGroupId = Joiner.on("-").join(TOPIC, "auto", System.currentTimeMillis());
+    consumerProps.setProperty(SOURCE_KAFKA_CONSUMERCONFIG_KEY_WITH_DOT + HighLevelConsumer.GROUP_ID_KEY, consumerGroupId);
+    consumerProps.setProperty(HighLevelConsumer.ENABLE_AUTO_COMMIT_KEY, "true");
+
+    // Create an instance of MockedHighLevelConsumer using an anonymous class
+    MockedHighLevelConsumer consumer = new MockedHighLevelConsumer(TOPIC, ConfigUtils.propertiesToConfig(consumerProps), NUM_PARTITIONS) {
+      @Override
+      public void processMessage(DecodeableKafkaRecord<byte[], byte[]> message) {
+        super.processMessage(message);
+        // Override the method to throw a custom exception
+        throw new RuntimeException("Simulated exception in processMessage");
+      }
+    };
+    consumer.startAsync().awaitRunning();
+
+    // assert all NUM_MSGS messages were processed.
+    consumer.awaitExactlyNMessages(NUM_MSGS, 10000);
+    consumer.shutDown();
   }
 
   private List<byte[]> createByteArrayMessages() {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -336,7 +336,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     public void run() {
       log.info("Starting queue processing.. " + Thread.currentThread().getName());
       KafkaConsumerRecord record = null;
-      while (!shutdownRequested) {
+      while (true) {
         try {
           record = queue.take();
           messagesRead.inc();
@@ -355,7 +355,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
           return;
         } catch (Exception e) {
           // Log the error and let the queue processor continue processing
-          log.error("Encountered exception while processing record so stopping queue processing. Record: {} Exception: {}", record, e);
+          log.error("Encountered exception while processing record. Record: {} Exception: {}", record, e);
         }
       }
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2177) issues and references them in the PR title. For example, "[GOBBLIN-2177] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2177


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
For `enable.auto.commit` as `true`:

The `QueueProcessor` has an infinite while loop which gets stopped upon encountering any Exception. This effectively drops the messages being consumed post such Exception.
The implemented fix ensures that for any non-Interrupted Exception, we log the occurrence and keep trying to process further messages.
For InterruptedException, we interrupt the current thread and stop the queue processor.
The infinite while loop is also updated to stop based on shutdown flag.

For `enable.auto.commit` as `false`:
Messages are not committed if an exception occurs. In this case we will stop queue processing to maintain the order of message commit. (If we avoid stopping here, messages may be committed out of order)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added a unit test to verify all messages are processed, even on encountering any Exception.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

