### PR TITLE
[GOBBLIN-2227] Make dag action and spec store monitor initialization config driven

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceGuiceModule.java
@@ -82,15 +82,15 @@ import org.apache.gobblin.service.modules.topology.TopologySpecFactory;
 import org.apache.gobblin.service.modules.troubleshooter.MySqlMultiContextIssueRepository;
 import org.apache.gobblin.service.modules.utils.FlowCompilationValidationHelper;
 import org.apache.gobblin.service.modules.utils.SharedFlowMetricsSingleton;
-import org.apache.gobblin.service.monitoring.DagManagementDagActionStoreChangeMonitor;
+import org.apache.gobblin.service.monitoring.DagActionChangeMonitor;
 import org.apache.gobblin.service.monitoring.DagManagementDagActionStoreChangeMonitorFactory;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.FsJobStatusRetriever;
 import org.apache.gobblin.service.monitoring.GitConfigMonitor;
+import org.apache.gobblin.service.monitoring.JobStatusMonitor;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
-import org.apache.gobblin.service.monitoring.KafkaJobStatusMonitor;
 import org.apache.gobblin.service.monitoring.KafkaJobStatusMonitorFactory;
-import org.apache.gobblin.service.monitoring.SpecStoreChangeMonitor;
+import org.apache.gobblin.service.monitoring.SpecChangeMonitor;
 import org.apache.gobblin.service.monitoring.SpecStoreChangeMonitorFactory;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
@@ -159,7 +159,7 @@ public class GobblinServiceGuiceModule implements Module {
 
     binder.bind(DagActionReminderScheduler.class);
     binder.bind(DagActionStore.class).to(MysqlDagActionStore.class);
-    binder.bind(DagManagementDagActionStoreChangeMonitor.class).toProvider(
+    binder.bind(DagActionChangeMonitor.class).toProvider(
         DagManagementDagActionStoreChangeMonitorFactory.class).in(Singleton.class);
     binder.bind(DagManagement.class).to(DagManagementTaskStreamImpl.class);
     binder.bind(DagManagementStateStore.class).to(MySqlDagManagementStateStore.class);
@@ -169,7 +169,7 @@ public class GobblinServiceGuiceModule implements Module {
     binder.bind(DagProcessingEngineMetrics.class);
     binder.bind(FlowLaunchHandler.class);
     binder.bind(MultiActiveLeaseArbiter.class).toProvider(DagActionProcessingMultiActiveLeaseArbiterFactory.class);
-    binder.bind(SpecStoreChangeMonitor.class).toProvider(SpecStoreChangeMonitorFactory.class).in(Singleton.class);
+    binder.bind(SpecChangeMonitor.class).toProvider(SpecStoreChangeMonitorFactory.class).in(Singleton.class);
 
     binder.bind(RequesterService.class).to(NoopRequesterService.class);
     binder.bind(SharedFlowMetricsSingleton.class);
@@ -188,7 +188,7 @@ public class GobblinServiceGuiceModule implements Module {
     }
 
     if (serviceConfig.isJobStatusMonitorEnabled()) {
-      binder.bind(KafkaJobStatusMonitor.class).toProvider(KafkaJobStatusMonitorFactory.class).in(Singleton.class);
+      binder.bind(JobStatusMonitor.class).toProvider(KafkaJobStatusMonitorFactory.class).in(Singleton.class);
       binder.bind(ErrorClassifier.class);
       binder.bind(ErrorPatternStore.class)
           .to(getClassByNameOrAlias(ErrorPatternStore.class, serviceConfig.getInnerConfig(),

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -77,11 +77,11 @@ import org.apache.gobblin.service.modules.restli.FlowConfigsV2ResourceHandler;
 import org.apache.gobblin.service.modules.restli.FlowExecutionResourceHandler;
 import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 import org.apache.gobblin.service.modules.topology.TopologySpecFactory;
-import org.apache.gobblin.service.monitoring.DagManagementDagActionStoreChangeMonitor;
+import org.apache.gobblin.service.monitoring.DagActionChangeMonitor;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.GitConfigMonitor;
-import org.apache.gobblin.service.monitoring.KafkaJobStatusMonitor;
-import org.apache.gobblin.service.monitoring.SpecStoreChangeMonitor;
+import org.apache.gobblin.service.monitoring.JobStatusMonitor;
+import org.apache.gobblin.service.monitoring.SpecChangeMonitor;
 import org.apache.gobblin.util.ConfigUtils;
 
 
@@ -150,7 +150,7 @@ public class GobblinServiceManager implements ApplicationLauncher {
   protected GitConfigMonitor gitConfigMonitor;
 
   @Inject(optional = true)
-  protected KafkaJobStatusMonitor jobStatusMonitor;
+  protected JobStatusMonitor jobStatusMonitor;
 
   @Inject
   protected MultiContextIssueRepository issueRepository;
@@ -166,10 +166,10 @@ public class GobblinServiceManager implements ApplicationLauncher {
   protected D2Announcer d2Announcer;
 
   @Inject(optional = true)
-  protected SpecStoreChangeMonitor specStoreChangeMonitor;
+  protected SpecChangeMonitor specStoreChangeMonitor;
 
   @Inject(optional = true)
-  protected DagManagementDagActionStoreChangeMonitor dagManagementDagActionStoreChangeMonitor;
+  protected DagActionChangeMonitor dagManagementDagActionStoreChangeMonitor;
 
   @Inject(optional = true)
   protected DagProcessingEngine dagProcessingEngine;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
@@ -24,5 +24,10 @@ import com.google.common.util.concurrent.Service;
  * A marker interface for dag action change monitors to generalize initialization in {@link org.apache.gobblin.service.modules.core.GobblinServiceManager#dagManagementDagActionStoreChangeMonitor}
  */
 public interface DagActionChangeMonitor extends Service {
+
+  /**
+   * Set the monitor to active state where it can start processing events.
+   * Should be called from {@link org.apache.gobblin.service.modules.core.GobblinServiceManager} after the service is started.
+   */
   void setActive();
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
@@ -1,0 +1,11 @@
+package org.apache.gobblin.service.monitoring;
+
+import com.google.common.util.concurrent.Service;
+
+
+/**
+ * A marker interface for dag action change monitors to generalize initialization in {@link org.apache.gobblin.service.modules.core.GobblinServiceManager#dagManagementDagActionStoreChangeMonitor}
+ */
+public interface DagActionChangeMonitor extends Service {
+  void setActive();
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionChangeMonitor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.service.monitoring;
 
 import com.google.common.util.concurrent.Service;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -59,7 +59,7 @@ import org.apache.gobblin.util.ExecutorsUtils;
  * connector between the API and execution layers of GaaS.
  */
 @Slf4j
-public abstract class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagActionStoreChangeEvent> {
+public abstract class DagActionStoreChangeMonitor extends HighLevelConsumer<String, DagActionStoreChangeEvent> implements DagActionChangeMonitor {
   public static final String DAG_ACTION_CHANGE_MONITOR_PREFIX = "dagActionChangeStore";
 
   // Metrics

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -166,6 +166,7 @@ public abstract class DagActionStoreChangeMonitor extends HighLevelConsumer<Stri
    This method should be called once by the {@link GobblinServiceManager} only after the FlowGraph and
    SpecCompiler are initialized and running.
    */
+  @Override
   public synchronized void setActive() {
     if (this.isActive) {
       return;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitorFactory.java
@@ -38,9 +38,9 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  */
 @Slf4j
 public class DagManagementDagActionStoreChangeMonitorFactory implements Provider<DagActionChangeMonitor> {
-  static final String DAG_ACTION_STORE_CHANGE_MONITOR_CLASS_KEY = "class";
-  static final String DEFAULT_DAG_ACTION_STORE_CHANGE_MONITOR_CLASS = DagManagementDagActionStoreChangeMonitor.class.getName();
-  static final String DAG_ACTION_STORE_CHANGE_MONITOR_NUM_THREADS_KEY = "numThreads";
+  private static final String DAG_ACTION_STORE_CHANGE_MONITOR_CLASS_KEY = "class";
+  private static final String DEFAULT_DAG_ACTION_STORE_CHANGE_MONITOR_CLASS = DagManagementDagActionStoreChangeMonitor.class.getName();
+  private static final String DAG_ACTION_STORE_CHANGE_MONITOR_NUM_THREADS_KEY = "numThreads";
 
   private final Config config;
   private final DagManagementStateStore dagManagementStateStore;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/JobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/JobStatusMonitor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.service.monitoring;
 
 import com.google.common.util.concurrent.Service;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/JobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/JobStatusMonitor.java
@@ -1,0 +1,10 @@
+package org.apache.gobblin.service.monitoring;
+
+import com.google.common.util.concurrent.Service;
+
+
+/**
+ * A marker interface for job status monitors to generalize initialization in {@link org.apache.gobblin.service.modules.core.GobblinServiceManager#jobStatusMonitor}
+ */
+public interface JobStatusMonitor extends Service {
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -89,7 +89,7 @@ import static org.apache.gobblin.util.retry.RetryerFactory.RetryType;
  * a {@link FileContextBasedFsStateStore}.
  */
 @Slf4j
-public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], byte[]> {
+public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], byte[]> implements JobStatusMonitor {
   public static final String JOB_STATUS_MONITOR_PREFIX = "jobStatusMonitor";
   //We use table suffix that is different from the Gobblin job state store suffix of jst to avoid confusion.
   //gst refers to the state store suffix for GaaS-orchestrated Gobblin jobs.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
@@ -1,0 +1,11 @@
+package org.apache.gobblin.service.monitoring;
+
+import com.google.common.util.concurrent.Service;
+
+
+/**
+ * A marker interface for spec change monitors to generalize initialization in {@link org.apache.gobblin.service.modules.core.GobblinServiceManager#specStoreChangeMonitor}
+ */
+public interface SpecChangeMonitor extends Service {
+  void setActive();
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.service.monitoring;
 
 import com.google.common.util.concurrent.Service;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecChangeMonitor.java
@@ -24,5 +24,10 @@ import com.google.common.util.concurrent.Service;
  * A marker interface for spec change monitors to generalize initialization in {@link org.apache.gobblin.service.modules.core.GobblinServiceManager#specStoreChangeMonitor}
  */
 public interface SpecChangeMonitor extends Service {
+
+  /**
+   * Set the monitor to active state where it can start processing events.
+   * Should be called from {@link org.apache.gobblin.service.modules.core.GobblinServiceManager} after the service is started.
+   */
   void setActive();
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
@@ -51,7 +51,7 @@ import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
  * a connector between the API and execution layers of GaaS.
  */
 @Slf4j
-public class SpecStoreChangeMonitor extends HighLevelConsumer<String, GenericStoreChangeEvent> {
+public class SpecStoreChangeMonitor extends HighLevelConsumer<String, GenericStoreChangeEvent> implements SpecChangeMonitor{
   public static final String SPEC_STORE_CHANGE_MONITOR_PREFIX = "specStoreChangeMonitor";
 
   // Metrics

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitor.java
@@ -51,7 +51,7 @@ import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
  * a connector between the API and execution layers of GaaS.
  */
 @Slf4j
-public class SpecStoreChangeMonitor extends HighLevelConsumer<String, GenericStoreChangeEvent> implements SpecChangeMonitor{
+public class SpecStoreChangeMonitor extends HighLevelConsumer<String, GenericStoreChangeEvent> implements SpecChangeMonitor {
   public static final String SPEC_STORE_CHANGE_MONITOR_PREFIX = "specStoreChangeMonitor";
 
   // Metrics
@@ -108,6 +108,7 @@ public class SpecStoreChangeMonitor extends HighLevelConsumer<String, GenericSto
    This method should be called once by the {@link GobblinServiceManager} only after the Scheduler is active to ensure
    calls to onAddSpec don't fail specCompilation.
    */
+  @Override
   public synchronized void setActive() {
     if (this.isActive) {
       return;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitorFactory.java
@@ -28,13 +28,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
 
 /**
- * A factory implementation that returns a {@link SpecStoreChangeMonitor} instance.
+ * A factory implementation that returns a {@link SpecChangeMonitor} instance.
  */
 @Slf4j
-public class SpecStoreChangeMonitorFactory implements Provider<SpecStoreChangeMonitor> {
+public class SpecStoreChangeMonitorFactory implements Provider<SpecChangeMonitor> {
+  static final String SPEC_STORE_CHANGE_MONITOR_CLASS_KEY = "class";
+  static final String DEFAULT_SPEC_STORE_CHANGE_MONITOR_CLASS = SpecStoreChangeMonitor.class.getName();
   static final String SPEC_STORE_CHANGE_MONITOR_NUM_THREADS_KEY = "numThreads";
 
   private final Config config;
@@ -48,19 +51,22 @@ public class SpecStoreChangeMonitorFactory implements Provider<SpecStoreChangeMo
     this.scheduler = scheduler;
   }
 
-  private SpecStoreChangeMonitor createSpecStoreChangeMonitor()
+  private SpecChangeMonitor createSpecStoreChangeMonitor()
       throws ReflectiveOperationException {
     Config specStoreChangeConfig = this.config.getConfig(SpecStoreChangeMonitor.SPEC_STORE_CHANGE_MONITOR_PREFIX);
-    log.info("SpecStoreChangeMonitor will be initialized with config {}", specStoreChangeConfig);
+    Class<?> specStoreChangeMonitorClass = Class.forName(
+        ConfigUtils.getString(specStoreChangeConfig, SPEC_STORE_CHANGE_MONITOR_CLASS_KEY, DEFAULT_SPEC_STORE_CHANGE_MONITOR_CLASS));
+    log.info("SpecStoreChangeMonitor class `{}` will be initialized with config {}", specStoreChangeMonitorClass, specStoreChangeConfig);
 
     String topic = ""; // Pass empty string because we expect underlying client to dynamically determine the Kafka topic
     int numThreads = ConfigUtils.getInt(specStoreChangeConfig, SPEC_STORE_CHANGE_MONITOR_NUM_THREADS_KEY, 5);
 
-    return new SpecStoreChangeMonitor(topic, specStoreChangeConfig, this.flowCatalog, this.scheduler, numThreads);
+    return (SpecChangeMonitor) GobblinConstructorUtils.invokeLongestConstructor(specStoreChangeMonitorClass, topic,
+        specStoreChangeConfig, this.flowCatalog, this.scheduler, numThreads);
   }
 
   @Override
-  public SpecStoreChangeMonitor get() {
+  public SpecChangeMonitor get() {
     try {
       return createSpecStoreChangeMonitor();
     } catch (ReflectiveOperationException e) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitorFactory.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/SpecStoreChangeMonitorFactory.java
@@ -36,9 +36,9 @@ import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
  */
 @Slf4j
 public class SpecStoreChangeMonitorFactory implements Provider<SpecChangeMonitor> {
-  static final String SPEC_STORE_CHANGE_MONITOR_CLASS_KEY = "class";
-  static final String DEFAULT_SPEC_STORE_CHANGE_MONITOR_CLASS = SpecStoreChangeMonitor.class.getName();
-  static final String SPEC_STORE_CHANGE_MONITOR_NUM_THREADS_KEY = "numThreads";
+  private static final String SPEC_STORE_CHANGE_MONITOR_CLASS_KEY = "class";
+  private static final String DEFAULT_SPEC_STORE_CHANGE_MONITOR_CLASS = SpecStoreChangeMonitor.class.getName();
+  private static final String SPEC_STORE_CHANGE_MONITOR_NUM_THREADS_KEY = "numThreads";
 
   private final Config config;
   private FlowCatalog flowCatalog;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2227


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Made the DagActionChangeMonitor, SpecStoreChangeMonitor config driven initialization 
Also changed DagActionChangeMonitor, SpecStoreChangeMonitor and JobStatusMonitor to bind using interface in place of Abstract class

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
NA

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

