### PR TITLE
[GOBBLIN-2188] Define `Initializer.AfterInitializeMemento` for GoT to tunnel state from `GenerateWorkUnits` to `CommitActivity`

### DIFF
--- a/gobblin-api/build.gradle
+++ b/gobblin-api/build.gradle
@@ -20,6 +20,8 @@ apply plugin: 'java'
 dependencies {
     compile externalDependency.guava
     compile externalDependency.gson
+    compile externalDependency.jacksonCore
+    compile externalDependency.jacksonMapper
     compile externalDependency.jasypt
     compile externalDependency.jodaTime
     compile externalDependency.commonsLang3

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -203,6 +203,7 @@ public class ConfigurationKeys {
   public static final String TASK_DATA_ROOT_DIR_KEY = "task.data.root.dir";
   public static final String SOURCE_CLASS_KEY = "source.class";
   public static final String CONVERTER_CLASSES_KEY = "converter.classes";
+  public static final String CONVERTER_INITIALIZERS_SERIALIZED_MEMENTOS_KEY = "converter.initializers.serialized.mementos";
   public static final String RECORD_STREAM_PROCESSOR_CLASSES_KEY = "recordStreamProcessor.classes";
   public static final String FORK_OPERATOR_CLASS_KEY = "fork.operator.class";
   public static final String DEFAULT_FORK_OPERATOR_CLASS = "org.apache.gobblin.fork.IdentityForkOperator";
@@ -434,6 +435,7 @@ public class ConfigurationKeys {
   public static final String WRITER_TRUNCATE_STAGING_TABLE = WRITER_PREFIX + ".truncate.staging.table";
   public static final String WRITER_OUTPUT_DIR = WRITER_PREFIX + ".output.dir";
   public static final String WRITER_BUILDER_CLASS = WRITER_PREFIX + ".builder.class";
+  public static final String WRITER_INITIALIZER_SERIALIZED_MEMENTO_KEY = "writer.initializer.serialized.memento";
   public static final String DEFAULT_WRITER_BUILDER_CLASS = "org.apache.gobblin.writer.AvroDataWriterBuilder";
   public static final String WRITER_FILE_NAME = WRITER_PREFIX + ".file.name";
   public static final String WRITER_FILE_PATH = WRITER_PREFIX + ".file.path";

--- a/gobblin-api/src/main/java/org/apache/gobblin/initializer/Initializer.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/initializer/Initializer.java
@@ -18,14 +18,90 @@
 package org.apache.gobblin.initializer;
 
 import java.io.Closeable;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 public interface Initializer extends Closeable {
 
   /**
-   * Initialize for the writer.
+   * Marker interface to convey an opaque snapshot of the internal state of any concrete {@link Initializer}, thus affording state serialization for
+   * eventual "revival" as a new `Initializer` holding equivalent internal state.  {@link #commemorate()} the memento after {@link #initialize()}
+   * and subsequently {@link #recall(AfterInitializeMemento)} before {@link #close()}ing it.
    *
-   * @param state
-   * @param workUnits WorkUnits created by Source
+   * Whereas the "Initializer Lifecycle", when synchronous and with the same instance, is:
+   *   [concrete `? implements Initializer` instance A]  `.initialize()` -> DO PROCESSING -> `.close()`
+   * When using `AfterInitializer` across instances and even memory-space boundaries it becomes:
+   *   [concrete `T0 implements Initializer` instance A] `.initialize()` -> `.commemorate()` -> PERSIST/TRANSMIT MEMENTO
+   *       -> DO PROCESSING ->
+   *   [concrete `T0 implements Initializer` instance B] RECEIVE MEMENTO -> `.recall()` -> `.close()`
+   *
+   * For both backwards compatibility and because not every concrete `Initializer` has internal state worth capturing, not every `Initializer`
+   * impl will implement an `AfterInitializeMemento`.  Those that do will supply a unique impl cultivating self-aware impl details of their
+   * `Initializer`.  An `AfterInitializeMemento` impl needs simply be (de)serializable by {@link ObjectMapper}.  An `Initializer` impl with an
+   * `AfterInitializeMemento` impl MUST NOT (re-)process any {@link org.apache.gobblin.source.workunit.WorkUnit}s during its {@link #close()}
+   * method: `WorkUnit` processing MUST proceed entirely within {@link #initialize()}.
+   */
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class") // to handle variety of concrete impls
+  public interface AfterInitializeMemento {
+    static Logger logger = LoggerFactory.getLogger(AfterInitializeMemento.class);
+
+    /**
+     * Convey attempt to work with a concrete {@link AfterInitializeMemento} of type other than the single expected companion type known to `forInitializer`.
+     * @see #castAsOrThrow(Class, Initializer)
+     */
+    static class MismatchedMementoException extends RuntimeException {
+      public MismatchedMementoException(AfterInitializeMemento memento, Class<?> asClass, Initializer forInitializer) {
+        super(String.format("Memento '%s' for Initializer '%s' of class '%s' - NOT '%s'", memento, forInitializer.getClass().getName(),
+            memento.getClass().getName(), asClass.getName()));
+      }
+    }
+
+    /** stringify as JSON */
+    static String serialize(AfterInitializeMemento memento) {
+      ObjectMapper objectMapper = new ObjectMapper();
+      try {
+        String result = objectMapper.writeValueAsString(memento);
+        logger.info("Serializing AfterInitializeMemento {} as '{}'", memento, result);
+        return result;
+      } catch (JsonProcessingException e) {
+        logger.error("Failed to serialize AfterInitializeMemento '" + memento + "'", e);
+        throw new RuntimeException(e);
+      }
+    }
+
+    /** destringify JSON */
+    static AfterInitializeMemento deserialize(String serialized) {
+      ObjectMapper objectMapper = new ObjectMapper();
+      try {
+        AfterInitializeMemento result = objectMapper.readValue(serialized, AfterInitializeMemento.class);
+        logger.info("Deserializing AfterInitializeMemento '{}' as {}", serialized, result);
+        return result;
+      } catch (JsonProcessingException e) {
+        logger.error("Failed to deserialize AfterInitializeMemento '" + serialized + "'", e);
+        throw new RuntimeException(e);
+      }
+    }
+
+    /** cast `this` concrete `AfterInitializeMemento` to `castClass`, else {@link MismatchedMementoException} */
+    default <T extends AfterInitializeMemento> T castAsOrThrow(Class<T> castClass, Initializer forInitializer)
+        throws MismatchedMementoException {
+      if (castClass.isAssignableFrom(this.getClass())) {
+        return (T) this;
+      } else {
+        throw new AfterInitializeMemento.MismatchedMementoException(this, castClass, forInitializer);
+      }
+    }
+  }
+
+  /**
+   * Initialize the writer/converter (e.g. using the state and/or {@link org.apache.gobblin.source.workunit.WorkUnit}s provided when constructing the instance)
    */
   public void initialize();
 
@@ -33,7 +109,23 @@ public interface Initializer extends Closeable {
    * Removed checked exception.
    * {@inheritDoc}
    * @see java.io.Closeable#close()
+   *
+   * NOTE: An `Initializer` impl with an `AfterInitializeMemento` impl MUST NOT (re-)process any {@link org.apache.gobblin.source.workunit.WorkUnit}s
+   * during its {@link #close()} method: `WorkUnit` processing MUST proceed entirely within {@link #initialize()}.
    */
   @Override
   public void close();
+
+  /** @return any `Initializer`-specific companion memento, as required to convey internal state after {@link #initialize()}, as needed to {@link #close()} */
+  default Optional<AfterInitializeMemento> commemorate() {
+    return Optional.empty();
+  }
+
+  /**
+   * "reinitialize" a fresh instance with (equiv.) post {@link #initialize()} internal state, per `Initializer`-specific companion `memento`
+   * to {@link #close()}
+   */
+  default void recall(AfterInitializeMemento memento) {
+    // noop
+  }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/initializer/MultiConverterInitializer.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/initializer/MultiConverterInitializer.java
@@ -18,27 +18,39 @@
 package org.apache.gobblin.converter.initializer;
 
 import java.util.List;
+import java.util.Optional;
 
 import lombok.ToString;
+
 import org.apache.gobblin.initializer.Initializer;
 import org.apache.gobblin.initializer.MultiInitializer;
 
 
 @ToString
 public class MultiConverterInitializer implements ConverterInitializer {
-  private final Initializer intializer;
+  private final Initializer initializer;
 
   public MultiConverterInitializer(List<ConverterInitializer> converterInitializers) {
-    this.intializer = new MultiInitializer(converterInitializers);
+    this.initializer = new MultiInitializer(converterInitializers);
   }
 
   @Override
   public void initialize() {
-    this.intializer.initialize();
+    this.initializer.initialize();
   }
 
   @Override
   public void close() {
-    this.intializer.close();
+    this.initializer.close();
+  }
+
+  @Override
+  public Optional<AfterInitializeMemento> commemorate() {
+    return this.initializer.commemorate();
+  }
+
+  @Override
+  public void recall(AfterInitializeMemento memento) {
+    this.initializer.recall(memento);
   }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/initializer/MultiInitializer.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/initializer/MultiInitializer.java
@@ -19,18 +19,46 @@ package org.apache.gobblin.initializer;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.google.common.io.Closer;
 
 
 /**
- * Wraps multiple writer initializer behind its interface. This is useful when there're more than one branch.
+ * Wraps multiple writer initializers, which is useful when more than one branch.
  */
 @ToString
 public class MultiInitializer implements Initializer {
+
+  /** Commemorate each (`Optional`) {@link org.apache.gobblin.initializer.Initializer.AfterInitializeMemento} of every wrapped {@link Initializer} */
+  @Data
+  @Setter(AccessLevel.NONE) // NOTE: non-`final` members solely to enable deserialization
+  @NoArgsConstructor // IMPORTANT: for jackson (de)serialization
+  @RequiredArgsConstructor
+  private static class Memento implements AfterInitializeMemento {
+    // WARNING: not possible to use `List<Optional<AfterInitializeMemento>>`, as first attempted, due to:
+    //   com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "present" (class java.util.Optional), not marked as
+    //   ignorable (0 known properties: ])
+    //     at [Source:(String)"{\"@class\":\"org.apache.gobblin.initializer.MultiInitializer$Memento\",\"orderedInitializersMementos\":[{\"present\":false}]}"]
+    //     (through reference chain: org.apache.gobblin.initializer.MultiInitializer$Memento[\"orderedInitializersMementos\"]->java.util.ArrayList[0]
+    //       ->java.util.Optional[\"present\"])",
+    // the following does NOT fix, probably due to `Optional`'s nesting with `List`:
+    //   @JsonIgnoreProperties(ignoreUnknown = true)
+    @NonNull private List<AfterInitializeMemento> orderedInitializersMementos;
+  }
+
+
   private final List<Initializer> initializers;
   private final Closer closer;
 
@@ -56,5 +84,22 @@ public class MultiInitializer implements Initializer {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public Optional<AfterInitializeMemento> commemorate() {
+    return Optional.of(new MultiInitializer.Memento(this.initializers.stream()
+        .map(Initializer::commemorate)
+        .map(opt -> opt.orElse(null))
+        .collect(Collectors.toList())));
+  }
+
+  @Override
+  public void recall(AfterInitializeMemento memento) {
+    Memento recollection = memento.castAsOrThrow(MultiInitializer.Memento.class, this);
+    Streams.zip(this.initializers.stream(), recollection.orderedInitializersMementos.stream(), (initializer, nullableInitializerMemento) -> {
+      Optional.ofNullable(nullableInitializerMemento).ifPresent(initializer::recall);
+      return null;
+    }).count(); // force evaluation, since `Streams.zip` used purely for side effects
   }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/initializer/MultiWriterInitializer.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/initializer/MultiWriterInitializer.java
@@ -17,31 +17,41 @@
 
 package org.apache.gobblin.writer.initializer;
 
-import org.apache.gobblin.initializer.Initializer;
-import org.apache.gobblin.initializer.MultiInitializer;
-
+import java.util.Optional;
 import java.util.List;
 
 import lombok.ToString;
+
+import org.apache.gobblin.initializer.Initializer;
+import org.apache.gobblin.initializer.MultiInitializer;
 
 
 @ToString
 public class MultiWriterInitializer implements WriterInitializer {
 
-  private final Initializer intializer;
+  private final Initializer initializer;
 
   public MultiWriterInitializer(List<WriterInitializer> writerInitializers) {
-    this.intializer = new MultiInitializer(writerInitializers);
+    this.initializer = new MultiInitializer(writerInitializers);
   }
 
   @Override
   public void initialize() {
-    this.intializer.initialize();
+    this.initializer.initialize();
   }
 
   @Override
   public void close() {
-    this.intializer.close();
+    this.initializer.close();
   }
 
+  @Override
+  public Optional<AfterInitializeMemento> commemorate() {
+    return this.initializer.commemorate();
+  }
+
+  @Override
+  public void recall(AfterInitializeMemento memento) {
+    this.initializer.recall(memento);
+  }
 }

--- a/gobblin-core/src/test/java/org/apache/gobblin/initializer/MultiInitializerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/initializer/MultiInitializerTest.java
@@ -121,6 +121,7 @@ public class MultiInitializerTest {
     }
   }
 
+
   @Test
   public void testMementoCommemorateToSerializeAndDeserializeForRecall() {
     // create "first generation" of concrete initializers
@@ -128,7 +129,7 @@ public class MultiInitializerTest {
     InitializerImplBNoMemento initializerB_1 = new InitializerImplBNoMemento();
     InitializerImplC initializerC_1 = new InitializerImplC();
 
-    // create the 1st-gen `MultiInitializer` and `initialize` all wrapped initializers
+    // create the 1st-gen `MultiInitializer`; `initialize` all wrapped initializers
     MultiInitializer multiInitializer1G = new MultiInitializer(Arrays.asList(initializerA_1, initializerB_1, initializerC_1));
     multiInitializer1G.initialize();
 
@@ -137,7 +138,7 @@ public class MultiInitializerTest {
     Assert.assertTrue(optMemento1G.isPresent());
     String serializedMemento = Initializer.AfterInitializeMemento.serialize(optMemento1G.get());
 
-    // create a new 2nd-gen `MultiInitializer` using a "second generation" of concrete initializers
+    // create a new 2nd-gen `MultiInitializer` with a "second generation" of concrete initializers... but DO NOT `initialize` them!
     InitializerImplA initializerA_2 = new InitializerImplA();
     InitializerImplBNoMemento initializerB_2 = new InitializerImplBNoMemento();
     InitializerImplC initializerC_2 = new InitializerImplC();
@@ -151,12 +152,12 @@ public class MultiInitializerTest {
     try {
       // verify not possible to `commemorate` prior to `recall()`
       multiInitializer2G.commemorate();
-      Assert.fail("`commemorate()` somehow possible even before `Initializer.initialize()` or `recall()`, despite `@NotNull` annotation on `state`");
+      Assert.fail("`commemorate()` somehow possible even before `Initializer.initialize()` or `recall()` - despite `@NotNull` annotation on `state`");
     } catch (NullPointerException npe) {
       // expected
     }
 
-    // now `deserialize` 1st-gen state and `recall` it to the 2nd-gen `MultiInitializer`
+    // next, `deserialize` 1st-gen state and `recall` it to the (un-`initialize`d) 2nd-gen `MultiInitializer`
     Initializer.AfterInitializeMemento deserializedMemento = Initializer.AfterInitializeMemento.deserialize(serializedMemento);
     multiInitializer2G.recall(deserializedMemento);
     Optional<Initializer.AfterInitializeMemento> optMemento2G = multiInitializer2G.commemorate();
@@ -169,7 +170,7 @@ public class MultiInitializerTest {
     multiInitializer2G.initialize();
     Optional<Initializer.AfterInitializeMemento> optMemento2G_alt = multiInitializer2G.commemorate();
     Assert.assertTrue(optMemento2G_alt.isPresent());
-    // verify not simply that mementos always equal
+    // verify not simply the case that mementos always equal
     Assert.assertNotEquals(optMemento2G.get(), optMemento2G_alt.get());
   }
 }

--- a/gobblin-core/src/test/java/org/apache/gobblin/initializer/MultiInitializerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/initializer/MultiInitializerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.initializer;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+
+/** Test {@link MultiInitializer} */
+public class MultiInitializerTest {
+  /** Concrete Initializer A - implements `AfterInitializeMemento` */
+  private static class InitializerImplA implements Initializer {
+    private static int instanceCounter = 0;
+
+    @Data
+    @NoArgsConstructor // IMPORTANT: for jackson (de)serialization
+    @RequiredArgsConstructor
+    private static class Memento implements Initializer.AfterInitializeMemento {
+      @NonNull private String state;
+    }
+
+    @Getter private String state;
+
+    @Override
+    public void initialize() {
+      this.state = "initialized-" + (++instanceCounter);
+    }
+
+    @Override
+    public void close() {
+      // noop
+    }
+
+    @Override
+    public Optional<AfterInitializeMemento> commemorate() {
+      return Optional.of(new Memento(this.state));
+    }
+
+    @Override
+    public void recall(AfterInitializeMemento memento) {
+      Memento recollection = memento.castAsOrThrow(Memento.class, this);
+      this.state = recollection.getState();
+    }
+  }
+
+
+  /** Concrete Initializer B - DOES NOT implement `AfterInitializeMemento`! */
+  private static class InitializerImplBNoMemento implements Initializer {
+    private static int instanceCounter = 0;
+
+    @Getter private String state;
+
+    @Override
+    public void initialize() {
+      this.state = "ignore-" + (++instanceCounter);
+    }
+
+    @Override
+    public void close() {
+      // noop
+    }
+  }
+
+
+  /** Concrete Initializer C - implements `AfterInitializeMemento` */
+  private static class InitializerImplC implements Initializer {
+    private static int instanceCounter = 0;
+
+    @Data
+    @NoArgsConstructor // IMPORTANT: for jackson (de)serialization
+    @RequiredArgsConstructor
+    private static class MyMemento implements AfterInitializeMemento {
+      @NonNull private int state;
+    }
+
+    @Getter private int state;
+
+    @Override
+    public void initialize() {
+      this.state = 41 + (++instanceCounter);
+    }
+
+    @Override
+    public void close() {
+      // noop
+    }
+
+    @Override
+    public Optional<AfterInitializeMemento> commemorate() {
+      return Optional.of(new MyMemento(this.state));
+    }
+
+    @Override
+    public void recall(AfterInitializeMemento memento) {
+      MyMemento recollection = memento.castAsOrThrow(MyMemento.class, this);
+      this.state = recollection.getState();
+    }
+  }
+
+  @Test
+  public void testMementoCommemorateToSerializeAndDeserializeForRecall() {
+    // create "first generation" of concrete initializers
+    InitializerImplA initializerA_1 = new InitializerImplA();
+    InitializerImplBNoMemento initializerB_1 = new InitializerImplBNoMemento();
+    InitializerImplC initializerC_1 = new InitializerImplC();
+
+    // create the 1st-gen `MultiInitializer` and `initialize` all wrapped initializers
+    MultiInitializer multiInitializer1G = new MultiInitializer(Arrays.asList(initializerA_1, initializerB_1, initializerC_1));
+    multiInitializer1G.initialize();
+
+    // `commemorate` and `serialize` 1st-gen state
+    Optional<Initializer.AfterInitializeMemento> optMemento1G = multiInitializer1G.commemorate();
+    Assert.assertTrue(optMemento1G.isPresent());
+    String serializedMemento = Initializer.AfterInitializeMemento.serialize(optMemento1G.get());
+
+    // create a new 2nd-gen `MultiInitializer` using a "second generation" of concrete initializers
+    InitializerImplA initializerA_2 = new InitializerImplA();
+    InitializerImplBNoMemento initializerB_2 = new InitializerImplBNoMemento();
+    InitializerImplC initializerC_2 = new InitializerImplC();
+    MultiInitializer multiInitializer2G = new MultiInitializer(Arrays.asList(initializerA_2, initializerB_2, initializerC_2));
+
+    // verify that state differs between 1st-gen and 2nd-gen `Initializer`s
+    Assert.assertNotEquals(initializerA_1.getState(), initializerA_2.getState());
+    Assert.assertNotEquals(initializerB_1.getState(), initializerB_2.getState());
+    Assert.assertNotEquals(initializerC_1.getState(), initializerC_2.getState());
+
+    try {
+      // verify not possible to `commemorate` prior to `recall()`
+      multiInitializer2G.commemorate();
+      Assert.fail("`commemorate()` somehow possible even before `Initializer.initialize()` or `recall()`, despite `@NotNull` annotation on `state`");
+    } catch (NullPointerException npe) {
+      // expected
+    }
+
+    // now `deserialize` 1st-gen state and `recall` it to the 2nd-gen `MultiInitializer`
+    Initializer.AfterInitializeMemento deserializedMemento = Initializer.AfterInitializeMemento.deserialize(serializedMemento);
+    multiInitializer2G.recall(deserializedMemento);
+    Optional<Initializer.AfterInitializeMemento> optMemento2G = multiInitializer2G.commemorate();
+    Assert.assertTrue(optMemento2G.isPresent());
+
+    // verify that post-`recall`ed memento equivalent to post-`initialize`d one
+    Assert.assertEquals(optMemento1G.get(), optMemento2G.get());
+
+    // WARNING: in real code, DO NOT `initialize` following `recall`, as it would reset the state of the wrapped initializers, negating the `recall`
+    multiInitializer2G.initialize();
+    Optional<Initializer.AfterInitializeMemento> optMemento2G_alt = multiInitializer2G.commemorate();
+    Assert.assertTrue(optMemento2G_alt.isPresent());
+    // verify not simply that mementos always equal
+    Assert.assertNotEquals(optMemento2G.get(), optMemento2G_alt.get());
+  }
+}

--- a/gobblin-metastore/build.gradle
+++ b/gobblin-metastore/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile externalDependency.slf4jToLog4j
 }
 
-// Begin HACK to get around POM being depenendent on the (empty) gobblin-rest-api instead of gobblin-rest-api-rest-client
+// Begin HACK to get around POM being dependent on the (empty) gobblin-rest-api instead of gobblin-rest-api-rest-client
 def installer = install.repositories.mavenInstaller
 [installer]*.pom*.whenConfigured {pom ->
     pom.dependencies.find {dep -> dep.groupId == project.group && dep.artifactId == 'gobblin-rest-api' }.artifactId = 'gobblin-rest-api-rest-client'

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/initializer/JdbcWriterInitializer.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/writer/initializer/JdbcWriterInitializer.java
@@ -69,7 +69,7 @@ public class JdbcWriterInitializer implements WriterInitializer {
   @NoArgsConstructor // IMPORTANT: for jackson (de)serialization
   @AllArgsConstructor
   private static class Memento implements AfterInitializeMemento {
-    // NOTE: as this clearly MAY be `null` (below), DO NOT mark `@NonNull`, to avoid:
+    // NOTE: as this clearly MAY be `null` (see below), DO NOT mark `@NonNull`, to avoid:
     //   userCreatedStagingTable is marked non-null but is null
     private String userCreatedStagingTable;
     @NonNull private Set<String> createdStagingTables;
@@ -244,7 +244,7 @@ public class JdbcWriterInitializer implements WriterInitializer {
         i++;
 
         if (isSkipStaging) {
-          LOG.info("User chose to skip staing table on branch " + this.branchId + " workunit " + i);
+          LOG.info("User chose to skip staging table on branch " + this.branchId + " workunit " + i);
           wu.setProp(stagingTableKey, publishTable);
 
           if (i == 0) {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/util/nesting/work/Workload.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/util/nesting/work/Workload.java
@@ -17,9 +17,10 @@
 
 package org.apache.gobblin.temporal.util.nesting.work;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Iterator;
 import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 
 /**


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2188


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Stateful writer/converter `Initializer`s, such as `JdbcWriterInitializer`, work fine with Gobblin-on-MR, but get disrupted by GoT. While GoMR does also launch an MR application, the remainder of the `MRJobLauncher` execution is within the same process.  An `Initializer` must execute at the end of WorkDiscovery, before `WorkUnit` processing may begin, but is `.close()`d only after Job Commit completes.  Crucially, with GoMR, the same `Initializer` instance remains in memory all throughout.  With GoT, in contrast, Work Discovery and Commit execute completely independently - creating new objects/instances, perhaps even on a new host/container.

Some `Initializer`s, such as the `JdbcWriter`'s `JdbcWriterInitializer` are stateful.  (In its case, to maintain the temp/staging table's name, so that may be dropped upon successful Commit.)  Specific state originates during Work Discovery (the `GenerateWorkUnitsImpl` activity in GoT) yet must be available during Commit (the `CommitActivityImpl` in GoT).

Accordingly we define the `Initializer.AfterInitializeMemento` interface so any concrete `Initializer` impl has the opportunity to optionally define an opaque snapshot of its internal state that may be (de)serialized and "revived" as a new `Initializer` instance of the same concrete type, and holding equivalent internal state.

The evolved `Initializer` interface/API provides `default` impls for the new methods `commemorate` and `recall`, making it source-compatible with existing implementations.  Any exiting `Initializer` that does NOT maintain internal state for its `close()` to use may be recompiled unchanged, for use with GoT.

This GoT enhancement leverages `JobState` to tunnel `AfterInitializeMemento`s, since it is serialized at the end of Work Discovery (in `GenerateWorkUnitsImpl`), to be loaded later as the Commit activity begins (in `CommitStepActivityImpl`).

**Review Tip:** first read how `Initializer.AfterInitializeMemento`s are created in `GenerateWorkUnitsImpl` and used by `CommitStepActivityImpl` before diving into their impl (and test).

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

includes new `MultiInitializerTest`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

