### PR TITLE
[GOBBLIN-2186] Emit GoT GTEs to time `WorkUnit` prep and to record volume of Work Discovery

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetFinder.java
@@ -149,10 +149,10 @@ public class IcebergDatasetFinder implements IterableDatasetFinder<IcebergDatase
    */
   protected IcebergDataset createIcebergDataset(IcebergCatalog sourceIcebergCatalog, String srcDbName, String srcTableName, IcebergCatalog destinationIcebergCatalog, String destDbName, String destTableName, Properties properties, FileSystem fs) throws IOException {
     IcebergTable srcIcebergTable = sourceIcebergCatalog.openTable(srcDbName, srcTableName);
-    Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Missing Source Iceberg Table: {%s}.{%s}", srcDbName, srcTableName));
+    Preconditions.checkArgument(sourceIcebergCatalog.tableAlreadyExists(srcIcebergTable), String.format("Source Iceberg Table not found: {%s}.{%s}", srcDbName, srcTableName));
     IcebergTable destIcebergTable = destinationIcebergCatalog.openTable(destDbName, destTableName);
     // TODO: Rethink strategy to enforce dest iceberg table
-    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Missing Destination Iceberg Table: {%s}.{%s}", destDbName, destTableName));
+    Preconditions.checkArgument(destinationIcebergCatalog.tableAlreadyExists(destIcebergTable), String.format("Destination Iceberg Table not found: {%s}.{%s}", destDbName, destTableName));
     return createSpecificDataset(srcIcebergTable, destIcebergTable, properties, fs, getConfigShouldCopyMetadataPath(properties));
   }
 

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -110,6 +110,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
   public static final String JOB_SKIPPED_TIME = "jobSkippedTime";
   public static final String WORKUNIT_PLAN_START_TIME = "workunitPlanStartTime";
   public static final String WORKUNIT_PLAN_END_TIME = "workunitPlanEndTime";
+  public static final String WORKUNITS_GENERATED_SUMMARY = "workUnitsGeneratedSummary";
   public static final String JOB_END_TIME = "jobEndTime";
   public static final String JOB_LAST_PROGRESS_EVENT_TIME = "jobLastProgressEventTime";
   public static final String JOB_COMPLETION_PERCENTAGE = "jobCompletionPercentage";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -72,7 +72,6 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
 
   // Since {@link SpecCompiler} is an {@link SpecCatalogListener}, it is expected that any Spec change should be reflected
   // to these data structures.
-  @Getter
   protected final Map<URI, TopologySpec> topologySpecMap;
 
   protected final Config config;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/StaticFlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/StaticFlowTemplate.java
@@ -68,7 +68,6 @@ public class StaticFlowTemplate implements FlowTemplate {
   private String description;
   @Getter
   private transient FlowCatalogWithTemplates catalog;
-  @Getter
   private List<JobTemplate> jobTemplates;
 
   private transient Config rawConfig;

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WorkUnitsSizeSummary.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WorkUnitsSizeSummary.java
@@ -53,6 +53,29 @@ public class WorkUnitsSizeSummary {
   @NonNull private List<Double> topLevelQuantilesMinSizes;
   @NonNull private List<Double> constituentQuantilesMinSizes;
 
+  /** Total size, counts, means, and medians: the most telling measurements packaged for ready consumption / observability */
+  @Data
+  @Setter(AccessLevel.NONE) // NOTE: non-`final` members solely to enable deserialization
+  @NoArgsConstructor // IMPORTANT: for jackson (de)serialization
+  @RequiredArgsConstructor
+  public static class Distillation {
+    @NonNull private long totalSize;
+    @NonNull private long topLevelWorkUnitsCount;
+    @NonNull private long constituentWorkUnitsCount;
+    @NonNull private double topLevelWorkUnitsMeanSize;
+    @NonNull private double constituentWorkUnitsMeanSize;
+    @NonNull private double topLevelWorkUnitsMedianSize;
+    @NonNull private double constituentWorkUnitsMedianSize;
+  }
+
+  @JsonIgnore // (because no-arg method resembles 'java bean property')
+  public Distillation distill() {
+    return new Distillation(this.totalSize, this.topLevelWorkUnitsCount, this.constituentWorkUnitsCount,
+        this.getTopLevelWorkUnitsMeanSize(), this.getConstituentWorkUnitsMeanSize(),
+        this.getTopLevelWorkUnitsMedianSize(), this.getConstituentWorkUnitsMedianSize()
+    );
+  }
+
   @JsonIgnore // (because no-arg method resembles 'java bean property')
   public double getTopLevelWorkUnitsMeanSize() {
     return this.totalSize * 1.0 / this.topLevelWorkUnitsCount;

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ProcessWorkUnitsWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ProcessWorkUnitsWorkflowImpl.java
@@ -121,7 +121,7 @@ public class ProcessWorkUnitsWorkflowImpl implements ProcessWorkUnitsWorkflow {
   private Optional<EventTimer> createOptJobEventTimer(WUProcessingSpec workSpec) {
     if (workSpec.isToDoJobLevelTiming()) {
       EventSubmitterContext eventSubmitterContext = workSpec.getEventSubmitterContext();
-      TemporalEventTimer.Factory timerFactory = new TemporalEventTimer.Factory(eventSubmitterContext);
+      TemporalEventTimer.Factory timerFactory = new TemporalEventTimer.WithinWorkflowFactory(eventSubmitterContext);
       return Optional.of(timerFactory.createJobTimer());
     } else {
       return Optional.empty();

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/helloworld/GreetingWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/helloworld/GreetingWorkflowImpl.java
@@ -57,7 +57,7 @@ public class GreetingWorkflowImpl implements GreetingWorkflow {
         /**
          * Example of the {@link TemporalEventTimer.Factory} invoking child activity for instrumentation.
          */
-        TemporalEventTimer.Factory timerFactory = new TemporalEventTimer.Factory(eventSubmitterContext);
+        TemporalEventTimer.Factory timerFactory = new TemporalEventTimer.WithinWorkflowFactory(eventSubmitterContext);
         try (TemporalEventTimer timer = timerFactory.create("getGreetingTime")) {
             LOG.info("Executing getGreeting");
             timer.withMetadata("name", name);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/EventTimer.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/EventTimer.java
@@ -42,17 +42,30 @@ import org.apache.gobblin.metrics.event.TimingEvent;
  */
 public interface EventTimer extends Closeable {
   /**
-   * Add additional metadata that will be used for post-processing when the timer is stopped via {@link #stop()}
+   * Add additional metadata that will be emitted with the timer, once {@link #stop()}ped
    * @param key
    * @param metadata
    */
   EventTimer withMetadata(String key, String metadata);
 
   /**
+   * Add additional metadata, after stringifying as JSON, that will be emitted with the timer, once {@link #stop()}ped
+   * @param key
+   * @param metadata (to convert to JSON)
+   */
+  <T> EventTimer withMetadataAsJson(String key, T metadata);
+
+  /**
    * Stops the timer and execute any post-processing (e.g. event submission)
    */
   void stop();
 
+  /** alias to {@link #stop()} */
+  default void submit() {
+    stop();
+  }
+
+  /** alias to {@link #stop()} */
   default void close() {
     stop();
   }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/TemporalEventTimer.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/TemporalEventTimer.java
@@ -19,7 +19,9 @@ package org.apache.gobblin.temporal.workflows.metrics;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.function.Supplier;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -29,35 +31,40 @@ import io.temporal.workflow.Workflow;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.GobblinEventBuilder;
 import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.runtime.util.GsonUtils;
 
 
 /**
- * Boilerplate for tracking elapsed time of events that is compatible with {@link Workflow}
- * by using activities to record time
+ * Encapsulates emission of {@link org.apache.gobblin.metrics.GobblinTrackingEvent}s, e.g. to convey timing duration and/or event metadata to
+ * gobblin-service (GaaS).  For use either within a {@link Workflow} (with emission in a sub-activity, for reliability) or within an
+ * {@link io.temporal.activity.Activity} (with direct event emission, since an activity may not itself launch further activities).  That choice
+ * is governed by the {@link Factory} used to create the timer: either {@link WithinWorkflowFactory} or {@link WithinActivityFactory}.
  *
- * This class is very similar to {@link TimingEvent} but uses {@link Workflow} compatible APIs. It's possible to refactor
- * this class to inherit the {@link TimingEvent} but extra care would be needed to remove the {@link EventSubmitter} field
- * since that class is not serializable without losing some information
+ * Implementation Note: While very similar to {@link TimingEvent}, it cannot inherit directly, since its {@link EventSubmitter} field is not serializable.
+ * @see EventTimer for details
  */
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class TemporalEventTimer implements EventTimer {
   private final SubmitGTEActivity trackingEventActivity;
   private final GobblinEventBuilder eventBuilder;
   private final EventSubmitterContext eventSubmitterContext;
+  private final Supplier<Instant> currentInstantSupplier;
   @Getter private final Instant startTime;
 
-  // Alias to stop()
-  public void submit() {
-    stop();
-  }
   @Override
   public void stop() {
-    stop(getCurrentTime());
+    stop(currentInstantSupplier.get());
   }
 
   @Override
   public TemporalEventTimer withMetadata(String key, String metadata) {
     this.eventBuilder.addMetadata(key, metadata);
+    return this;
+  }
+
+  @Override
+  public <T> TemporalEventTimer withMetadataAsJson(String key, T metadata) {
+    this.eventBuilder.addMetadata(key, GsonUtils.GSON_WITH_DATE_HANDLING.toJson(metadata));
     return this;
   }
 
@@ -71,51 +78,132 @@ public class TemporalEventTimer implements EventTimer {
     trackingEventActivity.submitGTE(this.eventBuilder, eventSubmitterContext);
   }
 
+
   /**
-   * {@link Workflow}-safe (i.e. deterministic) way for equivalent of {@link System#currentTimeMillis()}
-   * WARNING: DO NOT use from an {@link io.temporal.activity.Activity}
+   * Factory for creating {@link TemporalEventTimer}s, with convenience methods for well-known forms of GaaS-associated
+   * {@link org.apache.gobblin.metrics.GobblinTrackingEvent}s.
+   *
+   * This class is abstract; choose the concrete form befitting the execution context, either {@link WithinWorkflowFactory} or {@link WithinActivityFactory}.
    */
-  public static Instant getCurrentTime() {
-    return Instant.ofEpochMilli(Workflow.currentTimeMillis());
-  }
-
-  public static class Factory {
-    private static final ActivityOptions DEFAULT_OPTS = ActivityOptions.newBuilder()
-        .setStartToCloseTimeout(Duration.ofHours(12)) // maximum timeout for the actual event submission to kafka, waiting out a kafka outage
-        .build();
-    private final SubmitGTEActivity submitGTEActivity;
+  @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+  public abstract static class Factory {
     private final EventSubmitterContext eventSubmitterContext;
-
-    public Factory(EventSubmitterContext eventSubmitterContext) {
-      this(eventSubmitterContext, DEFAULT_OPTS);
-    }
-
-    public Factory(EventSubmitterContext eventSubmitterContext, ActivityOptions opts) {
-      this.submitGTEActivity = Workflow.newActivityStub(SubmitGTEActivity.class, opts);
-      this.eventSubmitterContext = eventSubmitterContext;
-    }
+    private final SubmitGTEActivity submitGTEActivity;
+    private final Supplier<Instant> currentInstantSupplier;
 
     public TemporalEventTimer create(String eventName, Instant startTime) {
       GobblinEventBuilder eventBuilder = new GobblinEventBuilder(eventName, eventSubmitterContext.getNamespace());
-      return new TemporalEventTimer(submitGTEActivity, eventBuilder, this.eventSubmitterContext, startTime);
+      return new TemporalEventTimer(this.submitGTEActivity, eventBuilder, this.eventSubmitterContext, currentInstantSupplier, startTime);
     }
 
     public TemporalEventTimer create(String eventName) {
-      return create(eventName, getCurrentTime());
+      return create(eventName, currentInstantSupplier.get());
     }
 
     /**
      * Utility for creating a timer that emits separate events at the start and end of a job. This imitates the behavior in
-     * {@link org.apache.gobblin.runtime.AbstractJobLauncher} and emits events that are compatible with the
-     * {@link org.apache.gobblin.runtime.job_monitor.KafkaAvroJobMonitor} to update GaaS flow statuses
+     * {@link org.apache.gobblin.runtime.AbstractJobLauncher} by emitting events that are compatible with the
+     * {@link org.apache.gobblin.service.monitoring.KafkaAvroJobStatusMonitor}, to update GaaS job/flow status and timing information.
      *
-     * @return a timer that emits an event at the beginning of the job and a completion event ends at the end of the job
+     * @return a timer that will emit a job completion (success) event once `.stop`ped;  *PLUS* immediately emit a job started event
      */
     public TemporalEventTimer createJobTimer() {
       TemporalEventTimer startTimer = create(TimingEvent.LauncherTimings.JOB_START); // update GaaS: `ExecutionStatus.RUNNING`
       startTimer.stop(Instant.EPOCH); // Emit start job event containing a stub end time
       // [upon `.stop()`] update GaaS: `ExecutionStatus.RUNNING`, `TimingEvent.JOB_END_TIME`:
       return create(TimingEvent.LauncherTimings.JOB_SUCCEEDED, startTimer.startTime);
+    }
+
+    /**
+     * Utility for creating a timer that emits an event to time the start and end of "Work Discovery" (i.e.
+     * {@link org.apache.gobblin.source.Source#getWorkunits}).  It SHOULD span only planning - NOT {@link org.apache.gobblin.source.workunit.WorkUnit}
+     * preparation, such as serialization, etc.  This imitates the behavior in {@link org.apache.gobblin.runtime.AbstractJobLauncher} by emitting events
+     * that are compatible with the {@link org.apache.gobblin.service.monitoring.KafkaAvroJobStatusMonitor}, to update GaaS job timing information, and
+     * ultimately participate in the {@link org.apache.gobblin.metrics.GaaSJobObservabilityEvent}.
+     *
+     * @return a timer that will emit a "work units creation" event once `.stop`ped` (upon (successful) "Work Discovery")
+     */
+    public TemporalEventTimer createWorkDiscoveryTimer() {
+      return create(TimingEvent.LauncherTimings.WORK_UNITS_CREATION); // [upon `.stop()`] update GaaS: `TimingEvent.WORKUNIT_PLAN_{START,END}_TIME`
+    }
+
+    /**
+     * Utility for creating an event to convey "Work Discovery" metadata, like {@link org.apache.gobblin.source.workunit.WorkUnit} count, size, and
+     * bin packing.  To include such info, the caller MUST invoke {@link #withMetadataAsJson(String, Object)} with
+     * {@link org.apache.gobblin.temporal.ddm.work.WorkUnitsSizeSummary.Distillation}.
+     *
+     * The event emitted would inform GaaS of the volume of work discovered (and bin packed), in case `WorkUnit` serialization were to fail for exceeding
+     * available memory.  The thence-known amount of work would guide config adjustment for a subsequent re-attempt.
+     *
+     * IMPORTANT: This event SHOULD be emitted separately from {@link #createWorkDiscoveryTimer()}, to preserve timing accuracy (of that other).
+     *
+     * @return an event to convey "work units preparation" (Work Discovery) metadata once `.stop`ped
+     */
+    public TemporalEventTimer createWorkPreparationTimer() {
+      // [upon `.stop()`] simply (again) set GaaS: `ExecutionStatus.RUNNING` and convey `TimingEvent.WORKUNITS_GENERATED_SUMMARY` (metadata)
+      // (the true purpose in "sending" is to record observable metadata about WU count, size, and bin packing)
+      return create(TimingEvent.LauncherTimings.WORK_UNITS_PREPARATION);
+    }
+  }
+
+
+  /**
+   *  Concrete {@link Factory} to use when executing within a {@link Workflow}.  It will (synchronously) emit the {@link TemporalEventTimer} in an
+   *  {@link io.temporal.activity.Activity}, both for reliability and to avoid blocking within the limited `Workflow` time allowance.  In
+   *  addition, it uses the `Workflow`-safe {@link Workflow#currentTimeMillis()}.
+   */
+  public static class WithinWorkflowFactory extends Factory {
+    private static final ActivityOptions DEFAULT_OPTS = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofHours(6)) // maximum timeout for the actual event submission to kafka, waiting out a kafka outage
+        .build();
+
+    public WithinWorkflowFactory(EventSubmitterContext eventSubmitterContext) {
+      this(eventSubmitterContext, DEFAULT_OPTS);
+    }
+
+    public WithinWorkflowFactory(EventSubmitterContext eventSubmitterContext, ActivityOptions opts) {
+      super(eventSubmitterContext, Workflow.newActivityStub(SubmitGTEActivity.class, opts), WithinWorkflowFactory::getCurrentInstant);
+    }
+
+    /**
+     * {@link Workflow}-safe (i.e. deterministic) way for equivalent of {@link System#currentTimeMillis()}'s {@link Instant}
+     *
+     * WARNING: DO NOT use from an {@link io.temporal.activity.Activity}, as that would throw:
+     *   Caused by: java.lang.Error: Called from non workflow or workflow callback thread
+     *     at io.temporal.internal.sync.DeterministicRunnerImpl.currentThreadInternal(DeterministicRunnerImpl.java:130)
+     *     at io.temporal.internal.sync.WorkflowInternal.getRootWorkflowContext(WorkflowInternal.java:404)
+     *     at io.temporal.internal.sync.WorkflowInternal.getWorkflowOutboundInterceptor(WorkflowInternal.java:400)
+     *     at io.temporal.internal.sync.WorkflowInternal.currentTimeMillis(WorkflowInternal.java:205)
+     *     at io.temporal.workflow.Workflow.currentTimeMillis(Workflow.java:524)
+     *     ...
+     */
+    public static Instant getCurrentInstant() {
+      return Instant.ofEpochMilli(Workflow.currentTimeMillis());
+    }
+  }
+
+  /**
+   *  Concrete {@link Factory} to use when executing within an {@link io.temporal.activity.Activity}.  It will (synchronously) emit the
+   *  {@link TemporalEventTimer} directly within the current `Activity`, since an activity may not itself launch further activities.  It uses
+   *  the standard {@link System#currentTimeMillis()}, since `Workflow` determinism is not a concern within an `Activity`.
+   */
+  public static class WithinActivityFactory extends Factory {
+    public WithinActivityFactory(EventSubmitterContext eventSubmitterContext) {
+      // reference the `SubmitGTEActivity` impl directly, w/o temporal involved (i.e. NOT via `newActivityStub`), to permit use inside an activity; otherwise:
+      //   io.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor  - Activity failure. ActivityId=..., activityType=..., attempt=4
+      //   java.lang.Error: Called from non workflow or workflow callback thread
+      //     at io.temporal.internal.sync.DeterministicRunnerImpl.currentThreadInternal(DeterministicRunnerImpl.java:130)
+      //     at io.temporal.internal.sync.WorkflowInternal.getRootWorkflowContext(WorkflowInternal.java:404)
+      //     at io.temporal.internal.sync.WorkflowInternal.newActivityStub(WorkflowInternal.java:239)
+      //     at io.temporal.workflow.Workflow.newActivityStub(Workflow.java:92)
+      //     at org.apache.gobblin.temporal.workflows.metrics.TemporalEventTimer$Factory.<init>(TemporalEventTimer.java:89)
+      //     ...
+      super(eventSubmitterContext, new SubmitGTEActivityImpl(), WithinActivityFactory::getCurrentInstant);
+    }
+
+    /** @return (standard) {@link System#currentTimeMillis()}'s {@link Instant}, abstracted merely for code clarity */
+    public static Instant getCurrentInstant() {
+      return Instant.ofEpochMilli(System.currentTimeMillis());
     }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2186


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

`GaaSJobObservabilityEvent`s for Gobblin-on-Temporal jobs presently have no values set for the fields `jobPlanningStartTimestamp` and `jobPlanningEndTimestamp`.  This is because, in contrast with Gobblin-on-MR, `GenerateWorkUnitsImpl` emits no `TimingEvent.LauncherTimings.WORK_UNITS_CREATION` GTE to record such values.

The historical impediment was that Temporal does not permit Activities to launch other Activities (only Workflows may do that).  `TemporalEventTimer`, however, emitted its GTE on a separate Activity for reliability.  This change reworks `TemporalEventTimer.Factory` to be useable within an `Activity`, by refactoring into complementary concrete realizations - `TemporalEventTimer.WithinWorkflowFactory` and `TemporalEventTimer.WithinActivityFactory`.  The latter sets up direct GTE emission within the same (current) `Activity`.

The alternative of reworking `GenerateWorkUnitsImpl` from an `Activity` into a `Workflow` would be challenging to accomplish, because "Work Discovery" may be quite long running \- 15-30 mins is not uncommon for large full-initial-copy Iceberg-Distcp jobs \- yet Temporal [allows a workflow-task to run for a maximum of 2 minutes](https://docs.temporal.io/encyclopedia/detecting-workflow-failures#workflow-task-timeout).  (Since we wish to emit this timing GTE *in the midst of* Work Discovery, it would not be easy to have one sub-activity first performing all of Work Discovery and another subsequently doing GTE emission once the first concludes.)

In addition, now that this refactoring happily unblocks GTE-emission from `GenerateWorkUnitsImpl` we were primed to emit new metadata (on another GTE), which is actually even more critical to emit *in the midst of* Work Discovery: one to record the volume of `WorkUnit`s discovered.   To be useful, this must be done prior to WU serialization, which is memory-intensive and may OOM.  If that should happen this GTE's durable measurement would inform re-configuration for any subsequent re-attempt.

Accordingly, we preserve total size and counts, means, and medians of both original and bin packed WUs.  This was inspired by a pair of log messages produced within `CopySource::getWorkUnits`:
```
Statistics for ConcurrentBoundedPriorityIterable: {ResourcePool: {softBound: [ ... ], hardBound: [ ...]},totalResourcesUsed: [ ... ], maxRequirementPerDimension: [entities: 231943.0, bytesCopied: 1.22419622769628E14], ... }
```
and
```
org.apache.gobblin.data.management.copy.CopySource - Bin packed work units. Initial work units: 27252, packed work units: 13175, max weight per bin: 500000000, max work units per bin: 100.
```

We often seek out these messages to diagnose and resolve failures during `WorkUnit` Discovery, but rather than merely logging, this durable emission sets up fully-automatic (machine-to-machine) right-sizing to orchestrate a potential re-attempt (in case of WU serialization OOM error).

(Actual handling of this new GTE `TimingEvent#WORKUNITS_GENERATED_SUMMARY` metadata by GaaS will require a separate change, e.g. [to `KafkaAvroJobStatusMonitor#parseJobStatus`](https://github.com/apache/gobblin/blob/7dbeebf7fecc748ea3ef90cc318214cf26ba5afa/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java#L120).)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

manual execution

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

