### PR TITLE
DagProcessingThread bug fix

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
@@ -65,10 +65,11 @@ public abstract class DagTask {
       boolean completedLease = this.leaseObtainedStatus.completeLease();
       this.dagProcEngineMetrics.markDagActionsConclude(this.dagAction.getDagActionType(), completedLease);
       return completedLease;
-    } catch (IOException e) {
+    } catch (Exception e) {
       this.dagProcEngineMetrics.markDagActionsConclude(this.dagAction.getDagActionType(), false);
       // TODO: Decide appropriate exception to throw and add to the commit method's signature
-      throw new RuntimeException(e);
+      log.error("Exception encountered in processing this DagTask.", e);
+      return false;
     }
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2201

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
DagProcessingEngine process dagTasks, and calls its conclude method in the end, conclude method in case of exception 
 throws RuntimeException due to which the thread is terminated and Dag processing stops. Updated the code to catch the Exceptions instead of specific IOException and not throw runtimeException and just log the error.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

