### PR TITLE
[GOBBLIN-2221] Change iceberg data files from byte[] to list of base64 encoded string

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergOverwritePartitionsStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergOverwritePartitionsStepTest.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -43,7 +44,7 @@ public class IcebergOverwritePartitionsStepTest {
   private IcebergTable mockIcebergTable;
   private IcebergCatalog mockIcebergCatalog;
   private Properties mockProperties;
-  private byte[] serializedDummyDataFiles;
+  private List<String> base64EncodedDataFiles;
   private IcebergOverwritePartitionsStep spyIcebergOverwritePartitionsStep;
 
   @BeforeMethod
@@ -52,14 +53,22 @@ public class IcebergOverwritePartitionsStepTest {
     mockIcebergCatalog = Mockito.mock(IcebergCatalog.class);
     mockProperties = new Properties();
 
-    List<DataFile> dummyDataFiles = createDummyDataFiles();
-    serializedDummyDataFiles = SerializationUtil.serializeToBytes(dummyDataFiles);
+    base64EncodedDataFiles = getEncodedDummyDataFiles();
 
     spyIcebergOverwritePartitionsStep = Mockito.spy(new IcebergOverwritePartitionsStep(destTableIdStr,
-        testPartitionColName, testPartitionColValue, serializedDummyDataFiles, mockProperties));
+        testPartitionColName, testPartitionColValue, base64EncodedDataFiles, mockProperties));
 
     Mockito.when(mockIcebergCatalog.openTable(Mockito.any(TableIdentifier.class))).thenReturn(mockIcebergTable);
     Mockito.doReturn(mockIcebergCatalog).when(spyIcebergOverwritePartitionsStep).createDestinationCatalog();
+  }
+
+  private List<String> getEncodedDummyDataFiles() {
+    List<DataFile> dummyDataFiles = createDummyDataFiles();
+    List<String> base64EncodedDataFiles = new ArrayList<>(dummyDataFiles.size());
+    for (DataFile dataFile : dummyDataFiles) {
+      base64EncodedDataFiles.add(SerializationUtil.serializeToBase64(dataFile));
+    }
+    return base64EncodedDataFiles;
   }
 
   @Test
@@ -116,7 +125,7 @@ public class IcebergOverwritePartitionsStepTest {
     mockProperties.setProperty(IcebergOverwritePartitionsStep.OVERWRITE_PARTITIONS_RETRYER_CONFIG_PREFIX + "." + RETRY_TIMES,
         Integer.toString(retryCount));
     spyIcebergOverwritePartitionsStep = Mockito.spy(new IcebergOverwritePartitionsStep(destTableIdStr,
-        testPartitionColName, testPartitionColValue, serializedDummyDataFiles, mockProperties));
+        testPartitionColName, testPartitionColValue, base64EncodedDataFiles, mockProperties));
     Mockito.when(mockIcebergCatalog.openTable(Mockito.any(TableIdentifier.class))).thenReturn(mockIcebergTable);
     Mockito.doReturn(mockIcebergCatalog).when(spyIcebergOverwritePartitionsStep).createDestinationCatalog();
     try {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-2221] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2221


### Description
- [ ] Change iceberg data files from byte[] to list of base64 encoded string as GSON library handles base64 encoded string pretty well.
- [ ] Based on profiling, deserialising a class with base 64 encoded string as a field is 10-15x more efficient (both memory & latency) compared to deserialising a class with byte[] field


### Tests
- [ ] Updated existing unit tests


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

