### PR TITLE
[GOBBLIN-2189] Implement ContainerCompletion callback in DynamicScalingYarnService

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/AbstractDynamicScalingYarnServiceManager.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/AbstractDynamicScalingYarnServiceManager.java
@@ -114,8 +114,8 @@ public abstract class AbstractDynamicScalingYarnServiceManager extends AbstractI
           dynamicScalingYarnService.calcDeltasAndRequestContainers();
         }
       } catch (FileNotFoundException fnfe) {
-        log.debug("Failed to get scaling directives - " + fnfe.getMessage()); // important message, but no need for a stack trace
         // FNFE comes when scaling directives path is not yet created, so we should just calc delta & request containers if needed
+        log.debug("Scaling directives file not found(possibly not yet created). Falling back to delta calculation. - " + fnfe.getMessage());
         dynamicScalingYarnService.calcDeltasAndRequestContainers();
       } catch (IOException e) {
         log.error("Failed to get scaling directives", e);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/AbstractDynamicScalingYarnServiceManager.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/AbstractDynamicScalingYarnServiceManager.java
@@ -110,9 +110,13 @@ public abstract class AbstractDynamicScalingYarnServiceManager extends AbstractI
         List<ScalingDirective> scalingDirectives = scalingDirectiveSource.getScalingDirectives();
         if (CollectionUtils.isNotEmpty(scalingDirectives)) {
           dynamicScalingYarnService.reviseWorkforcePlanAndRequestNewContainers(scalingDirectives);
+        } else {
+          dynamicScalingYarnService.calcDeltasAndRequestContainers();
         }
       } catch (FileNotFoundException fnfe) {
-        log.warn("Failed to get scaling directives - " + fnfe.getMessage()); // important message, but no need for a stack trace
+        log.debug("Failed to get scaling directives - " + fnfe.getMessage()); // important message, but no need for a stack trace
+        // FNFE comes when scaling directives path is not yet created, so we should just calc delta & request containers if needed
+        dynamicScalingYarnService.calcDeltasAndRequestContainers();
       } catch (IOException e) {
         log.error("Failed to get scaling directives", e);
       } catch (Throwable t) {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnService.java
@@ -17,10 +17,20 @@
 
 package org.apache.gobblin.temporal.yarn;
 
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import com.google.common.eventbus.EventBus;
@@ -28,6 +38,8 @@ import com.typesafe.config.Config;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.temporal.dynamic.ProfileDerivation;
+import org.apache.gobblin.temporal.dynamic.ProfileOverlay;
 import org.apache.gobblin.temporal.dynamic.ScalingDirective;
 import org.apache.gobblin.temporal.dynamic.StaffingDeltas;
 import org.apache.gobblin.temporal.dynamic.WorkerProfile;
@@ -47,6 +59,8 @@ public class DynamicScalingYarnService extends YarnService {
   private final WorkforceStaffing actualWorkforceStaffing;
   /** this holds the current total workforce plan as per latest received scaling directives */
   private final WorkforcePlan workforcePlan;
+  private final Set<ContainerId> removedContainerIds;
+  private final AtomicLong profileNameSuffixGenerator;
 
   public DynamicScalingYarnService(Config config, String applicationName, String applicationId,
       YarnConfiguration yarnConfiguration, FileSystem fs, EventBus eventBus) throws Exception {
@@ -54,12 +68,79 @@ public class DynamicScalingYarnService extends YarnService {
 
     this.actualWorkforceStaffing = WorkforceStaffing.initialize(0);
     this.workforcePlan = new WorkforcePlan(this.config, this.config.getInt(GobblinYarnConfigurationKeys.INITIAL_CONTAINERS_KEY));
+    this.removedContainerIds = ConcurrentHashMap.newKeySet();
+    this.profileNameSuffixGenerator = new AtomicLong();
   }
 
   @Override
   protected synchronized void requestInitialContainers() {
     StaffingDeltas deltas = this.workforcePlan.calcStaffingDeltas(this.actualWorkforceStaffing);
     requestNewContainersForStaffingDeltas(deltas);
+  }
+
+  /**
+   * Handle the completion of a container. A new container will be requested to replace the one
+   * that just exited depending on the exit status.
+   * <p>
+   * A container completes in either of the following conditions:
+   * <ol>
+   *   <li> The container gets stopped by the ApplicationMaster. </li>
+   *   <li> Some error happens in the container and caused the container to exit </li>
+   *   <li> The container gets preempted by the ResourceManager </li>
+   *   <li> The container gets killed due to some reason, for example, if it runs over the allowed amount of virtual or physical memory </li>
+   * </ol>
+   * A replacement container is needed in all except the first case.
+   * </p>
+   */
+  @Override
+  protected void handleContainerCompletion(ContainerStatus containerStatus) {
+    ContainerId completedContainerId = containerStatus.getContainerId();
+    ContainerInfo completedContainerInfo = this.containerMap.remove(completedContainerId);
+
+    if (completedContainerInfo == null) {
+      log.warn("Container {} not found in containerMap. This container onContainersCompleted() likely called before onContainersAllocated()",
+          completedContainerId);
+      this.removedContainerIds.add(completedContainerId);
+      return;
+    }
+
+    log.info("Container {} running profile {} completed with exit status {}",
+        completedContainerId, completedContainerInfo.getWorkerProfileName(), containerStatus.getExitStatus()
+    );
+
+    if (StringUtils.isNotBlank(containerStatus.getDiagnostics())) {
+      log.info("Container {} running profile {} completed with diagnostics: {}",
+          completedContainerId, completedContainerInfo.getWorkerProfileName(), containerStatus.getDiagnostics()
+      );
+    }
+
+    if (this.shutdownInProgress) {
+      log.info("Ignoring container completion for container {} as shutdown is in progress", completedContainerId);
+      return;
+    }
+
+    WorkerProfile workerProfile = completedContainerInfo.getWorkerProfile();
+
+    switch (containerStatus.getExitStatus()) {
+      case(ContainerExitStatus.ABORTED):
+        handleAbortedContainer(completedContainerId, completedContainerInfo);
+        break;
+      case(ContainerExitStatus.PREEMPTED):
+        log.info("Container {} for profile {} preempted, starting to launching a replacement container",
+            completedContainerId, completedContainerInfo.getWorkerProfileName());
+        requestContainersForWorkerProfile(workerProfile, 1);
+        break;
+      case(137): // General OOM exit status
+      case(ContainerExitStatus.KILLED_EXCEEDED_VMEM):
+      case(ContainerExitStatus.KILLED_EXCEEDED_PMEM):
+        handleContainerExitedWithOOM(completedContainerId, completedContainerInfo);
+        break;
+      case(1): // Same as linux exit status 1 Often occurs when launch_container.sh failed
+        log.info("Exit status 1.CompletedContainerInfo = {}", completedContainerInfo);
+        break;
+      default:
+        break;
+    }
   }
 
   /**
@@ -71,6 +152,23 @@ public class DynamicScalingYarnService extends YarnService {
     if (CollectionUtils.isEmpty(scalingDirectives)) {
       return;
     }
+
+    // Correct the actualWorkforceStaffing in case of handleContainerCompletion() getting called before onContainersAllocated()
+    Iterator<ContainerId> iterator = removedContainerIds.iterator();
+    while (iterator.hasNext()) {
+      ContainerId containerId = iterator.next();
+      ContainerInfo containerInfo = this.containerMap.remove(containerId);
+      if (containerInfo != null) {
+        WorkerProfile workerProfile = containerInfo.getWorkerProfile();
+        int currNumContainers = this.actualWorkforceStaffing.getStaffing(workerProfile.getName()).orElse(0);
+        if (currNumContainers > 0) {
+          this.actualWorkforceStaffing.reviseStaffing(workerProfile.getName(), currNumContainers - 1,
+              System.currentTimeMillis());
+        }
+        iterator.remove();
+      }
+    }
+
     this.workforcePlan.reviseWhenNewer(scalingDirectives);
     StaffingDeltas deltas = this.workforcePlan.calcStaffingDeltas(this.actualWorkforceStaffing);
     requestNewContainersForStaffingDeltas(deltas);
@@ -78,22 +176,64 @@ public class DynamicScalingYarnService extends YarnService {
 
   private synchronized void requestNewContainersForStaffingDeltas(StaffingDeltas deltas) {
     deltas.getPerProfileDeltas().forEach(profileDelta -> {
-      if (profileDelta.getDelta() > 0) { // scale up!
-        WorkerProfile workerProfile = profileDelta.getProfile();
-        String profileName = workerProfile.getName();
-        int currNumContainers = this.actualWorkforceStaffing.getStaffing(profileName).orElse(0);
-        int delta = profileDelta.getDelta();
+      WorkerProfile workerProfile = profileDelta.getProfile();
+      String profileName = workerProfile.getName();
+      int delta = profileDelta.getDelta();
+      int currNumContainers = this.actualWorkforceStaffing.getStaffing(profileName).orElse(0);
+      if (delta > 0) { // scale up!
         log.info("Requesting {} new containers for profile {} having currently {} containers", delta,
             WorkforceProfiles.renderName(profileName), currNumContainers);
         requestContainersForWorkerProfile(workerProfile, delta);
         // update our staffing after requesting new containers
         this.actualWorkforceStaffing.reviseStaffing(profileName, currNumContainers + delta, System.currentTimeMillis());
-      } else if (profileDelta.getDelta() < 0) { // scale down!
-        // TODO: Decide how to handle negative deltas
-        log.warn("Handling of Negative delta is not supported yet : Profile {} delta {} ",
-            profileDelta.getProfile().getName(), profileDelta.getDelta());
+      } else if (delta < 0) { // scale down!
+        log.info("Releasing {} containers for profile {} having currently {} containers", -delta,
+            WorkforceProfiles.renderName(profileName), currNumContainers);
+        releaseContainersForWorkerProfile(profileName, delta);
+        // update our staffing after releasing containers
+        int numContainersAfterRelease = Math.max(currNumContainers + delta, 0);
+        this.actualWorkforceStaffing.reviseStaffing(profileName, numContainersAfterRelease, System.currentTimeMillis());
       } // else, already at staffing plan (or at least have requested, so in-progress)
     });
+  }
+
+  private void handleAbortedContainer(ContainerId completedContainerId, ContainerInfo completedContainerInfo) {
+    // Case 1 : Container release requested while scaling down
+    if (this.releasedContainerCache.getIfPresent(completedContainerId) != null) {
+      log.info("Container {} was released while downscaling for profile {}", completedContainerId, completedContainerInfo.getWorkerProfileName());
+      this.releasedContainerCache.invalidate(completedContainerId);
+      return;
+    }
+
+    // Case 2 : Container release was not requested, we need to request a replacement container
+    log.info("Container {} aborted for profile {}, starting to launch a replacement container", completedContainerId, completedContainerInfo.getWorkerProfileName());
+    requestContainersForWorkerProfile(completedContainerInfo.getWorkerProfile(), 1);
+  }
+
+  private synchronized void handleContainerExitedWithOOM(ContainerId completedContainerId, ContainerInfo completedContainerInfo) {
+    log.info("Container {} for profile {} exited with OOM, starting to launch a replacement container",
+        completedContainerId, completedContainerInfo.getWorkerProfileName());
+
+    WorkerProfile workerProfile = completedContainerInfo.getWorkerProfile();
+    // Update the current staffing to reflect the container that exited with OOM
+    int currNumContainers = this.actualWorkforceStaffing.getStaffing(workerProfile.getName()).orElse(0);
+    if (currNumContainers > 0) {
+      this.actualWorkforceStaffing.reviseStaffing(workerProfile.getName(), currNumContainers - 1, System.currentTimeMillis());
+    }
+
+    // Request a replacement container
+    int currContainerMemoryMbs = workerProfile.getConfig().getInt(GobblinYarnConfigurationKeys.CONTAINER_MEMORY_MBS_KEY);
+    int newContainerMemoryMbs = currContainerMemoryMbs * 2; //TODO: make it configurable or auto-tunable
+    Optional<ProfileDerivation> optProfileDerivation = Optional.of(new ProfileDerivation(workerProfile.getName(),
+        new ProfileOverlay.Adding(new ProfileOverlay.KVPair(GobblinYarnConfigurationKeys.CONTAINER_MEMORY_MBS_KEY, newContainerMemoryMbs + ""))
+    ));
+    ScalingDirective scalingDirective = new ScalingDirective(
+        workerProfile.getName() + "-" + profileNameSuffixGenerator.getAndIncrement(),
+        1,
+        System.currentTimeMillis(),
+        optProfileDerivation
+    );
+    reviseWorkforcePlanAndRequestNewContainers(Collections.singletonList(scalingDirective));
   }
 
 }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -331,6 +331,7 @@ class YarnService extends AbstractIdleService {
   }
 
   protected synchronized void releaseContainersForWorkerProfile(String profileName, int numContainers) {
+    int numContainersToRelease = numContainers;
     Iterator<Map.Entry<ContainerId, ContainerInfo>> containerMapIterator = this.containerMap.entrySet().iterator();
     while (containerMapIterator.hasNext() && numContainers > 0) {
       Map.Entry<ContainerId, ContainerInfo> entry = containerMapIterator.next();
@@ -348,6 +349,8 @@ class YarnService extends AbstractIdleService {
         numContainers--;
       }
     }
+    LOGGER.info("Released {} containers out of {} requested for profile {}", numContainersToRelease - numContainers,
+        numContainersToRelease, profileName);
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -70,7 +70,6 @@ import org.apache.hadoop.yarn.util.Records;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -134,7 +133,6 @@ class YarnService extends AbstractIdleService {
   private final Optional<GobblinMetrics> gobblinMetrics;
   private final Optional<EventSubmitter> eventSubmitter;
 
-  @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
   private final AMRMClientAsync<AMRMClient.ContainerRequest> amrmClientAsync;
   private final NMClientAsync nmClientAsync;
@@ -490,8 +488,7 @@ class YarnService extends AbstractIdleService {
     }
   }
 
-  @VisibleForTesting
-  protected String buildContainerCommand(Container container, String workerProfileName, WorkerProfile workerProfile) {
+  private String buildContainerCommand(Container container, String workerProfileName, WorkerProfile workerProfile) {
     Config workerProfileConfig = workerProfile.getConfig();
 
     double workerJvmMemoryXmxRatio = ConfigUtils.getDouble(workerProfileConfig,

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/dynamic/DummyScalingDirectiveSource.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/dynamic/DummyScalingDirectiveSource.java
@@ -70,6 +70,18 @@ public class DummyScalingDirectiveSource implements ScalingDirectiveSource {
           new ScalingDirective("firstProfile", 5, currentTime),
           new ScalingDirective("secondProfile", 3, currentTime + 1)
       );
+    } else if (currNumInvocations == 3) {
+      // changing set point to 0 for both profiles so that all containers should be released
+      return Arrays.asList(
+          new ScalingDirective("firstProfile", 0, currentTime),
+          new ScalingDirective("secondProfile", 0, currentTime + 1)
+      );
+    } else if (currNumInvocations == 4) {
+      // increasing containers count for both profiles so that new containers should be launched
+      return Arrays.asList(
+          new ScalingDirective("firstProfile", 5, currentTime),
+          new ScalingDirective("secondProfile", 5, currentTime + 1)
+      );
     }
     return new ArrayList<>();
   }

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
@@ -69,14 +69,14 @@ public class DynamicScalingYarnServiceManagerTest {
   /** Note : this test uses {@link DummyScalingDirectiveSource}*/
   @Test
   public void testWithDummyScalingDirectiveSource() throws IOException, InterruptedException {
-    // DummyScalingDirectiveSource returns 2 scaling directives in first 3 invocations and after that it returns empty list
-    // so the total number of invocations after three invocations should always be 3
+    // DummyScalingDirectiveSource returns 2 scaling directives in first 5 invocations and after that it returns empty list
+    // so the total number of invocations after three invocations should always be 5
     TestDynamicScalingYarnServiceManager testDynamicScalingYarnServiceManager = new TestDynamicScalingYarnServiceManager(
         mockGobblinTemporalApplicationMaster, new DummyScalingDirectiveSource());
     testDynamicScalingYarnServiceManager.startUp();
-    Thread.sleep(5000); // 5 seconds sleep so that GetScalingDirectivesRunnable.run() is called for 5 times
+    Thread.sleep(7000); // 5 seconds sleep so that GetScalingDirectivesRunnable.run() is called for 7 times
     testDynamicScalingYarnServiceManager.shutDown();
-    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(3)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(5)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
   }
 
   @Test

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
@@ -70,11 +70,11 @@ public class DynamicScalingYarnServiceManagerTest {
   @Test
   public void testWithDummyScalingDirectiveSource() throws IOException, InterruptedException {
     // DummyScalingDirectiveSource returns 2 scaling directives in first 5 invocations and after that it returns empty list
-    // so the total number of invocations after three invocations should always be 5
+    // so the total number of invocations after five invocations should always be 5
     TestDynamicScalingYarnServiceManager testDynamicScalingYarnServiceManager = new TestDynamicScalingYarnServiceManager(
         mockGobblinTemporalApplicationMaster, new DummyScalingDirectiveSource());
     testDynamicScalingYarnServiceManager.startUp();
-    Thread.sleep(7000); // 5 seconds sleep so that GetScalingDirectivesRunnable.run() is called for 7 times
+    Thread.sleep(7000); // 7 seconds sleep so that GetScalingDirectivesRunnable.run() is called for 7 times
     testDynamicScalingYarnServiceManager.shutDown();
     Mockito.verify(mockDynamicScalingYarnService, Mockito.times(5)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
   }

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.temporal.yarn;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,6 +65,19 @@ public class DynamicScalingYarnServiceManagerTest {
     Thread.sleep(3000);
     testDynamicScalingYarnServiceManager.shutDown();
     Mockito.verify(mockDynamicScalingYarnService, Mockito.never()).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(3)).calcDeltasAndRequestContainers();
+  }
+
+  @Test
+  public void testWhenScalingDirectivesThrowsFNFE() throws IOException, InterruptedException {
+    Mockito.when(mockScalingDirectiveSource.getScalingDirectives()).thenThrow(FileNotFoundException.class);
+    TestDynamicScalingYarnServiceManager testDynamicScalingYarnServiceManager = new TestDynamicScalingYarnServiceManager(
+        mockGobblinTemporalApplicationMaster, mockScalingDirectiveSource);
+    testDynamicScalingYarnServiceManager.startUp();
+    Thread.sleep(2000);
+    testDynamicScalingYarnServiceManager.shutDown();
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.never()).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(2)).calcDeltasAndRequestContainers();
   }
 
   /** Note : this test uses {@link DummyScalingDirectiveSource}*/
@@ -77,6 +91,7 @@ public class DynamicScalingYarnServiceManagerTest {
     Thread.sleep(7000); // 7 seconds sleep so that GetScalingDirectivesRunnable.run() is called for 7 times
     testDynamicScalingYarnServiceManager.shutDown();
     Mockito.verify(mockDynamicScalingYarnService, Mockito.times(5)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(2)).calcDeltasAndRequestContainers();
   }
 
   @Test
@@ -95,6 +110,7 @@ public class DynamicScalingYarnServiceManagerTest {
     Thread.sleep(5000);
     testDynamicScalingYarnServiceManager.shutDown();
     Mockito.verify(mockDynamicScalingYarnService, Mockito.times(2)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(mockDynamicScalingYarnService, Mockito.times(3)).calcDeltasAndRequestContainers();
   }
 
   /** Test implementation of {@link AbstractDynamicScalingYarnServiceManager} which returns passed

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceTest.java
@@ -18,8 +18,8 @@
 package org.apache.gobblin.temporal.yarn;
 
 import java.util.Collections;
-
 import java.util.List;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -170,17 +170,12 @@ public class DynamicScalingYarnServiceTest {
     ContainerStatus containerStatus = Mockito.mock(ContainerStatus.class);
     Mockito.when(containerStatus.getContainerId()).thenReturn(containerId);
     Mockito.when(containerStatus.getExitStatus()).thenReturn(containerExitStatusCode);
-
-    dynamicScalingYarnServiceSpy.startUp();
     dynamicScalingYarnServiceSpy.containerMap.put(containerId, containerInfo); // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
-
     dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus);
-
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
     ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
-
     Resource capturedResource = resourceCaptor.getValue();
     Assert.assertEquals(capturedResource.getMemorySize(), (long) initMemoryMbs * DynamicScalingYarnService.DEFAULT_REPLACEMENT_CONTAINER_MEMORY_MULTIPLIER);
     Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
@@ -193,16 +188,12 @@ public class DynamicScalingYarnServiceTest {
     ContainerStatus containerStatus = Mockito.mock(ContainerStatus.class);
     Mockito.when(containerStatus.getContainerId()).thenReturn(containerId);
     Mockito.when(containerStatus.getExitStatus()).thenReturn(containerExitStatusCode);
-
-    dynamicScalingYarnServiceSpy.startUp();
     dynamicScalingYarnServiceSpy.containerMap.put(containerId, containerInfo); // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
-
     dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus);
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
-    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
     ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
-    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
-
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
     Resource capturedResource = resourceCaptor.getValue();
     Assert.assertEquals(capturedResource.getMemorySize(), initMemoryMbs);
     Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
@@ -230,7 +221,6 @@ public class DynamicScalingYarnServiceTest {
     Mockito.when(containerStatus3.getContainerId()).thenReturn(containerId3);
     Mockito.when(containerStatus3.getExitStatus()).thenReturn(ContainerExitStatus.KILLED_EXCEEDED_PMEM);
 
-    dynamicScalingYarnServiceSpy.startUp();
     // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
     dynamicScalingYarnServiceSpy.containerMap.put(containerId1, containerInfo1);
     dynamicScalingYarnServiceSpy.containerMap.put(containerId2, containerInfo2);
@@ -268,7 +258,6 @@ public class DynamicScalingYarnServiceTest {
     Mockito.when(containerStatus.getExitStatus()).thenReturn(containerExitStatusCode);
     dynamicScalingYarnServiceSpy.containerMap.put(containerId, containerInfo); // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
     dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus);
-    // All zero invocation since startup is not called and no new containers should be requested
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).requestContainers(Mockito.anyInt(), Mockito.any(Resource.class), Mockito.any(Optional.class));

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnServiceTest.java
@@ -17,38 +17,109 @@
 
 package org.apache.gobblin.temporal.yarn;
 
-import java.net.URL;
 import java.util.Collections;
 
+import java.util.List;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
 import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.temporal.dynamic.ScalingDirective;
+import org.apache.gobblin.temporal.dynamic.WorkerProfile;
 import org.apache.gobblin.temporal.dynamic.WorkforceProfiles;
+import org.apache.gobblin.yarn.GobblinYarnConfigurationKeys;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
 
 /** Tests for {@link DynamicScalingYarnService} */
 public class DynamicScalingYarnServiceTest {
   private Config defaultConfigs;
+  private final int initNumContainers = 1;
+  private final int initMemoryMbs = 1024;
+  private final int initCores = 1;
+  private final Resource initResource = Resource.newInstance(initMemoryMbs, initCores);
   private final YarnConfiguration yarnConfiguration = new YarnConfiguration();
   private final FileSystem mockFileSystem = Mockito.mock(FileSystem.class);
   private final EventBus eventBus = new EventBus("TemporalDynamicScalingYarnServiceTest");
+  private AMRMClientAsync mockAMRMClient;
+  private RegisterApplicationMasterResponse mockRegisterApplicationMasterResponse;
+  private WorkerProfile testBaselineworkerProfile;
+  private DynamicScalingYarnService dynamicScalingYarnServiceSpy;
 
   @BeforeClass
-  public void setup() {
-    URL url = DynamicScalingYarnServiceTest.class.getClassLoader()
-        .getResource(YarnServiceTest.class.getSimpleName() + ".conf"); // using same initial config as of YarnServiceTest
-    Assert.assertNotNull(url, "Could not find resource " + url);
-    this.defaultConfigs = ConfigFactory.parseURL(url).resolve();
+  public void setup() throws Exception {
+    this.defaultConfigs = ConfigFactory.empty()
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_CORES_KEY, ConfigValueFactory.fromAnyRef(initCores))
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_MEMORY_MBS_KEY, ConfigValueFactory.fromAnyRef(initMemoryMbs))
+        .withValue(GobblinYarnConfigurationKeys.INITIAL_CONTAINERS_KEY, ConfigValueFactory.fromAnyRef(initNumContainers));
+
+    this.testBaselineworkerProfile = new WorkerProfile(this.defaultConfigs);
+
+    mockAMRMClient = Mockito.mock(AMRMClientAsync.class);
+    mockRegisterApplicationMasterResponse = Mockito.mock(RegisterApplicationMasterResponse.class);
+
+    MockedStatic<AMRMClientAsync> amrmClientAsyncMockStatic = Mockito.mockStatic(AMRMClientAsync.class);
+
+    amrmClientAsyncMockStatic.when(() -> AMRMClientAsync.createAMRMClientAsync(anyInt(), any(AMRMClientAsync.CallbackHandler.class)))
+        .thenReturn(mockAMRMClient);
+    Mockito.doNothing().when(mockAMRMClient).init(any(YarnConfiguration.class));
+
+    Mockito.when(mockAMRMClient.registerApplicationMaster(anyString(), anyInt(), anyString()))
+        .thenReturn(mockRegisterApplicationMasterResponse);
+    Mockito.when(mockRegisterApplicationMasterResponse.getMaximumResourceCapability())
+        .thenReturn(Mockito.mock(Resource.class));
+  }
+
+  @BeforeMethod
+  public void setupMethod() throws Exception {
+    DynamicScalingYarnService dynamicScalingYarnService = new DynamicScalingYarnService(this.defaultConfigs, "testApp", "testAppId", yarnConfiguration, mockFileSystem, eventBus);
+    dynamicScalingYarnServiceSpy = Mockito.spy(dynamicScalingYarnService);
+    Mockito.doNothing().when(dynamicScalingYarnServiceSpy).requestContainers(Mockito.anyInt(), Mockito.any(Resource.class), Mockito.any(Optional.class));
+    dynamicScalingYarnServiceSpy.containerMap.clear();
+  }
+
+  @AfterMethod
+  public void cleanupMethod() {
+    dynamicScalingYarnServiceSpy.containerMap.clear();
+    Mockito.reset(dynamicScalingYarnServiceSpy);
+  }
+
+  @Test
+  public void testDynamicScalingYarnServiceStartupWithInitialContainers() throws Exception {
+    dynamicScalingYarnServiceSpy.startUp();
+    ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).requestContainers(Mockito.eq(initNumContainers), resourceCaptor.capture(), Mockito.any(Optional.class));
+    Resource capturedResource = resourceCaptor.getValue();
+    Assert.assertEquals(capturedResource.getMemorySize(), initMemoryMbs);
+    Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
   }
 
   @Test
@@ -60,5 +131,128 @@ public class DynamicScalingYarnServiceTest {
     ScalingDirective baseScalingDirective = new ScalingDirective(WorkforceProfiles.BASELINE_NAME, numNewContainers, System.currentTimeMillis());
     dynamicScalingYarnServiceSpy.reviseWorkforcePlanAndRequestNewContainers(Collections.singletonList(baseScalingDirective));
     Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).requestContainers(Mockito.eq(numNewContainers), Mockito.any(Resource.class), Mockito.any(Optional.class));
+  }
+
+  @DataProvider(name = "OOMExitStatusProvider")
+  public Object[][] OOMExitStatusProvider() {
+    return new Object[][] {
+        {ContainerExitStatus.KILLED_EXCEEDED_PMEM},
+        {ContainerExitStatus.KILLED_EXCEEDED_VMEM},
+        {DynamicScalingYarnService.GENERAL_OOM_EXIT_STATUS_CODE}
+    };
+  }
+
+  @DataProvider(name = "NonOOMExitStatusProviderWhichRequestReplacementContainer")
+  public Object[][] NonOOMExitStatusProviderWhichRequestReplacementContainer() {
+    return new Object[][] {
+        {ContainerExitStatus.ABORTED},
+        {ContainerExitStatus.PREEMPTED}
+    };
+  }
+
+  @Test(dataProvider = "OOMExitStatusProvider")
+  public void testHandleContainerCompletionForStatusOOM(int containerExitStatusCode) throws Exception {
+    ContainerId containerId = generateRandomContainerId();
+    DynamicScalingYarnService.ContainerInfo containerInfo = createBaselineContainerInfo(containerId);
+    ContainerStatus containerStatus = Mockito.mock(ContainerStatus.class);
+    Mockito.when(containerStatus.getContainerId()).thenReturn(containerId);
+    Mockito.when(containerStatus.getExitStatus()).thenReturn(containerExitStatusCode);
+
+    dynamicScalingYarnServiceSpy.startUp();
+    dynamicScalingYarnServiceSpy.containerMap.put(containerId, containerInfo); // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
+
+    dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus);
+
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(1)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
+    ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
+
+    Resource capturedResource = resourceCaptor.getValue();
+    Assert.assertEquals(capturedResource.getMemorySize(), (long) initMemoryMbs * DynamicScalingYarnService.DEFAULT_REPLACEMENT_CONTAINER_MEMORY_MULTIPLIER);
+    Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
+  }
+
+  @Test(dataProvider = "NonOOMExitStatusProviderWhichRequestReplacementContainer")
+  public void testHandleContainerCompletionForNonOOMStatusWhichRequestReplacementContainer(int containerExitStatusCode) throws Exception {
+    ContainerId containerId = generateRandomContainerId();
+    DynamicScalingYarnService.ContainerInfo containerInfo = createBaselineContainerInfo(containerId);
+    ContainerStatus containerStatus = Mockito.mock(ContainerStatus.class);
+    Mockito.when(containerStatus.getContainerId()).thenReturn(containerId);
+    Mockito.when(containerStatus.getExitStatus()).thenReturn(containerExitStatusCode);
+
+    dynamicScalingYarnServiceSpy.startUp();
+    dynamicScalingYarnServiceSpy.containerMap.put(containerId, containerInfo); // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
+
+    dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus);
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(0)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
+    ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(2)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
+
+    Resource capturedResource = resourceCaptor.getValue();
+    Assert.assertEquals(capturedResource.getMemorySize(), initMemoryMbs);
+    Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
+  }
+
+  @Test
+  public void testHandleContainerCompletionForAllOOMStatus() throws Exception {
+    ContainerId containerId1 = generateRandomContainerId();
+    ContainerId containerId2 = generateRandomContainerId();
+    ContainerId containerId3 = generateRandomContainerId();
+
+    DynamicScalingYarnService.ContainerInfo containerInfo1 = createBaselineContainerInfo(containerId1);
+    DynamicScalingYarnService.ContainerInfo containerInfo2 = createBaselineContainerInfo(containerId2);
+    DynamicScalingYarnService.ContainerInfo containerInfo3 = createBaselineContainerInfo(containerId3);
+
+    ContainerStatus containerStatus1 = Mockito.mock(ContainerStatus.class);
+    Mockito.when(containerStatus1.getContainerId()).thenReturn(containerId1);
+    Mockito.when(containerStatus1.getExitStatus()).thenReturn(ContainerExitStatus.KILLED_EXCEEDED_VMEM);
+
+    ContainerStatus containerStatus2 = Mockito.mock(ContainerStatus.class);
+    Mockito.when(containerStatus2.getContainerId()).thenReturn(containerId2);
+    Mockito.when(containerStatus2.getExitStatus()).thenReturn(DynamicScalingYarnService.GENERAL_OOM_EXIT_STATUS_CODE);
+
+    ContainerStatus containerStatus3 = Mockito.mock(ContainerStatus.class);
+    Mockito.when(containerStatus3.getContainerId()).thenReturn(containerId3);
+    Mockito.when(containerStatus3.getExitStatus()).thenReturn(ContainerExitStatus.KILLED_EXCEEDED_PMEM);
+
+    dynamicScalingYarnServiceSpy.startUp();
+    // Required to be done for test otherwise containerMap is always empty since it is updated after containers are allocated
+    dynamicScalingYarnServiceSpy.containerMap.put(containerId1, containerInfo1);
+    dynamicScalingYarnServiceSpy.containerMap.put(containerId2, containerInfo2);
+    dynamicScalingYarnServiceSpy.containerMap.put(containerId3, containerInfo3);
+
+    dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus1);
+    dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus2);
+    dynamicScalingYarnServiceSpy.handleContainerCompletion(containerStatus3);
+
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(3)).reviseWorkforcePlanAndRequestNewContainers(Mockito.anyList());
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(4)).requestContainersForWorkerProfile(Mockito.any(WorkerProfile.class), Mockito.anyInt());
+    ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
+    Mockito.verify(dynamicScalingYarnServiceSpy, Mockito.times(4)).requestContainers(Mockito.eq(1), resourceCaptor.capture(), Mockito.any(Optional.class));
+
+    List<Resource> capturedResources = resourceCaptor.getAllValues();
+    Assert.assertEquals(capturedResources.size(), 4);
+
+    Resource capturedResource = capturedResources.get(0);
+    Assert.assertEquals(capturedResource.getMemorySize(), initMemoryMbs);
+    Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
+
+    for (int idx = 1 ; idx < 4 ; idx++) {
+      capturedResource = capturedResources.get(idx);
+      Assert.assertEquals(capturedResource.getMemorySize(), (long) initMemoryMbs * DynamicScalingYarnService.DEFAULT_REPLACEMENT_CONTAINER_MEMORY_MULTIPLIER);
+      Assert.assertEquals(capturedResource.getVirtualCores(), initCores);
+    }
+  }
+
+  private ContainerId generateRandomContainerId() {
+    return ContainerId.newContainerId(ApplicationAttemptId.newInstance(ApplicationId.newInstance(1, 0),
+        0), (long) (Math.random() * 1000));
+  }
+
+  private DynamicScalingYarnService.ContainerInfo createBaselineContainerInfo(ContainerId containerId) {
+    Container container = Container.newInstance(containerId, null, null, initResource, null, null);
+    return dynamicScalingYarnServiceSpy.new ContainerInfo(container, WorkforceProfiles.BASELINE_NAME_RENDERING, testBaselineworkerProfile);
   }
 }

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/YarnServiceTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/yarn/YarnServiceTest.java
@@ -20,8 +20,13 @@ package org.apache.gobblin.temporal.yarn;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.gobblin.temporal.dynamic.WorkerProfile;
+import org.apache.gobblin.temporal.dynamic.WorkforceProfiles;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
@@ -103,12 +108,6 @@ public class YarnServiceTest {
         .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_XMX_RATIO_KEY, ConfigValueFactory.fromAnyRef(jvmMemoryXmxRatio))
         .withValue(GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, ConfigValueFactory.fromAnyRef(jvmMemoryOverheadMbs));
 
-    Resource resource = Resource.newInstance(resourceMemoryMB, 2);
-
-    Container mockContainer = Mockito.mock(Container.class);
-    Mockito.when(mockContainer.getResource()).thenReturn(resource);
-    Mockito.when(mockContainer.getAllocationRequestId()).thenReturn(0L);
-
     YarnService yarnService = new YarnService(
         config,
         "testApplicationName",
@@ -118,9 +117,13 @@ public class YarnServiceTest {
         eventBus
     );
 
-    yarnService.startUp();
-
-    String command = yarnService.buildContainerCommand(mockContainer, "testHelixParticipantId", "testHelixInstanceTag");
+    WorkerProfile workerProfile = new WorkerProfile(config);
+    ContainerId containerId = ContainerId.newContainerId(ApplicationAttemptId.newInstance(ApplicationId.newInstance(1, 0),
+        0), 0);
+    Resource resource = Resource.newInstance(resourceMemoryMB, 2);
+    Container container = Container.newInstance(containerId, null, null, resource, null, null);
+    YarnService.ContainerInfo containerInfo = yarnService.new ContainerInfo(container, WorkforceProfiles.BASELINE_NAME_RENDERING, workerProfile);
+    String command = containerInfo.getStartupCommand();
     Assert.assertTrue(command.contains("-Xmx" + expectedJvmMemory + "M"));
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2189


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Implemented handleContainerCompletion(...) which launches replacement container based on exit status
Handled Scaling down of containers based on negative delta
Refactored YarnService to remove use of helix related tags and names

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated one existing test
Manually triggered DummyDynamicScalingYarnServiceManager to check if scale down is happening or not, the stripped logs from that are 

```
2025-01-21 09:09:59 PST [,,] INFO  [DynamicScalingYarnService STARTING] org.apache.gobblin.temporal.yarn.YarnService  - Requesting initial containers
2025-01-21 09:09:59 PST [,,] INFO  [DynamicScalingYarnService STARTING] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 2 new containers for profile <<BASELINE>> having currently 0 containers
2025-01-21 09:09:59 PST [,,] INFO  [DynamicScalingYarnService STARTING] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 2 containers with resource = <memory:8192, vCores:2> and allocation request id = Optional.of(0)
...
2025-01-21 09:10:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 2 new containers for profile secondProfile having currently 0 containers
2025-01-21 09:10:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 2 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(1)
2025-01-21 09:10:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 3 new containers for profile firstProfile having currently 0 containers
2025-01-21 09:10:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 3 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(2)
...
2025-01-21 09:11:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 1 new containers for profile secondProfile having currently 2 containers
2025-01-21 09:11:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 1 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(3)
2025-01-21 09:11:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 2 new containers for profile firstProfile having currently 3 containers
2025-01-21 09:11:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 2 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(4)
...
2025-01-21 09:13:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Releasing 3 containers for profile secondProfile having currently 3 containers
2025-01-21 09:13:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Releasing 5 containers for profile firstProfile having currently 5 containers
...
2025-01-21 09:14:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 5 new containers for profile secondProfile having currently 0 containers
2025-01-21 09:14:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 5 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(5)
2025-01-21 09:14:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.DynamicScalingYarnService  - Requesting 5 new containers for profile firstProfile having currently 0 containers
2025-01-21 09:14:17 PST [,,] INFO  [DynamicScalingExecutor] org.apache.gobblin.temporal.yarn.YarnService  - Requesting 5 containers with resource = <memory:2048, vCores:2> and allocation request id = Optional.of(6)
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

