### PR TITLE
Wrap temporal heartbeat runnable

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
@@ -103,7 +103,7 @@ public class CommitActivityImpl implements CommitActivity {
       JobState jobState = Help.loadJobState(workSpec, fs);
 
       int heartBeatInterval = JobStateUtils.getHeartBeatInterval(jobState);
-      heartBeatExecutor.scheduleAtFixedRate(() -> activityExecutionContext.heartbeat("Running Commit Activity"),
+      heartBeatExecutor.scheduleAtFixedRate(ExecutorsUtils.safeRunnable(() -> activityExecutionContext.heartbeat("Running Commit Activity")),
           heartBeatInterval, heartBeatInterval, TimeUnit.MINUTES);
 
       optJobName = Optional.ofNullable(jobState.getJobName());

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/GenerateWorkUnitsImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/GenerateWorkUnitsImpl.java
@@ -138,7 +138,7 @@ public class GenerateWorkUnitsImpl implements GenerateWorkUnits {
     log.info("Created jobState: {}", jobState.toJsonString(true));
 
     int heartBeatInterval = JobStateUtils.getHeartBeatInterval(jobState);
-    heartBeatExecutor.scheduleAtFixedRate(() -> activityExecutionContext.heartbeat("Running GenerateWorkUnits"),
+    heartBeatExecutor.scheduleAtFixedRate(ExecutorsUtils.safeRunnable(() -> activityExecutionContext.heartbeat("Running GenerateWorkUnits")),
         heartBeatInterval, heartBeatInterval, TimeUnit.MINUTES);
 
     Path workDirRoot = JobStateUtils.getWorkDirRoot(jobState);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/ProcessWorkUnitImpl.java
@@ -86,7 +86,7 @@ public class ProcessWorkUnitImpl implements ProcessWorkUnit {
       log.info("{} - loaded; found {} workUnits", correlator, workUnits.size());
       JobState jobState = Help.loadJobState(wu, fs);
       int heartBeatInterval = JobStateUtils.getHeartBeatInterval(jobState);
-      heartBeatExecutor.scheduleAtFixedRate(() -> activityExecutionContext.heartbeat("Running ProcessWorkUnit Activity"),
+      heartBeatExecutor.scheduleAtFixedRate(ExecutorsUtils.safeRunnable(() -> activityExecutionContext.heartbeat("Running ProcessWorkUnit Activity")),
           heartBeatInterval, heartBeatInterval, TimeUnit.MINUTES);
       troubleshooter = AutomaticTroubleshooterFactory.createForJob(jobState.getProperties());
       troubleshooter.start();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ExecutorsUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ExecutorsUtils.java
@@ -28,20 +28,22 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import org.apache.gobblin.util.executors.MDCPropagatingCallable;
-import org.apache.gobblin.util.executors.MDCPropagatingRunnable;
-import org.apache.gobblin.util.executors.MDCPropagatingScheduledExecutorService;
 import org.slf4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.apache.gobblin.util.executors.MDCPropagatingCallable;
 import org.apache.gobblin.util.executors.MDCPropagatingExecutorService;
+import org.apache.gobblin.util.executors.MDCPropagatingRunnable;
+import org.apache.gobblin.util.executors.MDCPropagatingScheduledExecutorService;
 
 
 /**
@@ -49,6 +51,7 @@ import org.apache.gobblin.util.executors.MDCPropagatingExecutorService;
  *
  * @author Yinan Li
  */
+@Slf4j
 public class ExecutorsUtils {
 
   private static final ThreadFactory DEFAULT_THREAD_FACTORY = newThreadFactory(Optional.<Logger>absent());
@@ -160,6 +163,27 @@ public class ExecutorsUtils {
       return runnable;
     }
     return new MDCPropagatingRunnable(runnable);
+  }
+
+
+  /**
+   * Wraps a {@link Runnable} task with exception handling to ensure that
+   * any thrown exception does not terminate the thread or scheduled executor.
+   * This is useful for long-running or recurring tasks where resilience is critical.
+   *
+   * @param runnable the task to wrap
+   * @return a safe {@link Runnable} that logs and suppresses exceptions
+   */
+  public static Runnable safeRunnable(Runnable runnable) {
+    return () -> {
+      try {
+        runnable.run();
+      } catch (Exception exception) {
+        // Catch all exceptions to prevent the thread from dying
+        // and log the exception
+        log.error("Caught exception in runnable {}", exception.getMessage());
+      }
+    };
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/ExecutorsUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/ExecutorsUtilsTest.java
@@ -129,4 +129,26 @@ public class ExecutorsUtilsTest {
 
     ExecutorsUtils.parallelize(nums, sleepAndMultiply, 2, 1, Optional.<Logger> absent());
   }
+
+  @Test
+  public void testSafeRunnableRunsSuccessfully() {
+    Runnable mockRunnable = Mockito.mock(Runnable.class);
+    ExecutorsUtils.safeRunnable(mockRunnable).run();
+    Mockito.verify(mockRunnable, Mockito.times(1)).run();
+  }
+
+  @Test
+  public void testSafeRunnableHandlesException() {
+    Runnable mockRunnable = Mockito.mock(Runnable.class);
+    Mockito.doThrow(new RuntimeException("Test exception")).when(mockRunnable).run();
+    Runnable safeRunnable = ExecutorsUtils.safeRunnable(mockRunnable);
+    try {
+      safeRunnable.run();
+      safeRunnable.run();
+      Mockito.verify(mockRunnable, Mockito.times(2)).run();
+    } catch (Exception e) {
+      Assert.fail("Exception should not be thrown from safeRunnable");
+    }
+  }
+
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Temporal heartbeat is sent periodically using ScheduledExecutorService but in case any exception is thrown while sending heartbeat from temporal it will kill the heartbeat runnable task and even though activity might be still running it will be killed after sometime when server doesn't receive any heartbeat from activity, to avoid this we can wrap the runnable to print exception instead so that next heartbeat events can be sent properly
   - Added `safeRunnable` in `ExecutorsUtils`
   - Refactored Activity codes to use `safeRunnable`

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`testSafeRunnableRunsSuccessfully`,`testSafeRunnableHandlesException`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

