### PR TITLE
GOBBLIN-2184. Disable releases for apache.snapshots repo

### DIFF
--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -25,6 +25,9 @@ repositories {
   }
   maven {
     url "https://repository.apache.org/content/repositories/snapshots"
+    mavenContent {
+      snapshotsOnly()
+    }
   }
   maven {
     url "https://linkedin.jfrog.io/artifactory/open-source/"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.

https://issues.apache.org/jira/browse/GOBBLIN-2184

## How was this patch tested?

Local build:

```
$ ./gradlew compileJava
...
BUILD SUCCESSFUL in 3m 1s
209 actionable tasks: 209 executed
```