### PR TITLE
GOBBLIN-2263: Plumb DagAction store-insert time onto JobSpec for downstream latency metrics

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -24,6 +24,10 @@ subprojects {
     mavenCentral()
     maven {
       url "https://repository.cloudera.com/artifactory/cloudera-repos/"
+      content {
+        // io.grpc artifacts are available from Maven Central. Excluding them here avoids querying the Cloudera
+        excludeGroup "io.grpc"
+      }
     }
 
     // Conjars is a read only repository that hosts older artifacts, necessary for hive 1.0.1 and hadoop 2.10

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -179,6 +179,10 @@ public class ConfigurationKeys {
   public static final String FLOW_EDGE_ID_KEY = "flow.edgeId";
   public static final String FLOW_DESCRIPTION_KEY = "flow.description";
   public static final String FLOW_EXECUTION_ID_KEY = "flow.executionId";
+  // Stamped onto the JobSpec config by LaunchDagProc, carrying the DagAction store row-insert time in millis
+  // (sourced upstream from the CDC binlog event timestamp). Enables downstream executors to measure end-to-end
+  // LAUNCH-to-submission latency including CDC propagation. Absent / -1 when the source timestamp is unknown.
+  public static final String DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY = "dagAction.launch.storeInsertTimeMillis";
   public static final String FLOW_FAILURE_OPTION = "flow.failureOption";
   public static final String FLOW_APPLY_RETENTION = "flow.applyRetention";
   public static final String FLOW_APPLY_INPUT_RETENTION = "flow.applyInputRetention";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/DagActionStoreChangeEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/DagActionStoreChangeEvent.avsc
@@ -51,10 +51,10 @@
     "doc" : "type of dag action",
     "compliance" : "NONE"
   }, {
-    "name" : "dbUpdateTimeMillis",
+    "name" : "storeInsertTimeMillis",
     "type" : [ "null", "long" ],
     "default" : null,
-    "doc" : "Source-database row modification time in epoch millis (e.g., MySQL binlog EventTimestamp on the dag_action row INSERT). Distinct from the kafka publish time on changeEventIdentifier — this is the original DB-side timestamp, used by downstream consumers to measure end-to-end CDC+orchestration latency. Null when the producer cannot determine it.",
+    "doc" : "DagAction store row-insert time in epoch millis, sourced upstream from the MySQL binlog EventTimestamp on the dag_action row INSERT. Distinct from the kafka publish time on changeEventIdentifier — this is the original DB-side timestamp, used by downstream consumers to measure end-to-end CDC+orchestration latency. Null when the producer cannot determine it.",
     "compliance" : "NONE"
   } ]
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/DagActionStoreChangeEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/DagActionStoreChangeEvent.avsc
@@ -50,6 +50,11 @@
     },
     "doc" : "type of dag action",
     "compliance" : "NONE"
-  }
-  ]
+  }, {
+    "name" : "dbUpdateTimeMillis",
+    "type" : [ "null", "long" ],
+    "default" : null,
+    "doc" : "Source-database row modification time in epoch millis (e.g., MySQL binlog EventTimestamp on the dag_action row INSERT). Distinct from the kafka publish time on changeEventIdentifier — this is the original DB-side timestamp, used by downstream consumers to measure end-to-end CDC+orchestration latency. Null when the producer cannot determine it.",
+    "compliance" : "NONE"
+  } ]
 }

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
@@ -132,7 +132,7 @@ public class DagManagementDagActionStoreChangeMonitorTest {
         new GenericStoreChangeEvent(key, String.valueOf(txidCounter), System.currentTimeMillis(), operationType);
     txidCounter++;
     return new DagActionStoreChangeEvent(genericStoreChangeEvent, flowGroup, flowName, String.valueOf(flowExecutionId),
-        jobName, dagAction);
+        jobName, dagAction, null);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
@@ -154,6 +154,9 @@ public class DagActionReminderScheduler {
     dataMap.put(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, dagAction.getFlowExecutionId());
     dataMap.put(ReminderJob.FLOW_ACTION_TYPE_KEY, dagAction.getDagActionType());
     dataMap.put(ReminderJob.FLOW_ACTION_EVENT_TIME_KEY, leaseParams.getEventTimeMillis());
+    // Carry the source DagActionStore row-insert time through the Quartz reminder so a host-failure-driven
+    // reattempt still preserves the original timestamp for end-to-end latency instrumentation.
+    dataMap.put(ReminderJob.FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY, leaseParams.getStoreInsertTimeMillis());
 
     return JobBuilder.newJob(ReminderJob.class)
         .withIdentity(createJobKey(leaseParams, isDeadlineReminder))
@@ -190,6 +193,7 @@ public class DagActionReminderScheduler {
   public static class ReminderJob implements Job {
     public static final String FLOW_ACTION_TYPE_KEY = "flow.actionType";
     public static final String FLOW_ACTION_EVENT_TIME_KEY = "flow.eventTime";
+    public static final String FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY = "flow.storeInsertTimeMillis";
     private final DagManagement dagManagement;
 
     @Override
@@ -202,10 +206,16 @@ public class DagActionReminderScheduler {
       long flowExecutionId = jobDataMap.getLong(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
       DagActionStore.DagActionType dagActionType = (DagActionStore.DagActionType) jobDataMap.get(FLOW_ACTION_TYPE_KEY);
       long eventTimeMillis = jobDataMap.getLong(FLOW_ACTION_EVENT_TIME_KEY);
+      // Restore the original DagActionStore row-insert time so downstream LaunchDagProc can still stamp
+      // the JobSpec on a reminder-driven reattempt. Defaults to UNKNOWN for reminders scheduled by older
+      // code paths that did not populate the key.
+      long storeInsertTimeMillis = jobDataMap.containsKey(FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY)
+          ? jobDataMap.getLong(FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY)
+          : DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS;
 
       DagActionStore.LeaseParams reminderLeaseParams = new DagActionStore.LeaseParams(
           new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName, dagActionType),
-          true, eventTimeMillis);
+          true, eventTimeMillis, storeInsertTimeMillis);
       log.info("DagProc reminder triggered for dagAction event: {}", reminderLeaseParams);
 
       try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -100,19 +100,37 @@ public interface DagActionStore {
    * {@link DagAction} along with the time it was requested, denoted by the `eventTimeMillis` field. It also tracks
    * whether it has been previously passed to the {@link MultiActiveLeaseArbiter} to attempt ownership over the flow
    * event, indicated by the 'isReminder' field (true when it has been previously attempted).
+   *
+   * The `storeInsertTimeMillis` field carries the original DagAction store row-insert time (sourced upstream
+   * from the CDC binlog event timestamp) when known. It is independent of `eventTimeMillis`, which the lease
+   * arbiter may rewrite via consensus. A value of {@link #UNKNOWN_STORE_INSERT_TIME_MILLIS} signals "not provided"
+   * and is the default for callers that do not have access to the source timestamp.
    */
+  long UNKNOWN_STORE_INSERT_TIME_MILLIS = -1L;
+
   @Data
-  @RequiredArgsConstructor
   class LeaseParams {
     final DagAction dagAction;
     final boolean isReminder;
     final long eventTimeMillis;
+    final long storeInsertTimeMillis;
+
+    public LeaseParams(DagAction dagAction, boolean isReminder, long eventTimeMillis, long storeInsertTimeMillis) {
+      this.dagAction = dagAction;
+      this.isReminder = isReminder;
+      this.eventTimeMillis = eventTimeMillis;
+      this.storeInsertTimeMillis = storeInsertTimeMillis;
+    }
+
+    public LeaseParams(DagAction dagAction, boolean isReminder, long eventTimeMillis) {
+      this(dagAction, isReminder, eventTimeMillis, UNKNOWN_STORE_INSERT_TIME_MILLIS);
+    }
 
     /**
      * Creates a lease object for a dagAction and eventTimeMillis representing an original event (isReminder is False)
      */
     public LeaseParams(DagAction dagAction, long eventTimeMillis) {
-      this(dagAction, false, eventTimeMillis);
+      this(dagAction, false, eventTimeMillis, UNKNOWN_STORE_INSERT_TIME_MILLIS);
     }
 
     public LeaseParams(DagAction dagAction) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionStore.java
@@ -103,13 +103,13 @@ public interface DagActionStore {
    *
    * The `storeInsertTimeMillis` field carries the original DagAction store row-insert time (sourced upstream
    * from the CDC binlog event timestamp) when known. It is independent of `eventTimeMillis`, which the lease
-   * arbiter may rewrite via consensus. A value of {@link #UNKNOWN_STORE_INSERT_TIME_MILLIS} signals "not provided"
+   * arbiter may rewrite via consensus. A value of {@link LeaseParams#UNKNOWN_STORE_INSERT_TIME_MILLIS} signals "not provided"
    * and is the default for callers that do not have access to the source timestamp.
    */
-  long UNKNOWN_STORE_INSERT_TIME_MILLIS = -1L;
-
   @Data
   class LeaseParams {
+    public static final long UNKNOWN_STORE_INSERT_TIME_MILLIS = -1L;
+
     final DagAction dagAction;
     final boolean isReminder;
     final long eventTimeMillis;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiter.java
@@ -313,8 +313,9 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         if (isWithinEpsilon) {
          DagActionStore.DagAction updatedDagAction =
               adoptConsensusFlowExecutionId ? leaseParams.updateDagActionFlowExecutionId(dbEventTimestamp.getTime()) : leaseParams.getDagAction();
+         // Preserve storeInsertTimeMillis through consensus so downstream consumers can measure end-to-end latency.
          DagActionStore.LeaseParams updatedLeaseParams = new DagActionStore.LeaseParams(updatedDagAction,
-             dbEventTimestamp.getTime());
+             false, dbEventTimestamp.getTime(), leaseParams.getStoreInsertTimeMillis());
           log.debug("tryAcquireLease for {} - CASE 2: Same event, lease is valid", contextualizeLeasing(updatedLeaseParams));
           // Utilize db timestamp for reminder
           return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedLeaseParams,
@@ -322,8 +323,9 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
         }
         DagActionStore.DagAction updatedDagAction =
             adoptConsensusFlowExecutionId ? leaseParams.getDagAction().updateFlowExecutionId(dbCurrentTimestamp.getTime()) : leaseParams.getDagAction();
+        // Preserve storeInsertTimeMillis through consensus so downstream consumers can measure end-to-end latency.
         DagActionStore.LeaseParams updatedLeaseParams = new DagActionStore.LeaseParams(updatedDagAction,
-            dbCurrentTimestamp.getTime());
+            false, dbCurrentTimestamp.getTime(), leaseParams.getStoreInsertTimeMillis());
         log.debug("tryAcquireLease for {} - CASE 3: Distinct event, lease is valid", contextualizeLeasing(updatedLeaseParams));
         // Utilize db lease acquisition timestamp for wait time and currentTimestamp as the new eventTimestamp
         return new LeaseAttemptStatus.LeasedToAnotherStatus(updatedLeaseParams,
@@ -537,8 +539,11 @@ public class MysqlMultiActiveLeaseArbiter implements MultiActiveLeaseArbiter {
     }
     DagActionStore.DagAction updatedDagAction =
         adoptConsensusFlowExecutionId ? leaseParams.updateDagActionFlowExecutionId(selectInfoResult.eventTimeMillis) : leaseParams.dagAction;
+    // Preserve storeInsertTimeMillis through consensus so downstream LaunchDagProc can stamp the JobSpec
+    // for end-to-end LAUNCH-to-submission latency instrumentation that includes CDC propagation.
     DagActionStore.LeaseParams consensusLeaseParams =
-        new DagActionStore.LeaseParams(updatedDagAction, selectInfoResult.getEventTimeMillis());
+        new DagActionStore.LeaseParams(updatedDagAction, false, selectInfoResult.getEventTimeMillis(),
+            leaseParams.getStoreInsertTimeMillis());
     // If no db current timestamp is present, then use the full db linger value for duration
     long minimumLingerDurationMillis = dbCurrentTimestamp.isPresent() ?
         selectInfoResult.getLeaseAcquisitionTimeMillis().get() + selectInfoResult.getDbLinger()

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -71,7 +71,7 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
       FlowSpec flowSpec = dagManagementStateStore.getFlowSpec(FlowSpec.Utils.createFlowSpecUri(getDagId().getFlowId()));
       flowSpec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, getDagId().getFlowExecutionId());
       long storeInsertTimeMillis = getDagTask().getLeaseParams().getStoreInsertTimeMillis();
-      if (storeInsertTimeMillis != DagActionStore.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
+      if (storeInsertTimeMillis != DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
         flowSpec.addProperty(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
             storeInsertTimeMillis);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -33,6 +33,7 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
 import org.apache.gobblin.runtime.troubleshooter.IssueSeverity;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagUtils;
 import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
@@ -69,6 +70,11 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
     try {
       FlowSpec flowSpec = dagManagementStateStore.getFlowSpec(FlowSpec.Utils.createFlowSpecUri(getDagId().getFlowId()));
       flowSpec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, getDagId().getFlowExecutionId());
+      long storeInsertTimeMillis = getDagTask().getLeaseParams().getStoreInsertTimeMillis();
+      if (storeInsertTimeMillis != DagActionStore.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
+        flowSpec.addProperty(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+            storeInsertTimeMillis);
+      }
       Optional<Dag<JobExecutionPlan>> dag = this.flowCompilationValidationHelper.createExecutionPlanIfValid(flowSpec).toJavaUtil();
       if (dag.isPresent()) {
         dagManagementStateStore.addDag(dag.get());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
@@ -42,6 +42,14 @@ public abstract class DagTask {
   private final LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus;
   private final DagProcessingEngineMetrics dagProcEngineMetrics;
 
+  /**
+   * Returns the consensus {@link DagActionStore.LeaseParams} for this task, exposing the per-event metadata that
+   * the lease arbiter agreed on — including {@code storeInsertTimeMillis} for downstream latency instrumentation.
+   */
+  public DagActionStore.LeaseParams getLeaseParams() {
+    return this.leaseObtainedStatus.getConsensusLeaseParams();
+  }
+
   public DagTask(DagActionStore.DagAction dagAction, LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus,
       DagManagementStateStore dagManagementStateStore, DagProcessingEngineMetrics dagProcEngineMetrics) {
     this.dagAction = dagAction;

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
@@ -46,6 +47,7 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class DagActionReminderSchedulerTest {
@@ -102,6 +104,69 @@ public class DagActionReminderSchedulerTest {
     Assert.assertEquals(dataMap.get(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_TYPE_KEY),
         DagActionStore.DagActionType.LAUNCH);
     Assert.assertEquals(dataMap.get(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_EVENT_TIME_KEY), launchLeaseParams.getEventTimeMillis());
+  }
+
+  @Test
+  public void testCreateReminderJobDetailStashesStoreInsertTimeMillis() {
+    long sourceStoreInsertTime = 1700000000000L;
+    DagActionStore.LeaseParams paramsWithStoreInsertTime = new DagActionStore.LeaseParams(
+        launchDagAction, false, eventTimeMillis, sourceStoreInsertTime);
+
+    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(paramsWithStoreInsertTime, false);
+    JobDataMap dataMap = jobDetail.getJobDataMap();
+    Assert.assertEquals(
+        dataMap.getLong(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY),
+        sourceStoreInsertTime,
+        "Reminder JobDataMap should stash storeInsertTimeMillis so host-failure reattempts preserve it");
+  }
+
+  @Test
+  public void testReminderJobExecuteCarriesStoreInsertTimeMillis() {
+    long sourceStoreInsertTime = 1700000000000L;
+    DagActionStore.LeaseParams paramsWithStoreInsertTime = new DagActionStore.LeaseParams(
+        launchDagAction, false, eventTimeMillis, sourceStoreInsertTime);
+    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(paramsWithStoreInsertTime, false);
+    JobExecutionContext context = mock(JobExecutionContext.class);
+    when(context.getMergedJobDataMap()).thenReturn(jobDetail.getJobDataMap());
+
+    DagManagement capturedDagManagement = mock(DagManagement.class);
+    ArgumentCaptor<DagActionStore.LeaseParams> captor = ArgumentCaptor.forClass(DagActionStore.LeaseParams.class);
+    try {
+      doNothing().when(capturedDagManagement).addDagAction(captor.capture());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    new DagActionReminderScheduler.ReminderJob(capturedDagManagement).execute(context);
+
+    DagActionStore.LeaseParams reconstructed = captor.getValue();
+    Assert.assertEquals(reconstructed.getStoreInsertTimeMillis(), sourceStoreInsertTime,
+        "Reminder fire path should restore storeInsertTimeMillis from JobDataMap");
+    Assert.assertTrue(reconstructed.isReminder(), "Reminder-driven LeaseParams must carry isReminder=true");
+  }
+
+  @Test
+  public void testReminderJobExecuteFallsBackToUnknownWhenKeyAbsent() {
+    // Simulates a reminder scheduled by an older code path that did not stash the storeInsertTimeMillis key.
+    JobDetail jobDetail = DagActionReminderScheduler.createReminderJobDetail(launchLeaseParams, false);
+    JobDataMap dataMap = jobDetail.getJobDataMap();
+    dataMap.remove(DagActionReminderScheduler.ReminderJob.FLOW_ACTION_STORE_INSERT_TIME_MILLIS_KEY);
+    JobExecutionContext context = mock(JobExecutionContext.class);
+    when(context.getMergedJobDataMap()).thenReturn(dataMap);
+
+    DagManagement capturedDagManagement = mock(DagManagement.class);
+    ArgumentCaptor<DagActionStore.LeaseParams> captor = ArgumentCaptor.forClass(DagActionStore.LeaseParams.class);
+    try {
+      doNothing().when(capturedDagManagement).addDagAction(captor.capture());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    new DagActionReminderScheduler.ReminderJob(capturedDagManagement).execute(context);
+
+    Assert.assertEquals(captor.getValue().getStoreInsertTimeMillis(),
+        DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS,
+        "Reminders scheduled by older code paths (no key) must fall back to UNKNOWN, not throw");
   }
 
   /*

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/MysqlMultiActiveLeaseArbiterTest.java
@@ -470,6 +470,46 @@ public class MysqlMultiActiveLeaseArbiterTest {
   }
 
   /**
+   * Verifies the consensus {@link DagActionStore.LeaseParams} returned by {@code tryAcquireLease} preserves the
+   * caller-supplied {@code storeInsertTimeMillis} across all three internal construction sites:
+   *   - CASE 1 / fresh-lease (selectInfoResult path) on first acquisition
+   *   - CASE 2 (within-epsilon, lease still valid) on repeated acquisition with the same event
+   *   - CASE 3 (distinct event, lease still valid) after sleeping past epsilon
+   * The arbiter consensus rewrites {@code eventTimeMillis} but must NOT clobber {@code storeInsertTimeMillis}.
+   */
+  @Test
+  public void testStoreInsertTimeMillisPreservedThroughConsensus() throws Exception {
+    final long sourceStoreInsertTime = 1700000000000L;
+    DagActionStore.LeaseParams paramsWithStoreInsertTime = new DagActionStore.LeaseParams(
+        getUniqueLaunchDagAction(), false, eventTimeMillis, sourceStoreInsertTime);
+
+    // CASE 1 / fresh-lease: storeInsertTimeMillis should travel onto the consensus LeaseParams
+    LeaseAttemptStatus firstStatus =
+        mysqlMultiActiveLeaseArbiter.tryAcquireLease(paramsWithStoreInsertTime, true);
+    Assert.assertTrue(firstStatus instanceof LeaseAttemptStatus.LeaseObtainedStatus,
+        firstStatus.getClass().getSimpleName() + " expected LeaseObtainedStatus");
+    Assert.assertEquals(firstStatus.getConsensusLeaseParams().getStoreInsertTimeMillis(), sourceStoreInsertTime,
+        "Fresh-lease consensus path dropped storeInsertTimeMillis");
+
+    // CASE 2: same event again within epsilon → LeasedToAnotherStatus (within-epsilon branch)
+    LeaseAttemptStatus secondStatus =
+        mysqlMultiActiveLeaseArbiter.tryAcquireLease(paramsWithStoreInsertTime, true);
+    Assert.assertTrue(secondStatus instanceof LeaseAttemptStatus.LeasedToAnotherStatus,
+        secondStatus.getClass().getSimpleName() + " expected LeasedToAnotherStatus");
+    Assert.assertEquals(secondStatus.getConsensusLeaseParams().getStoreInsertTimeMillis(), sourceStoreInsertTime,
+        "CASE 2 (within-epsilon) dropped storeInsertTimeMillis");
+
+    // CASE 3: distinct event (sleep past epsilon) while lease still valid → LeasedToAnotherStatus (distinct-event branch)
+    Thread.sleep(MORE_THAN_EPSILON);
+    LeaseAttemptStatus thirdStatus =
+        mysqlMultiActiveLeaseArbiter.tryAcquireLease(paramsWithStoreInsertTime, true);
+    Assert.assertTrue(thirdStatus instanceof LeaseAttemptStatus.LeasedToAnotherStatus,
+        thirdStatus.getClass().getSimpleName() + " expected LeasedToAnotherStatus");
+    Assert.assertEquals(thirdStatus.getConsensusLeaseParams().getStoreInsertTimeMillis(), sourceStoreInsertTime,
+        "CASE 3 (distinct event, lease valid) dropped storeInsertTimeMillis");
+  }
+
+  /**
    * Marks the lease associated with the dagAction as completed by fabricating a LeaseObtainedStatus
    * @return SelectInfoResult object containing the event information used to complete the lease
    */

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/KillDagProcTest.java
@@ -55,9 +55,11 @@ import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagTestUtils;
 import org.apache.gobblin.service.modules.orchestration.DagUtils;
 import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
+import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
 import org.apache.gobblin.service.modules.orchestration.MysqlDagActionStore;
+import org.apache.gobblin.service.modules.orchestration.MultiActiveLeaseArbiter;
 import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.KillDagTask;
 import org.apache.gobblin.service.modules.orchestration.task.LaunchDagTask;
@@ -126,9 +128,8 @@ public class KillDagProcTest {
     doReturn(Optional.of(dag)).when(dagManagementStateStore).getDag(any());
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
 
-    LaunchDagProc launchDagProc = new LaunchDagProc(new LaunchDagTask(new DagActionStore.DagAction("fg", "flow1",
-        flowExecutionId, MysqlDagActionStore.NO_JOB_NAME_DEFAULT, DagActionStore.DagActionType.LAUNCH),
-        null, this.dagManagementStateStore, mockedDagProcEngineMetrics), flowCompilationValidationHelper, ConfigFactory.empty());
+    LaunchDagProc launchDagProc = new LaunchDagProc(buildLaunchDagTask("flow1", flowExecutionId),
+        flowCompilationValidationHelper, ConfigFactory.empty());
     launchDagProc.process(this.dagManagementStateStore, this.mockedDagProcEngineMetrics);
 
     List<SpecProducer<Spec>> specProducers = dag.getNodes().stream().map(n -> {
@@ -207,10 +208,8 @@ public class KillDagProcTest {
     doReturn(new ImmutablePair<>(Optional.of(dag.getStartNodes().get(0)), Optional.of(jobStatus))).when(dagManagementStateStore).getDagNodeWithJobStatus(any());
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
 
-    LaunchDagProc launchDagProc = new LaunchDagProc(new LaunchDagTask(new DagActionStore.DagAction("fg", "flow2",
-        flowExecutionId, MysqlDagActionStore.NO_JOB_NAME_DEFAULT, DagActionStore.DagActionType.LAUNCH),
-        null, this.dagManagementStateStore, this.mockedDagProcEngineMetrics), flowCompilationValidationHelper,
-        ConfigFactory.empty());
+    LaunchDagProc launchDagProc = new LaunchDagProc(buildLaunchDagTask("flow2", flowExecutionId),
+        flowCompilationValidationHelper, ConfigFactory.empty());
     launchDagProc.process(this.dagManagementStateStore, this.mockedDagProcEngineMetrics);
 
     List<SpecProducer<Spec>> specProducers = dag.getNodes().stream().map(n -> {
@@ -244,5 +243,16 @@ public class KillDagProcTest {
         .submit(eq(TimingEvent.LauncherTimings.JOB_CANCEL), anyMap());
     Mockito.verify(this.mockedEventSubmitter, Mockito.times(numOfCancelledFlows))
         .submit(eq(TimingEvent.FlowTimings.FLOW_CANCELLED), anyMap());
+  }
+
+  private LaunchDagTask buildLaunchDagTask(String flowName, long flowExecutionId) {
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction("fg", flowName, flowExecutionId,
+        MysqlDagActionStore.NO_JOB_NAME_DEFAULT, DagActionStore.DagActionType.LAUNCH);
+    DagActionStore.LeaseParams consensusLeaseParams = new DagActionStore.LeaseParams(
+        dagAction, false, System.currentTimeMillis(), DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS);
+    LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus = new LeaseAttemptStatus.LeaseObtainedStatus(
+        consensusLeaseParams, System.currentTimeMillis(), 0L, mock(MultiActiveLeaseArbiter.class));
+    return new LaunchDagTask(dagAction, leaseObtainedStatus, this.dagManagementStateStore,
+        this.mockedDagProcEngineMetrics);
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -61,6 +61,8 @@ import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
 import org.apache.gobblin.service.modules.orchestration.DagTestUtils;
 import org.apache.gobblin.service.modules.orchestration.DagUtils;
+import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
+import org.apache.gobblin.service.modules.orchestration.MultiActiveLeaseArbiter;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
 import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
@@ -132,8 +134,8 @@ public class LaunchDagProcTest {
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
     List<SpecProducer<Spec>> specProducers = ReevaluateDagProcTest.getDagSpecProducers(dag);
     LaunchDagProc launchDagProc = new LaunchDagProc(
-        new LaunchDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, "job0",
-            DagActionStore.DagActionType.LAUNCH), null, this.dagManagementStateStore,
+        buildLaunchDagTask(flowGroup, flowName, flowExecutionId, "job0",
+            DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS, this.dagManagementStateStore,
             this.mockedDagProcEngineMetrics),
         flowCompilationValidationHelper, ConfigFactory.empty());
 
@@ -170,8 +172,8 @@ public class LaunchDagProcTest {
     FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
     doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
     LaunchDagProc launchDagProc = new LaunchDagProc(
-        new LaunchDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId,
-            "jn", DagActionStore.DagActionType.LAUNCH), null, this.dagManagementStateStore,
+        buildLaunchDagTask(flowGroup, flowName, flowExecutionId, "jn",
+            DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS, this.dagManagementStateStore,
             this.mockedDagProcEngineMetrics),
         flowCompilationValidationHelper, ConfigFactory.empty());
 
@@ -196,8 +198,8 @@ public class LaunchDagProcTest {
     FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
     doReturn(com.google.common.base.Optional.absent()).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
     LaunchDagProc launchDagProc = new LaunchDagProc(
-        new LaunchDagTask(new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, "job0",
-            DagActionStore.DagActionType.LAUNCH), null, this.dagManagementStateStore,
+        buildLaunchDagTask(flowGroup, flowName, flowExecutionId, "job0",
+            DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS, this.dagManagementStateStore,
             this.mockedDagProcEngineMetrics),
         flowCompilationValidationHelper, ConfigFactory.empty());
 
@@ -206,6 +208,84 @@ public class LaunchDagProcTest {
     // Verify that a service-layer issue was emitted for the compilation failure
     Mockito.verify(this.mockedEventSubmitter, Mockito.atLeastOnce())
         .submit((GobblinEventBuilder) argThat(builder -> builder instanceof IssueEventBuilder));
+  }
+
+  @Test
+  public void launchDagStampsStoreInsertTimeMillisWhenProvided() throws IOException, InterruptedException, URISyntaxException, SpecNotFoundException {
+    String flowGroup = "fg";
+    String flowName = "fn-stamp";
+    long flowExecutionId = 12345L;
+    long storeInsertTimeMillis = 1730000000000L;
+
+    // Override the default getFlowSpec stub with a captured instance so we can inspect the post-initialize config.
+    FlowSpec capturedFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1").build();
+    doReturn(capturedFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
+
+    Dag<JobExecutionPlan> dag = DagTestUtils.buildDag("1", flowExecutionId,
+        DagProcessingEngine.FailureOption.FINISH_ALL_POSSIBLE.name(), 1, "user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
+    doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
+
+    LaunchDagProc launchDagProc = new LaunchDagProc(
+        buildLaunchDagTask(flowGroup, flowName, flowExecutionId, "job0", storeInsertTimeMillis,
+            this.dagManagementStateStore, this.mockedDagProcEngineMetrics),
+        flowCompilationValidationHelper, ConfigFactory.empty());
+
+    launchDagProc.process(this.dagManagementStateStore, mockedDagProcEngineMetrics);
+
+    Assert.assertTrue(
+        capturedFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        "FlowSpec config should carry the storeInsertTimeMillis stamp when LeaseParams provides a non-UNKNOWN value");
+    Assert.assertEquals(
+        capturedFlowSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        storeInsertTimeMillis);
+  }
+
+  @Test
+  public void launchDagSkipsStoreInsertTimeMillisStampWhenUnknown() throws IOException, InterruptedException, URISyntaxException, SpecNotFoundException {
+    String flowGroup = "fg";
+    String flowName = "fn-skip";
+    long flowExecutionId = 12345L;
+
+    FlowSpec capturedFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1").build();
+    doReturn(capturedFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
+
+    Dag<JobExecutionPlan> dag = DagTestUtils.buildDag("1", flowExecutionId,
+        DagProcessingEngine.FailureOption.FINISH_ALL_POSSIBLE.name(), 1, "user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    FlowCompilationValidationHelper flowCompilationValidationHelper = mock(FlowCompilationValidationHelper.class);
+    doReturn(com.google.common.base.Optional.of(dag)).when(flowCompilationValidationHelper).createExecutionPlanIfValid(any());
+
+    LaunchDagProc launchDagProc = new LaunchDagProc(
+        buildLaunchDagTask(flowGroup, flowName, flowExecutionId, "job0",
+            DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS, this.dagManagementStateStore,
+            this.mockedDagProcEngineMetrics),
+        flowCompilationValidationHelper, ConfigFactory.empty());
+
+    launchDagProc.process(this.dagManagementStateStore, mockedDagProcEngineMetrics);
+
+    Assert.assertFalse(
+        capturedFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        "FlowSpec config should NOT carry the storeInsertTimeMillis stamp when LeaseParams carries UNKNOWN");
+  }
+
+  private static LaunchDagTask buildLaunchDagTask(String flowGroup, String flowName, long flowExecutionId,
+      String jobName, long storeInsertTimeMillis, DagManagementStateStore dagManagementStateStore,
+      DagProcessingEngineMetrics dagProcEngineMetrics) {
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName,
+        DagActionStore.DagActionType.LAUNCH);
+    DagActionStore.LeaseParams consensusLeaseParams = new DagActionStore.LeaseParams(
+        dagAction, false, System.currentTimeMillis(), storeInsertTimeMillis);
+    LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus = new LeaseAttemptStatus.LeaseObtainedStatus(
+        consensusLeaseParams, System.currentTimeMillis(), 0L, mock(MultiActiveLeaseArbiter.class));
+    return new LaunchDagTask(dagAction, leaseObtainedStatus, dagManagementStateStore, dagProcEngineMetrics);
   }
 
   // This creates a dag like this


### PR DESCRIPTION
Dear Gobblin maintainers,

  Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


  ### JIRA
  - [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-2263) issues and references them in the PR title. For example, "[GOBBLIN-2263] My Gobblin PR"
      - JIRA to be filed; happy to retitle once assigned.


  ### Description
  - [x] Here are some details about my PR, including screenshots (if applicable):

  Downstream executors (e.g., a GridGateway producer that submits jobs after `LaunchDagProc`) cannot today measure the true end-to-end latency from when a LAUNCH `DagAction` row landed in the `dag_action` store to when the executor accepts the job, because that source timestamp is not propagated onto the `JobSpec` config. The two existing anchors fall short:

  - `flow.executionId` is set to `System.currentTimeMillis()` at REST-handler time for ad-hoc flows (close enough), but for scheduled flows it is rewritten by `MysqlMultiActiveLeaseArbiter` to the post-CDC consensus DB timestamp — silently skipping CDC propagation latency.
  - `LeaseParams.eventTimeMillis` is stamped at change-monitor consume time (`System.currentTimeMillis()` in the one-arg constructor at `DagActionStore.java:118-120`) — also after CDC.

  **Change:**
  - Adds an optional `dbUpdateTimeMillis` field to the `DagActionStoreChangeEvent` Avro schema so MySQL CDC producers can carry the binlog event timestamp (true row-modification time) across the kafka hop. Optional (`["null","long"]`, default `null`) for backwards compatibility — older producers continue to work unchanged.
  - Adds `storeInsertTimeMillis` to `DagActionStore.LeaseParams` with a sentinel `UNKNOWN_STORE_INSERT_TIME_MILLIS = -1L` for callers that do not have it. All existing constructors continue to work; a new four-arg constructor accepts the timestamp.
  - Adds `DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY = "dagAction.launch.storeInsertTimeMillis"` to `ConfigurationKeys`.
  - `LaunchDagProc.initialize()` stamps the value onto the `FlowSpec` config when the carrier `LeaseParams` provides one (skipping it when `UNKNOWN_STORE_INSERT_TIME_MILLIS`), alongside the existing `FLOW_EXECUTION_ID_KEY` stamp.
  - `DagTask` exposes the consensus `LeaseParams` via `getLeaseParams()` so `DagProc` subclasses can read per-event metadata.

  The PR is plumbing-only: it does not change which timestamp is consumed by `MultiActiveLeaseArbiter`, lease consensus semantics, or any existing behavior. Downstream consumers can opt in by reading the new JobSpec key; absence is fully backwards-compatible.


  ### Tests
  - [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

  This change is pure pass-through plumbing on an optional field. The Avro field is exercised by the generated builder/setter on schema regeneration; `LaunchDagProc` only writes the key when the value is non-sentinel, and existing tests construct `LeaseParams` via the legacy constructors which default to `UNKNOWN_STORE_INSERT_TIME_MILLIS`, so they remain valid. Downstream behavioral tests (anchor-precedence, large-latency, scheduled vs ad-hoc) live in the consumer side (LinkedIn-internal ddm-common). I'm happy to add a small `LaunchDagProcTest` case asserting the stamp is added iff the lease params carry a non-sentinel value if reviewers prefer.


  ### Commits

  - [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
      1. Subject is separated from body by a blank line
      2. Subject is limited to 50 characters
      3. Subject does not end with a period
      4. Subject uses the imperative mood ("add", not "adding")
      5. Body wraps at 72 characters
      6. Body explains "what" and "why", not "how"