### PR TITLE
[GOBBLIN-2257] Fix thread-safety of specSyncObjects after parallel onAddSpec

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -97,8 +98,10 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
   @Getter
   protected final SpecStore specStore;
   // a map which keeps a handle of condition variables for each spec being added to the flow catalog
-  // to provide synchronization needed for flow specs
-  private final Map<String, Object> specSyncObjects = new HashMap<>();
+  // to provide synchronization needed for flow specs.
+  // Must be ConcurrentHashMap because onAddSpec is no longer synchronized (GOBBLIN-2257), so
+  // multiple updateOrAddSpecHelper calls can concurrently put/remove entries.
+  private final Map<String, Object> specSyncObjects = new ConcurrentHashMap<>();
 
   public FlowCatalog(Config config) {
     this(config, Optional.absent());
@@ -359,7 +362,7 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
       if (exponentialBackoff.awaitNextRetryIfAvailable()) {
         return getSpecHelper(uri, exponentialBackoff);
       } else {
-        log.error(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog" + ", suspecting current modification on SpecStore", uri), snfe);
+        log.warn(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog" + ", suspecting current modification on SpecStore", uri), snfe);
       }
     }
     return spec;


### PR DESCRIPTION
## Summary

GOBBLIN-2257 removed `synchronized` from `onAddSpec` and introduced a multi-threaded executor for parallel flow compilation, improving `flowConfigsV2` GET API P99 latency. However, `FlowCatalog.specSyncObjects` is a plain `HashMap` that is now accessed concurrently from multiple `updateOrAddSpecHelper` calls without synchronization.

### The bug

In `updateOrAddSpecHelper`, concurrent threads call:
- `specSyncObjects.put(...)` (adding sync objects)
- `specSyncObjects.remove(...)` (cleaning up after persist)

`HashMap` is not thread-safe for concurrent modifications. This causes:
- **Lost entries** — a flow's syncObject disappears from the map
- **`LaunchDagProc - error`** — `getSyncObject()` returns null, breaking synchronization with `NonScheduledJobRunner`, causing DAG initialization failures
- **`DagNode or its job status not found for Reevaluate`** — orphaned DAGs from failed initialization

### The fix

- **`HashMap` → `ConcurrentHashMap`** for `specSyncObjects` — drop-in replacement, no API change, no impact on P99 latency improvement
- **Downgrade "SpecStore is missing in FlowCatalog" log from ERROR to WARN** — with concurrent writes to SpecStore, `getSpecURIs()` can list a URI before `addSpec()` fully commits the data. This is a transient condition already handled by exponential backoff retries; ERROR level creates false alarms in monitoring

## Test plan

- [ ] Existing `FlowCatalogTest` passes
- [ ] Verify in production: `LaunchDagProc - error` and `DagNode not found` errors should stop occurring
- [ ] Verify in production: "SpecStore is missing in FlowCatalog" now logs at WARN instead of ERROR
