### PR TITLE
[GOBBLIN-2194] Close temporal metrics scope on job completion

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/cluster/GobblinTemporalTaskRunner.java
@@ -49,7 +49,6 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
 import io.temporal.client.WorkflowClient;
-import io.temporal.serviceclient.WorkflowServiceStubs;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
@@ -137,15 +137,9 @@ public abstract class GobblinJobLauncher extends AbstractJobLauncher {
   @Override
   public void close() throws IOException {
     try {
-      cancelJob(jobListener);
-    } catch (Exception e) {
-      log.error("Exception occurred while cancelling job", e);
+      cleanupWorkingDirectory();
     } finally {
-      try {
-        cleanupWorkingDirectory();
-      } finally {
-        super.close();
-      }
+      super.close();
     }
   }
 

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinJobLauncher.java
@@ -137,7 +137,9 @@ public abstract class GobblinJobLauncher extends AbstractJobLauncher {
   @Override
   public void close() throws IOException {
     try {
-      executeCancellation();
+      cancelJob(jobListener);
+    } catch (Exception e) {
+      log.error("Exception occurred while cancelling job", e);
     } finally {
       try {
         cleanupWorkingDirectory();

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.temporal.joblauncher;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -187,5 +188,16 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
   @Override
   protected void addTasksToCurrentJob(List<WorkUnit> workUnitsToAdd) {
     log.warn("NOT IMPLEMENTED: Temporal addTasksToCurrentJob");
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      this.workflowServiceStubs.getOptions().getMetricsScope().close();
+    } catch (Exception e) {
+      log.error("Exception occurred while closing MetricsScope ", e);
+    } finally {
+      super.close();
+    }
   }
 }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobScheduler.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobScheduler.java
@@ -218,7 +218,11 @@ public class GobblinTemporalJobScheduler extends JobScheduler implements Standar
             throw new RuntimeException(e);
           }
         }));
-        launcher.launchJob(listener);
+        try {
+          launcher.launchJob(listener);
+        } finally {
+          launcher.close();
+        }
       }
     } catch (Exception je) {
       LOGGER.error("Failed to schedule or run job " + jobUri, je);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/client/TemporalWorkflowClientFactory.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/client/TemporalWorkflowClientFactory.java
@@ -46,11 +46,12 @@ import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.temporal.GobblinTemporalConfigurationKeys;
 import org.apache.gobblin.temporal.ddm.work.assistance.MDCContextPropagator;
 import org.apache.gobblin.temporal.workflows.metrics.TemporalMetricsHelper;
+import org.apache.gobblin.temporal.workflows.service.ManagedWorkflowServiceStubs;
 import org.apache.gobblin.util.ConfigUtils;
 
 
 public class TemporalWorkflowClientFactory {
-    public static WorkflowServiceStubs createServiceInstance(String connectionUri) throws Exception {
+    public static ManagedWorkflowServiceStubs createServiceInstance(String connectionUri) throws Exception {
         GobblinClusterUtils.setSystemProperties(ConfigFactory.load());
         Config config = GobblinClusterUtils.addDynamicConfig(ConfigFactory.load());
         String SHARED_KAFKA_CONFIG_PREFIX_WITH_DOT = "gobblin.kafka.sharedConfig.";
@@ -119,7 +120,7 @@ public class TemporalWorkflowClientFactory {
                 .setSslContext(sslContext)
                 .setMetricsScope(metricsScope)
                 .build();
-        return WorkflowServiceStubs.newServiceStubs(options);
+        return new ManagedWorkflowServiceStubs(WorkflowServiceStubs.newServiceStubs(options));
     }
 
     public static WorkflowClient createClientInstance(WorkflowServiceStubs service, String namespace) {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.temporal.workflows.service;
+
+import java.io.Closeable;
+
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A wrapper class of {@link WorkflowServiceStubs} that implements the Closeable interface.
+ * It manages the lifecycle of {@link WorkflowServiceStubs}, ensuring proper shutdown and resource cleanup.
+ */
+@Getter
+@Slf4j
+public class ManagedWorkflowServiceStubs implements Closeable {
+  private final WorkflowServiceStubs workflowServiceStubs;
+
+  public ManagedWorkflowServiceStubs(WorkflowServiceStubs serviceStubs) {
+    this.workflowServiceStubs = serviceStubs;
+  }
+
+  @Override
+  public void close() {
+    try {
+      workflowServiceStubs.getOptions().getMetricsScope().close();
+      workflowServiceStubs.shutdown();
+    }
+    catch (Exception e) {
+      log.error("Exception occurred while closing ManagedWorkflowServiceStubs", e);
+    }
+  }
+}

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
@@ -39,8 +39,12 @@ public class ManagedWorkflowServiceStubs implements Closeable {
   @Override
   public void close() {
     try {
-      workflowServiceStubs.getOptions().getMetricsScope().close();
-      workflowServiceStubs.shutdown();
+      try {
+        workflowServiceStubs.getOptions().getMetricsScope().close();
+      }
+      finally {
+        workflowServiceStubs.shutdown();
+      }
     }
     catch (Exception e) {
       log.error("Exception occurred while closing ManagedWorkflowServiceStubs", e);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/service/ManagedWorkflowServiceStubs.java
@@ -39,15 +39,16 @@ public class ManagedWorkflowServiceStubs implements Closeable {
   @Override
   public void close() {
     try {
-      try {
-        workflowServiceStubs.getOptions().getMetricsScope().close();
-      }
-      finally {
-        workflowServiceStubs.shutdown();
-      }
+      workflowServiceStubs.getOptions().getMetricsScope().close();
     }
     catch (Exception e) {
-      log.error("Exception occurred while closing ManagedWorkflowServiceStubs", e);
+      log.error("Exception occurred while closing metrics scope", e);
+    }
+    try {
+      workflowServiceStubs.shutdown();
+    }
+    catch (Exception e) {
+      log.error("Exception occurred while shutting down WorkflowServiceStubs", e);
     }
   }
 }

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncherTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncherTest.java
@@ -49,6 +49,7 @@ import org.apache.gobblin.runtime.locks.FileBasedJobLock;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.temporal.GobblinTemporalConfigurationKeys;
 import org.apache.gobblin.temporal.workflows.client.TemporalWorkflowClientFactory;
+import org.apache.gobblin.temporal.workflows.service.ManagedWorkflowServiceStubs;
 import org.apache.gobblin.util.JobLauncherUtils;
 
 import static org.mockito.Mockito.mock;
@@ -83,6 +84,7 @@ public class GobblinTemporalJobLauncherTest {
   @BeforeClass
   public void setUp() throws Exception {
     mockServiceStubs = mock(WorkflowServiceStubs.class);
+    ManagedWorkflowServiceStubs managedWorkflowServiceStubs = new ManagedWorkflowServiceStubs(mockServiceStubs);
     mockClient = mock(WorkflowClient.class);
     mockExecutionInfo = mock(WorkflowExecutionInfo.class);
     DescribeWorkflowExecutionResponse mockResponse = mock(DescribeWorkflowExecutionResponse.class);
@@ -93,7 +95,7 @@ public class GobblinTemporalJobLauncherTest {
 
     mockWorkflowClientFactory = Mockito.mockStatic(TemporalWorkflowClientFactory.class);
     mockWorkflowClientFactory.when(() -> TemporalWorkflowClientFactory.createServiceInstance(Mockito.anyString()))
-        .thenReturn(mockServiceStubs);
+        .thenReturn(managedWorkflowServiceStubs);
     mockWorkflowClientFactory.when(() -> TemporalWorkflowClientFactory.createClientInstance(Mockito.any(), Mockito.anyString()))
         .thenReturn(mockClient);
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2194) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2194


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

As part of https://github.com/apache/gobblin/pull/4095, a bug was introduced where the Metrics Scope object was not being closed, resulting in a non-daemon thread being alive. This resulted in AM container not getting shut down on application completion.

This PR implements the fix to close metrics scope wherever it is initialized. 
It also covers calling close on JobLauncher upon its completion, which now results in cleanly closing the resources launched by JobLauncher.
Instead of calling `executeCancellation()` directly we now call `cancelJob()` in `GobblinJobLauncher.close()` since the latter cancels the job in synchronized manner which in turn calls `executeCancellation()`.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in a local project where the application master shuts down.
![image](https://github.com/user-attachments/assets/b9807526-7e12-4cc9-af7c-a80cfadf8b4a)

`ApplicationLauncher has already stopped` gets printed when the shutdown hook gets called from [ServiceBasedAppLauncher](https://github.com/apache/gobblin/blob/d58bbc0a12689e83696360f86235925743d1be3a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/app/ServiceBasedAppLauncher.java#L167) indicating a JVM shutdown.
Having the same state as the AM shutdown container fix PR. See the Tests section [here](https://github.com/apache/gobblin/pull/4094).

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

