### PR TITLE
[GOBBLIN-2191] Shutdown GobblinJobLauncher executor

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -643,6 +643,12 @@ public class GobblinYarnAppLauncher {
     LOGGER.info("Application Tracking URL: " + applicationReport.getTrackingUrl());
     LOGGER.info("Application User: " + applicationReport.getUser() + " Queue: " + applicationReport.getQueue());
 
+    // Temporal workflow tracking url
+    String temporalWorkflowTrackingUrl = ConfigUtils.getString(config, "gobblin.temporal.ui.server.url", "");
+    if (!temporalWorkflowTrackingUrl.isEmpty()) {
+      LOGGER.info("Temporal Workflow Tracking URL: " + temporalWorkflowTrackingUrl);
+    }
+    
     return applicationId;
   }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -645,10 +645,10 @@ public class GobblinYarnAppLauncher {
 
     // Temporal workflow tracking url
     String temporalWorkflowTrackingUrl = ConfigUtils.getString(config, "gobblin.temporal.ui.server.url", "");
-    if (!temporalWorkflowTrackingUrl.isEmpty()) {
+    if (StringUtils.isNotBlank(temporalWorkflowTrackingUrl)) {
       LOGGER.info("Temporal Workflow Tracking URL: " + temporalWorkflowTrackingUrl);
     }
-    
+
     return applicationId;
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2191) issues and references them in the PR title. For example, "[GOBBLIN-2191] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2191


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Temporal Application Master is not shutting down due to a non-daemon thread being alive. This thread is coming from the unclosed ExecutorService created in GobblinJobLauncher.

The ExecutorService is now being closed leading to a graceful shutdown of Temporal Application Master.

Also add a log statement to print Temporal Workflow Tracking URL

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Verified in a test project which prints below log message in Application Master container.
![image](https://github.com/user-attachments/assets/91c3e72c-7d43-4a64-8101-a41f6a428f32)

`ApplicationLauncher has already stopped` gets printed when the shutdown hook gets called from [ServiceBasedAppLauncher](https://github.com/apache/gobblin/blob/d58bbc0a12689e83696360f86235925743d1be3a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/app/ServiceBasedAppLauncher.java#L167) indicating a JVM shutdown.

Temporal Workflow Tracking URL log:
![image](https://github.com/user-attachments/assets/2341a58c-b934-4122-8560-64e0b8b2485d)

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

