### PR TITLE
[GOBBLIN-2203] Add Support for Delete Manifests in Iceberg Full Table Replication

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergTable.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -60,7 +59,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.util.measurement.GrowthMilestoneTracker;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 import static org.apache.gobblin.data.management.copy.iceberg.IcebergSnapshotInfo.ManifestFileInfo;
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2203


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When Manifest file is a DELETE Manifest `ManifestFiles.readPaths(manifest, io)` throws exception 
`Caused by: java.lang.IllegalArgumentException: Cannot read a delete manifest with a ManifestReader: GenericManifestFile{content=DELETES, ...` to fix this issue I have changed to read Delete Manifest separately and fetch all delete file paths from them (there doesn't exists any direct iceberg API which can give this)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added `testGetSnapshotInfosForDataFilesOnlyTable` to test each functionality for table containing only data files and updated other test to validate data & delete files both

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

