### PR TITLE
Add Quartz scheduler liveness metrics

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ServiceMetricNames.java
@@ -68,6 +68,16 @@ public class ServiceMetricNames {
   public static final String SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "ScheduledFlows";
   public static final String NON_SCHEDULED_FLOW_METER = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "NonScheduledFlows";
   public static final String SKIPPED_FLOWS = GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "SkippedFlows";
+  public static final String SCHEDULED_FLOW_TRIGGER_FIRED_METER =
+      GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowScheduler.scheduledFlowTriggersFired";
+  public static final String SCHEDULED_FLOW_TRIGGER_FAILED_METER =
+      GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowScheduler.scheduledFlowTriggerFailures";
+  public static final String LAST_SCHEDULED_FLOW_TRIGGER_FIRE_TIME_MILLIS =
+      GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowScheduler.lastScheduledFlowTriggerFireTimeMillis";
+  public static final String LAST_SCHEDULED_FLOW_TRIGGER_FIRE_AGE_MILLIS =
+      GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowScheduler.lastScheduledFlowTriggerFireAgeMillis";
+  public static final String SCHEDULED_FLOW_SPECS_COUNT =
+      GOBBLIN_SERVICE_PREFIX_WITH_DELIMITER + "flowScheduler.scheduledFlowSpecsCount";
   public static final String RUNNING_FLOWS_COUNTER = "RunningFlows";
   public static final String SERVICE_USERS = "ServiceUsers";
   public static final String COMPILED = "Compiled";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -130,6 +130,11 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       GobblinServiceJobScheduler.class);
   private static final ContextAwareMeter scheduledFlows = metricContext.contextAwareMeter(ServiceMetricNames.SCHEDULED_FLOW_METER);
   private static final ContextAwareMeter nonScheduledFlows = metricContext.contextAwareMeter(ServiceMetricNames.NON_SCHEDULED_FLOW_METER);
+  private static final ContextAwareMeter scheduledFlowTriggersFired =
+      metricContext.contextAwareMeter(ServiceMetricNames.SCHEDULED_FLOW_TRIGGER_FIRED_METER);
+  private static final ContextAwareMeter scheduledFlowTriggerFailures =
+      metricContext.contextAwareMeter(ServiceMetricNames.SCHEDULED_FLOW_TRIGGER_FAILED_METER);
+  private static volatile long lastScheduledFlowTriggerFireTimeMillis = -1L;
 
   /**
    * If current instances is nominated as a handler for DR traffic from down GaaS-Instance.
@@ -191,7 +196,31 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
           () -> totalAddSpecTimeValue));
       metricContext.register(metricContext.newContextAwareGauge(RuntimeMetrics.GOBBLIN_JOB_SCHEDULER_NUM_JOBS_SCHEDULED_DURING_STARTUP,
           () -> numJobsScheduledDuringStartupValue));
+      metricContext.register(metricContext.newContextAwareGauge(
+          ServiceMetricNames.LAST_SCHEDULED_FLOW_TRIGGER_FIRE_TIME_MILLIS,
+          GobblinServiceJobScheduler::getLastScheduledFlowTriggerFireTimeMillis));
+      metricContext.register(metricContext.newContextAwareGauge(
+          ServiceMetricNames.LAST_SCHEDULED_FLOW_TRIGGER_FIRE_AGE_MILLIS,
+          GobblinServiceJobScheduler::getLastScheduledFlowTriggerFireAgeMillis));
+      metricContext.register(metricContext.newContextAwareGauge(ServiceMetricNames.SCHEDULED_FLOW_SPECS_COUNT,
+          () -> this.scheduledFlowSpecs.size()));
     }
+  }
+
+  @VisibleForTesting
+  static long getLastScheduledFlowTriggerFireTimeMillis() {
+    return lastScheduledFlowTriggerFireTimeMillis;
+  }
+
+  @VisibleForTesting
+  static long getLastScheduledFlowTriggerFireAgeMillis() {
+    long lastFireTimeMillis = lastScheduledFlowTriggerFireTimeMillis;
+    return lastFireTimeMillis < 0 ? -1L : System.currentTimeMillis() - lastFireTimeMillis;
+  }
+
+  @VisibleForTesting
+  static void resetLastScheduledFlowTriggerFireTimeMillis() {
+    lastScheduledFlowTriggerFireTimeMillis = -1L;
   }
 
   public synchronized void setActive(boolean isActive) {
@@ -669,10 +698,12 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
 
     @Override
     public void executeImpl(JobExecutionContext context) throws JobExecutionException {
+      boolean trackScheduledFlowTrigger = false;
       try {
         // TODO: move this out of the try clause after location NPE source
         JobDetail jobDetail = context.getJobDetail();
         _log.info("Starting FlowSpec " + jobDetail.getKey());
+        trackScheduledFlowTrigger = !jobDetail.getKey().getName().contains("reminder");
 
         JobDataMap dataMap = jobDetail.getJobDataMap();
         JobScheduler jobScheduler = (JobScheduler) dataMap.get(JOB_SCHEDULER_KEY);
@@ -698,6 +729,8 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         } else {
           jobProps.setProperty(ConfigurationKeys.ORCHESTRATOR_TRIGGER_EVENT_TIME_MILLIS_KEY,
               String.valueOf(triggerTimeMillis));
+          lastScheduledFlowTriggerFireTimeMillis = System.currentTimeMillis();
+          scheduledFlowTriggersFired.mark();
           if (trigger.getNextFireTime() == null) {
             _log.info(
                 jobSchedulerTracePrefixBuilder(jobProps) + "triggerTime: {} nextTriggerTime: NA - Job triggered by "
@@ -712,6 +745,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
       } catch (Throwable t) {
         if (t instanceof NullPointerException) {
           log.warn("NullPointerException encountered while trying to execute flow. Message: " + t.getMessage(), t);
+        }
+        if (trackScheduledFlowTrigger) {
+          scheduledFlowTriggerFailures.mark();
         }
         throw new JobExecutionException(t);
       } finally {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobSchedulerTest.java
@@ -167,6 +167,8 @@ public class GobblinServiceJobSchedulerTest {
     doNothing().when(mockJobScheduler)
         .runJob(any(Properties.class), any(JobListener.class));
 
+    GobblinServiceJobScheduler.resetLastScheduledFlowTriggerFireTimeMillis();
+    long beforeExecute = System.currentTimeMillis();
     try {
       // This should not throw a NullPointerException if the code is properly handling null values
       job.executeImpl(mockContext);
@@ -175,6 +177,10 @@ public class GobblinServiceJobSchedulerTest {
       // Verify that runJob was called
       verify(mockJobScheduler, times(1)).runJob(any(Properties.class),
           any(JobListener.class));
+      Assert.assertTrue(GobblinServiceJobScheduler.getLastScheduledFlowTriggerFireTimeMillis() >= beforeExecute,
+          "Regular scheduled flow trigger executions should refresh the scheduler liveness timestamp");
+      Assert.assertTrue(GobblinServiceJobScheduler.getLastScheduledFlowTriggerFireAgeMillis() >= 0,
+          "Regular scheduled flow trigger executions should expose a non-negative liveness age");
     } catch (JobExecutionException e) {
       // Check if the cause is a NullPointerException
       if (e.getCause() instanceof NullPointerException) {
@@ -185,6 +191,40 @@ public class GobblinServiceJobSchedulerTest {
         throw e;
       }
     }
+  }
+
+  @Test
+  public void testReminderJobDoesNotRefreshScheduledFlowTriggerLiveness()
+      throws Exception {
+    JobExecutionContext mockContext = mock(JobExecutionContext.class);
+    JobDetail mockJobDetail = mock(JobDetail.class);
+    JobDataMap mockJobDataMap = mock(JobDataMap.class);
+    Trigger mockTrigger = mock(Trigger.class);
+
+    Properties jobProps = new Properties();
+    jobProps.setProperty(ConfigurationKeys.FLOW_NAME_KEY, "testFlow");
+    jobProps.setProperty(ConfigurationKeys.FLOW_GROUP_KEY, "testGroup");
+    jobProps.setProperty(ConfigurationKeys.SCHEDULER_PRESERVED_CONSENSUS_EVENT_TIME_MILLIS_KEY, "12345");
+    jobProps.setProperty(ConfigurationKeys.SCHEDULER_EXPECTED_REMINDER_TIME_MILLIS_KEY, "23456");
+
+    JobScheduler mockJobScheduler = mock(JobScheduler.class);
+    JobListener mockJobListener = mock(JobListener.class);
+
+    when(mockContext.getJobDetail()).thenReturn(mockJobDetail);
+    when(mockContext.getTrigger()).thenReturn(mockTrigger);
+    when(mockJobDetail.getJobDataMap()).thenReturn(mockJobDataMap);
+    when(mockJobDetail.getKey()).thenReturn(new org.quartz.JobKey("testFlow-reminder_for_12345", "testGroup"));
+    when(mockJobDataMap.get(GobblinServiceJobScheduler.JOB_SCHEDULER_KEY)).thenReturn(mockJobScheduler);
+    when(mockJobDataMap.get(GobblinServiceJobScheduler.PROPERTIES_KEY)).thenReturn(jobProps);
+    when(mockJobDataMap.get(GobblinServiceJobScheduler.JOB_LISTENER_KEY)).thenReturn(mockJobListener);
+    when(mockTrigger.getPreviousFireTime()).thenReturn(new java.util.Date());
+    doNothing().when(mockJobScheduler).runJob(any(Properties.class), any(JobListener.class));
+
+    GobblinServiceJobScheduler.resetLastScheduledFlowTriggerFireTimeMillis();
+    new GobblinServiceJobScheduler.GobblinServiceJob().executeImpl(mockContext);
+
+    Assert.assertEquals(GobblinServiceJobScheduler.getLastScheduledFlowTriggerFireTimeMillis(), -1L,
+        "Reminder triggers should not mask liveness failures for regular scheduled-flow Quartz triggers");
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add explicit Gobblin Service scheduler liveness metrics so operators can alert when Quartz stops firing scheduled-flow triggers.
- Track the last regular scheduled-flow trigger fire time and age separately from reminder triggers, since reminders should not mask scheduler liveness failures.
- Preserve the existing broad `ScheduledFlows` meter while adding more targeted fired/failure metrics for alerting.

## Test plan
- [x] `JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" ./gradlew :gobblin-service:test --tests "org.apache.gobblin.service.modules.scheduler.GobblinServiceJobSchedulerTest"`
- [x] `git diff --check`
- [ ] `mint build` not applicable: this checkout is not a LinkedIn multiproduct directory

## Notes
- The new `flowScheduler.lastScheduledFlowTriggerFireAgeMillis` gauge is intended for a scheduler-liveness SLO alert: page if the age exceeds the expected schedule interval while scheduled flow specs are present.
- The first validation attempt with newer Java failed before compilation due the repository's Gradle/Groovy compatibility; JDK 8 validation passed.

Made with [Cursor](https://cursor.com)