### PR TITLE
Propagate fs (file system) job properties to workunit

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
@@ -52,7 +52,7 @@ public class TestCompactionTaskUtils {
         .setConfiguration(MRCompactor.COMPACTION_DEST_DIR, basePath)
         .setConfiguration(MRCompactor.COMPACTION_DEST_SUBDIR, outputSubdirType)
         .setConfiguration(MRCompactor.COMPACTION_TMP_DEST_DIR, "/tmp/compaction/" + name)
-        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "30000d")
+        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "3000d")
         .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO, "1d")
         .setConfiguration(ConfigurationKeys.MAX_TASK_RETRIES_KEY, "0");
   }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/test/TestCompactionTaskUtils.java
@@ -52,7 +52,7 @@ public class TestCompactionTaskUtils {
         .setConfiguration(MRCompactor.COMPACTION_DEST_DIR, basePath)
         .setConfiguration(MRCompactor.COMPACTION_DEST_SUBDIR, outputSubdirType)
         .setConfiguration(MRCompactor.COMPACTION_TMP_DEST_DIR, "/tmp/compaction/" + name)
-        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "3000d")
+        .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "30000d")
         .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO, "1d")
         .setConfiguration(ConfigurationKeys.MAX_TASK_RETRIES_KEY, "0");
   }

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/ProcessWorkUnitsJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/launcher/ProcessWorkUnitsJobLauncher.java
@@ -90,7 +90,7 @@ public class ProcessWorkUnitsJobLauncher extends GobblinTemporalJobLauncher {
       EventSubmitterContext eventSubmitterContext = new EventSubmitterContext.Builder()
           .withEventSubmitter(eventSubmitter)
           .build();
-      PriorJobStateWUProcessingSpec wuSpec = new PriorJobStateWUProcessingSpec(nameNodeUri, workUnitsDir.toString(), eventSubmitterContext);
+      PriorJobStateWUProcessingSpec wuSpec = new PriorJobStateWUProcessingSpec(nameNodeUri, workUnitsDir.toString(), eventSubmitterContext, this.jobProps);
       if (this.jobProps.containsKey(GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_WORK_MAX_BRANCHES_PER_TREE) &&
           this.jobProps.containsKey(GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_WORK_MAX_SUB_TREES_PER_TREE)) {
         int maxBranchesPerTree = PropertiesUtils.getRequiredPropAsInt(this.jobProps, GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_WORK_MAX_BRANCHES_PER_TREE);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/EagerFsDirBackedWorkUnitClaimCheckWorkload.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/EagerFsDirBackedWorkUnitClaimCheckWorkload.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.temporal.ddm.work;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.Properties;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -44,16 +45,19 @@ import org.apache.gobblin.util.WorkUnitSizeInfo;
 public class EagerFsDirBackedWorkUnitClaimCheckWorkload extends AbstractEagerFsDirBackedWorkload<WorkUnitClaimCheck> {
   private EventSubmitterContext eventSubmitterContext;
 
-  public EagerFsDirBackedWorkUnitClaimCheckWorkload(URI fileSystemUri, String hdfsDir, EventSubmitterContext eventSubmitterContext) {
+  private Properties fileSystemProperties;
+
+  public EagerFsDirBackedWorkUnitClaimCheckWorkload(URI fileSystemUri, String hdfsDir, EventSubmitterContext eventSubmitterContext, Properties fileSystemProperties) {
     super(fileSystemUri, hdfsDir);
     this.eventSubmitterContext = eventSubmitterContext;
+    this.fileSystemProperties = fileSystemProperties;
   }
 
   @Override
   protected WorkUnitClaimCheck fromFileStatus(FileStatus fileStatus) {
     // begin by setting all correlators to empty string - later we'll `acknowledgeOrdering()`
     Path filePath = fileStatus.getPath();
-    return new WorkUnitClaimCheck("", this.getFileSystemUri(), filePath.toString(), extractTunneledWorkUnitSizeInfo(filePath), this.eventSubmitterContext);
+    return new WorkUnitClaimCheck("", this.getFileSystemUri(), filePath.toString(), extractTunneledWorkUnitSizeInfo(filePath), this.eventSubmitterContext, fileSystemProperties);
   }
 
   @Override

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/PriorJobStateWUProcessingSpec.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/PriorJobStateWUProcessingSpec.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -51,8 +52,8 @@ public class PriorJobStateWUProcessingSpec extends WUProcessingSpec {
   @NonNull private List<Tag<?>> tags = new ArrayList<>();
   @NonNull private String metricsSuffix = GobblinTemporalConfigurationKeys.DEFAULT_GOBBLIN_TEMPORAL_JOB_METRICS_SUFFIX;
 
-  public PriorJobStateWUProcessingSpec(URI fileSystemUri, String workUnitsDir, EventSubmitterContext eventSubmitterContext) {
-    super(fileSystemUri, workUnitsDir, eventSubmitterContext);
+  public PriorJobStateWUProcessingSpec(URI fileSystemUri, String workUnitsDir, EventSubmitterContext eventSubmitterContext, Properties jobProps) {
+    super(fileSystemUri, workUnitsDir, eventSubmitterContext, jobProps);
   }
 
   @JsonIgnore

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WUProcessingSpec.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WUProcessingSpec.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.temporal.ddm.work;
 
 import java.net.URI;
+import java.util.Properties;
 
 import org.apache.hadoop.fs.Path;
 
@@ -51,6 +52,7 @@ public class WUProcessingSpec implements FileSystemApt, FileSystemJobStateful {
   @NonNull private URI fileSystemUri;
   @NonNull private String workUnitsDir;
   @NonNull private EventSubmitterContext eventSubmitterContext;
+  @NonNull private Properties fileSystemProperties;
   @NonNull @Setter(AccessLevel.PUBLIC) private Tuning tuning = Tuning.DEFAULT;
 
   /** whether to conduct job-level timing (and send results via GTE) */
@@ -62,7 +64,7 @@ public class WUProcessingSpec implements FileSystemApt, FileSystemJobStateful {
   @JsonIgnore // (because no-arg method resembles 'java bean property')
   @Override
   public State getFileSystemConfig() {
-    return new State(); // TODO - figure out how to truly set!
+    return new State(fileSystemProperties);
   }
 
   @JsonIgnore // (because no-arg method resembles 'java bean property')

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WorkUnitClaimCheck.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/work/WorkUnitClaimCheck.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.temporal.ddm.work;
 
 import java.net.URI;
+import java.util.Properties;
 
 import org.apache.hadoop.fs.Path;
 
@@ -59,11 +60,12 @@ public class WorkUnitClaimCheck implements FileSystemApt, FileSystemJobStateful 
   @NonNull private String workUnitPath;
   @NonNull private WorkUnitSizeInfo workUnitSizeInfo;
   @NonNull private EventSubmitterContext eventSubmitterContext;
+  @NonNull private Properties fileSystemProperties;
 
   @JsonIgnore // (because no-arg method resembles 'java bean property')
   @Override
   public State getFileSystemConfig() {
-    return new State(); // TODO - figure out how to truly set!
+    return new State(fileSystemProperties);
   }
 
   @JsonIgnore // (because no-arg method resembles 'java bean property')

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/ddm/work/EagerFsDirBackedWorkUnitClaimCheckWorkloadTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/ddm/work/EagerFsDirBackedWorkUnitClaimCheckWorkloadTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -53,7 +54,7 @@ public class EagerFsDirBackedWorkUnitClaimCheckWorkloadTest {
     URI fileSystemUri = new URI("hdfs://localhost:9000");
     String hdfsDir = "/test/dir";
     eventSubmitterContext = Mockito.mock(EventSubmitterContext.class);
-    workload = Mockito.spy(new EagerFsDirBackedWorkUnitClaimCheckWorkload(fileSystemUri, hdfsDir, eventSubmitterContext));
+    workload = Mockito.spy(new EagerFsDirBackedWorkUnitClaimCheckWorkload(fileSystemUri, hdfsDir, eventSubmitterContext, new Properties()));
     mockFileSystem = Mockito.mock(FileSystem.class);
 
     MockedStatic<HadoopUtils> mockedHadoopUtils = Mockito.mockStatic(HadoopUtils.class);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Adds fs (file system) properties to temporal job properties
- [ ] Propagates fs (file system) job properties to Work units


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] Passing properties via constructors & getter / setters


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

