### PR TITLE
Keep Kafka consumer and DAG-processing threads alive across uncaught exceptions

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/HighLevelConsumerTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/HighLevelConsumerTest.java
@@ -205,6 +205,43 @@ public class HighLevelConsumerTest extends KafkaTestBase {
     consumer.shutDown();
   }
 
+  /**
+   * Verifies that with auto-commit=false, a RuntimeException from processMessage does not kill the
+   * QueueProcessor: the in-loop try/catch logs and continues with the next record. Before this
+   * change, the exception would propagate out, exit run(), and silently kill the partition's worker.
+   * The failing record is effectively dropped — operators alert on consumerLoopExceptions.
+   */
+  @Test
+  public void testQueueProcessorContinuesAfterExceptionAutoCommitDisabled() throws Exception {
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty(ConfigurationKeys.KAFKA_BROKERS, _kafkaBrokers);
+    consumerProps.setProperty(Kafka09ConsumerClient.GOBBLIN_CONFIG_VALUE_DESERIALIZER_CLASS_KEY, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    consumerProps.setProperty(SOURCE_KAFKA_CONSUMERCONFIG_KEY_WITH_DOT + KAFKA_AUTO_OFFSET_RESET_KEY, "earliest");
+    String consumerGroupId = Joiner.on("-").join(TOPIC, "continue", System.currentTimeMillis());
+    consumerProps.setProperty(SOURCE_KAFKA_CONSUMERCONFIG_KEY_WITH_DOT + HighLevelConsumer.GROUP_ID_KEY, consumerGroupId);
+    consumerProps.setProperty(HighLevelConsumer.ENABLE_AUTO_COMMIT_KEY, "false");
+    consumerProps.put(HighLevelConsumer.OFFSET_COMMIT_TIME_THRESHOLD_SECS_KEY, 1);
+
+    // Throw on the first record only; subsequent records should flow through normally.
+    java.util.concurrent.atomic.AtomicBoolean firstCall = new java.util.concurrent.atomic.AtomicBoolean(true);
+    MockedHighLevelConsumer consumer = new MockedHighLevelConsumer(TOPIC, ConfigUtils.propertiesToConfig(consumerProps), NUM_PARTITIONS) {
+      @Override
+      public void processMessage(DecodeableKafkaRecord<byte[], byte[]> message) {
+        if (firstCall.compareAndSet(true, false)) {
+          throw new RuntimeException("Simulated failure on first record");
+        }
+        super.processMessage(message);
+      }
+    };
+    consumer.startAsync().awaitRunning();
+
+    // One record is dropped (auto-commit=false: inner catch rethrows, outer catches and logs,
+    // offset for the failing record is never added to partitionOffsetsToCommit). Remaining
+    // NUM_MSGS-1 records flow through normally.
+    consumer.awaitExactlyNMessages(NUM_MSGS - 1, 15_000);
+    consumer.shutDown();
+  }
+
   private List<byte[]> createByteArrayMessages() {
     List<byte[]> records = Lists.newArrayList();
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/kafka/HighLevelConsumer.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -97,6 +98,7 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
   @Getter
   private MetricContext metricContext;
   protected Counter messagesRead;
+  protected Meter consumerLoopExceptions;
   @Getter
   private final GobblinKafkaConsumerClient gobblinKafkaConsumerClient;
   protected final ScheduledExecutorService consumerExecutor;
@@ -201,6 +203,8 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     String prefix = getMetricsPrefix();
     this.messagesRead = this.metricContext.counter(prefix +
         RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ);
+    this.consumerLoopExceptions = this.metricContext.meter(prefix +
+        RuntimeMetrics.GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_LOOP_EXCEPTIONS);
     this.queueSizeGauges = new ContextAwareGauge[numThreads];
     for (int i = 0; i < numThreads; i++) {
       // An 'effectively' final variable is needed inside the lambda expression below
@@ -240,10 +244,16 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     buildMetricsContextAndMetrics();
     // Method that starts threads that processes queues
     processQueues();
-    // Main thread that constantly polls messages from kafka
+    // Main thread that constantly polls messages from kafka. Guard with try/catch so an uncaught
+    // exception doesn't kill the poll thread and leave the service in a "server up, consumer down" state.
     consumerExecutor.execute(() -> {
       while (!shutdownRequested) {
-        consume();
+        try {
+          consume();
+        } catch (Throwable t) {
+          log.error("consume() threw; continuing poll loop", t);
+          consumerLoopExceptions.mark();
+        }
       }
     });
   }
@@ -335,24 +345,26 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
     @Override
     public void run() {
       log.info("Starting queue processing.. " + Thread.currentThread().getName());
-      KafkaConsumerRecord record = null;
-      try {
-        while (true) {
+      // Try/catch INSIDE the while so an uncaught exception logs + increments a meter and continues
+      // with the next record, instead of escaping and killing this partition's worker thread. The
+      // failing record is effectively dropped — operators alert on consumerLoopExceptions.
+      while (!Thread.currentThread().isInterrupted()) {
+        KafkaConsumerRecord record = null;
+        try {
           record = queue.take();
           messagesRead.inc();
           try {
             HighLevelConsumer.this.processMessage((DecodeableKafkaRecord) record);
             recordsProcessed.incrementAndGet();
-          }
-          catch (Exception e) {
-            // Rethrow exception in case auto commit is disabled
+          } catch (Exception e) {
+            // Rethrow so the outer catch logs + marks the meter + skips the offset commit below
+            // (preserves the GOBBLIN-2177 watermark invariant: don't commit an offset we failed on).
             if (!HighLevelConsumer.this.enableAutoCommit) {
               throw e;
             }
-            // Continue with processing next records in case auto commit is enabled
+            // auto-commit=true: swallow and continue (pre-existing behavior).
             log.error("Encountered exception while processing record. Record: {} Exception: {}", record, e);
           }
-
           if (!HighLevelConsumer.this.enableAutoCommit) {
             KafkaPartition partition =
                 new KafkaPartition.Builder().withId(record.getPartition()).withTopicName(HighLevelConsumer.this.topic)
@@ -360,12 +372,14 @@ public abstract class HighLevelConsumer<K,V> extends AbstractIdleService {
             // Committed offset should always be the offset of the next record to be read (hence +1)
             partitionOffsetsToCommit.put(partition, record.getOffset() + 1);
           }
+        } catch (InterruptedException e) {
+          log.warn("Thread interrupted while processing queue ", e);
+          Thread.currentThread().interrupt();
+          return;
+        } catch (Throwable t) {
+          log.error("Encountered exception processing record; continuing. Record: {}", record, t);
+          consumerLoopExceptions.mark();
         }
-      } catch(InterruptedException e){
-        log.warn("Thread interrupted while processing queue ", e);
-        Thread.currentThread().interrupt();
-      } catch (Exception e) {
-        log.error("Encountered exception while processing record so stopping queue processing. Record: {} Exception: {}", record, e);
       }
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/metrics/RuntimeMetrics.java
@@ -29,6 +29,9 @@ public class RuntimeMetrics {
   public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_MESSAGES_READ =
       "gobblin.kafka.highLevelConsumer.messagesRead";
   public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_QUEUE_SIZE_PREFIX = "gobblin.kafka.highLevelConsumer.queueSize";
+  // Wire this metric to on-call paging: rate indicates the consumer loop is repeatedly throwing.
+  public static final String GOBBLIN_KAFKA_HIGH_LEVEL_CONSUMER_LOOP_EXCEPTIONS =
+      "gobblin.kafka.highLevelConsumer.loopExceptions";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_TOTAL_SPECS = "gobblin.jobMonitor.kafka.totalSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_NEW_SPECS = "gobblin.jobMonitor.kafka.newSpecs";
   public static final String GOBBLIN_JOB_MONITOR_KAFKA_UPDATED_SPECS = "gobblin.jobMonitor.kafka.updatedSpecs";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagProcessingEngine.java
@@ -145,27 +145,35 @@ public class DagProcessingEngine extends AbstractIdleService {
     public void run() {
       log.info("Starting DagProcEngineThread to process dag tasks. Thread id: {}", threadID);
 
-      while (true) {
-        DagTask dagTask = dagTaskStream.next(); // blocking call
-        if (dagTask == null) {
-          //todo - add a metrics to count the times dagTask was null
-          log.warn("Ignoring null dag task!");
-          continue;
-        }
-        DagProc<?> dagProc = dagTask.host(dagProcFactory);
+      while (!Thread.currentThread().isInterrupted()) {
+        // Outer try/catch so exceptions from dagTaskStream.next() or dagTask.host() log + continue
+        // instead of killing the thread — consumer/DAG-processing must stay alive as long as the
+        // service is alive.
         try {
-          dagProc.process(dagManagementStateStore, dagProcEngineMetrics);
-          dagTask.conclude();
-          log.info(dagProc.contextualizeStatus("concluded dagTask"));
-        } catch (Exception e) {
-          log.error("DagProcEngineThread: " + dagProc.contextualizeStatus("error"), e);
-          dagManagementStateStore.getDagManagerMetrics().dagProcessingExceptionMeter.mark();
-          if (!DagProcessingEngine.isTransientException(e)) {
-            log.warn(dagProc.contextualizeStatus("ignoring non-transient exception by concluding so no retries"));
-            dagManagementStateStore.getDagManagerMetrics().dagProcessingNonRetryableExceptionMeter.mark();
-            dagTask.conclude();
+          DagTask dagTask = dagTaskStream.next(); // blocking call
+          if (dagTask == null) {
+            //todo - add a metrics to count the times dagTask was null
+            log.warn("Ignoring null dag task!");
+            continue;
           }
-          // TODO add the else block for transient exceptions and add conclude task only if retry limit is not breached
+          DagProc<?> dagProc = dagTask.host(dagProcFactory);
+          try {
+            dagProc.process(dagManagementStateStore, dagProcEngineMetrics);
+            dagTask.conclude();
+            log.info(dagProc.contextualizeStatus("concluded dagTask"));
+          } catch (Exception e) {
+            log.error("DagProcEngineThread: " + dagProc.contextualizeStatus("error"), e);
+            dagManagementStateStore.getDagManagerMetrics().dagProcessingExceptionMeter.mark();
+            if (!DagProcessingEngine.isTransientException(e)) {
+              log.warn(dagProc.contextualizeStatus("ignoring non-transient exception by concluding so no retries"));
+              dagManagementStateStore.getDagManagerMetrics().dagProcessingNonRetryableExceptionMeter.mark();
+              dagTask.conclude();
+            }
+            // TODO add the else block for transient exceptions and add conclude task only if retry limit is not breached
+          }
+        } catch (Throwable t) {
+          log.error("DagProcEngineThread iteration failed; continuing. Thread id: {}", threadID, t);
+          dagManagementStateStore.getDagManagerMetrics().dagProcessingExceptionMeter.mark();
         }
       }
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagActionStoreChangeMonitor.java
@@ -176,10 +176,16 @@ public abstract class DagActionStoreChangeMonitor extends HighLevelConsumer<Stri
     initializeMonitor();
     // Method that starts threads that processes queues
     processQueues();
-    // Main thread that constantly polls messages from kafka
+    // Main thread that constantly polls messages from kafka. Guard with try/catch so an uncaught
+    // exception from consume() doesn't leave the service in a "server up, consumer down" state.
     consumerExecutor.execute(() -> {
       while (!shutdownRequested) {
-        consume();
+        try {
+          consume();
+        } catch (Throwable t) {
+          log.error("consume() threw; continuing poll loop", t);
+          consumerLoopExceptions.mark();
+        }
       }
     });
   }


### PR DESCRIPTION
### Dear Gobblin maintainers,

Please accept this PR. I understand that until you sign your ICLA, we cannot actually accept your PR.

- My name is Daisy Modi
- I work for LinkedIn
- I have signed the ICLA

### JIRA
- Filing a GOBBLIN ticket as a follow-up — happy to update the PR title with the ticket number once filed.

### Description of PR

GaaS depends on three long-lived worker loops that previously exited silently on any uncaught exception, leaving the service running but non-functional ("server up, consumer down"):

1. `HighLevelConsumer.startUp()` — the Kafka poll loop. `consume()` only caught `InterruptedException`; any other exception escaped the lambda and the poll thread stopped.
2. `HighLevelConsumer.QueueProcessor.run()` — the per-partition record-processing loop. Its outer `catch (Exception)` exited `run()` and silently killed the worker for that partition.
3. `DagProcessingEngine.DagProcEngineThread.run()` — the DAG-task-processing loop. The top-of-iteration blocking calls (`dagTaskStream.next()`, `dagTask.host()`) sat outside any `try/catch`.

**Fix:** move the `try/catch` **inside** each `while` loop so an uncaught exception logs + marks a meter + iterates to the next cycle, instead of escaping and terminating the thread. `DagActionStoreChangeMonitor.setActive()` inlines the same broken poll-loop pattern; it gets the same wrap.

**Watermark invariant preserved** (GOBBLIN-2177): under `auto-commit=false` the inner catch still rethrows before `partitionOffsetsToCommit` is updated for the failing record, and the new outer in-loop catch handles that without advancing the offset map for the failing record. The failing record is dropped in steady state; operators alert on the `loopExceptions` meter and investigate.

**Retry semantics considered and deferred.** The specific failure modes that would escape `processMessage` aren't well-understood yet, so retrying could add complexity without known benefit. Alert-on-failure is the intended guardrail; retry can be added later if specific retryable failure modes emerge.

One new metric (wire to on-call paging):
- `gobblin.kafka.highLevelConsumer.loopExceptions`

DagProc-side reuses the existing `dagProcessingExceptionMeter`.

### Tests

- `HighLevelConsumerTest#testQueueProcessorContinuesAfterExceptionAutoCommitDisabled` — new integration test: `auto-commit=false`, `processMessage` throws on the first record, subsequent records still flow through (`NUM_MSGS - 1` observed; the failing record is dropped).
- Existing `testQueueProcessorRuntimeExceptionEncounteredAutoCommitEnabled` continues to pass unchanged.

### Commits

- One squashed commit.

### Documentation and Formatting

- No new user-visible config.
- Minimal restructure — existing patterns and class structure preserved.