### PR TITLE
[GOBBLIN-2257] Fix thread-safety of shared maps after parallel onAddSpec

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -97,8 +98,10 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
   @Getter
   protected final SpecStore specStore;
   // a map which keeps a handle of condition variables for each spec being added to the flow catalog
-  // to provide synchronization needed for flow specs
-  private final Map<String, Object> specSyncObjects = new HashMap<>();
+  // to provide synchronization needed for flow specs.
+  // Must be ConcurrentHashMap because onAddSpec is no longer synchronized (GOBBLIN-2257), so
+  // multiple updateOrAddSpecHelper calls can concurrently put/remove entries.
+  private final Map<String, Object> specSyncObjects = new ConcurrentHashMap<>();
 
   public FlowCatalog(Config config) {
     this(config, Optional.absent());
@@ -359,7 +362,7 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
       if (exponentialBackoff.awaitNextRetryIfAvailable()) {
         return getSpecHelper(uri, exponentialBackoff);
       } else {
-        log.error(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog" + ", suspecting current modification on SpecStore", uri), snfe);
+        log.warn(String.format("The URI %s discovered in SpecStore is missing in FlowCatalog" + ", suspecting current modification on SpecStore", uri), snfe);
       }
     }
     return spec;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -156,8 +156,11 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
     this.serviceName = serviceName;
     this.flowCatalog = flowCatalog;
     this.orchestrator = orchestrator;
-    this.scheduledFlowSpecs = Maps.newHashMap();
-    this.lastUpdatedTimeForFlowSpec = Maps.newHashMap();
+    // Must be concurrent maps because onAddSpec is no longer synchronized (GOBBLIN-2257),
+    // so multiple onAddSpec callbacks can concurrently read/write these maps.
+    // NonScheduledJobRunner also removes entries from a separate thread.
+    this.scheduledFlowSpecs = Maps.newConcurrentMap();
+    this.lastUpdatedTimeForFlowSpec = Maps.newConcurrentMap();
     this.loadSpecsBatchSize = Integer.parseInt(ConfigUtils.configToProperties(config).getProperty(ConfigurationKeys.LOAD_SPEC_BATCH_SIZE, String.valueOf(ConfigurationKeys.DEFAULT_LOAD_SPEC_BATCH_SIZE)));
     this.skipSchedulingFlowsAfterNumDays = Integer.parseInt(ConfigUtils.configToProperties(config).getProperty(ConfigurationKeys.SKIP_SCHEDULING_FLOWS_AFTER_NUM_DAYS, String.valueOf(ConfigurationKeys.DEFAULT_NUM_DAYS_TO_SKIP_AFTER)));
     this.isNominatedDRHandler = config.hasPath(GOBBLIN_SERVICE_SCHEDULER_DR_NOMINATED)


### PR DESCRIPTION
## Summary

GOBBLIN-2257 removed `synchronized` from `onAddSpec` and introduced a multi-threaded executor for parallel flow compilation, improving `flowConfigsV2` GET API P99 latency. However, the listener callbacks and FlowCatalog internals that were implicitly protected by that `synchronized` block now run concurrently without thread-safe data structures.

### The bug

**`GobblinServiceJobScheduler.onAddSpec()`** reads and writes `scheduledFlowSpecs` and `lastUpdatedTimeForFlowSpec` — both plain `HashMap`s — from multiple concurrent callback threads. `NonScheduledJobRunner` also removes entries from a separate thread pool. Concurrent `HashMap` modifications cause structural corruption:
- Lost map entries → flows not tracked, not cleaned up
- Orphaned DAGs → `LaunchDagProc - error`, `DagNode or its job status not found`
- Corrupted internal HashMap state → potential infinite loops, NPEs

**`FlowCatalog.specSyncObjects`** (also a plain `HashMap`) is similarly accessed concurrently from `updateOrAddSpecHelper` (multiple API request threads) and `NonScheduledJobRunner`.

### The fix

- **`GobblinServiceJobScheduler`**: `Maps.newHashMap()` → `Maps.newConcurrentMap()` for both `scheduledFlowSpecs` and `lastUpdatedTimeForFlowSpec`
- **`FlowCatalog`**: `HashMap` → `ConcurrentHashMap` for `specSyncObjects`
- **`FlowCatalog`**: Downgrade "SpecStore is missing in FlowCatalog" log from ERROR to WARN — with concurrent SpecStore writes, `getSpecURIs()` can list a URI before `addSpec()` fully commits. This transient condition is already handled by exponential backoff retries; ERROR level creates false alarms in monitoring

All changes are drop-in replacements with no API changes and no impact on the P99 latency improvement from GOBBLIN-2257.

## Test plan

- [ ] Existing `FlowCatalogTest` and `GobblinServiceJobSchedulerTest` pass
- [ ] Verify in production: `LaunchDagProc - error` and `DagNode not found` errors should stop occurring
- [ ] Verify in production: "SpecStore is missing in FlowCatalog" now logs at WARN instead of ERROR
