### PR TITLE
Add COMPILED & RUNNING events to GaSJobObservabilityEventProducer

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSFlowObservabilityEvent.avsc
@@ -50,13 +50,15 @@
         "type": "enum",
         "name": "FlowStatus",
         "symbols": [
+          "COMPILED",
+          "RUNNING",
           "SUCCEEDED",
           "COMPILATION_FAILURE",
           "SUBMISSION_FAILURE",
           "EXECUTION_FAILURE",
           "CANCELLED"
         ],
-        "doc": "Final flow status for the GaaS flow",
+        "doc": "Flow status for the GaaS flow",
         "compliance": "NONE"
       }
     },

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSJobObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSJobObservabilityEvent.avsc
@@ -62,13 +62,15 @@
         "type": "enum",
         "name": "JobStatus",
         "symbols": [
+          "COMPILED",
+          "RUNNING",
           "SUCCEEDED",
           "COMPILATION_FAILURE",
           "SUBMISSION_FAILURE",
           "EXECUTION_FAILURE",
           "CANCELLED"
         ],
-        "doc": "Final job status for this job in the GaaS flow",
+        "doc": "Job status for this job in the GaaS flow",
         "compliance": "NONE"
       }
     },

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/GaaSJobObservabilityEventProducer.java
@@ -244,6 +244,11 @@ public abstract class GaaSJobObservabilityEventProducer implements Closeable {
 
   private static JobStatus convertExecutionStatusTojobState(State state, ExecutionStatus executionStatus) {
     switch (executionStatus) {
+      // Add more mapping for new events rather than just terminal ones
+      case COMPILED:
+        return JobStatus.COMPILED;
+      case RUNNING:
+        return JobStatus.RUNNING;
       case FAILED:
         // TODO: Separate failure cases to SUBMISSION FAILURE and COMPILATION FAILURE, investigate events to populate these fields
         if (state.contains(TimingEvent.JOB_END_TIME)) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -22,6 +22,7 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -233,6 +234,12 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
           // as much as FAILED does if we chose to emit ObservabilityEvent for FAILED_PENDING_RETRY
           boolean retryRequired = modifyStateIfRetryRequired(jobStatus);
 
+          if (Objects.equals(status, "COMPILED")) {
+            this.eventProducer.emitObservabilityEvent(jobStatus);
+          }
+          if (updatedJobStatus.getRight() == NewState.RUNNING) {
+            this.eventProducer.emitObservabilityEvent(jobStatus);
+          }
           if (updatedJobStatus.getRight() == NewState.FINISHED && !retryRequired) {
             // do not send event if retry is required, because it can alert users to re-submit a job that is already set to be retried by GaaS
             this.eventProducer.emitObservabilityEvent(jobStatus);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, 
    - https://issues.apache.org/jira/browse/GOBBLIN-2183


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

Currently only terminal events (failed, complete & cancelled) are emitted by `GaSJobObservabilityEventProducer`. This PR adds COMPILED and RUNNING events to the producer providing visibility into stuck flows/job & also enabling us to deriving metrics like realtime scheduling/execution delays compared to now where we can derive that only after the terminal event is emitted.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Modified existing tests in `KafkaAvroJobStatusMonitorTest` to check for the newly added events.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

