### PR TITLE
[GOBBLIN-2206] Revert extra exevute bit getting set in ManifestDistcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/ManifestBasedDataset.java
@@ -153,10 +153,11 @@ public class ManifestBasedDataset implements IterableCopyableDataset {
             if (srcFile.isDirectory() && !srcFile.getPermission().getUserAction().implies(FsAction.EXECUTE)
                 && !ancestorOwnerAndPermissionsForSetPermissionStep.containsKey(PathUtils.getPathWithoutSchemeAndAuthority(fileToCopy).toString())
                 && !targetFs.exists(fileToCopy)) {
-              List<OwnerAndPermission> ancestorsOwnerAndPermission = new ArrayList<>(copyableFile.getAncestorsOwnerAndPermission());
-              OwnerAndPermission srcFileOwnerPermission = new OwnerAndPermission(srcFile.getOwner(), srcFile.getGroup(), srcFile.getPermission());
-              ancestorsOwnerAndPermission.add(0, srcFileOwnerPermission);
-              ancestorOwnerAndPermissionsForSetPermissionStep.put(fileToCopy.toString(), ancestorsOwnerAndPermission);
+              List<OwnerAndPermission> ancestorsOwnerAndPermissionUpdated = new ArrayList<>();
+              OwnerAndPermission srcFileOwnerPermissionReplicatedForDest = new OwnerAndPermission(copyableFile.getDestinationOwnerAndPermission());
+              ancestorsOwnerAndPermissionUpdated.add(srcFileOwnerPermissionReplicatedForDest);
+              copyableFile.getAncestorsOwnerAndPermission().forEach(ancestorOwnPerm -> ancestorsOwnerAndPermissionUpdated.add(new OwnerAndPermission(ancestorOwnPerm)));
+              ancestorOwnerAndPermissionsForSetPermissionStep.put(fileToCopy.toString(), ancestorsOwnerAndPermissionUpdated);
             }
 
             // Always grab the parent since the above permission setting should be setting the permission for a folder itself

--- a/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/sampleManifestWithOnlyDirectory.json
+++ b/gobblin-data-management/src/test/resources/manifestBasedDistcpTest/sampleManifestWithOnlyDirectory.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id":"1",
+    "fileName":"/tmp/dataset",
+    "fileGroup":"/tmp/dataset",
+    "fileSizeInBytes":"1024"
+  }
+]

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/OwnerAndPermission.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/OwnerAndPermission.java
@@ -35,7 +35,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 
 /**
@@ -66,7 +65,7 @@ public class OwnerAndPermission implements Writable {
    *
    * @param other the {@code OwnerAndPermission} instance to copy from.
    */
-  public OwnerAndPermission(@NonNull OwnerAndPermission other) {
+  public OwnerAndPermission(OwnerAndPermission other) {
     this(other.owner, other.group, new FsPermission(other.fsPermission),
         other.aclEntries == null ? Lists.newArrayList() : Lists.newArrayList(other.aclEntries));
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/OwnerAndPermission.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/OwnerAndPermission.java
@@ -35,6 +35,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 
 /**
@@ -52,6 +53,22 @@ public class OwnerAndPermission implements Writable {
 
   public OwnerAndPermission(String owner, String group, FsPermission fsPermission) {
     this(owner, group, fsPermission, Lists.newArrayList());
+  }
+
+
+  /**
+   * Copy constructor for {@link OwnerAndPermission}.
+   * <p>
+   * Creates a new instance by copying the values from another {@link OwnerAndPermission} object.
+   * Performs a deep copy of {@link FsPermission} and a shallow copy of the {@code aclEntries} list,
+   * since {@link org.apache.hadoop.fs.permission.AclEntry} is immutable.
+   * </p>
+   *
+   * @param other the {@code OwnerAndPermission} instance to copy from.
+   */
+  public OwnerAndPermission(@NonNull OwnerAndPermission other) {
+    this(other.owner, other.group, new FsPermission(other.fsPermission),
+        other.aclEntries == null ? Lists.newArrayList() : Lists.newArrayList(other.aclEntries));
   }
 
   @Override

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/OwnerAndPermissionTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/OwnerAndPermissionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.filesystem;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclEntryScope;
+import org.apache.hadoop.fs.permission.AclEntryType;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/** Tests for {@link OwnerAndPermission}*/
+public class OwnerAndPermissionTest {
+
+  @Test
+  public void testOwnerAndPermissionCopyConstructor() {
+    String owner = "testOwner";
+    String group = "testGroup";
+    FsPermission permission = new FsPermission((short) 0755);
+    AclEntry aclEntry = new AclEntry.Builder()
+        .setPermission(FsAction.READ_WRITE)
+        .setName("test-acl")
+        .setScope(AclEntryScope.DEFAULT)
+        .setType(AclEntryType.GROUP)
+        .build();
+    List<AclEntry> aclEntries = Collections.singletonList(aclEntry);
+
+    OwnerAndPermission ownerAndPermission = new OwnerAndPermission(owner, group, permission, aclEntries);
+    OwnerAndPermission copyOwnerAndPermission = new OwnerAndPermission(ownerAndPermission);
+
+    Assert.assertEquals(copyOwnerAndPermission.getOwner(), owner);
+    Assert.assertEquals(copyOwnerAndPermission.getGroup(), group);
+    Assert.assertEquals(copyOwnerAndPermission.getFsPermission(), permission);
+    Assert.assertEquals(copyOwnerAndPermission.getAclEntries(), aclEntries);
+
+    Assert.assertNotSame(ownerAndPermission, copyOwnerAndPermission);
+    Assert.assertNotSame(ownerAndPermission.getFsPermission(), copyOwnerAndPermission.getFsPermission());
+    Assert.assertNotSame(ownerAndPermission.getAclEntries(), copyOwnerAndPermission.getAclEntries());
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2206


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In Manifest Distcp we need permissions to be exactly similar to source but due to `FileAwareInputStreamDataWriter::setOwnerExecuteBitIfDirectory` extra execute bit gets set to owner permission even if owner doesn't have execute permission. The fix is to add extra permission in setPermissionStep to override this behaviour

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`testSetPermissionWhenCopyingDirectoryWithOwnerExecutePermissionSetUnset`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

