### PR TITLE
[GOBBLIN-2212] Fix AvroCompactionTaskTest & OrcCompactionTaskTest

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
@@ -52,7 +52,7 @@ public class TestCompactionTaskUtils {
         .setConfiguration(MRCompactor.COMPACTION_DEST_DIR, basePath)
         .setConfiguration(MRCompactor.COMPACTION_DEST_SUBDIR, outputSubdirType)
         .setConfiguration(MRCompactor.COMPACTION_TMP_DEST_DIR, "/tmp/compaction/" + name)
-        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "3000d")
+        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "30000d")
         .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO, "1d")
         .setConfiguration(ConfigurationKeys.MAX_TASK_RETRIES_KEY, "0");
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR fixes the failing UTs in AvroCompactionTaskTest & OrcCompactionTaskTest - https://issues.apache.org/jira/browse/GOBBLIN-2212


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
- [ ] The tests are using 3000 days look back config to scan for datasets to be processed. The test is using 2017.04.03 as timestamp to create records. Hence tests started to fail around 2025.06.20
- [ ] Increasing the config value to 30000 days, giving us a buffer of around 74 yrs. This is not a proper fix but a quick workaround which should not impact much.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

