### PR TITLE
[GOBBLIN-2226] Construct iceberg data files during commit step

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergPartitionCopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/iceberg/IcebergPartitionCopyableFile.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.iceberg;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.util.SerializationUtil;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.data.management.copy.CopyableFile;
+
+
+/**
+ * An extension of {@link CopyableFile} that includes a base64-encoded Iceberg {@link DataFile}.
+ */
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = true)
+@Slf4j
+public class IcebergPartitionCopyableFile extends CopyableFile {
+
+  /**
+   * Base64-encoded Iceberg {@link DataFile} associated with this copyable file.
+   */
+  private String base64EncodedDataFile;
+
+  public IcebergPartitionCopyableFile(CopyableFile copyableFile, DataFile dataFile) {
+    super(copyableFile.getOrigin(), copyableFile.getDestination(), copyableFile.getDestinationOwnerAndPermission(),
+        copyableFile.getAncestorsOwnerAndPermission(), copyableFile.getChecksum(), copyableFile.getPreserve(),
+        copyableFile.getFileSet(), copyableFile.getOriginTimestamp(), copyableFile.getUpstreamTimestamp(),
+        copyableFile.getAdditionalMetadata(), copyableFile.datasetOutputPath, copyableFile.getDataFileVersionStrategy());
+    this.base64EncodedDataFile = SerializationUtil.serializeToBase64(dataFile);
+  }
+
+  public DataFile getDataFile() {
+    return SerializationUtil.deserializeFromBase64(base64EncodedDataFile);
+  }
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergDatasetTest.java
@@ -447,7 +447,7 @@ public class IcebergDatasetTest {
     String objectType = new Gson().fromJson(json, JsonObject.class)
         .getAsJsonPrimitive("object-type")
         .getAsString();
-    return objectType.equals("org.apache.gobblin.data.management.copy.CopyableFile");
+    return objectType.equals("org.apache.gobblin.data.management.copy.CopyableFile") || objectType.equals("org.apache.gobblin.data.management.copy.iceberg.IcebergPartitionCopyableFile");
   }
 
   private static void verifyFsOwnershipAndPermissionPreservation(Collection<CopyEntity> copyEntities, Map<Path, FileStatus> expectedPathsAndFileStatuses) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergOverwritePartitionsStepTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/iceberg/IcebergOverwritePartitionsStepTest.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.data.management.copy.iceberg;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -26,7 +25,6 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.util.SerializationUtil;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -44,7 +42,6 @@ public class IcebergOverwritePartitionsStepTest {
   private IcebergTable mockIcebergTable;
   private IcebergCatalog mockIcebergCatalog;
   private Properties mockProperties;
-  private List<String> base64EncodedDataFiles;
   private IcebergOverwritePartitionsStep spyIcebergOverwritePartitionsStep;
 
   @BeforeMethod
@@ -53,22 +50,13 @@ public class IcebergOverwritePartitionsStepTest {
     mockIcebergCatalog = Mockito.mock(IcebergCatalog.class);
     mockProperties = new Properties();
 
-    base64EncodedDataFiles = getEncodedDummyDataFiles();
-
     spyIcebergOverwritePartitionsStep = Mockito.spy(new IcebergOverwritePartitionsStep(destTableIdStr,
-        testPartitionColName, testPartitionColValue, base64EncodedDataFiles, mockProperties));
+        testPartitionColName, testPartitionColValue, mockProperties));
+
+    spyIcebergOverwritePartitionsStep.setDataFiles(getDummyDataFiles());
 
     Mockito.when(mockIcebergCatalog.openTable(Mockito.any(TableIdentifier.class))).thenReturn(mockIcebergTable);
     Mockito.doReturn(mockIcebergCatalog).when(spyIcebergOverwritePartitionsStep).createDestinationCatalog();
-  }
-
-  private List<String> getEncodedDummyDataFiles() {
-    List<DataFile> dummyDataFiles = createDummyDataFiles();
-    List<String> base64EncodedDataFiles = new ArrayList<>(dummyDataFiles.size());
-    for (DataFile dataFile : dummyDataFiles) {
-      base64EncodedDataFiles.add(SerializationUtil.serializeToBase64(dataFile));
-    }
-    return base64EncodedDataFiles;
   }
 
   @Test
@@ -125,7 +113,10 @@ public class IcebergOverwritePartitionsStepTest {
     mockProperties.setProperty(IcebergOverwritePartitionsStep.OVERWRITE_PARTITIONS_RETRYER_CONFIG_PREFIX + "." + RETRY_TIMES,
         Integer.toString(retryCount));
     spyIcebergOverwritePartitionsStep = Mockito.spy(new IcebergOverwritePartitionsStep(destTableIdStr,
-        testPartitionColName, testPartitionColValue, base64EncodedDataFiles, mockProperties));
+        testPartitionColName, testPartitionColValue, mockProperties));
+
+    spyIcebergOverwritePartitionsStep.setDataFiles(getDummyDataFiles());
+
     Mockito.when(mockIcebergCatalog.openTable(Mockito.any(TableIdentifier.class))).thenReturn(mockIcebergTable);
     Mockito.doReturn(mockIcebergCatalog).when(spyIcebergOverwritePartitionsStep).createDestinationCatalog();
     try {
@@ -142,7 +133,7 @@ public class IcebergOverwritePartitionsStepTest {
     }
   }
 
-  private List<DataFile> createDummyDataFiles() {
+  private List<DataFile> getDummyDataFiles() {
     DataFile dataFile1 = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath("/path/to/db/foo/data/datafile1.orc")
         .withFileSizeInBytes(1234)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-2226


### Description
- [ ] Instead of adding all the data files to Post publish step for iceberg partition copy, this PR adds Data file to each Iceberg partition copyable file during work unit generation & then adds all the data files to post publish step during commit step, hence avoiding serialisation & deserialisation of all the data files at once

- [ ] Changes:
- [ ] During WU generation, Copyable file is created and serialised. This PR adds an extension to Copyable file, IcebergPartitionCopyable file which contains the corresponding data file
- [ ] During Commit step, in Iceberg post commit step, all the data files are collected from all the iceberg copyable file & the then gets added to IcebergOverwritePartitionsStep


### Tests
- [ ] Updated existing tests
- [ ] Manually copied 35tb (66k) iceberg partition


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

