### PR TITLE
[GOBBLIN-2223] Optimise writing of serialised Work Unit to File system

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/compat/hadoop/TextSerializer.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/compat/hadoop/TextSerializer.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.compat.hadoop;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -31,20 +30,21 @@ public class TextSerializer {
    * Serialize a String using the same logic as a Hadoop Text object
    */
   public static void writeStringAsText(DataOutput stream, String str) throws IOException {
-    byte[] utf8Encoded = str.getBytes(StandardCharsets.UTF_8);
-    writeVLong(stream, utf8Encoded.length);
-    stream.write(utf8Encoded);
+    writeVLong(stream, str.length());
+    stream.writeBytes(str);
   }
 
   /**
    * Deserialize a Hadoop Text object into a String
    */
   public static String readTextAsString(DataInput in) throws IOException {
-    int bufLen = (int)readVLong(in);
-    byte[] buf = new byte[bufLen];
-    in.readFully(buf);
+    int bufLen = (int) readVLong(in);
+    StringBuilder sb = new StringBuilder();
 
-    return new String(buf, StandardCharsets.UTF_8);
+    for (int i = 0; i < bufLen; i++) {
+      sb.append((char) in.readByte());
+    }
+    return sb.toString();
   }
 
   /**

--- a/gobblin-api/src/main/java/org/apache/gobblin/compat/hadoop/TextSerializer.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/compat/hadoop/TextSerializer.java
@@ -30,6 +30,12 @@ public class TextSerializer {
    * Serialize a String using the same logic as a Hadoop Text object
    */
   public static void writeStringAsText(DataOutput stream, String str) throws IOException {
+    // TODO: Use writeChars instead of writeBytes to support unicode
+    for (int i = 0; i < str.length(); i++) {
+      if (str.charAt(i) > 0x7F) {
+        throw new IllegalArgumentException("Non-ASCII character detected.");
+      }
+    }
     writeVLong(stream, str.length());
     stream.writeBytes(str);
   }

--- a/gobblin-api/src/test/java/org/apache/gobblin/compat/TextSerializerTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/compat/TextSerializerTest.java
@@ -33,6 +33,26 @@ import org.apache.gobblin.compat.hadoop.TextSerializer;
 
 public class TextSerializerTest {
   private static final String[] textsToSerialize = new String[]{"abracadabra", Strings.repeat("longString", 128000)};
+  private static final String[] serializationErrorText = new String[]{".ß¸´ˇ", Strings.repeat("ˀ.¸¯.", 128000)};
+
+  @Test
+  public void testSerializeError() throws IOException {
+    // Use our serializer, verify Hadoop deserializer can read it back
+    for (String textToSerialize : serializationErrorText) {
+      ByteArrayOutputStream bOs = new ByteArrayOutputStream();
+      DataOutputStream dataOutputStream = new DataOutputStream(bOs);
+
+      try {
+        TextSerializer.writeStringAsText(dataOutputStream, textToSerialize);
+        Assert.fail("Expected IOException not thrown");
+      } catch (Exception e) {
+        Assert.assertTrue(e instanceof IllegalArgumentException);
+        // Expected exception
+      } finally {
+        dataOutputStream.close();
+      }
+    }
+  }
 
   @Test
   public void testSerialize()


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-2223


### Description
- [ ] string.getBytes() does additional memory allocation to get byte[]
- [ ] Instead of above approach, write the string by going through each character without additional memory allocation


### Tests
- [ ] Updated existing unit test to consider characters with ascii range > 127 also
- [ ] Manual replication for 13.5k workunits for copying ~35tb data & 66k files


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

