### PR TITLE
Remove WARN log aggregation from AutomaticTroubleshooter

### DIFF
--- a/gobblin-modules/gobblin-troubleshooter/src/main/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterImpl.java
+++ b/gobblin-modules/gobblin-troubleshooter/src/main/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterImpl.java
@@ -84,7 +84,7 @@ public class AutomaticTroubleshooterImpl implements AutomaticTroubleshooter {
     org.apache.log4j.Logger rootLogger = LogManager.getRootLogger();
 
     troubleshooterLogger = new AutoTroubleshooterLogAppender(issueRepository);
-    troubleshooterLogger.setThreshold(Level.WARN);
+    troubleshooterLogger.setThreshold(Level.ERROR);
     troubleshooterLogger.activateOptions();
     rootLogger.addAppender(troubleshooterLogger);
 

--- a/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
+++ b/gobblin-modules/gobblin-troubleshooter/src/test/java/org/apache/gobblin/troubleshooter/AutomaticTroubleshooterTest.java
@@ -43,16 +43,16 @@ public class AutomaticTroubleshooterTest {
     AutomaticTroubleshooter troubleshooter = AutomaticTroubleshooterFactory.createForJob(new Properties());
     try {
       troubleshooter.start();
-      log.warn("Test warning");
+      log.error("Test error");
 
       troubleshooter.refineIssues();
       troubleshooter.logIssueSummary();
 
       String summaryMessage = troubleshooter.getIssueSummaryMessage();
-      assertTrue(summaryMessage.contains("Test warning"));
+      assertTrue(summaryMessage.contains("Test error"));
 
       String detailedMessage = troubleshooter.getIssueDetailsMessage();
-      assertTrue(detailedMessage.contains("Test warning"));
+      assertTrue(detailedMessage.contains("Test error"));
 
       EventSubmitter eventSubmitter = mock(EventSubmitter.class);
       troubleshooter.reportJobIssuesAsEvents(eventSubmitter);
@@ -72,7 +72,7 @@ public class AutomaticTroubleshooterTest {
     AutomaticTroubleshooter troubleshooter = AutomaticTroubleshooterFactory.createForJob(properties);
     try {
       troubleshooter.start();
-      log.warn("Test warning");
+      log.error("Test error");
 
       troubleshooter.refineIssues();
       troubleshooter.logIssueSummary();
@@ -81,6 +81,22 @@ public class AutomaticTroubleshooterTest {
 
       assertEquals(0, troubleshooter.getIssueRepository().getAll().size());
       verify(eventSubmitter, never()).submit((GobblinEventBuilder) any());
+    } finally {
+      troubleshooter.stop();
+    }
+  }
+
+  @Test
+  public void warnLogsAreNotCaptured()
+      throws Exception {
+    AutomaticTroubleshooter troubleshooter = AutomaticTroubleshooterFactory.createForJob(new Properties());
+    try {
+      troubleshooter.start();
+      log.warn("Test warning that should be ignored");
+
+      troubleshooter.refineIssues();
+
+      assertEquals(0, troubleshooter.getIssueRepository().getAll().size());
     } finally {
       troubleshooter.stop();
     }
@@ -96,7 +112,7 @@ public class AutomaticTroubleshooterTest {
     try {
       troubleshooter.start();
 
-      log.warn("Test warning");
+      log.error("Test error");
 
       troubleshooter.refineIssues();
       troubleshooter.logIssueSummary();


### PR DESCRIPTION
Raise the log appender threshold from WARN to ERROR so only ERROR and FATAL logs are aggregated by the troubleshooter.  This reduces noise in the issue repository and keeps it focused on actionable errors.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

