### PR TITLE
[GOBBLIN-2207]Make temporal unique classifier GaaS attempt aware

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -191,7 +191,7 @@ public class ConfigurationKeys {
   public static final String JOB_GROUP_KEY = "job.group";
   public static final String JOB_TAG_KEY = "job.tag";
   public static final String JOB_DESCRIPTION_KEY = "job.description";
-  public static final String JOB_CURRENT_ATTEMPTS = "job.currentAttempts";
+  public static final String JOB_ATTEMPT_ID = "job.attemptId";
   public static final String JOB_CURRENT_GENERATION = "job.currentGeneration";
   // Job launcher type
   public static final String JOB_LAUNCHER_TYPE_KEY = "launcher.type";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -183,9 +183,9 @@ public class HelixUtils {
           jobProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, jobExecutionId)));
     }
 
-    if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
+    if (jobProps.containsKey(ConfigurationKeys.JOB_ATTEMPT_ID)) {
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
-          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "1")));
+          jobProps.getProperty(ConfigurationKeys.JOB_ATTEMPT_ID, "1")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD,
           jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_GENERATION, "1")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -399,9 +399,9 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.FLOW_NAME_FIELD,
         jobProps.getProperty(ConfigurationKeys.FLOW_NAME_KEY)));
 
-    if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
+    if (jobProps.containsKey(ConfigurationKeys.JOB_ATTEMPT_ID)) {
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
-          jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "1")));
+          jobProps.getProperty(ConfigurationKeys.JOB_ATTEMPT_ID, "1")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD,
           jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_GENERATION, "1")));
       metadataTags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagUtils.java
@@ -128,7 +128,7 @@ public class DagUtils {
 
   public static JobSpec getJobSpec(DagNode<JobExecutionPlan> dagNode) {
     JobSpec jobSpec = dagNode.getValue().getJobSpec();
-    Map<String, String> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, String.valueOf(dagNode.getValue().getCurrentAttempts()),
+    Map<String, String> configWithCurrentAttempts = ImmutableMap.of(ConfigurationKeys.JOB_ATTEMPT_ID, String.valueOf(dagNode.getValue().getCurrentAttempts()),
         ConfigurationKeys.JOB_CURRENT_GENERATION, String.valueOf(dagNode.getValue().getCurrentGeneration()));
     Properties configAsProperties = (Properties) jobSpec.getConfigAsProperties().clone();
     configAsProperties.putAll(configWithCurrentAttempts);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
@@ -62,6 +62,7 @@ public class Help {
   public static final String USER_TO_PROXY_KEY = "user.to.proxy";
   public static final String USER_TO_PROXY_SEARCH_KEY = "userToProxy";
   public static final String GAAS_FLOW_ID_SEARCH_KEY = "gaasFlowIdSearchKey";
+  public static final String DEFAULT_GAAS_ATTEMPT_ID = "1";
 
   // treat `JobState` as immutable and cache, for reuse among activities executed by the same worker
   private static final transient Cache<Path, JobState> jobStateByPath = CacheBuilder.newBuilder().recordStats().build();
@@ -105,7 +106,9 @@ public class Help {
         ? workerConfig.getString(USER_TO_PROXY_KEY) : "";
     String gaasFlowExecId = workerConfig.hasPath(ConfigurationKeys.GAAS_JOB_EXEC_ID)
         ? workerConfig.getString(ConfigurationKeys.GAAS_JOB_EXEC_ID) : UUID.randomUUID().toString();
-    return userToProxy + "_" + gaasFlowExecId;
+    String gaasAttemptId = workerConfig.hasPath(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)
+        ? workerConfig.getString(ConfigurationKeys.JOB_CURRENT_ATTEMPTS) : DEFAULT_GAAS_ATTEMPT_ID;
+    return userToProxy + "_" + gaasFlowExecId + "_" + gaasAttemptId;
   }
 
   public static FileSystem loadFileSystem(FileSystemApt a) throws IOException {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/assistance/Help.java
@@ -106,9 +106,9 @@ public class Help {
         ? workerConfig.getString(USER_TO_PROXY_KEY) : "";
     String gaasFlowExecId = workerConfig.hasPath(ConfigurationKeys.GAAS_JOB_EXEC_ID)
         ? workerConfig.getString(ConfigurationKeys.GAAS_JOB_EXEC_ID) : UUID.randomUUID().toString();
-    String gaasAttemptId = workerConfig.hasPath(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)
-        ? workerConfig.getString(ConfigurationKeys.JOB_CURRENT_ATTEMPTS) : DEFAULT_GAAS_ATTEMPT_ID;
-    return userToProxy + "_" + gaasFlowExecId + "_" + gaasAttemptId;
+    String gaasAttemptId = workerConfig.hasPath(ConfigurationKeys.JOB_ATTEMPT_ID)
+        ? workerConfig.getString(ConfigurationKeys.JOB_ATTEMPT_ID) : DEFAULT_GAAS_ATTEMPT_ID;
+    return String.join("_", userToProxy, gaasFlowExecId, gaasAttemptId);
   }
 
   public static FileSystem loadFileSystem(FileSystemApt a) throws IOException {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/EventSubmitterContext.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/workflows/metrics/EventSubmitterContext.java
@@ -109,9 +109,9 @@ public class EventSubmitterContext {
         this.tags.add(new Tag<>(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, jobProps.getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
       }
 
-      if (jobProps.containsKey(ConfigurationKeys.JOB_CURRENT_ATTEMPTS)) {
+      if (jobProps.containsKey(ConfigurationKeys.JOB_ATTEMPT_ID)) {
         this.tags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD,
-            jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_ATTEMPTS, "1")));
+            jobProps.getProperty(ConfigurationKeys.JOB_ATTEMPT_ID, "1")));
         this.tags.add(new Tag<>(TimingEvent.FlowEventConstants.CURRENT_GENERATION_FIELD,
             jobProps.getProperty(ConfigurationKeys.JOB_CURRENT_GENERATION, "1")));
         this.tags.add(new Tag<>(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2207
    


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Make temporal unique classifier GaaS attempt aware.
    Currently temporal unique classifier is a combination of flowExecId, and jobUniqueId , since during retries , flowExecId and JobUniqueId is same, we need to account for attemptId in temporal unique classifier


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

