### PR TITLE
Restore reminder clearing on DagActionStore DELETE via wildcard match

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/DagManagementDagActionStoreChangeMonitorTest.java
@@ -45,8 +45,11 @@ import org.apache.gobblin.service.monitoring.OperationType;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 /**
@@ -100,12 +103,14 @@ public class DagManagementDagActionStoreChangeMonitorTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    doNothing().when(dagActionReminderScheduler).unscheduleReminderJob(any(), anyBoolean());
-
+    doReturn(0).when(dagActionReminderScheduler).unscheduleRemindersForDagAction(any(), anyBoolean());
   }
 
   /**
-   * Tests process message with a DELETE type message.
+   * Tests that a DELETE for a deadline-type DagAction clears both deadline-group and retry-group reminders for that
+   * DagAction on the local Quartz scheduler. Cross-host clearing follows from the change-monitor's broadcast consumer
+   * group semantics (see DagActionStoreChangeMonitor's UUID-suffixed group id) — every GaaS instance independently
+   * receives the DELETE and runs the same clear against its in-memory RAMJobStore.
    */
   @Test
   public void testProcessMessageWithDelete() throws SchedulerException {
@@ -114,12 +119,10 @@ public class DagManagementDagActionStoreChangeMonitorTest {
     DagActionStore.DagAction dagAction = new DagActionStore.DagAction(FLOW_GROUP, FLOW_NAME, Long.parseLong(FLOW_EXECUTION_ID), JOB_NAME,
         DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE);
     mockDagManagementDagActionStoreChangeMonitor.processMessageForTest(consumerRecord);
-    /* TODO: skip deadline removal for now and let them fire
     verify(mockDagManagementDagActionStoreChangeMonitor.getDagActionReminderScheduler(), times(1))
-        .unscheduleReminderJob(eq(dagAction), eq(true));
+        .unscheduleRemindersForDagAction(eq(dagAction), eq(true));
     verify(mockDagManagementDagActionStoreChangeMonitor.getDagActionReminderScheduler(), times(1))
-        .unscheduleReminderJob(eq(dagAction), eq(false));
-     */
+        .unscheduleRemindersForDagAction(eq(dagAction), eq(false));
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderScheduler.java
@@ -18,8 +18,11 @@
 package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.quartz.Job;
@@ -34,6 +37,7 @@ import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.impl.StdSchedulerFactory;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
 
@@ -106,6 +110,49 @@ public class DagActionReminderScheduler {
     if (!quartzScheduler.deleteJob(createJobKey(leaseParams, isDeadlineTrigger))) {
       log.warn("Reminder not found for {}. Possibly the event is received out-of-order.", leaseParams);
     }
+  }
+
+  /**
+   * Clears all reminders whose job-key matches the {@link DagActionStore.DagAction} (any eventTimeMillis) within the
+   * given reminder group (deadline or retry). Used by the DagActionStore DELETE handler, which receives only the
+   * {@link DagActionStore.DagAction} fields and does not have access to the {@code eventTimeMillis} that was baked into
+   * the originally-scheduled key.
+   *
+   * @return number of reminders cleared from the local Quartz scheduler
+   */
+  public int unscheduleRemindersForDagAction(DagActionStore.DagAction dagAction, boolean isDeadlineReminder)
+      throws SchedulerException {
+    String group = isDeadlineReminder ? DeadlineReminderKeyGroup : RetryReminderKeyGroup;
+    String keyNamePrefix = createDagActionKeyNamePrefix(dagAction);
+    Set<JobKey> jobKeysInGroup = quartzScheduler.getJobKeys(GroupMatcher.jobGroupEquals(group));
+    List<JobKey> toDelete = new ArrayList<>();
+    for (JobKey k : jobKeysInGroup) {
+      if (k.getName().startsWith(keyNamePrefix)) {
+        toDelete.add(k);
+      }
+    }
+    if (toDelete.isEmpty()) {
+      log.debug("No {} reminders to clear for {}.", group, dagAction);
+      return 0;
+    }
+    log.info("Clearing {} {} reminders for {}.", toDelete.size(), group, dagAction);
+    quartzScheduler.deleteJobs(toDelete);
+    return toDelete.size();
+  }
+
+  /**
+   * Returns the job-key-name prefix shared by every reminder scheduled for the given {@link DagActionStore.DagAction},
+   * regardless of {@code eventTimeMillis}. Mirrors the first five segments of {@link #createDagActionReminderKey}
+   * with a trailing separator so prefix matches cannot span unrelated keys.
+   */
+  @VisibleForTesting
+  static String createDagActionKeyNamePrefix(DagActionStore.DagAction dagAction) {
+    return String.join(".",
+        dagAction.getFlowGroup(),
+        dagAction.getFlowName(),
+        String.valueOf(dagAction.getFlowExecutionId()),
+        dagAction.getJobName(),
+        String.valueOf(dagAction.getDagActionType())) + ".";
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/DagManagementDagActionStoreChangeMonitor.java
@@ -74,14 +74,14 @@ public class DagManagementDagActionStoreChangeMonitor extends DagActionStoreChan
           break;
         case "DELETE":
           log.debug("Deleted dagAction from DagActionStore: {}", dagAction);
-          /* TODO: skip deadline removal for now and let them fire
           if (dagActionType == DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE
               || dagActionType == DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE) {
-            this.dagActionReminderScheduler.unscheduleReminderJob(dagAction, true);
-            // clear any deadline reminders as well as any retry reminders
-            this.dagActionReminderScheduler.unscheduleReminderJob(dagAction, false);
+            // Clear both deadline-group and retry-group reminders for this DagAction. The wildcard variant is required
+            // because the Quartz key embeds the per-lease-attempt eventTimeMillis (added by GOBBLIN-2016) which is not
+            // carried on the DagActionStore change event; see DagActionReminderScheduler#unscheduleRemindersForDagAction.
+            this.dagActionReminderScheduler.unscheduleRemindersForDagAction(dagAction, true);
+            this.dagActionReminderScheduler.unscheduleRemindersForDagAction(dagAction, false);
           }
-           */
           break;
         default:
           log.warn(

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagActionReminderSchedulerTest.java
@@ -181,6 +181,68 @@ public class DagActionReminderSchedulerTest {
     this.dagActionReminderScheduler.unscheduleReminderJob(launchLeaseParams2, true);
   }
 
+  @Test
+  public void testCreateDagActionKeyNamePrefixSharedAcrossEventTimes() {
+    String prefix = DagActionReminderScheduler.createDagActionKeyNamePrefix(launchDagAction);
+    Assert.assertTrue(DagActionReminderScheduler.createDagActionReminderKey(launchLeaseParams).startsWith(prefix),
+        "Both eventTime-keyed reminder keys for the same DagAction must share the prefix");
+    Assert.assertTrue(DagActionReminderScheduler.createDagActionReminderKey(launchLeaseParams2).startsWith(prefix),
+        "Both eventTime-keyed reminder keys for the same DagAction must share the prefix");
+    Assert.assertTrue(prefix.endsWith("."),
+        "Prefix must end with the segment separator so it cannot match unrelated keys (e.g., LAUNCH vs LAUNCH2)");
+  }
+
+  /*
+  Schedule deadline reminders at two distinct eventTimes for the same DagAction (simulating multiple lease attempts),
+  then assert the wildcard clear removes both — i.e., the DagActionStore DELETE path no longer needs to know the
+  original eventTimeMillis to find the scheduled reminders.
+   */
+  @Test
+  public void testUnscheduleRemindersForDagActionClearsAllEventTimes() throws SchedulerException {
+    this.dagActionReminderScheduler.scheduleReminder(launchLeaseParams, 50000, true);
+    this.dagActionReminderScheduler.scheduleReminder(launchLeaseParams2, 50000, true);
+    Assert.assertTrue(this.dagActionReminderScheduler.quartzScheduler.checkExists(
+        DagActionReminderScheduler.createJobKey(launchLeaseParams, true)));
+    Assert.assertTrue(this.dagActionReminderScheduler.quartzScheduler.checkExists(
+        DagActionReminderScheduler.createJobKey(launchLeaseParams2, true)));
+
+    int cleared = this.dagActionReminderScheduler.unscheduleRemindersForDagAction(launchDagAction, true);
+    Assert.assertEquals(cleared, 2,
+        "Wildcard clear must remove both eventTime-keyed reminders for the DagAction");
+    Assert.assertFalse(this.dagActionReminderScheduler.quartzScheduler.checkExists(
+        DagActionReminderScheduler.createJobKey(launchLeaseParams, true)));
+    Assert.assertFalse(this.dagActionReminderScheduler.quartzScheduler.checkExists(
+        DagActionReminderScheduler.createJobKey(launchLeaseParams2, true)));
+  }
+
+  /*
+  Reminders scheduled in the deadline group must not be cleared when the wildcard clear is invoked for the retry group,
+  and vice-versa. Guards against the prefix scan accidentally crossing groups.
+   */
+  @Test
+  public void testUnscheduleRemindersForDagActionScopedToGroup() throws SchedulerException {
+    this.dagActionReminderScheduler.scheduleReminder(launchLeaseParams, 50000, true);
+    this.dagActionReminderScheduler.scheduleReminder(launchLeaseParams2, 50000, false);
+
+    int clearedRetry = this.dagActionReminderScheduler.unscheduleRemindersForDagAction(launchDagAction, false);
+    Assert.assertEquals(clearedRetry, 1, "Should clear only the retry-group reminder");
+    Assert.assertTrue(this.dagActionReminderScheduler.quartzScheduler.checkExists(
+        DagActionReminderScheduler.createJobKey(launchLeaseParams, true)),
+        "Deadline-group reminder must remain after a retry-group clear");
+
+    int clearedDeadline = this.dagActionReminderScheduler.unscheduleRemindersForDagAction(launchDagAction, true);
+    Assert.assertEquals(clearedDeadline, 1, "Should clear the remaining deadline-group reminder");
+  }
+
+  @Test
+  public void testUnscheduleRemindersForDagActionNoopWhenNoneScheduled() throws SchedulerException {
+    DagActionStore.DagAction other = new DagActionStore.DagAction(
+        flowGroup, flowName, flowExecutionId, jobName, DagActionStore.DagActionType.RESUME);
+    int cleared = this.dagActionReminderScheduler.unscheduleRemindersForDagAction(other, true);
+    Assert.assertEquals(cleared, 0,
+        "Clearing reminders for a DagAction that never scheduled any must return 0, not throw");
+  }
+
   // Test multiple schedulers can co-exist and run their jobs of different types
   @Test
   public void testMultipleSchedules() throws SchedulerException, InterruptedException, IOException {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA

- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN) issues and references them in the PR title. For example, "\[GOBBLIN-XXXX\] My Gobblin PR"
  - JIRA to be filed; happy to retitle once assigned.

### Description

- [ ] Here are some details about my PR, including screenshots (if applicable):

`DagManagementDagActionStoreChangeMonitor.handleDagAction` has had this TODO since [GOBBLIN-2016 / #3995](https://github.com/apache/gobblin/pull/3995) (Jul 2024):

```java
case "DELETE":
  log.debug("Deleted dagAction from DagActionStore: {}", dagAction);
  /* TODO: skip deadline removal for now and let them fire
  if (dagActionType == DagActionStore.DagActionType.ENFORCE_JOB_START_DEADLINE
      || dagActionType == DagActionStore.DagActionType.ENFORCE_FLOW_FINISH_DEADLINE) {
    this.dagActionReminderScheduler.unscheduleReminderJob(dagAction, true);
    // clear any deadline reminders as well as any retry reminders
    this.dagActionReminderScheduler.unscheduleReminderJob(dagAction, false);
  }
   */
  break;
```

**Background.** [GOBBLIN-2090 / #3973](https://github.com/apache/gobblin/pull/3973) (Jun 2024, titled literally _"delete deadline triggers in all hosts"_) introduced this clearing path so that when a deadline `DagAction` row is deleted from `dag_action`, every GaaS instance independently clears its in-memory Quartz reminder for that action. Cross-host coverage falls out of the `DagActionStoreChangeMonitor` consumer group id (`DAG_ACTION_CHANGE_MONITOR_PREFIX + UUID.randomUUID()`) — every instance is in its own group, so every instance receives every CDC event and runs the same handler against its own `RAMJobStore`.

**What broke.** Three weeks later, GOBBLIN-2016 / #3995 added `eventTimeMillis` to the Quartz job-key name to disambiguate concurrent lease attempts (KILL/RESUME issued in quick succession, retry reminders firing while the original lease is still valid, etc.):

```
flowGroup.flowName.flowExecId.jobName.dagActionType.eventTimeMillis
```

`eventTimeMillis` is per-lease-attempt consensus state computed by `MysqlMultiActiveLeaseArbiter`. It is **not** persisted on the `dag_action` row and **not** carried on `DagActionStoreChangeEvent`. Structurally, no plumbing change on the CDC event can recover it at DELETE time — there can be multiple `eventTimeMillis` values per DagAction (one per attempt), so there is no single value the producer could put on the event. The author of #3995 punted with the TODO above and accepted "let them fire and no-op via the lease arbiter."

**Change.** Restore the GOBBLIN-2090 cross-host clearing semantics by **prefix-matching** on the five DagAction fields (everything the DELETE event has) rather than constructing an exact key:

- New method `DagActionReminderScheduler#unscheduleRemindersForDagAction(DagAction, boolean isDeadlineReminder)` that:
  - Looks up all `JobKey`s in the relevant group via `Scheduler.getJobKeys(GroupMatcher.jobGroupEquals(group))`.
  - Filters by `JobKey.getName().startsWith(prefix)` where the prefix is the first five segments + trailing `.` (helper `createDagActionKeyNamePrefix`).
  - Calls `Scheduler.deleteJobs(...)` on matches in bulk.
- New `@VisibleForTesting` helper `createDagActionKeyNamePrefix(DagAction)` that mirrors the first five segments of `createDagActionReminderKey` and ensures the trailing separator so prefix matches cannot span unrelated keys.
- `DagManagementDagActionStoreChangeMonitor.handleDagAction("DELETE", ...)` is uncommented and calls the new method twice — once for `DeadlineReminderKeyGroup`, once for `RetryReminderKeyGroup`. Scope is unchanged from GOBBLIN-2090: only `ENFORCE_JOB_START_DEADLINE` and `ENFORCE_FLOW_FINISH_DEADLINE` DELETEs trigger the clear. KILL/RESUME retry reminders continue to no-op via the lease arbiter on fire, matching prior behavior.

**Why prefix-match is correct here.**
- The doc-comment on `createDagActionReminderKey` already notes: _"Applicable only for KILL and RESUME actions; duplication for other actions is an error."_ For deadline actions the prefix-match set size is ≤1 in normal operation, so the wildcard is semantically equivalent to exact-match for the cases we clear.
- For the multi-attempt cases (#3995's motivating scenarios), the wildcard correctly clears _all_ outstanding reminders for the DagAction, regardless of how many `eventTimeMillis` values ended up in the local scheduler.
- The fan-out (every instance clears its own scheduler) is preserved by the broadcast consumer-group semantics; we are not centralizing or coordinating state.

**Edge cases considered.**
- _Race: reminder scheduled just after DELETE arrived_ — the trailing schedule survives and fires later; on fire it goes through the lease arbiter and returns `NoLongerLeasingStatus`. Strictly no worse than the status quo "let them fire" behavior.
- _Idempotent DELETE_ — prefix scan returns 0 on the second delivery; safe.
- _Dot characters in `flowGroup`/`flowName`_ — would create ambiguity between e.g. `flowGroup="a.b", flowName="c"` and `flowGroup="a", flowName="b.c"`. This ambiguity is pre-existing in the key construction (same risk for the exact-match `unscheduleReminderJob`) and is out of scope for this PR; in practice these identifiers are alphanumeric.
- _KILL/RESUME retry reminders not cleared_ — intentional, matches GOBBLIN-2090 scope. A follow-up could extend coverage if reviewers want.

### Tests

- [ ] My PR adds the following unit tests **OR** does not need testing for this extremely good reason:

Four new TestNG cases in `DagActionReminderSchedulerTest`:
- `testCreateDagActionKeyNamePrefixSharedAcrossEventTimes` — asserts the prefix is shared by every `createDagActionReminderKey` output for the same DagAction across distinct `eventTimeMillis` values, and that the prefix ends in `.` so it cannot match unrelated keys.
- `testUnscheduleRemindersForDagActionClearsAllEventTimes` — schedules two deadline reminders for the same DagAction at distinct `eventTimeMillis` (simulating multiple lease attempts), invokes the wildcard clear, asserts both keys are gone and the returned count is 2.
- `testUnscheduleRemindersForDagActionScopedToGroup` — schedules a deadline-group and a retry-group reminder; asserts clearing one group does not touch the other.
- `testUnscheduleRemindersForDagActionNoopWhenNoneScheduled` — asserts the wildcard clear returns 0 (and does not throw) when nothing is scheduled for the DagAction.

Existing `testRemindersForMultipleFlowExecutions` continues to cover the exact-match `unscheduleReminderJob` path, which is unchanged.

Test update in `DagManagementDagActionStoreChangeMonitorTest.testProcessMessageWithDelete`: the prior assertion block was inside the TODO `/* ... */` and could never trigger. It now verifies the DELETE handler invokes `unscheduleRemindersForDagAction(dagAction, true)` _and_ `unscheduleRemindersForDagAction(dagAction, false)` exactly once each for a deadline-type DELETE.

All affected unit tests pass locally:
```
:gobblin-service:test --tests DagActionReminderSchedulerTest  → 13 tests passing (4 new)
```

### Commits

- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"
