### PR TITLE
GOBBLIN-2265: Reliable terminal job-completion status for temporal-on-YARN (AM final status + launcher hooks + exit codes + prompt un-register)

### DIFF
--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
@@ -51,7 +51,8 @@ public interface GobblinTemporalConfigurationKeys {
   String GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_PREFIX = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "arg.";
   String GOBBLIN_TEMPORAL_JOB_LAUNCHER_CONFIG_OVERRIDES = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "config.overrides";
 
-  // When true (default), the AM emits its own terminal job-completion GTEs (JOB_SUCCEEDED/JOB_FAILED).
+  // When true (default), the Temporal workflow (which runs on a Temporal worker, not the YARN AM) emits its own
+  // terminal job-completion GTEs (JOB_SUCCEEDED/JOB_FAILED).
   // Set false when a GGW/Azkaban-pod launcher subclass is the single terminal-GTE source, to avoid duplicates.
   String GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = PREFIX + "job.completion.gte.emission.enabled";
   boolean DEFAULT_GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = true;

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
@@ -56,6 +56,12 @@ public interface GobblinTemporalConfigurationKeys {
   // Set false when a GGW/Azkaban-pod launcher subclass is the single terminal-GTE source, to avoid duplicates.
   String GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = PREFIX + "job.completion.gte.emission.enabled";
   boolean DEFAULT_GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = true;
+
+  // Bounded fallback wait (minutes) for in-flight containers to stop during AM shutdown before un-registering.
+  // The normal path is woken immediately by YarnService#notifyIfAllContainersStopped(); this only caps how long a
+  // missed-notify can stall the AM un-register.
+  String GOBBLIN_TEMPORAL_CONTAINERS_STOP_WAIT_TIMEOUT_MINUTES = PREFIX + "containers.stop.wait.timeout.minutes";
+  int DEFAULT_GOBBLIN_TEMPORAL_CONTAINERS_STOP_WAIT_TIMEOUT_MINUTES = 2;
   String GOBBLIN_TEMPORAL_WORK_DIR_CLEANUP_ENABLED = PREFIX + "work.dir.cleanup.enabled";
   String DEFAULT_GOBBLIN_TEMPORAL_WORK_DIR_CLEANUP_ENABLED = "true";
   String WORK_DIR_PATHS_TO_DELETE = PREFIX + "work.dir.paths.to.delete";

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/GobblinTemporalConfigurationKeys.java
@@ -50,6 +50,11 @@ public interface GobblinTemporalConfigurationKeys {
 
   String GOBBLIN_TEMPORAL_JOB_LAUNCHER_ARG_PREFIX = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "arg.";
   String GOBBLIN_TEMPORAL_JOB_LAUNCHER_CONFIG_OVERRIDES = GOBBLIN_TEMPORAL_JOB_LAUNCHER_PREFIX + "config.overrides";
+
+  // When true (default), the AM emits its own terminal job-completion GTEs (JOB_SUCCEEDED/JOB_FAILED).
+  // Set false when a GGW/Azkaban-pod launcher subclass is the single terminal-GTE source, to avoid duplicates.
+  String GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = PREFIX + "job.completion.gte.emission.enabled";
+  boolean DEFAULT_GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED = true;
   String GOBBLIN_TEMPORAL_WORK_DIR_CLEANUP_ENABLED = PREFIX + "work.dir.cleanup.enabled";
   String DEFAULT_GOBBLIN_TEMPORAL_WORK_DIR_CLEANUP_ENABLED = "true";
   String WORK_DIR_PATHS_TO_DELETE = PREFIX + "work.dir.paths.to.delete";

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
@@ -150,13 +150,20 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
         recordsWritten = commitStats.getRecordsWritten();
         bytesWritten = commitStats.getBytesWritten();
       }
-      jobSuccessTimer.stop();
+      // JOB_SUCCEEDED terminal GTE. Gated by GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED (default true)
+      // so deployments that designate the GGW/Azkaban pod launcher as the single terminal-GTE source can
+      // suppress this AM-side emission and avoid duplicates.
+      if (isAmTerminalGteEmissionEnabled(temporalJobProps)) {
+        jobSuccessTimer.stop(); // update GaaS: `ExecutionStatus.COMPLETE`; `TimingEvent.JOB_END_TIME`
+      }
       isSuccessful = true;
       return new ExecGobblinStats(numWUsGenerated, numWUsCommitted, recordsWritten, bytesWritten,
           jobProps.getProperty(Help.USER_TO_PROXY_KEY));
     } catch (Exception e) {
-      // Emit a failed GobblinTrackingEvent to record job failures
-      timerFactory.create(TimingEvent.LauncherTimings.JOB_FAILED).submit(); // update GaaS: `ExecutionStatus.FAILED`; `TimingEvent.JOB_END_TIME`
+      // JOB_FAILED terminal GTE, gated by the same flag as the success path above.
+      if (isAmTerminalGteEmissionEnabled(temporalJobProps)) {
+        timerFactory.create(TimingEvent.LauncherTimings.JOB_FAILED).submit(); // update GaaS: `ExecutionStatus.FAILED`; `TimingEvent.JOB_END_TIME`
+      }
       throw ApplicationFailure.newNonRetryableFailureWithCause(
           String.format("Failed Gobblin job %s", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY)),
           e.getClass().getName(), e);
@@ -179,6 +186,17 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
         log.error("Failed to cleanup work dirs", e);
       }
     }
+  }
+
+  /**
+   * @return whether the AM should emit its own terminal job-completion GTEs (JOB_SUCCEEDED / JOB_FAILED).
+   * Controlled by {@link GobblinTemporalConfigurationKeys#GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED}
+   * (default {@code true}); set {@code false} when the GGW/Azkaban pod launcher is the single terminal-GTE source.
+   */
+  private static boolean isAmTerminalGteEmissionEnabled(Properties temporalJobProps) {
+    return PropertiesUtils.getPropAsBoolean(temporalJobProps,
+        GobblinTemporalConfigurationKeys.GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED,
+        String.valueOf(GobblinTemporalConfigurationKeys.DEFAULT_GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED));
   }
 
   protected ProcessWorkUnitsWorkflow createProcessWorkUnitsWorkflow(Properties jobProps) {

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/ddm/workflow/impl/ExecuteGobblinWorkflowImpl.java
@@ -152,8 +152,8 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
       }
       // JOB_SUCCEEDED terminal GTE. Gated by GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED (default true)
       // so deployments that designate the GGW/Azkaban pod launcher as the single terminal-GTE source can
-      // suppress this AM-side emission and avoid duplicates.
-      if (isAmTerminalGteEmissionEnabled(temporalJobProps)) {
+      // suppress this Temporal-worker emission and avoid duplicates.
+      if (isWorkflowTerminalGteEmissionEnabled(temporalJobProps)) {
         jobSuccessTimer.stop(); // update GaaS: `ExecutionStatus.COMPLETE`; `TimingEvent.JOB_END_TIME`
       }
       isSuccessful = true;
@@ -161,7 +161,7 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
           jobProps.getProperty(Help.USER_TO_PROXY_KEY));
     } catch (Exception e) {
       // JOB_FAILED terminal GTE, gated by the same flag as the success path above.
-      if (isAmTerminalGteEmissionEnabled(temporalJobProps)) {
+      if (isWorkflowTerminalGteEmissionEnabled(temporalJobProps)) {
         timerFactory.create(TimingEvent.LauncherTimings.JOB_FAILED).submit(); // update GaaS: `ExecutionStatus.FAILED`; `TimingEvent.JOB_END_TIME`
       }
       throw ApplicationFailure.newNonRetryableFailureWithCause(
@@ -189,11 +189,12 @@ public class ExecuteGobblinWorkflowImpl implements ExecuteGobblinWorkflow {
   }
 
   /**
-   * @return whether the AM should emit its own terminal job-completion GTEs (JOB_SUCCEEDED / JOB_FAILED).
+   * @return whether this Temporal workflow (which executes on a Temporal worker, not the YARN ApplicationMaster)
+   * should emit its own terminal job-completion GTEs (JOB_SUCCEEDED / JOB_FAILED).
    * Controlled by {@link GobblinTemporalConfigurationKeys#GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED}
    * (default {@code true}); set {@code false} when the GGW/Azkaban pod launcher is the single terminal-GTE source.
    */
-  private static boolean isAmTerminalGteEmissionEnabled(Properties temporalJobProps) {
+  private static boolean isWorkflowTerminalGteEmissionEnabled(Properties temporalJobProps) {
     return PropertiesUtils.getPropAsBoolean(temporalJobProps,
         GobblinTemporalConfigurationKeys.GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED,
         String.valueOf(GobblinTemporalConfigurationKeys.DEFAULT_GOBBLIN_TEMPORAL_JOB_COMPLETION_GTE_EMISSION_ENABLED));

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -38,6 +39,7 @@ import io.temporal.workflow.Workflow;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.slf4j.Logger;
 
 import org.apache.gobblin.annotation.Alpha;
@@ -81,6 +83,14 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
   protected String namespace;
   protected String workflowId;
 
+  // In temporal-on-yarn each AM JVM launches exactly one workflow (see {@link #handleLaunchFinalization}),
+  // so a static field is the single source of terminal status for the AM. Populated by
+  // {@link #handleLaunchFinalization} -> {@link #captureTerminalWorkflowStatus} (normal completion, while
+  // Temporal stubs are still open). Read by {@code GobblinTemporalApplicationMaster.main()} after
+  // {@code start()} returns to drive {@code System.exit}, and by the temporal {@code YarnService} to derive
+  // the {@link FinalApplicationStatus} reported to YARN on un-register.
+  private static volatile WorkflowExecutionStatus lastTerminalStatus = null;
+
   public GobblinTemporalJobLauncher(Properties jobProps, Path appWorkDir,
                                     List<? extends Tag<?>> metadataTags, ConcurrentHashMap<String, Boolean> runningMap, EventBus eventBus)
           throws Exception {
@@ -97,7 +107,62 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
 
     // non-null value indicates job has been submitted
     this.workflowId = null;
+    // Reset the process-wide terminal-status cache for this fresh launcher. In a real AM JVM only one
+    // launcher ever runs, but tests re-instantiate within the same JVM and must not see leaked status.
+    lastTerminalStatus = null;
     startCancellationExecutor();
+  }
+
+  /**
+   * Query Temporal for the current execution status of {@link #workflowId}. Returns
+   * {@code WORKFLOW_EXECUTION_STATUS_UNSPECIFIED} as a safe fallback if the describe call fails, so callers
+   * downstream emit a JOB_FAILED rather than swallowing the GTE entirely.
+   */
+  private WorkflowExecutionStatus fetchWorkflowStatus() {
+    try {
+      WorkflowStub workflowStub = this.client.newUntypedWorkflowStub(this.workflowId);
+      DescribeWorkflowExecutionRequest request = DescribeWorkflowExecutionRequest.newBuilder()
+          .setNamespace(this.namespace)
+          .setExecution(workflowStub.getExecution())
+          .build();
+      DescribeWorkflowExecutionResponse response = managedWorkflowServiceStubs.getWorkflowServiceStubs()
+          .blockingStub().describeWorkflowExecution(request);
+      return response.getWorkflowExecutionInfo().getStatus();
+    } catch (Exception e) {
+      log.warn("Failed to describe workflow {} for completion GTE; treating as UNSPECIFIED (will emit JOB_FAILED)",
+          this.workflowId, e);
+      return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
+    }
+  }
+
+  /**
+   * Map a Temporal {@link WorkflowExecutionStatus} to the YARN {@link FinalApplicationStatus} the AM should
+   * report when it un-registers, so a launcher polling the {@code ApplicationReport} sees the true outcome
+   * instead of an unconditional SUCCEEDED. Kept in lockstep with {@link #computeExitCode}: COMPLETED -> SUCCEEDED,
+   * CANCELED -> KILLED, everything else -> FAILED. A {@code null} status means the AM is going down without ever
+   * having observed the workflow reach a terminal state (e.g. RM preemption / AMRM error mid-run, or a crash
+   * before the job finished), so the job did NOT complete successfully -> FAILED.
+   */
+  @VisibleForTesting
+  public static FinalApplicationStatus mapWorkflowStatusToFinalAppStatus(WorkflowExecutionStatus status) {
+    if (status == null) {
+      return FinalApplicationStatus.FAILED;
+    }
+    switch (status) {
+      case WORKFLOW_EXECUTION_STATUS_COMPLETED:
+        return FinalApplicationStatus.SUCCEEDED;
+      case WORKFLOW_EXECUTION_STATUS_CANCELED:
+        return FinalApplicationStatus.KILLED;
+      case WORKFLOW_EXECUTION_STATUS_FAILED:
+      case WORKFLOW_EXECUTION_STATUS_TERMINATED:
+      case WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+      case WORKFLOW_EXECUTION_STATUS_RUNNING:
+      case WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW:
+      case WORKFLOW_EXECUTION_STATUS_UNSPECIFIED:
+      case UNRECOGNIZED:
+      default:
+        return FinalApplicationStatus.FAILED;
+    }
   }
 
   /** @return {@link Config} now featuring all overrides rooted at {@link GobblinTemporalConfigurationKeys#GOBBLIN_TEMPORAL_JOB_LAUNCHER_CONFIG_OVERRIDES} */
@@ -114,8 +179,41 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
     // for achieving batch job behavior. Given the current constraints of yarn applications requiring a static proxy user
     // during application creation, it is not possible to have multiple workflows running in the same application.
     // and so it makes sense to just kill the job after this is completed
+    // Capture the terminal workflow status now, while Temporal service stubs are guaranteed open. AM main()
+    // reads this cache to set the JVM exit code, and the temporal YarnService reads it to derive the
+    // FinalApplicationStatus reported to YARN on un-register.
+    captureTerminalWorkflowStatus();
     log.info("Requesting the AM to shutdown after the job {} completed", this.jobContext.getJobId());
     eventBus.post(new ClusterManagerShutdownRequest());
+  }
+
+  @VisibleForTesting
+  void captureTerminalWorkflowStatus() {
+    if (this.workflowId == null) {
+      return;
+    }
+    WorkflowExecutionStatus status = fetchWorkflowStatus();
+    lastTerminalStatus = status;
+    log.info("Captured terminal workflow status {} for workflow {}", status, this.workflowId);
+  }
+
+  /**
+   * @return the most recently captured terminal {@link WorkflowExecutionStatus} for the AM's single workflow,
+   * or {@code null} if {@link #handleLaunchFinalization} never ran (e.g., AM crashed before any job was
+   * submitted, or before the workflow reached a terminal state).
+   */
+  public static WorkflowExecutionStatus getLastTerminalStatus() {
+    return lastTerminalStatus;
+  }
+
+  /**
+   * Convert a {@link WorkflowExecutionStatus} into a process exit code: {@code 0} for a clean
+   * {@code COMPLETED} workflow, {@code 1} for anything else (failed, cancelled, terminated, timed out,
+   * still running at shutdown, unspecified/unknown, or {@code null} = no terminal status captured). Used by
+   * {@code GobblinTemporalApplicationMaster.main()} to surface job-level failures as non-zero AM JVM exit codes.
+   */
+  public static int computeExitCode(WorkflowExecutionStatus status) {
+    return status == WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED ? 0 : 1;
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -109,7 +109,7 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
     this.workflowId = null;
     // Reset the process-wide terminal-status cache for this fresh launcher. In a real AM JVM only one
     // launcher ever runs, but tests re-instantiate within the same JVM and must not see leaked status.
-    lastTerminalStatus = null;
+    setLastTerminalStatus(null);
     startCancellationExecutor();
   }
 
@@ -193,7 +193,7 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
       return;
     }
     WorkflowExecutionStatus status = fetchWorkflowStatus();
-    lastTerminalStatus = status;
+    setLastTerminalStatus(status);
     log.info("Captured terminal workflow status {} for workflow {} (drives FinalApplicationStatus and AM exit code)",
         status, this.workflowId);
   }
@@ -205,6 +205,13 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
    */
   public static WorkflowExecutionStatus getLastTerminalStatus() {
     return lastTerminalStatus;
+  }
+
+  // Static mutator so the process-wide cache is written from a static context (the launcher-instance lifecycle
+  // delegates here): avoids FindBugs ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD while preserving the single-source
+  // bridge from the launcher instance to GobblinTemporalApplicationMaster.main() / the temporal YarnService.
+  private static void setLastTerminalStatus(WorkflowExecutionStatus status) {
+    lastTerminalStatus = status;
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -20,19 +20,15 @@ package org.apache.gobblin.temporal.joblauncher;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
@@ -81,14 +77,6 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
   private static final Logger log = Workflow.getLogger(GobblinTemporalJobLauncher.class);
   private static final int TERMINATION_TIMEOUT_SECONDS = 3;
 
-  // Transient gRPC failures where the workflow's true terminal status is simply unknowable *right now* (Temporal
-  // momentarily unreachable / throttled / a slow describe) rather than evidence the job failed. These are retried
-  // a bounded number of times before falling back, so a blip is not mis-reported as a terminal JOB_FAILED GTE.
-  private static final Set<Status.Code> RETRYABLE_DESCRIBE_STATUS_CODES = ImmutableSet.of(
-      Status.Code.UNAVAILABLE, Status.Code.DEADLINE_EXCEEDED, Status.Code.RESOURCE_EXHAUSTED);
-  private static final int DESCRIBE_WORKFLOW_MAX_ATTEMPTS = 3;
-  private static final long DESCRIBE_WORKFLOW_RETRY_BASE_BACKOFF_MILLIS = 2000L;
-
   protected ManagedWorkflowServiceStubs managedWorkflowServiceStubs;
   protected WorkflowClient client;
   protected String queueName;
@@ -127,48 +115,28 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
 
   /**
    * Query Temporal for the current execution status of {@link #workflowId}. Transient gRPC failures
-   * ({@link #RETRYABLE_DESCRIBE_STATUS_CODES}: UNAVAILABLE / DEADLINE_EXCEEDED / RESOURCE_EXHAUSTED) are retried
-   * with linear backoff up to {@link #DESCRIBE_WORKFLOW_MAX_ATTEMPTS}, so a momentary Temporal outage does not get
-   * mis-reported as a job failure. Returns {@code WORKFLOW_EXECUTION_STATUS_UNSPECIFIED} as a safe fallback only
-   * after retries are exhausted (or on a non-retryable error), so callers downstream emit a JOB_FAILED rather
-   * than swallowing the GTE entirely.
+   * (e.g. UNAVAILABLE / DEADLINE_EXCEEDED / RESOURCE_EXHAUSTED) are already retried with backoff by the Temporal
+   * service stubs' configured {@code RpcRetryOptions} (tunable via {@code gobblin.temporal.rpc.retry.options.*};
+   * see {@code TemporalWorkflowClientFactory}), so this method intentionally adds no retry loop of its own.
+   * Returns {@code WORKFLOW_EXECUTION_STATUS_UNSPECIFIED} as a safe fallback only if the describe still fails
+   * (i.e. Temporal stayed unreachable beyond those configured retries), so callers downstream emit a JOB_FAILED
+   * rather than swallowing the GTE entirely.
    */
   private WorkflowExecutionStatus fetchWorkflowStatus() {
-    for (int attempt = 1; attempt <= DESCRIBE_WORKFLOW_MAX_ATTEMPTS; attempt++) {
-      try {
-        WorkflowStub workflowStub = this.client.newUntypedWorkflowStub(this.workflowId);
-        DescribeWorkflowExecutionRequest request = DescribeWorkflowExecutionRequest.newBuilder()
-            .setNamespace(this.namespace)
-            .setExecution(workflowStub.getExecution())
-            .build();
-        DescribeWorkflowExecutionResponse response = managedWorkflowServiceStubs.getWorkflowServiceStubs()
-            .blockingStub().describeWorkflowExecution(request);
-        return response.getWorkflowExecutionInfo().getStatus();
-      } catch (StatusRuntimeException e) {
-        Status.Code code = e.getStatus().getCode();
-        boolean retryable = RETRYABLE_DESCRIBE_STATUS_CODES.contains(code) && attempt < DESCRIBE_WORKFLOW_MAX_ATTEMPTS;
-        if (!retryable) {
-          log.warn("Failed to describe workflow {} for completion GTE (gRPC {}, attempt {}/{}); treating as "
-                  + "UNSPECIFIED (will emit JOB_FAILED)", this.workflowId, code, attempt, DESCRIBE_WORKFLOW_MAX_ATTEMPTS, e);
-          return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
-        }
-        log.warn("Transient gRPC {} describing workflow {} for completion GTE (attempt {}/{}); retrying",
-            code, this.workflowId, attempt, DESCRIBE_WORKFLOW_MAX_ATTEMPTS, e);
-        try {
-          Thread.sleep(DESCRIBE_WORKFLOW_RETRY_BASE_BACKOFF_MILLIS * attempt);
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          log.warn("Interrupted while backing off to re-describe workflow {}; treating as UNSPECIFIED", this.workflowId);
-          return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
-        }
-      } catch (Exception e) {
-        log.warn("Failed to describe workflow {} for completion GTE; treating as UNSPECIFIED (will emit JOB_FAILED)",
-            this.workflowId, e);
-        return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
-      }
+    try {
+      WorkflowStub workflowStub = this.client.newUntypedWorkflowStub(this.workflowId);
+      DescribeWorkflowExecutionRequest request = DescribeWorkflowExecutionRequest.newBuilder()
+          .setNamespace(this.namespace)
+          .setExecution(workflowStub.getExecution())
+          .build();
+      DescribeWorkflowExecutionResponse response = managedWorkflowServiceStubs.getWorkflowServiceStubs()
+          .blockingStub().describeWorkflowExecution(request);
+      return response.getWorkflowExecutionInfo().getStatus();
+    } catch (Exception e) {
+      log.warn("Failed to describe workflow {} for completion GTE even after the service stubs' configured RPC "
+          + "retries; treating as UNSPECIFIED (will emit JOB_FAILED)", this.workflowId, e);
+      return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
     }
-    // Retries exhausted on transient errors: status genuinely unknown -> fall back so a terminal GTE is still emitted.
-    return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -194,7 +194,8 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
     }
     WorkflowExecutionStatus status = fetchWorkflowStatus();
     lastTerminalStatus = status;
-    log.info("Captured terminal workflow status {} for workflow {}", status, this.workflowId);
+    log.info("Captured terminal workflow status {} for workflow {} (drives FinalApplicationStatus and AM exit code)",
+        status, this.workflowId);
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncher.java
@@ -20,15 +20,19 @@ package org.apache.gobblin.temporal.joblauncher;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
@@ -77,6 +81,14 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
   private static final Logger log = Workflow.getLogger(GobblinTemporalJobLauncher.class);
   private static final int TERMINATION_TIMEOUT_SECONDS = 3;
 
+  // Transient gRPC failures where the workflow's true terminal status is simply unknowable *right now* (Temporal
+  // momentarily unreachable / throttled / a slow describe) rather than evidence the job failed. These are retried
+  // a bounded number of times before falling back, so a blip is not mis-reported as a terminal JOB_FAILED GTE.
+  private static final Set<Status.Code> RETRYABLE_DESCRIBE_STATUS_CODES = ImmutableSet.of(
+      Status.Code.UNAVAILABLE, Status.Code.DEADLINE_EXCEEDED, Status.Code.RESOURCE_EXHAUSTED);
+  private static final int DESCRIBE_WORKFLOW_MAX_ATTEMPTS = 3;
+  private static final long DESCRIBE_WORKFLOW_RETRY_BASE_BACKOFF_MILLIS = 2000L;
+
   protected ManagedWorkflowServiceStubs managedWorkflowServiceStubs;
   protected WorkflowClient client;
   protected String queueName;
@@ -114,25 +126,49 @@ public abstract class GobblinTemporalJobLauncher extends GobblinJobLauncher {
   }
 
   /**
-   * Query Temporal for the current execution status of {@link #workflowId}. Returns
-   * {@code WORKFLOW_EXECUTION_STATUS_UNSPECIFIED} as a safe fallback if the describe call fails, so callers
-   * downstream emit a JOB_FAILED rather than swallowing the GTE entirely.
+   * Query Temporal for the current execution status of {@link #workflowId}. Transient gRPC failures
+   * ({@link #RETRYABLE_DESCRIBE_STATUS_CODES}: UNAVAILABLE / DEADLINE_EXCEEDED / RESOURCE_EXHAUSTED) are retried
+   * with linear backoff up to {@link #DESCRIBE_WORKFLOW_MAX_ATTEMPTS}, so a momentary Temporal outage does not get
+   * mis-reported as a job failure. Returns {@code WORKFLOW_EXECUTION_STATUS_UNSPECIFIED} as a safe fallback only
+   * after retries are exhausted (or on a non-retryable error), so callers downstream emit a JOB_FAILED rather
+   * than swallowing the GTE entirely.
    */
   private WorkflowExecutionStatus fetchWorkflowStatus() {
-    try {
-      WorkflowStub workflowStub = this.client.newUntypedWorkflowStub(this.workflowId);
-      DescribeWorkflowExecutionRequest request = DescribeWorkflowExecutionRequest.newBuilder()
-          .setNamespace(this.namespace)
-          .setExecution(workflowStub.getExecution())
-          .build();
-      DescribeWorkflowExecutionResponse response = managedWorkflowServiceStubs.getWorkflowServiceStubs()
-          .blockingStub().describeWorkflowExecution(request);
-      return response.getWorkflowExecutionInfo().getStatus();
-    } catch (Exception e) {
-      log.warn("Failed to describe workflow {} for completion GTE; treating as UNSPECIFIED (will emit JOB_FAILED)",
-          this.workflowId, e);
-      return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
+    for (int attempt = 1; attempt <= DESCRIBE_WORKFLOW_MAX_ATTEMPTS; attempt++) {
+      try {
+        WorkflowStub workflowStub = this.client.newUntypedWorkflowStub(this.workflowId);
+        DescribeWorkflowExecutionRequest request = DescribeWorkflowExecutionRequest.newBuilder()
+            .setNamespace(this.namespace)
+            .setExecution(workflowStub.getExecution())
+            .build();
+        DescribeWorkflowExecutionResponse response = managedWorkflowServiceStubs.getWorkflowServiceStubs()
+            .blockingStub().describeWorkflowExecution(request);
+        return response.getWorkflowExecutionInfo().getStatus();
+      } catch (StatusRuntimeException e) {
+        Status.Code code = e.getStatus().getCode();
+        boolean retryable = RETRYABLE_DESCRIBE_STATUS_CODES.contains(code) && attempt < DESCRIBE_WORKFLOW_MAX_ATTEMPTS;
+        if (!retryable) {
+          log.warn("Failed to describe workflow {} for completion GTE (gRPC {}, attempt {}/{}); treating as "
+                  + "UNSPECIFIED (will emit JOB_FAILED)", this.workflowId, code, attempt, DESCRIBE_WORKFLOW_MAX_ATTEMPTS, e);
+          return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
+        }
+        log.warn("Transient gRPC {} describing workflow {} for completion GTE (attempt {}/{}); retrying",
+            code, this.workflowId, attempt, DESCRIBE_WORKFLOW_MAX_ATTEMPTS, e);
+        try {
+          Thread.sleep(DESCRIBE_WORKFLOW_RETRY_BASE_BACKOFF_MILLIS * attempt);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          log.warn("Interrupted while backing off to re-describe workflow {}; treating as UNSPECIFIED", this.workflowId);
+          return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
+        }
+      } catch (Exception e) {
+        log.warn("Failed to describe workflow {} for completion GTE; treating as UNSPECIFIED (will emit JOB_FAILED)",
+            this.workflowId, e);
+        return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
+      }
     }
+    // Retries exhausted on transient errors: status genuinely unknown -> fall back so a terminal GTE is still emitted.
+    return WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED;
   }
 
   /**

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/DynamicScalingYarnService.java
@@ -111,6 +111,8 @@ public class DynamicScalingYarnService extends YarnService {
       log.warn("Container {} not found in containerMap. This container onContainersCompleted() likely called before onContainersAllocated()",
           completedContainerId);
       this.removedContainerIds.add(completedContainerId);
+      // Still wake shutDown()'s waiter in case this completion was the last tracked container during shutdown.
+      notifyIfAllContainersStopped();
       return;
     }
 
@@ -124,6 +126,9 @@ public class DynamicScalingYarnService extends YarnService {
 
     if (this.shutdownInProgress) {
       log.info("Ignoring container completion for container {} as shutdown is in progress", completedContainerId);
+      // The base handler skips replacement during shutdown; we still must wake the shutDown() waiter
+      // so the AM un-registers promptly instead of blocking the full container-stop wait timeout.
+      notifyIfAllContainersStopped();
       return;
     }
 

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/GobblinTemporalApplicationMaster.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/GobblinTemporalApplicationMaster.java
@@ -27,10 +27,13 @@ import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.temporal.api.enums.v1.WorkflowExecutionStatus;
+
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.temporal.cluster.GobblinTemporalClusterManager;
+import org.apache.gobblin.temporal.joblauncher.GobblinTemporalJobLauncher;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.JvmUtils;
 import org.apache.gobblin.util.PathUtils;
@@ -166,6 +169,17 @@ public class GobblinTemporalApplicationMaster extends GobblinTemporalClusterMana
 
         applicationMaster.start();
       }
+
+      // Surface the underlying workflow outcome as the AM JVM exit code so GGW/Grid Gateway dashboards see
+      // failures end-to-end. The status was captured into a static cache by GobblinTemporalJobLauncher via
+      // handleLaunchFinalization on normal completion (this is also what the temporal YarnService uses to derive
+      // the FinalApplicationStatus reported to YARN). A null cache means the workflow never reached a terminal
+      // state under this AM (preemption/error/crash mid-run) -> non-zero exit, consistent with FinalApplicationStatus.
+      WorkflowExecutionStatus terminalStatus = GobblinTemporalJobLauncher.getLastTerminalStatus();
+      int exitCode = GobblinTemporalJobLauncher.computeExitCode(terminalStatus);
+      LOGGER.info("GobblinTemporalApplicationMaster exiting with code {} (workflow terminal status: {})",
+          exitCode, terminalStatus);
+      System.exit(exitCode);
     } catch (ParseException pe) {
       printUsage(options);
       System.exit(1);

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -260,17 +260,21 @@ class YarnService extends AbstractIdleService {
         this.nmClientAsync.stopContainerAsync(containerInfo.getContainer().getId(), containerInfo.getContainer().getNodeId());
       }
 
-      if (!this.containerMap.isEmpty()) {
-        synchronized (this.allContainersStopped) {
-          try {
-            // Bounded fallback only: a missed notify must not stall the AM un-register. The normal path
-            // is woken immediately by notifyIfAllContainersStopped() as soon as the last container stops.
-            Duration waitTimeout = Duration.ofMinutes(2);
-            this.allContainersStopped.wait(waitTimeout.toMillis());
-            LOGGER.info("Finished waiting for containers to stop ({} still tracked)", this.containerMap.size());
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
+      synchronized (this.allContainersStopped) {
+        try {
+          // Bounded fallback only: a missed notify must not stall the AM un-register. The normal path
+          // is woken immediately by notifyIfAllContainersStopped() as soon as the last container stops.
+          // Re-check emptiness *inside* the monitor and loop on the condition: if the last container was
+          // removed (and notifyIfAllContainersStopped() fired) between entering shutDown() and acquiring
+          // this monitor, an already-empty map must not wait, and a spurious wake-up must not exit early.
+          long deadlineMs = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
+          long remainingMs;
+          while (!this.containerMap.isEmpty() && (remainingMs = deadlineMs - System.currentTimeMillis()) > 0) {
+            this.allContainersStopped.wait(remainingMs);
           }
+          LOGGER.info("Finished waiting for containers to stop ({} still tracked)", this.containerMap.size());
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
         }
       }
 
@@ -295,7 +299,10 @@ class YarnService extends AbstractIdleService {
    * workflow outcome (see {@link GobblinTemporalJobLauncher#getLastTerminalStatus()}). Reporting the true status
    * — rather than an unconditional SUCCEEDED — lets a launcher polling the {@code ApplicationReport} observe job
    * failures/cancellations end-to-end, and keeps the YARN status consistent with the AM JVM exit code. A
-   * {@code null} captured status (no workflow ran) maps to SUCCEEDED. Overridable for tests.
+   * {@code null} captured status (no workflow ever reached a terminal state, e.g. the AM is going down before
+   * the job finished) maps to FAILED, matching
+   * {@link GobblinTemporalJobLauncher#mapWorkflowStatusToFinalAppStatus(io.temporal.api.enums.v1.WorkflowExecutionStatus)}.
+   * Overridable for tests.
    */
   protected FinalApplicationStatus getFinalApplicationStatusForUnregister() {
     io.temporal.api.enums.v1.WorkflowExecutionStatus captured = GobblinTemporalJobLauncher.getLastTerminalStatus();

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -263,10 +263,11 @@ class YarnService extends AbstractIdleService {
       if (!this.containerMap.isEmpty()) {
         synchronized (this.allContainersStopped) {
           try {
-            // Wait 5 minutes for the containers to stop
-            Duration waitTimeout = Duration.ofMinutes(5);
+            // Bounded fallback only: a missed notify must not stall the AM un-register. The normal path
+            // is woken immediately by notifyIfAllContainersStopped() as soon as the last container stops.
+            Duration waitTimeout = Duration.ofMinutes(2);
             this.allContainersStopped.wait(waitTimeout.toMillis());
-            LOGGER.info("All of the containers have been stopped");
+            LOGGER.info("Finished waiting for containers to stop ({} still tracked)", this.containerMap.size());
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
           }
@@ -297,8 +298,10 @@ class YarnService extends AbstractIdleService {
    * {@code null} captured status (no workflow ran) maps to SUCCEEDED. Overridable for tests.
    */
   protected FinalApplicationStatus getFinalApplicationStatusForUnregister() {
-    return GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(
-        GobblinTemporalJobLauncher.getLastTerminalStatus());
+    io.temporal.api.enums.v1.WorkflowExecutionStatus captured = GobblinTemporalJobLauncher.getLastTerminalStatus();
+    FinalApplicationStatus derived = GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(captured);
+    LOGGER.info("Derived FinalApplicationStatus {} for un-register from captured workflow status {}", derived, captured);
+    return derived;
   }
 
   public void updateToken() throws IOException{
@@ -557,6 +560,26 @@ class YarnService extends AbstractIdleService {
    */
   protected void handleContainerCompletion(ContainerStatus containerStatus) {
     this.containerMap.remove(containerStatus.getContainerId());
+    // If this completion empties the container map during shutdown, wake the shutDown() waiter
+    // immediately instead of letting it block for the full wait timeout.
+    notifyIfAllContainersStopped();
+  }
+
+  /**
+   * Wake any thread blocked in {@link #shutDown()} once the last container has been removed from
+   * {@link #containerMap}. Container teardown is observed via two asynchronous callbacks that race —
+   * AMRM {@code onContainersCompleted} (-> {@link #handleContainerCompletion}) and NM
+   * {@code onContainerStopped}. Whichever empties the map last must issue the notify; otherwise the
+   * AM un-register in {@link #shutDown()} is delayed by the full wait timeout, which in turn makes
+   * YARN observe the AM container exit before a clean {@code finishApplicationMaster} and fail the
+   * attempt despite a successful workflow.
+   */
+  protected void notifyIfAllContainersStopped() {
+    if (this.containerMap.isEmpty()) {
+      synchronized (this.allContainersStopped) {
+        this.allContainersStopped.notifyAll();
+      }
+    }
   }
 
   private ImmutableMap.Builder<String, String> buildContainerStatusEventMetadata(ContainerStatus containerStatus) {
@@ -746,11 +769,7 @@ class YarnService extends AbstractIdleService {
       }
 
       LOGGER.info(String.format("Container %s has been stopped", containerId));
-      if (containerMap.isEmpty()) {
-        synchronized (allContainersStopped) {
-          allContainersStopped.notify();
-        }
-      }
+      notifyIfAllContainersStopped();
     }
 
     @Override

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -106,6 +106,7 @@ import org.apache.gobblin.yarn.GobblinYarnMetricTagNames;
 import org.apache.gobblin.yarn.YarnHelixUtils;
 import org.apache.gobblin.temporal.dynamic.WorkerProfile;
 import org.apache.gobblin.temporal.dynamic.WorkforceProfiles;
+import org.apache.gobblin.temporal.joblauncher.GobblinTemporalJobLauncher;
 
 /**
  * This class is responsible for all Yarn-related stuffs including ApplicationMaster registration,
@@ -272,7 +273,9 @@ class YarnService extends AbstractIdleService {
         }
       }
 
-      this.amrmClientAsync.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED, null, null);
+      FinalApplicationStatus finalStatus = getFinalApplicationStatusForUnregister();
+      LOGGER.info("Un-registering ApplicationMaster with FinalApplicationStatus {}", finalStatus);
+      this.amrmClientAsync.unregisterApplicationMaster(finalStatus, null, null);
     } catch (IOException | YarnException e) {
       LOGGER.error("Failed to unregister the ApplicationMaster", e);
     } finally {
@@ -284,6 +287,18 @@ class YarnService extends AbstractIdleService {
         }
       }
     }
+  }
+
+  /**
+   * Derive the {@link FinalApplicationStatus} to report to YARN on un-register from the AM's captured Temporal
+   * workflow outcome (see {@link GobblinTemporalJobLauncher#getLastTerminalStatus()}). Reporting the true status
+   * — rather than an unconditional SUCCEEDED — lets a launcher polling the {@code ApplicationReport} observe job
+   * failures/cancellations end-to-end, and keeps the YARN status consistent with the AM JVM exit code. A
+   * {@code null} captured status (no workflow ran) maps to SUCCEEDED. Overridable for tests.
+   */
+  protected FinalApplicationStatus getFinalApplicationStatusForUnregister() {
+    return GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(
+        GobblinTemporalJobLauncher.getLastTerminalStatus());
   }
 
   public void updateToken() throws IOException{

--- a/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
+++ b/gobblin-temporal/src/main/java/org/apache/gobblin/temporal/yarn/YarnService.java
@@ -104,6 +104,7 @@ import org.apache.gobblin.yarn.GobblinYarnConfigurationKeys;
 import org.apache.gobblin.yarn.GobblinYarnEventConstants;
 import org.apache.gobblin.yarn.GobblinYarnMetricTagNames;
 import org.apache.gobblin.yarn.YarnHelixUtils;
+import org.apache.gobblin.temporal.GobblinTemporalConfigurationKeys;
 import org.apache.gobblin.temporal.dynamic.WorkerProfile;
 import org.apache.gobblin.temporal.dynamic.WorkforceProfiles;
 import org.apache.gobblin.temporal.joblauncher.GobblinTemporalJobLauncher;
@@ -267,7 +268,10 @@ class YarnService extends AbstractIdleService {
           // Re-check emptiness *inside* the monitor and loop on the condition: if the last container was
           // removed (and notifyIfAllContainersStopped() fired) between entering shutDown() and acquiring
           // this monitor, an already-empty map must not wait, and a spurious wake-up must not exit early.
-          long deadlineMs = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
+          int waitTimeoutMinutes = ConfigUtils.getInt(this.config,
+              GobblinTemporalConfigurationKeys.GOBBLIN_TEMPORAL_CONTAINERS_STOP_WAIT_TIMEOUT_MINUTES,
+              GobblinTemporalConfigurationKeys.DEFAULT_GOBBLIN_TEMPORAL_CONTAINERS_STOP_WAIT_TIMEOUT_MINUTES);
+          long deadlineMs = System.currentTimeMillis() + Duration.ofMinutes(waitTimeoutMinutes).toMillis();
           long remainingMs;
           while (!this.containerMap.isEmpty() && (remainingMs = deadlineMs - System.currentTimeMillis()) > 0) {
             this.allContainersStopped.wait(remainingMs);

--- a/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncherTest.java
+++ b/gobblin-temporal/src/test/java/org/apache/gobblin/temporal/joblauncher/GobblinTemporalJobLauncherTest.java
@@ -44,6 +44,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.example.simplejson.SimpleJsonSource;
 import org.apache.gobblin.runtime.JobState;
@@ -60,6 +62,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -96,6 +99,13 @@ public class GobblinTemporalJobLauncherTest {
     public org.apache.gobblin.runtime.JobContext getJobContext() {
       return this.jobContext;
     }
+
+    // Drive only the normal-flow status-capture half of handleLaunchFinalization. We deliberately skip the
+    // eventBus.post(ClusterManagerShutdownRequest) tail because the unit-test constructor passes a null
+    // eventBus, and the capture-vs-broadcast pieces are independent for our tests' purposes.
+    public void triggerHandleLaunchFinalizationForTest() {
+      this.captureTerminalWorkflowStatus();
+    }
   }
 
 
@@ -126,6 +136,10 @@ public class GobblinTemporalJobLauncherTest {
 
   @BeforeMethod
   public void methodSetUp() throws Exception {
+    // Reset invocation counts on the class-scoped mocks so per-test `verify(... times(N))` assertions
+    // are not polluted by interactions from earlier tests in the suite.
+    Mockito.clearInvocations(mockClient, mockExecutionInfo);
+
     mockStub = mock(WorkflowStub.class);
     when(mockClient.newUntypedWorkflowStub(Mockito.anyString())).thenReturn(mockStub);
     when(mockStub.getExecution()).thenReturn(WorkflowExecution.getDefaultInstance());
@@ -302,6 +316,128 @@ public class GobblinTemporalJobLauncherTest {
 
     assertFalse(stagingDir.exists(), "close() should trigger cleanup and delete the staging directory");
     tmpDir.delete();
+  }
+
+
+  @Test
+  public void testMapWorkflowStatusToFinalAppStatusForCompletedReturnsSucceeded() {
+    assertEquals(GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(
+            WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+        FinalApplicationStatus.SUCCEEDED);
+  }
+
+  @Test
+  public void testMapWorkflowStatusToFinalAppStatusForCancelledReturnsKilled() {
+    assertEquals(GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(
+            WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_CANCELED),
+        FinalApplicationStatus.KILLED);
+  }
+
+  @Test
+  public void testMapWorkflowStatusToFinalAppStatusForNullReturnsFailed() {
+    // A null captured status means the AM is going down without the workflow having reached a terminal state
+    // (preemption/error/crash mid-run) -> the job did not complete -> FAILED, consistent with computeExitCode(null)==1.
+    assertEquals(GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(null),
+        FinalApplicationStatus.FAILED);
+  }
+
+  @Test
+  public void testComputeExitCodeForNullReturnsOne() {
+    assertEquals(GobblinTemporalJobLauncher.computeExitCode(null), 1);
+  }
+
+  @Test
+  public void testMapWorkflowStatusToFinalAppStatusForFailureAndNonTerminalReturnsFailed() {
+    WorkflowExecutionStatus[] failed = new WorkflowExecutionStatus[] {
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+    };
+    for (WorkflowExecutionStatus status : failed) {
+      assertEquals(GobblinTemporalJobLauncher.mapWorkflowStatusToFinalAppStatus(status),
+          FinalApplicationStatus.FAILED, "Expected FAILED for " + status);
+    }
+  }
+
+  @Test
+  public void testComputeExitCodeForCompletedReturnsZero() {
+    assertEquals(GobblinTemporalJobLauncher.computeExitCode(
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED), 0);
+  }
+
+  @Test
+  public void testComputeExitCodeForAnyNonCompletedReturnsOne() {
+    // Every non-COMPLETED terminal status (and the non-terminal ones we collapse to JOB_FAILED) must
+    // produce a non-zero exit code so the AM JVM surfaces the failure to GGW.
+    WorkflowExecutionStatus[] nonSuccess = new WorkflowExecutionStatus[] {
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_CANCELED,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+    };
+    for (WorkflowExecutionStatus status : nonSuccess) {
+      assertEquals(GobblinTemporalJobLauncher.computeExitCode(status), 1,
+          "Expected non-zero exit code for " + status);
+    }
+  }
+
+  @Test
+  public void testHandleLaunchFinalizationPopulatesLastTerminalStatus() throws Exception {
+    jobLauncher.submitJob(null);
+    when(mockExecutionInfo.getStatus())
+        .thenReturn(WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED);
+
+    jobLauncher.triggerHandleLaunchFinalizationForTest();
+
+    // The status must be cached so that AM main() can read it after close() has shut down Temporal stubs.
+    assertEquals(GobblinTemporalJobLauncher.getLastTerminalStatus(),
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED);
+  }
+
+  @Test
+  public void testLastTerminalStatusSurvivesClose() throws Exception {
+    jobLauncher.submitJob(null);
+    when(mockExecutionInfo.getStatus())
+        .thenReturn(WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED);
+
+    jobLauncher.triggerHandleLaunchFinalizationForTest();
+    jobLauncher.close();
+
+    // close() shuts down Temporal stubs; the cached status must remain readable so AM main() can drive exit.
+    assertEquals(GobblinTemporalJobLauncher.getLastTerminalStatus(),
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED);
+  }
+
+  @Test
+  public void testConstructorResetsStaleTerminalStatus() throws Exception {
+    // Simulate a previous launcher in the same JVM having captured a terminal status.
+    jobLauncher.submitJob(null);
+    when(mockExecutionInfo.getStatus())
+        .thenReturn(WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED);
+    jobLauncher.triggerHandleLaunchFinalizationForTest();
+    assertEquals(GobblinTemporalJobLauncher.getLastTerminalStatus(),
+        WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_FAILED);
+
+    // A new launcher (mirrors a fresh AM JVM or test-suite reuse) must clear the static cache so a prior
+    // run's status does not leak into the new launcher's exit code. The job name + lock dir must be unique
+    // so the per-job FileBasedJobLock the parent launcher acquires doesn't reject the second construction.
+    File tmpDir = Files.createTempDir();
+    Path appWorkDir = new Path(tmpDir.getAbsolutePath(), "freshAppWorkDir");
+    String freshJobName = "freshLauncherJob";
+    Properties freshProps = (Properties) jobProperties.clone();
+    freshProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, freshJobName);
+    freshProps.setProperty(ConfigurationKeys.JOB_ID_KEY, JobLauncherUtils.newJobId(freshJobName));
+    freshProps.setProperty(FileBasedJobLock.JOB_LOCK_DIR, new Path(tmpDir.getAbsolutePath(), "freshLockDir").toString());
+    freshProps.setProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, new Path(tmpDir.getAbsolutePath(), "freshStateStore").toString());
+    new GobblinTemporalJobLauncherForTest(freshProps, appWorkDir);
+
+    assertNull(GobblinTemporalJobLauncher.getLastTerminalStatus());
   }
 
   @Test

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -549,6 +549,7 @@ public class GobblinYarnAppLauncher {
     if (finalStatus != FinalApplicationStatus.SUCCEEDED) {
       this.exitCode = 1;
     }
+    LOGGER.info("Application reached terminal FinalApplicationStatus {}; launcher exitCode={}", finalStatus, this.exitCode);
     onTerminalApplicationStatus(applicationReport, finalStatus);
   }
 
@@ -1092,6 +1093,7 @@ public class GobblinYarnAppLauncher {
       // Always kill so the RM cannot re-attempt the AM (no-op if the app already finished). If the terminal
       // outcome wasn't already dispatched by the report-monitor path, this is a cancel/forced shutdown ->
       // surface it as KILLED (the subclass emits JOB_CANCEL). The token, not a racy report read, is the gate.
+      LOGGER.info("Graceful-shutdown wait complete; force-killing application {} to prevent AM re-attempt", this.applicationId.get());
       this.yarnClient.killApplication(this.applicationId.get());
       if (this.terminalHandled.compareAndSet(false, true)) {
         this.exitCode = 1;

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -1096,28 +1096,32 @@ public class GobblinYarnAppLauncher {
       }
       sendGracefulShutdownSignal(amContainerId.get());
       pollForApplicationCompletionUntil(timeoutMs);
-      // If the app reached a terminal state on its own during the poll (e.g. SUCCEEDED/FAILED) but the
-      // report-monitor path hasn't dispatched it yet, surface the *real* outcome rather than an unconditional
-      // KILLED. Re-fetch the report once and, if it's already terminal, dispatch that status; handleTerminalAppStatus
-      // claims the same one-shot token, so this is a no-op if the monitor path won the race.
+      // Re-fetch the report once after the poll to decide between two cases:
+      //  (a) the app already reached a terminal state on its own (e.g. SUCCEEDED/FAILED) -> surface the *real*
+      //      outcome and skip the kill entirely; there is no running AM to re-attempt. handleTerminalAppStatus
+      //      claims the same one-shot token, so this is a no-op if the report-monitor path won the race.
+      //  (b) the app is still running (or we couldn't read its state) -> force-kill so the RM cannot re-attempt
+      //      the AM, and if nothing else dispatched the terminal outcome record it as a cancel/forced KILLED
+      //      (the subclass emits JOB_CANCEL). The token, not a racy report read, is the gate.
+      boolean alreadyTerminal = false;
       try {
         ApplicationReport finalReport = this.yarnClient.getApplicationReport(this.applicationId.get());
         if (isApplicationCompleted(finalReport)) {
-          LOGGER.info("Application {} already terminal ({}) at graceful-shutdown; dispatching real status instead of KILLED",
+          alreadyTerminal = true;
+          LOGGER.info("Application {} already terminal ({}) at graceful-shutdown; dispatching real status, skipping kill",
               this.applicationId.get(), finalReport.getFinalApplicationStatus());
           handleTerminalAppStatus(finalReport);
         }
       } catch (YarnException | IOException e) {
-        LOGGER.warn("Could not re-fetch ApplicationReport before force-kill; will fall back to KILLED if unhandled", e);
+        LOGGER.warn("Could not re-fetch ApplicationReport before force-kill; will force-kill as a precaution", e);
       }
-      // Always kill so the RM cannot re-attempt the AM (no-op if the app already finished). If the terminal
-      // outcome still wasn't dispatched above or by the report-monitor path, this is a cancel/forced shutdown ->
-      // surface it as KILLED (the subclass emits JOB_CANCEL). The token, not a racy report read, is the gate.
-      LOGGER.info("Graceful-shutdown wait complete; force-killing application {} to prevent AM re-attempt", this.applicationId.get());
-      this.yarnClient.killApplication(this.applicationId.get());
-      if (this.terminalHandled.compareAndSet(false, true)) {
-        this.exitCode = 1;
-        onTerminalApplicationStatus(null, FinalApplicationStatus.KILLED);
+      if (!alreadyTerminal) {
+        LOGGER.info("Graceful-shutdown wait complete; force-killing application {} to prevent AM re-attempt", this.applicationId.get());
+        this.yarnClient.killApplication(this.applicationId.get());
+        if (this.terminalHandled.compareAndSet(false, true)) {
+          this.exitCode = 1;
+          onTerminalApplicationStatus(null, FinalApplicationStatus.KILLED);
+        }
       }
     } catch (YarnException | IOException e) {
       LOGGER.warn("Could not signal AM for graceful shutdown; proceeding with stop", e);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -557,6 +557,12 @@ public class GobblinYarnAppLauncher {
    * Terminal-outcome hooks. No-op in OSS (the OSS launcher emits no GTE); a subclass (e.g. the GGW/Azkaban-pod
    * launcher) overrides these to emit the single terminal GTE. {@code finalStatus} maps via
    * {@link #mapFinalAppStatusToEventName}.
+   *
+   * @param applicationReport the terminal {@link ApplicationReport}, or {@code null} when no report is available
+   *                          — the forced-kill / cancel path in {@link #signalGracefulShutdownAndWaitForTerminal()}
+   *                          dispatches {@code KILLED} without one. Overriding subclasses must not assume it is
+   *                          non-null (guard before dereferencing, e.g. when enriching the emitted event).
+   * @param finalStatus the terminal {@link FinalApplicationStatus} driving the event name (never {@code null})
    */
   protected void onTerminalApplicationStatus(ApplicationReport applicationReport, FinalApplicationStatus finalStatus) {
   }
@@ -1090,8 +1096,22 @@ public class GobblinYarnAppLauncher {
       }
       sendGracefulShutdownSignal(amContainerId.get());
       pollForApplicationCompletionUntil(timeoutMs);
+      // If the app reached a terminal state on its own during the poll (e.g. SUCCEEDED/FAILED) but the
+      // report-monitor path hasn't dispatched it yet, surface the *real* outcome rather than an unconditional
+      // KILLED. Re-fetch the report once and, if it's already terminal, dispatch that status; handleTerminalAppStatus
+      // claims the same one-shot token, so this is a no-op if the monitor path won the race.
+      try {
+        ApplicationReport finalReport = this.yarnClient.getApplicationReport(this.applicationId.get());
+        if (isApplicationCompleted(finalReport)) {
+          LOGGER.info("Application {} already terminal ({}) at graceful-shutdown; dispatching real status instead of KILLED",
+              this.applicationId.get(), finalReport.getFinalApplicationStatus());
+          handleTerminalAppStatus(finalReport);
+        }
+      } catch (YarnException | IOException e) {
+        LOGGER.warn("Could not re-fetch ApplicationReport before force-kill; will fall back to KILLED if unhandled", e);
+      }
       // Always kill so the RM cannot re-attempt the AM (no-op if the app already finished). If the terminal
-      // outcome wasn't already dispatched by the report-monitor path, this is a cancel/forced shutdown ->
+      // outcome still wasn't dispatched above or by the report-monitor path, this is a cancel/forced shutdown ->
       // surface it as KILLED (the subclass emits JOB_CANCEL). The token, not a racy report read, is the gate.
       LOGGER.info("Graceful-shutdown wait complete; force-killing application {} to prevent AM re-attempt", this.applicationId.get());
       this.yarnClient.killApplication(this.applicationId.get());

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.avro.Schema;
@@ -103,6 +104,7 @@ import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.metrics.kafka.KafkaAvroSchemaRegistry;
 import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
 import org.apache.gobblin.metrics.reporter.util.KafkaReporterUtils;
@@ -237,6 +239,20 @@ public class GobblinYarnAppLauncher {
 
   private volatile boolean stopped = false;
 
+  // Launcher-side exit-code propagation + terminal hooks. This launcher (the GGW/Azkaban-pod process that submits
+  // the YARN application and polls its ApplicationReport) surfaces the AM's terminal outcome as a non-zero process
+  // exit, and exposes protected no-op hooks ({@link #onTerminalApplicationStatus}, {@link #onLostAmVisibility},
+  // {@link #onApplicationLaunchFailure}) so a subclass (e.g. the GGW/Azkaban-pod launcher) can emit the single
+  // terminal GTE. The OSS class itself does not emit any GTE.
+
+  // Set non-zero on any terminal AM failure observed by the launcher; read by main() to drive System.exit.
+  @Getter
+  private volatile int exitCode = 0;
+
+  // Dispatches the terminal outcome exactly once across the report-monitor path and the cancel/forced-kill path,
+  // without relying on a (racy) ApplicationReport state check.
+  private final AtomicBoolean terminalHandled = new AtomicBoolean(false);
+
   private final boolean emailNotificationOnShutdown;
   private final boolean detachOnExitEnabled;
 
@@ -359,31 +375,39 @@ public class GobblinYarnAppLauncher {
       this.tokenRefreshManager.get().loginAndScheduleTokenRenewal();
     }
 
-    startYarnClient();
+    try {
+      startYarnClient();
 
-    this.applicationId = getReconnectableApplicationId();
+      this.applicationId = getReconnectableApplicationId();
 
-    if (!this.applicationId.isPresent()) {
-      LOGGER.info("No reconnectable application found so submitting a new application");
-      this.yarnClient = potentialYarnClients.get(this.originalYarnRMAddress);
-      this.applicationId = Optional.of(setupAndSubmitApplication());
-    }
-
-    if (helixClusterLifecycleManager.isPresent()) {
-      this.helixClusterLifecycleManager.get()
-          .getIsApplicationRunningFlag().compareAndSet(false, isApplicationRunning());
-    }
-
-    this.applicationStatusMonitor.scheduleAtFixedRate(() -> {
-      try {
-        eventBus.post(new ApplicationReportArrivalEvent(yarnClient.getApplicationReport(applicationId.get())));
-      } catch (YarnException | IOException e) {
-        LOGGER.error("Failed to get application report for Gobblin Yarn application " + applicationId.get(), e);
-        eventBus.post(new GetApplicationReportFailureEvent(e));
+      if (!this.applicationId.isPresent()) {
+        LOGGER.info("No reconnectable application found so submitting a new application");
+        this.yarnClient = potentialYarnClients.get(this.originalYarnRMAddress);
+        this.applicationId = Optional.of(setupAndSubmitApplication());
       }
-    }, 0, this.appReportIntervalMinutes, TimeUnit.MINUTES);
 
-    addServices();
+      if (helixClusterLifecycleManager.isPresent()) {
+        this.helixClusterLifecycleManager.get()
+            .getIsApplicationRunningFlag().compareAndSet(false, isApplicationRunning());
+      }
+
+      this.applicationStatusMonitor.scheduleAtFixedRate(() -> {
+        try {
+          eventBus.post(new ApplicationReportArrivalEvent(yarnClient.getApplicationReport(applicationId.get())));
+        } catch (YarnException | IOException e) {
+          LOGGER.error("Failed to get application report for Gobblin Yarn application " + applicationId.get(), e);
+          eventBus.post(new GetApplicationReportFailureEvent(e));
+        }
+      }, 0, this.appReportIntervalMinutes, TimeUnit.MINUTES);
+
+      addServices();
+    } catch (Exception e) {
+      // Submission/allocation failed (or the app never got far enough to be monitored). Surface this as a
+      // non-zero exit + terminal GTE before propagating, so GaaS isn't left without a terminal state.
+      LOGGER.error("Failed to launch the Gobblin Yarn application", e);
+      handleApplicationLaunchFailure(e);
+      throw e;
+    }
   }
 
   public boolean isApplicationRunning() {
@@ -496,6 +520,8 @@ public class GobblinYarnAppLauncher {
         LOGGER.error("Gobblin Yarn application failed for the following reason: " + applicationReport.getDiagnostics());
       }
 
+      handleTerminalAppStatus(applicationReport);
+
       try {
         GobblinYarnAppLauncher.this.stop();
       } catch (IOException ioe) {
@@ -510,6 +536,63 @@ public class GobblinYarnAppLauncher {
     }
   }
 
+  /**
+   * On a terminal {@link ApplicationReport}: update {@link #exitCode} so the launcher JVM surfaces the failure
+   * to GGW/Grid Gateway dashboards, then dispatch to the overridable {@link #onTerminalApplicationStatus} hook.
+   */
+  @VisibleForTesting
+  void handleTerminalAppStatus(ApplicationReport applicationReport) {
+    if (!this.terminalHandled.compareAndSet(false, true)) {
+      return;
+    }
+    FinalApplicationStatus finalStatus = applicationReport.getFinalApplicationStatus();
+    if (finalStatus != FinalApplicationStatus.SUCCEEDED) {
+      this.exitCode = 1;
+    }
+    onTerminalApplicationStatus(applicationReport, finalStatus);
+  }
+
+  /**
+   * Terminal-outcome hooks. No-op in OSS (the OSS launcher emits no GTE); a subclass (e.g. the GGW/Azkaban-pod
+   * launcher) overrides these to emit the single terminal GTE. {@code finalStatus} maps via
+   * {@link #mapFinalAppStatusToEventName}.
+   */
+  protected void onTerminalApplicationStatus(ApplicationReport applicationReport, FinalApplicationStatus finalStatus) {
+  }
+
+  /** Map a YARN {@link FinalApplicationStatus} to the {@code KafkaAvroJobStatusMonitor} event name. Public so a
+   * subclass in another module can reuse it. */
+  public static String mapFinalAppStatusToEventName(FinalApplicationStatus status) {
+    if (status == null) {
+      return TimingEvent.LauncherTimings.JOB_FAILED;
+    }
+    switch (status) {
+      case SUCCEEDED:
+        return TimingEvent.LauncherTimings.JOB_SUCCEEDED;
+      case KILLED:
+        return TimingEvent.LauncherTimings.JOB_CANCEL;
+      case FAILED:
+      case UNDEFINED:
+      default:
+        return TimingEvent.LauncherTimings.JOB_FAILED;
+    }
+  }
+
+  /** @return the YARN {@link ApplicationId} of the launched application, if it has been submitted. */
+  protected Optional<ApplicationId> getApplicationId() {
+    return this.applicationId;
+  }
+
+  /** @return the configured application name. */
+  protected String getApplicationName() {
+    return this.applicationName;
+  }
+
+  /** @return the launcher {@link Config} (carries flow/job identifiers populated by the GGW/Azkaban submitter). */
+  protected Config getConfig() {
+    return this.config;
+  }
+
   @Subscribe
   public void handleGetApplicationReportFailureEvent(
       GetApplicationReportFailureEvent getApplicationReportFailureEvent) {
@@ -518,6 +601,8 @@ public class GobblinYarnAppLauncher {
       LOGGER.warn(String
           .format("Number of consecutive failures to get the ApplicationReport %d exceeds the threshold %d",
               numConsecutiveFailures, this.maxGetApplicationReportFailures));
+
+      handleLostAmVisibility();
 
       try {
         stop();
@@ -531,6 +616,40 @@ public class GobblinYarnAppLauncher {
         }
       }
     }
+  }
+
+  /**
+   * Called when the launcher has given up polling the AM (consecutive ApplicationReport fetch failures
+   * exceeded the threshold). Flip the exit code, then dispatch to the overridable {@link #onLostAmVisibility} hook.
+   */
+  @VisibleForTesting
+  void handleLostAmVisibility() {
+    if (!this.terminalHandled.compareAndSet(false, true)) {
+      return;
+    }
+    this.exitCode = 1;
+    onLostAmVisibility();
+  }
+
+  /** Hook: launcher lost visibility of the AM (report-fetch failures exceeded the threshold). See {@link #onTerminalApplicationStatus}. */
+  protected void onLostAmVisibility() {
+  }
+
+  /**
+   * Called when the application is never successfully launched (submission/allocation failure, or the app never
+   * reaches RUNNING). Flip the exit code, then dispatch to the overridable {@link #onApplicationLaunchFailure} hook.
+   */
+  @VisibleForTesting
+  void handleApplicationLaunchFailure(Throwable cause) {
+    if (!this.terminalHandled.compareAndSet(false, true)) {
+      return;
+    }
+    this.exitCode = 1;
+    onApplicationLaunchFailure(cause);
+  }
+
+  /** Hook: the AM was never launched. See {@link #onTerminalApplicationStatus}. */
+  protected void onApplicationLaunchFailure(Throwable cause) {
   }
 
   @VisibleForTesting
@@ -970,6 +1089,14 @@ public class GobblinYarnAppLauncher {
       }
       sendGracefulShutdownSignal(amContainerId.get());
       pollForApplicationCompletionUntil(timeoutMs);
+      // Always kill so the RM cannot re-attempt the AM (no-op if the app already finished). If the terminal
+      // outcome wasn't already dispatched by the report-monitor path, this is a cancel/forced shutdown ->
+      // surface it as KILLED (the subclass emits JOB_CANCEL). The token, not a racy report read, is the gate.
+      this.yarnClient.killApplication(this.applicationId.get());
+      if (this.terminalHandled.compareAndSet(false, true)) {
+        this.exitCode = 1;
+        onTerminalApplicationStatus(null, FinalApplicationStatus.KILLED);
+      }
     } catch (YarnException | IOException e) {
       LOGGER.warn("Could not signal AM for graceful shutdown; proceeding with stop", e);
     } catch (InterruptedException e) {
@@ -1180,6 +1307,19 @@ public class GobblinYarnAppLauncher {
       }
     });
 
-    gobblinYarnAppLauncher.launch();
+    try {
+      gobblinYarnAppLauncher.launch();
+    } catch (Exception e) {
+      // launch() already invoked handleApplicationLaunchFailure (sets exitCode=1, emits terminal GTE) before
+      // rethrowing. Swallow here so we reach the explicit System.exit below with the non-zero code.
+      LOGGER.error("GobblinYarnAppLauncher launch failed", e);
+    }
+
+    // Surface AM-level failures (FAILED/KILLED/UNDEFINED FinalApplicationStatus, lost-AM-visibility on
+    // exhausted report fetches, or a never-launched application) as a non-zero launcher process exit so
+    // GGW/Grid Gateway dashboards see them end-to-end. SUCCEEDED keeps exitCode at the field's default of 0.
+    int finalExitCode = gobblinYarnAppLauncher.getExitCode();
+    LOGGER.info("GobblinYarnAppLauncher exiting with code {}", finalExitCode);
+    System.exit(finalExitCode);
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTerminalGteTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTerminalGteTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.yarn;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.metrics.event.TimingEvent;
+
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Focused unit tests for the launcher-side exit-code + terminal-hook dispatch logic in
+ * {@link GobblinYarnAppLauncher}. The OSS class itself does not emit GTEs (a subclass overrides the hooks to do
+ * that), so these tests cover only: the {@link FinalApplicationStatus} -> event-name mapping, the exit-code
+ * propagation, and that the protected hooks are dispatched. Avoids the full {@link MiniYARNCluster} / Helix
+ * stack by constructing a real-methods Mockito stand-in and injecting the {@code exitCode} field the code reads.
+ */
+public class GobblinYarnAppLauncherTerminalGteTest {
+
+  private GobblinYarnAppLauncher launcher;
+  private ApplicationId applicationId;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    this.launcher = mock(GobblinYarnAppLauncher.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    this.applicationId = mock(ApplicationId.class);
+    when(this.applicationId.toString()).thenReturn("application_1700000000000_0001");
+    setField("exitCode", 0);
+    setField("terminalHandled", new AtomicBoolean(false));
+  }
+
+  private void setField(String name, Object value) throws Exception {
+    Field f = GobblinYarnAppLauncher.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(this.launcher, value);
+  }
+
+  private int readExitCode() throws Exception {
+    Field f = GobblinYarnAppLauncher.class.getDeclaredField("exitCode");
+    f.setAccessible(true);
+    return (int) f.get(this.launcher);
+  }
+
+  private ApplicationReport mockReport(FinalApplicationStatus status) {
+    ApplicationReport report = mock(ApplicationReport.class);
+    when(report.getApplicationId()).thenReturn(this.applicationId);
+    when(report.getFinalApplicationStatus()).thenReturn(status);
+    return report;
+  }
+
+  // ---------- mapFinalAppStatusToEventName ----------
+
+  @Test
+  public void testMapFinalAppStatusSucceeded() {
+    assertEquals(GobblinYarnAppLauncher.mapFinalAppStatusToEventName(FinalApplicationStatus.SUCCEEDED),
+        TimingEvent.LauncherTimings.JOB_SUCCEEDED);
+  }
+
+  @Test
+  public void testMapFinalAppStatusKilled() {
+    assertEquals(GobblinYarnAppLauncher.mapFinalAppStatusToEventName(FinalApplicationStatus.KILLED),
+        TimingEvent.LauncherTimings.JOB_CANCEL);
+  }
+
+  @Test
+  public void testMapFinalAppStatusFailed() {
+    assertEquals(GobblinYarnAppLauncher.mapFinalAppStatusToEventName(FinalApplicationStatus.FAILED),
+        TimingEvent.LauncherTimings.JOB_FAILED);
+  }
+
+  @Test
+  public void testMapFinalAppStatusUndefined() {
+    assertEquals(GobblinYarnAppLauncher.mapFinalAppStatusToEventName(FinalApplicationStatus.UNDEFINED),
+        TimingEvent.LauncherTimings.JOB_FAILED);
+  }
+
+  // ---------- handleTerminalAppStatus: exit-code wiring + hook dispatch ----------
+
+  @Test
+  public void testHandleTerminalAppStatusFailedSetsExitCodeOne() throws Exception {
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.FAILED));
+    assertEquals(readExitCode(), 1);
+  }
+
+  @Test
+  public void testHandleTerminalAppStatusKilledSetsExitCodeOne() throws Exception {
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.KILLED));
+    assertEquals(readExitCode(), 1);
+  }
+
+  @Test
+  public void testHandleTerminalAppStatusUndefinedSetsExitCodeOne() throws Exception {
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.UNDEFINED));
+    assertEquals(readExitCode(), 1);
+  }
+
+  @Test
+  public void testHandleTerminalAppStatusSucceededLeavesExitCodeZero() throws Exception {
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.SUCCEEDED));
+    assertEquals(readExitCode(), 0);
+  }
+
+  @Test
+  public void testHandleTerminalAppStatusDispatchesToHook() {
+    // The protected hook is the seam a subclass (e.g. RobinGobblinYarnAppLauncher) overrides to emit the single
+    // terminal GTE; verify it is invoked with the observed report + status.
+    ApplicationReport report = mockReport(FinalApplicationStatus.FAILED);
+    this.launcher.handleTerminalAppStatus(report);
+    Mockito.verify(this.launcher).onTerminalApplicationStatus(report, FinalApplicationStatus.FAILED);
+  }
+
+  // ---------- handleLostAmVisibility ----------
+
+  @Test
+  public void testHandleLostAmVisibilitySetsExitCodeAndDispatchesHook() throws Exception {
+    this.launcher.handleLostAmVisibility();
+    assertEquals(readExitCode(), 1);
+    Mockito.verify(this.launcher).onLostAmVisibility();
+  }
+
+  // ---------- handleApplicationLaunchFailure ----------
+
+  @Test
+  public void testHandleApplicationLaunchFailureSetsExitCodeAndDispatchesHook() throws Exception {
+    RuntimeException cause = new RuntimeException("submit failed");
+    this.launcher.handleApplicationLaunchFailure(cause);
+    assertEquals(readExitCode(), 1);
+    Mockito.verify(this.launcher).onApplicationLaunchFailure(cause);
+  }
+
+  @Test
+  public void testTerminalHandledGuardDispatchesOnlyOnce() throws Exception {
+    // The first terminal outcome wins; a later path (e.g. the cancel/kill path firing after a SUCCEEDED was
+    // already dispatched by the monitor) must be a no-op and must not override the exit code or re-dispatch.
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.SUCCEEDED));
+    this.launcher.handleTerminalAppStatus(mockReport(FinalApplicationStatus.FAILED));
+    assertEquals(readExitCode(), 0);
+    Mockito.verify(this.launcher, Mockito.times(1))
+        .onTerminalApplicationStatus(Mockito.any(), Mockito.any());
+  }
+}

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -94,6 +94,7 @@ import org.apache.gobblin.yarn.helix.HelixMessageSubTypes;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -568,9 +569,13 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     launcher.signalGracefulShutdownAndWaitForTerminal();
 
     verify(mockYarnClient, times(1)).signalToContainer(eq(containerId), eq(SignalContainerCommand.GRACEFUL_SHUTDOWN));
-    // getApplicationReport: once in getAmContainerId(), once in pollForApplicationCompletionUntil() when checking terminal state
-    verify(mockYarnClient, times(2)).getApplicationReport(appId);
+    // getApplicationReport: once in getAmContainerId(), once in pollForApplicationCompletionUntil() when checking
+    // terminal state, and once in the post-poll re-fetch that decides between surfacing the real terminal status
+    // versus force-killing
+    verify(mockYarnClient, times(3)).getApplicationReport(appId);
     verify(mockYarnClient, times(1)).getApplicationAttemptReport(attemptId);
+    // app is already terminal (FINISHED) after the poll, so the launcher surfaces the real status and skips the kill
+    verify(mockYarnClient, never()).killApplication(appId);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Makes a temporal-on-YARN job's true outcome reliably observable end-to-end **without** a fragile JVM shutdown hook, exposes clean extension points so a single launcher subclass can be the sole terminal-`GobblinTrackingEvent` (GTE) source, and fixes a shutdown race that delayed the AM's YARN un-register by minutes. (Reworks the earlier shutdown-hook approach after finding it could silently drop the GTE.)

Tracks [GOBBLIN-2265](https://issues.apache.org/jira/browse/GOBBLIN-2265).

## Problem

1. The YARN `ApplicationMaster` un-registered with a hardcoded `FinalApplicationStatus.SUCCEEDED`, so a launcher polling the `ApplicationReport` saw SUCCEEDED even when the workflow FAILED.
2. An earlier attempt emitted the terminal GTE from a JVM shutdown hook — but `RootMetricContext` registers its own shutdown hook that closes the Kafka event reporters, and hook ordering is non-deterministic, so the GTE could be dropped.
3. The AM and launcher returned success exit codes in some failure scenarios, masking failures on dashboards.
4. **AM un-register was delayed by minutes on shutdown.** `YarnService.shutDown()` waits on `allContainersStopped`, but the last container's removal did not reliably notify that monitor (the AMRM `onContainersCompleted` path never notified, and `DynamicScalingYarnService` additionally early-returned on the `shutdownInProgress` branch without notifying). The waiter then slept the full timeout, so `unregisterApplicationMaster` fired minutes late and YARN failed the attempt even for a successful workflow.

## Changes

- **AM reports the real outcome to YARN.** The temporal `YarnService` un-registers with a `FinalApplicationStatus` derived from the captured Temporal workflow status (`COMPLETED→SUCCEEDED`, `CANCELED→KILLED`, else `FAILED`), kept in lockstep with the AM JVM exit code (`mapWorkflowStatusToFinalAppStatus` / `computeExitCode`).
- **Removed the unreliable shutdown-hook GTE emitter**; kept status capture + exit-code propagation.
- **Feature flag (default `true`)** — `gobblin.temporal.job.completion.gte.emission.enabled` gates the AM in-workflow `JOB_SUCCEEDED`/`JOB_FAILED`, so OSS stays self-complete; deployments that designate a launcher subclass as the single GTE source set it `false`.
- **`GobblinYarnAppLauncher` — exit code + hooks, no emission.** Surfaces FAILED/KILLED/UNDEFINED, lost-AM-visibility, and **never-launched** applications as a non-zero exit code, and exposes protected **no-op** hooks (`onTerminalApplicationStatus` / `onLostAmVisibility` / `onApplicationLaunchFailure`) plus `getApplicationId`/`getApplicationName`/`getConfig` accessors. **The OSS launcher itself emits no GTE** — a subclass overrides the hooks to emit the single terminal GTE.
- **Prompt AM un-register on shutdown.** Added `YarnService.notifyIfAllContainersStopped()` and call it from `handleContainerCompletion` and `onContainerStopped`, and from **both** early-return paths of `DynamicScalingYarnService.handleContainerCompletion` — so whichever callback removes the last container wakes `shutDown()` immediately. Reduced the fallback wait from 5m to 2m (now only a missed-notify backstop). In testing this collapsed the time-to-un-register from ~8 min to seconds after the last container stops.

## Downstream idempotency

`KafkaJobStatusMonitor` only fires the observability event / REEVALUATE dag action on the **first** transition into a finished status (`isNewStateTransitionToFinal`), so a duplicate terminal GTE (or a Kafka redelivery) for the same flow execution is a no-op — no source-side dedup is required for correctness.

## Testing

- `gobblin-temporal` and `gobblin-yarn` compile clean; unit tests pass, incl. new `mapWorkflowStatusToFinalAppStatus` cases and launcher exit-code/hook-dispatch tests.
- End-to-end on a prod-ltx1 GaaS distcp flow: workflow `COMPLETED` → un-register `SUCCEEDED`, AM exit `0`; a permission-denied source produced workflow `FAILED` → un-register `FAILED`, AM exit `1`. With the shutdown fix, the un-register fired within seconds of the last container stopping instead of waiting out the timeout.

## Note

The LinkedIn-internal `RobinGobblinYarnAppLauncher` (separate repo) overrides the new hooks to be the single terminal-GTE source; that change lands in a follow-up PR after this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
