### PR TITLE
GOBBLIN-2263: Isolate launch FlowSpec metadata

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,13 +69,8 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
   protected Optional<Dag<JobExecutionPlan>> initialize(DagManagementStateStore dagManagementStateStore)
       throws IOException {
     try {
-      FlowSpec flowSpec = dagManagementStateStore.getFlowSpec(FlowSpec.Utils.createFlowSpecUri(getDagId().getFlowId()));
-      flowSpec.addProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, getDagId().getFlowExecutionId());
-      long storeInsertTimeMillis = getDagTask().getLeaseParams().getStoreInsertTimeMillis();
-      if (storeInsertTimeMillis != DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
-        flowSpec.addProperty(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
-            storeInsertTimeMillis);
-      }
+      FlowSpec flowSpec = buildLaunchFlowSpec(
+          dagManagementStateStore.getFlowSpec(FlowSpec.Utils.createFlowSpecUri(getDagId().getFlowId())));
       Optional<Dag<JobExecutionPlan>> dag = this.flowCompilationValidationHelper.createExecutionPlanIfValid(flowSpec).toJavaUtil();
       if (dag.isPresent()) {
         dagManagementStateStore.addDag(dag.get());
@@ -86,6 +82,34 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
           ExceptionUtils.getStackTrace(e));
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Creates an execution-local {@link FlowSpec} with per-launch metadata. Scheduled FlowSpecs can be retained and
+   * reused by the scheduler, so this avoids mutating their long-lived catalog definition with run-specific values.
+   */
+  private FlowSpec buildLaunchFlowSpec(FlowSpec sourceFlowSpec) {
+    long storeInsertTimeMillis = getDagTask().getLeaseParams().getStoreInsertTimeMillis();
+    Config launchConfig = sourceFlowSpec.getConfig()
+        .withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
+            ConfigValueFactory.fromAnyRef(getDagId().getFlowExecutionId()))
+        .withoutPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY);
+    if (storeInsertTimeMillis != DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
+      launchConfig = launchConfig.withValue(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+          ConfigValueFactory.fromAnyRef(storeInsertTimeMillis));
+    }
+
+    FlowSpec.Builder builder = FlowSpec.builder(sourceFlowSpec.getUri())
+        .withVersion(sourceFlowSpec.getVersion())
+        .withDescription(sourceFlowSpec.getDescription())
+        .withConfig(launchConfig);
+    if (sourceFlowSpec.getTemplateURIs().isPresent()) {
+      builder.withTemplates(sourceFlowSpec.getTemplateURIs().get());
+    }
+    if (sourceFlowSpec.getChildSpecs().isPresent()) {
+      builder.withChildSpecs(sourceFlowSpec.getChildSpecs().get());
+    }
+    return builder.build();
   }
 
   @Override

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProcTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -216,10 +217,13 @@ public class LaunchDagProcTest {
     String flowName = "fn-stamp";
     long flowExecutionId = 12345L;
     long storeInsertTimeMillis = 1730000000000L;
+    long staleStoreInsertTimeMillis = storeInsertTimeMillis - 1000L;
 
-    // Override the default getFlowSpec stub with a captured instance so we can inspect the post-initialize config.
-    FlowSpec capturedFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1").build();
-    doReturn(capturedFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
+    FlowSpec sourceFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1")
+        .withConfig(ConfigFactory.empty().withValue(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+            ConfigValueFactory.fromAnyRef(staleStoreInsertTimeMillis)))
+        .build();
+    doReturn(sourceFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
 
     Dag<JobExecutionPlan> dag = DagTestUtils.buildDag("1", flowExecutionId,
         DagProcessingEngine.FailureOption.FINISH_ALL_POSSIBLE.name(), 1, "user5", ConfigFactory.empty()
@@ -237,12 +241,17 @@ public class LaunchDagProcTest {
 
     launchDagProc.process(this.dagManagementStateStore, mockedDagProcEngineMetrics);
 
+    ArgumentCaptor<FlowSpec> flowSpecCaptor = ArgumentCaptor.forClass(FlowSpec.class);
+    verify(flowCompilationValidationHelper).createExecutionPlanIfValid(flowSpecCaptor.capture());
+    FlowSpec launchFlowSpec = flowSpecCaptor.getValue();
     Assert.assertTrue(
-        capturedFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
-        "FlowSpec config should carry the storeInsertTimeMillis stamp when LeaseParams provides a non-UNKNOWN value");
+        launchFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        "Launch FlowSpec config should carry the storeInsertTimeMillis stamp when LeaseParams provides a non-UNKNOWN value");
     Assert.assertEquals(
-        capturedFlowSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        launchFlowSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
         storeInsertTimeMillis);
+    Assert.assertEquals(sourceFlowSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        staleStoreInsertTimeMillis, "Source FlowSpec should not be mutated with per-launch metadata");
   }
 
   @Test
@@ -250,9 +259,13 @@ public class LaunchDagProcTest {
     String flowGroup = "fg";
     String flowName = "fn-skip";
     long flowExecutionId = 12345L;
+    long staleStoreInsertTimeMillis = 1730000000000L;
 
-    FlowSpec capturedFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1").build();
-    doReturn(capturedFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
+    FlowSpec sourceFlowSpec = FlowSpec.builder("/test/flow/spec").withVersion("1")
+        .withConfig(ConfigFactory.empty().withValue(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+            ConfigValueFactory.fromAnyRef(staleStoreInsertTimeMillis)))
+        .build();
+    doReturn(sourceFlowSpec).when(this.dagManagementStateStore).getFlowSpec(any());
 
     Dag<JobExecutionPlan> dag = DagTestUtils.buildDag("1", flowExecutionId,
         DagProcessingEngine.FailureOption.FINISH_ALL_POSSIBLE.name(), 1, "user5", ConfigFactory.empty()
@@ -271,9 +284,14 @@ public class LaunchDagProcTest {
 
     launchDagProc.process(this.dagManagementStateStore, mockedDagProcEngineMetrics);
 
+    ArgumentCaptor<FlowSpec> flowSpecCaptor = ArgumentCaptor.forClass(FlowSpec.class);
+    verify(flowCompilationValidationHelper).createExecutionPlanIfValid(flowSpecCaptor.capture());
+    FlowSpec launchFlowSpec = flowSpecCaptor.getValue();
     Assert.assertFalse(
-        capturedFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
-        "FlowSpec config should NOT carry the storeInsertTimeMillis stamp when LeaseParams carries UNKNOWN");
+        launchFlowSpec.getConfig().hasPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        "Launch FlowSpec config should NOT carry stale storeInsertTimeMillis when LeaseParams carries UNKNOWN");
+    Assert.assertEquals(sourceFlowSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        staleStoreInsertTimeMillis, "Source FlowSpec should not be mutated when launch storeInsertTimeMillis is UNKNOWN");
   }
 
   private static LaunchDagTask buildLaunchDagTask(String flowGroup, String flowName, long flowExecutionId,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2263


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    - Builds an execution-local `FlowSpec` in `LaunchDagProc` before adding per-launch metadata like `flow.executionId` and `dagAction.launch.storeInsertTimeMillis`.
    - Clears stale `dagAction.launch.storeInsertTimeMillis` from the launch copy before applying the current DagAction timestamp.
    - Avoids mutating the catalog/scheduled `FlowSpec`, preventing scheduled flows from retaining stale per-run latency anchors across launches.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Updated `LaunchDagProcTest` to verify launch copies receive the current store-insert timestamp and do not mutate the source `FlowSpec`.
    - Updated `LaunchDagProcTest` to verify UNKNOWN store-insert time does not carry a stale timestamp into the launch copy.
    - `JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" ./gradlew :gobblin-service:compileTestJava`
    - `JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" ./gradlew :gobblin-service:checkstyleMain :gobblin-service:checkstyleTest`
    - Attempted `JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" ./gradlew :gobblin-service:test --tests org.apache.gobblin.service.modules.orchestration.proc.LaunchDagProcTest`; the suite failed in `TestMetastoreDatabaseFactory` setup because Docker/Testcontainers is not available in this environment.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

Made with [Cursor](https://cursor.com)