### PR TITLE
[GOBBLIN-2259] Coerce $UNKNOWN ExecutionStatus to PENDING in FlowExec…

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
@@ -220,13 +220,27 @@ public class FlowExecutionResource extends ComplexKeyResourceTemplate<FlowStatus
 
     jobStatusArray.sort(Comparator.comparing((org.apache.gobblin.service.JobStatus js) -> js.getExecutionStatistics().getExecutionStartTime()));
 
+    // $UNKNOWN is a Pegasus in-memory sentinel (not declared in ExecutionStatus.pdl) that arises
+    // when no flow-level (NA/NA) status event was persisted for an execution. This can happen when
+    // the FlowSucceeded/FlowFailed GobblinTrackingEvent is emitted by the orchestrator but
+    // KafkaAvroJobStatusMonitor fails to persist it to the state store (e.g., Kafka consumer
+    // shard-rebalance / checkpoint issues). Serializing $UNKNOWN produces HTTP 500 and poisons the
+    // whole collection response. Coerce to PENDING so the record serializes; polling callers will
+    // keep polling until a terminal state becomes known.
+    ExecutionStatus flowExecutionStatus = monitoringFlowStatus.getFlowExecutionStatus();
+    if (flowExecutionStatus == ExecutionStatus.$UNKNOWN) {
+      log.warn("FlowExecution {}/{}/{} has $UNKNOWN flow status; coercing to PENDING. Check state store for data quality issue.",
+          flowId.getFlowGroup(), flowId.getFlowName(), monitoringFlowStatus.getFlowExecutionId());
+      flowExecutionStatus = ExecutionStatus.PENDING;
+    }
+
     return new FlowExecution()
         .setId(new FlowStatusId().setFlowGroup(flowId.getFlowGroup()).setFlowName(flowId.getFlowName())
             .setFlowExecutionId(monitoringFlowStatus.getFlowExecutionId()))
         .setExecutionStatistics(new FlowStatistics().setExecutionStartTime(getFlowStartTime(monitoringFlowStatus))
             .setExecutionEndTime(flowEndTime))
         .setMessage(flowMessage)
-        .setExecutionStatus(monitoringFlowStatus.getFlowExecutionStatus())
+        .setExecutionStatus(flowExecutionStatus)
         .setJobStatuses(jobStatusArray)
         .setIssues(new IssueArray(flowIssues));
   }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowExecutionResourceHandlerTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowExecutionResourceHandlerTest.java
@@ -17,11 +17,37 @@
 
 package org.apache.gobblin.service;
 
+import java.util.Collections;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import org.apache.gobblin.service.monitoring.FlowStatus;
+
 
 public class FlowExecutionResourceHandlerTest {
+
+  @Test
+  public void testConvertFlowStatusCoercesUnknownToPending() {
+    FlowStatus unknownFlowStatus = new FlowStatus("flowName", "flowGroup", 123L,
+        Collections.emptyIterator(), ExecutionStatus.$UNKNOWN);
+
+    FlowExecution flowExecution = FlowExecutionResource.convertFlowStatus(unknownFlowStatus, false);
+
+    Assert.assertNotNull(flowExecution);
+    Assert.assertEquals(flowExecution.getExecutionStatus(), ExecutionStatus.PENDING);
+  }
+
+  @Test
+  public void testConvertFlowStatusPreservesValidStatus() {
+    FlowStatus runningFlowStatus = new FlowStatus("flowName", "flowGroup", 123L,
+        Collections.emptyIterator(), ExecutionStatus.RUNNING);
+
+    FlowExecution flowExecution = FlowExecutionResource.convertFlowStatus(runningFlowStatus, false);
+
+    Assert.assertNotNull(flowExecution);
+    Assert.assertEquals(flowExecution.getExecutionStatus(), ExecutionStatus.RUNNING);
+  }
 
   @Test
   public void testEstimateCopyTimeLeftSanityCheck() {


### PR DESCRIPTION
…utionResource

ExecutionStatus.$UNKNOWN is a Pegasus in-memory sentinel, not a symbol declared in ExecutionStatus.pdl. When it reaches the response, Rest.li rejects it during serialization and returns HTTP 500 for the entire collection - a single poisoned record takes down every execution in the same latestFlowExecution batch.

Guard at the REST boundary: coerce $UNKNOWN to PENDING before building the FlowExecution response, and log a WARN so the underlying data-quality issue (missing flow-level status event or schema skew) stays observable.

Added tests:
- testConvertFlowStatusCoercesUnknownToPending
- testConvertFlowStatusPreservesValidStatus

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

