### PR TITLE
[GOBBLIN-2262] Bump default thread counts for spec catalog listener and DAG processing engine

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -83,6 +83,9 @@ public class ConfigurationKeys {
   public static final String STATE_STORE_DB_PASSWORD_KEY = "state.store.db.password";
   public static final String STATE_STORE_DB_TABLE_KEY = "state.store.db.table";
   public static final String DEFAULT_STATE_STORE_DB_TABLE = "gobblin_job_state";
+  public static final String STATE_STORE_DB_MAX_CONNECTIONS_KEY = "state.store.db.maxConnections";
+  // Matches HikariCP's built-in default; preserves prior behavior of `MysqlStateStore.newDataSource`
+  public static final int DEFAULT_STATE_STORE_DB_MAX_CONNECTIONS = 10;
   public static final String MYSQL_GET_MAX_RETRIES = "mysql.get.max.retries";
   public static final int DEFAULT_MYSQL_GET_MAX_RETRIES = 3;
 

--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -164,9 +164,9 @@ public class ServiceConfigKeys {
   public static final String GOBBLIN_SERVICE_DAG_PROCESSING_ENGINE_PREFIX = ServiceConfigKeys.GOBBLIN_SERVICE_PREFIX + "dagProcessingEngine.";
   public static final String NUM_DAG_PROC_THREADS_KEY = GOBBLIN_SERVICE_DAG_PROCESSING_ENGINE_PREFIX + "numThreads";
   public static final String DAG_PROC_ENGINE_NON_RETRYABLE_EXCEPTIONS_KEY = GOBBLIN_SERVICE_DAG_PROCESSING_ENGINE_PREFIX + "nonRetryableExceptions";
-  public static final Integer DEFAULT_NUM_DAG_PROC_THREADS = 3;
+  public static final Integer DEFAULT_NUM_DAG_PROC_THREADS = 150;
   public static final String NUM_SPEC_CATALOG_LISTENER_THREADS_KEY = GOBBLIN_SERVICE_PREFIX + "specCatalogListener.numThreads";
-  public static final int DEFAULT_NUM_SPEC_CATALOG_LISTENER_THREADS = 3;
+  public static final int DEFAULT_NUM_SPEC_CATALOG_LISTENER_THREADS = 150;
   public static final long DEFAULT_FLOW_FINISH_DEADLINE_MILLIS = TimeUnit.HOURS.toMillis(24);
 
   public static final String ERROR_PATTERN_STORE_CLASS = ServiceConfigKeys.GOBBLIN_SERVICE_PREFIX + "errorPatternStore.class";

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
@@ -241,6 +241,10 @@ public class MysqlStateStore<T extends State> implements StateStore<T> {
     //   perhaps non-zero would have desirable runtime perf, but anything >0 currently fails unit tests (even 1!);
     //   (so experimenting with a higher number would first require adjusting tests)
     dataSource.setMinimumIdle(0);
+    // Expose Hikari `maximumPoolSize` as configurable so callers (e.g. spec stores) backed by large thread pools
+    // can size connections to match concurrent `getConnection()` demand. Default preserves HikariCP's built-in (10).
+    dataSource.setMaximumPoolSize(ConfigUtils.getInt(config, ConfigurationKeys.STATE_STORE_DB_MAX_CONNECTIONS_KEY,
+        ConfigurationKeys.DEFAULT_STATE_STORE_DB_MAX_CONNECTIONS));
     dataSource.setUsername(passwordManager.readPassword(
         config.getString(ConfigurationKeys.STATE_STORE_DB_USER_KEY)));
     dataSource.setPassword(passwordManager.readPassword(


### PR DESCRIPTION
## Dear Gobblin maintainers,

I am submitting the following PR for your kind review.

## JIRA
- [GOBBLIN-2262](https://issues.apache.org/jira/browse/GOBBLIN-2262)

## Description

Increases two thread-pool defaults from 3 to 150 in `ServiceConfigKeys`:

- `DEFAULT_NUM_SPEC_CATALOG_LISTENER_THREADS` — controls the executor used by `FlowCatalog`'s `SpecCatalogListenersList` for parallel flow compilation on the **submission path** (`POST /flowconfigs`).
- `DEFAULT_NUM_DAG_PROC_THREADS` — controls the executor used by `DagProcessingEngine` on the **execution path**.

### Motivation

Both pools ultimately invoke `MultiHopFlowCompiler.compileFlow`, which calls `DataMovementAuthorizer.isMovementAuthorized` ([`MultiHopFlowCompiler.java:242`](https://github.com/apache/gobblin/blob/master/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java#L242)). Under high authorization-service latency, the default pool size of 3 becomes the binding throughput limit on both paths and queues flow submissions and executions even when downstream resources have plenty of capacity.

The pool sizes remain configurable via:
- `gobblin.service.specCatalogListener.numThreads`
- `gobblin.service.dagProcessingEngine.numThreads`

Deployments preferring the previous behavior can override either back to 3.

### Tests

Existing tests reference these constants symbolically (e.g. `DagProcessingEngineTest.java` uses `ServiceConfigKeys.DEFAULT_NUM_DAG_PROC_THREADS` directly), so they auto-adjust to the new default and require no changes.