### PR TITLE
[DRAFT]CommitActivityImpl: close FileSystem asynchronously to prevent DFSClient hang

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
@@ -102,7 +102,7 @@ public class CommitActivityImpl implements CommitActivity {
     int numDeserializationThreads = DEFAULT_NUM_DESERIALIZATION_THREADS;
     Optional<String> optJobName = Optional.empty();
     AutomaticTroubleshooter troubleshooter = null;
-    try (FileSystem fs = Help.loadFileSystem(workSpec)) {
+    try (FileSystem fs = Help.loadFileSystemForce(workSpec)) {
       JobState jobState = Help.loadJobState(workSpec, fs);
 
       int heartBeatInterval = JobStateUtils.getHeartBeatInterval(jobState);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/activity/impl/CommitActivityImpl.java
@@ -102,7 +102,9 @@ public class CommitActivityImpl implements CommitActivity {
     int numDeserializationThreads = DEFAULT_NUM_DESERIALIZATION_THREADS;
     Optional<String> optJobName = Optional.empty();
     AutomaticTroubleshooter troubleshooter = null;
-    try (FileSystem fs = Help.loadFileSystemForce(workSpec)) {
+    FileSystem fs = null;
+    try {
+      fs = Help.loadFileSystem(workSpec);
       JobState jobState = Help.loadJobState(workSpec, fs);
 
       int heartBeatInterval = JobStateUtils.getHeartBeatInterval(jobState);
@@ -172,11 +174,35 @@ public class CommitActivityImpl implements CommitActivity {
           new IOException(e)
       );
     } finally {
+      closeFileSystemAsync(fs);
       String errCorrelator = String.format("Commit [%s]", calcCommitId(workSpec));
       EventSubmitter eventSubmitter = workSpec.getEventSubmitterContext().create();
       Help.finalizeTroubleshooting(troubleshooter, eventSubmitter, log, errCorrelator);
       ExecutorsUtils.shutdownExecutorService(heartBeatExecutor, com.google.common.base.Optional.of(log));
     }
+  }
+
+  /**
+   * Closes a {@link FileSystem} on a daemon thread to avoid blocking the caller.
+   *
+   * Using a non-cached (force-loaded) FileSystem means each commit activity owns its own {@link org.apache.hadoop.hdfs.DFSClient}
+   * and therefore its own IPC {@code Client}. Closing that Client via {@code Client.stop()} waits for all open
+   * connections to drain, which can hang indefinitely when connection threads are blocked in native socket reads.
+   * By closing asynchronously we keep the activity thread unblocked while cleanup proceeds in the background.
+   */
+  private void closeFileSystemAsync(FileSystem fs) {
+    if (fs == null) {
+      return;
+    }
+    Thread t = new Thread(() -> {
+      try {
+        fs.close();
+      } catch (IOException e) {
+        log.warn("Async FileSystem close encountered an error (fs: {})", fs.getUri(), e);
+      }
+    }, "CommitActivity-AsyncFSClose");
+    t.setDaemon(true);
+    t.start();
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

                                                                                                                                                                                                  
  CommitActivity was observed hanging indefinitely after completing all commit work. A thread dump confirmed the Temporal Activity Executor thread was stuck in Client.stop() (inside              
  DistributedFileSystem.close()), waiting for the connections map to become empty. A heap dump confirmed 1 shared IPC Client with 22 live Connection objects still in the map and running=false    
  (stop had been called), but zero active Connection reader threads — meaning no one would ever drain the map or call notifyAll() on the connectionsLock.
                                                                                                                                                                                                   
  The root cause is still under investigation, but the immediate trigger is:                                                                                                                       
   
  - CommitActivity calls Help.loadFileSystem(workSpec) which returns the shared/cached FileSystem (via FileSystem.get()).                                                                          
  - Closing that shared instance calls Client.stop() on the single shared IPC Client, which waits for all 22 open connections to drain.
  - The Connection reader threads that would drain the map were not alive at dump time (likely killed during a partial JVM shutdown sequence), so Client.stop() waited forever — blocking the      
  activity thread and preventing Temporal from completing or timing out the activity.                                                                                                              
  - With the activity thread stuck, the CommitActivityHeartBeatExecutor also stopped sending heartbeats, causing the JVM to enter a perpetual shutdown loop (DestroyJavaVM elapsed ~9 hours).      
                                                                                                                                                                                                   
  Note on loadFileSystemForce: The non-cached variant was evaluated as an alternative but introduces a separate failure mode: each call creates a new private ViewFileSystem →                     
  PerformanceTrackingDistributedFileSystem per mount point, each spawning an OpenTelemetry PeriodicMetricReader daemon thread. With 10 deserialization threads × N mount points, this exhausts the 
  OS native thread limit and produces OutOfMemoryError: unable to create native thread.                                                                                                            
                                                                             
  Mitigation

  Move the FileSystem.close() call off the activity thread onto a dedicated daemon thread (CommitActivity-AsyncFSClose). The activity thread returns immediately after kicking off the close; the  
  daemon thread handles cleanup in the background and is killed harmlessly if the JVM exits before it completes.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

