### PR TITLE
DQ handling for no bytes read scenarios and metrics for bytes read/written

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/qualitychecker/task/TaskLevelPolicy.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/qualitychecker/task/TaskLevelPolicy.java
@@ -32,7 +32,8 @@ public abstract class TaskLevelPolicy {
 
   public enum Result {
     PASSED, // The test passed
-    FAILED // The test failed
+    FAILED, // The test failed
+    NOT_EVALUATED // The test was not evaluated
   }
 
   public TaskLevelPolicy(State state, TaskLevelPolicy.Type type) {

--- a/gobblin-core/src/main/java/org/apache/gobblin/policies/size/FileSizePolicy.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/policies/size/FileSizePolicy.java
@@ -67,7 +67,7 @@ public class FileSizePolicy extends TaskLevelPolicy {
       return String.format("FileSizePolicy [bytesRead=%s, bytesWritten=%s]", transferBytes.getBytesRead(),
           transferBytes.getBytesWritten());
     } else {
-      return "FileSizePolicy [bytesRead=null, bytesWritten=null]";
+      return "Transfer bytes information not available";
     }
   }
 
@@ -94,7 +94,7 @@ public class FileSizePolicy extends TaskLevelPolicy {
     String bytesReadString = state.getProp(BYTES_READ_KEY);
     String bytesWrittenString = state.getProp(BYTES_WRITTEN_KEY);
     if (bytesReadString == null) {
-      log.error("Missing value(s): bytesReadStr={}, bytesWrittenStr={}", bytesReadString, bytesWrittenString);
+      log.error("Missing value(s): bytesReadStr=null, bytesWrittenStr={}", bytesWrittenString);
       return Optional.empty();
     }
     try {
@@ -105,7 +105,7 @@ public class FileSizePolicy extends TaskLevelPolicy {
       }
       long bytesWritten = 0;
       if (bytesWrittenString == null) {
-        log.error("Missing bytesWritten value: bytesWrittenStr={}", bytesWrittenString);
+        log.error("Missing bytesWritten value: bytesWrittenStr=null, assuming 0 bytes written.");
       } else {
         bytesWritten = Long.parseLong(bytesWrittenString);
       }

--- a/gobblin-core/src/test/java/org/apache/gobblin/policies/size/FileSizePolicyTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/policies/size/FileSizePolicyTest.java
@@ -69,4 +69,15 @@ public class FileSizePolicyTest {
     Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.NOT_EVALUATED);
   }
 
+  @Test
+  public void testEmptyDirectoryHandling() {
+    State state = new State();
+    // Test case: Empty directory with 0 bytes read, no bytes written (directory case)
+    state.setProp(FileSizePolicy.BYTES_READ_KEY, 0L);
+    // Don't set BYTES_WRITTEN_KEY to simulate directory copy scenario
+
+    FileSizePolicy policy = new FileSizePolicy(state, TaskLevelPolicy.Type.FAIL);
+    Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.NOT_EVALUATED);
+  }
+
 }

--- a/gobblin-core/src/test/java/org/apache/gobblin/policies/size/FileSizePolicyTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/policies/size/FileSizePolicyTest.java
@@ -49,7 +49,7 @@ public class FileSizePolicyTest {
     State state = new State();
     // No properties set at all
     FileSizePolicy policy = new FileSizePolicy(state, TaskLevelPolicy.Type.FAIL);
-    Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.FAILED);
+    Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.NOT_EVALUATED);
   }
 
   @Test
@@ -64,9 +64,9 @@ public class FileSizePolicyTest {
     // Reset state and only set bytes written, not bytes read
     state = new State();
     state.setProp(FileSizePolicy.BYTES_WRITTEN_KEY, 1000L);
-
+    // bytes read is null
     policy = new FileSizePolicy(state, TaskLevelPolicy.Type.FAIL);
-    Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.FAILED);
+    Assert.assertEquals(policy.executePolicy(), TaskLevelPolicy.Result.NOT_EVALUATED);
   }
 
 }

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -28,6 +28,8 @@ public class ServiceMetricNames {
   public static final String DATA_QUALITY_SUCCESS_FILE_COUNT = "dataQualitySuccessFileCount";
   public static final String DATA_QUALITY_FAILURE_FILE_COUNT = "dataQualityFailureFileCount";
   public static final String DATA_QUALITY_NON_EVALUATED_FILE_COUNT = "dataQualityNonEvaluatedFileCount";
+  public static final String DATA_QUALITY_BYTES_READ = "dataQualityBytesRead";
+  public static final String DATA_QUALITY_BYTES_WRITTEN = "dataQualityBytesWritten";
 
   // Flow Compilation Meters and Timer
   public static final String FLOW_COMPILATION_SUCCESSFUL_METER = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowCompilation.successful";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -334,9 +334,7 @@ public class Task implements TaskIFace {
             Log.warn("Unknown data quality status encountered: " + result);
             forkDataQualityStatus = DataQualityStatus.UNKNOWN;
           }
-          if (DataQualityStatus.FAILED == forkDataQualityStatus) {
-            overallTaskDataQuality = DataQualityStatus.FAILED;
-          }
+          overallTaskDataQuality = forkDataQualityStatus;
         }
       }
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-2219] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


https://issues.apache.org/jira/browse/GOBBLIN-2219

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

- Changes handles scenarios where a task may not be doing any data copy, earlier such scenarios were reported as data quality failed
- Post analyzing DQ results we identified genuine scenarios where tasks are not doing any effective data copy, these cases are
    - Hive based copy here copy entities are created for pre and post publish step, which translates to tasks doing no data copy
    - Iceberg based copy, similarly has just post publish step
    - Azure copy, where copy of empty directory is enabled, and no data is copied in empty directory copy
- In all such scenarios we will mark data quality of these tasks as not evaluated, so that overall data quality evaluation ignores these tasks results
- We have also introduced additional metrics such as bytes read and bytes written for data quality evaluation. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit test and dev testing

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

