### PR TITLE
GOBBLIN-2263: Refresh DagAction latency anchor

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtils.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -76,10 +77,20 @@ public class DagProcUtils {
    */
   public static void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag,
       Dag.DagId dagId) throws IOException {
+    submitNextNodes(dagManagementStateStore, dag, dagId, DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS);
+  }
+
+  public static void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag,
+      Dag.DagId dagId, DagActionStore.LeaseParams leaseParams) throws IOException {
+    submitNextNodes(dagManagementStateStore, dag, dagId, getStoreInsertTimeMillis(leaseParams));
+  }
+
+  private static void submitNextNodes(DagManagementStateStore dagManagementStateStore, Dag<JobExecutionPlan> dag,
+      Dag.DagId dagId, long storeInsertTimeMillis) throws IOException {
     Set<Dag.DagNode<JobExecutionPlan>> nextNodes = DagUtils.getNext(dag);
     if (nextNodes.size() == 1) {
       Dag.DagNode<JobExecutionPlan> dagNode = nextNodes.iterator().next();
-      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, dagId);
+      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, dagId, storeInsertTimeMillis);
     } else {
       for (Dag.DagNode<JobExecutionPlan> dagNode : nextNodes) {
         JobExecutionPlan jobExecutionPlan = dagNode.getValue();
@@ -98,9 +109,21 @@ public class DagProcUtils {
    */
   public static void submitJobToExecutor(DagManagementStateStore dagManagementStateStore, Dag.DagNode<JobExecutionPlan> dagNode,
       Dag.DagId dagId) {
+    submitJobToExecutor(dagManagementStateStore, dagNode, dagId,
+        DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS);
+  }
+
+  public static void submitJobToExecutor(DagManagementStateStore dagManagementStateStore, Dag.DagNode<JobExecutionPlan> dagNode,
+      Dag.DagId dagId, DagActionStore.LeaseParams leaseParams) {
+    submitJobToExecutor(dagManagementStateStore, dagNode, dagId, getStoreInsertTimeMillis(leaseParams));
+  }
+
+  private static void submitJobToExecutor(DagManagementStateStore dagManagementStateStore,
+      Dag.DagNode<JobExecutionPlan> dagNode, Dag.DagId dagId, long storeInsertTimeMillis) {
     DagUtils.incrementJobAttempt(dagNode);
     JobExecutionPlan jobExecutionPlan = DagUtils.getJobExecutionPlan(dagNode);
     JobSpec jobSpec = DagUtils.getJobSpec(dagNode);
+    stampDagActionStoreInsertTimeMillis(jobSpec, storeInsertTimeMillis);
     Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), jobExecutionPlan);
 
     String specExecutorUri = DagUtils.getSpecExecutorUri(dagNode);
@@ -164,6 +187,22 @@ public class DagProcUtils {
     }
 
     log.info("Submitted job {} for dagId {}", DagUtils.getJobName(dagNode), dagId);
+  }
+
+  static void stampDagActionStoreInsertTimeMillis(JobSpec jobSpec, long storeInsertTimeMillis) {
+    Config jobConfig = jobSpec.getConfig().withoutPath(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY);
+    if (storeInsertTimeMillis != DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS) {
+      jobConfig = jobConfig.withValue(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+          ConfigValueFactory.fromAnyRef(storeInsertTimeMillis));
+    }
+    jobSpec.setConfig(jobConfig);
+    jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobConfig));
+  }
+
+  private static long getStoreInsertTimeMillis(DagActionStore.LeaseParams leaseParams) {
+    return leaseParams == null
+        ? DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS
+        : leaseParams.getStoreInsertTimeMillis();
   }
 
   public static void cancelDagNode(Dag.DagNode<JobExecutionPlan> dagNodeToCancel, DagManagementStateStore dagManagementStateStore) throws IOException {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/LaunchDagProc.java
@@ -97,7 +97,7 @@ public class LaunchDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
           "DAG could not be compiled for " + getDagId());
       dagProcEngineMetrics.markDagActionsAct(getDagActionType(), false);
     } else {
-      DagProcUtils.submitNextNodes(dagManagementStateStore, dag.get(), getDagId());
+      DagProcUtils.submitNextNodes(dagManagementStateStore, dag.get(), getDagId(), getDagTask().getLeaseParams());
       DagProcUtils.setAndEmitFlowEvent(eventSubmitter, dag.get(), TimingEvent.FlowTimings.FLOW_RUNNING);
       dagManagementStateStore.getDagManagerMetrics().conditionallyMarkFlowAsState(DagUtils.getFlowId(dag.get()),
           Dag.FlowState.RUNNING);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProc.java
@@ -79,7 +79,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
       // but when reevaluate/resume/launch dag proc found multiple parallel jobs to run next, it creates reevaluate
       // dag actions for each of those parallel job and in this scenario there is no job status available.
       // If the job status is not present, this job was never launched, submit it now.
-      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
+      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId(), getDagTask().getLeaseParams());
       dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);
       return;
     }
@@ -124,7 +124,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
       // dag failed and is also not retryable. in that case if this job's retry passes, overall status of the dag can be
       // set to PASS, which would be incorrect.
       dag.setFlowEvent(null);
-      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId());
+      DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, getDagId(), getDagTask().getLeaseParams());
     } else if (DagProcUtils.isDagFinished(dag)) {
       String flowEvent = DagProcUtils.calcFlowStatus(dag);
       dag.setFlowEvent(flowEvent);
@@ -179,7 +179,7 @@ public class ReevaluateDagProc extends DagProc<Pair<Optional<Dag.DagNode<JobExec
       case COMPLETE:
         dagManagementStateStore.getDagManagerMetrics().incrementExecutorSuccess(dagNode);
         if (!DagProcUtils.isDagFinished(dag)) { // this may fail when dag failure option is finish_running and some dag node has failed
-          DagProcUtils.submitNextNodes(dagManagementStateStore, dag, getDagId());
+          DagProcUtils.submitNextNodes(dagManagementStateStore, dag, getDagId(), getDagTask().getLeaseParams());
         }
         break;
       default:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProc.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/proc/ResumeDagProc.java
@@ -97,7 +97,7 @@ public class ResumeDagProc extends DagProc<Optional<Dag<JobExecutionPlan>>> {
     // if it fails here, it will check point the failed dag in the (running) dag store again, which is idempotent
     dagManagementStateStore.deleteFailedDag(getDagId());
 
-    DagProcUtils.submitNextNodes(dagManagementStateStore, failedDag.get(), getDagId());
+    DagProcUtils.submitNextNodes(dagManagementStateStore, failedDag.get(), getDagId(), getDagTask().getLeaseParams());
 
     DagProcUtils.sendEnforceFlowFinishDeadlineDagAction(dagManagementStateStore, getDagTask().getDagAction());
     dagProcEngineMetrics.markDagActionsAct(getDagActionType(), true);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/task/DagTask.java
@@ -47,6 +47,10 @@ public abstract class DagTask {
    * the lease arbiter agreed on — including {@code storeInsertTimeMillis} for downstream latency instrumentation.
    */
   public DagActionStore.LeaseParams getLeaseParams() {
+    if (this.leaseObtainedStatus == null || this.leaseObtainedStatus.getConsensusLeaseParams() == null) {
+      return new DagActionStore.LeaseParams(this.dagAction, false, System.currentTimeMillis(),
+          DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS);
+    }
     return this.leaseObtainedStatus.getConsensusLeaseParams();
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtilsTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/DagProcUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.gobblin.config.ConfigBuilder;
@@ -43,9 +44,11 @@ import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
 import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagerMetrics;
+import org.apache.gobblin.service.modules.orchestration.DagUtils;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.commons.lang.StringUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -123,6 +126,43 @@ public class DagProcUtilsTest {
     Mockito.verify(metrics, Mockito.times(1)).incrementRunningJobMetrics(dagNode);
     Mockito.verify(metrics, Mockito.times(1)).incrementJobsSentToExecutor(dagNode);
     Mockito.verifyNoMoreInteractions(dagManagementStateStore);
+  }
+
+  @Test
+  public void testSubmitJobToExecutorReplacesStaleStoreInsertTimeMillis()
+      throws URISyntaxException, IOException, ExecutionException, InterruptedException {
+    Dag.DagId dagId = new Dag.DagId("flowGroup3", "flowName3", 2345678);
+    long staleStoreInsertTimeMillis = 1730000000000L;
+    long freshStoreInsertTimeMillis = staleStoreInsertTimeMillis + 60000L;
+    JobExecutionPlan jobExecutionPlan = getJobExecutionPlans().get(2);
+    JobSpec jobSpec = jobExecutionPlan.getJobSpec();
+    Config staleJobConfig = jobSpec.getConfig().withValue(
+        ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+        ConfigValueFactory.fromAnyRef(staleStoreInsertTimeMillis));
+    jobSpec.setConfig(staleJobConfig);
+    jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(staleJobConfig));
+    Dag.DagNode<JobExecutionPlan> dagNode = new Dag.DagNode<>(jobExecutionPlan);
+    DagManagerMetrics metrics = Mockito.mock(DagManagerMetrics.class);
+    Mockito.when(dagManagementStateStore.getDagManagerMetrics()).thenReturn(metrics);
+    SpecProducer<Spec> producer = DagUtils.getSpecProducer(dagNode);
+    Mockito.doReturn(CompletableFuture.completedFuture("urn")).when(producer).addSpec(Mockito.any(Spec.class));
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction("flowGroup3", "flowName3", 2345678, "job1",
+        DagActionStore.DagActionType.REEVALUATE);
+    DagActionStore.LeaseParams leaseParams = new DagActionStore.LeaseParams(dagAction, false,
+        System.currentTimeMillis(), freshStoreInsertTimeMillis);
+
+    DagProcUtils.submitJobToExecutor(dagManagementStateStore, dagNode, dagId, leaseParams);
+
+    ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
+    Mockito.verify(producer).addSpec(specCaptor.capture());
+    JobSpec submittedJobSpec = (JobSpec) specCaptor.getValue();
+    Assert.assertEquals(
+        submittedJobSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        freshStoreInsertTimeMillis);
+    Assert.assertEquals(
+        submittedJobSpec.getConfigAsProperties()
+            .getProperty(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        String.valueOf(freshStoreInsertTimeMillis));
   }
 
   @Test(expectedExceptions = RuntimeException.class)

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/proc/ReevaluateDagProcTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -31,12 +32,14 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
 import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.service.ExecutionStatus;
@@ -44,14 +47,17 @@ import org.apache.gobblin.service.modules.core.GobblinServiceManager;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.orchestration.DagActionStore;
 import org.apache.gobblin.service.modules.orchestration.DagManagementStateStore;
+import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
 import org.apache.gobblin.service.modules.orchestration.DagTestUtils;
 import org.apache.gobblin.service.modules.orchestration.DagUtils;
-import org.apache.gobblin.service.modules.orchestration.DagProcessingEngine;
+import org.apache.gobblin.service.modules.orchestration.LeaseAttemptStatus;
+import org.apache.gobblin.service.modules.orchestration.MultiActiveLeaseArbiter;
 import org.apache.gobblin.service.modules.orchestration.MySqlDagManagementStateStoreTest;
 import org.apache.gobblin.service.modules.orchestration.task.DagProcessingEngineMetrics;
 import org.apache.gobblin.service.modules.orchestration.task.ReevaluateDagTask;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.monitoring.JobStatus;
+import org.apache.gobblin.util.ConfigUtils;
 
 import org.apache.gobblin.runtime.troubleshooter.IssueSeverity;
 
@@ -118,10 +124,8 @@ public class ReevaluateDagProcTest {
         .when(dagManagementStateStore).getDagNodeWithJobStatus(any());
     doReturn(Optional.of(dag)). when(dagManagementStateStore).getDag(dagId);
 
-    ReevaluateDagProc
-        reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(new DagActionStore.DagAction(flowGroup, flowName,
-        flowExecutionId, "job0", DagActionStore.DagActionType.REEVALUATE), null,
-        dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job0"),
+        ConfigFactory.empty());
     reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
     // next job is sent to spec producer
     Mockito.verify(specProducers.get(1), Mockito.times(1)).addSpec(any());
@@ -171,10 +175,8 @@ public class ReevaluateDagProcTest {
 
     List<SpecProducer<Spec>> specProducers = getDagSpecProducers(dag);
 
-    ReevaluateDagProc
-        reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(new DagActionStore.DagAction(flowGroup, flowName,
-        flowExecutionId, "job0", DagActionStore.DagActionType.REEVALUATE), null,
-        dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job0"),
+        ConfigFactory.empty());
     reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     // no new job to launch for this one job flow
@@ -205,10 +207,8 @@ public class ReevaluateDagProcTest {
     doReturn(new ImmutablePair<>(Optional.of(dag.getNodes().get(0)), Optional.empty()))
         .when(dagManagementStateStore).getDagNodeWithJobStatus(any());
 
-    ReevaluateDagProc
-        reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(new DagActionStore.DagAction(flowGroup, flowName,
-        flowExecutionId, "job0", DagActionStore.DagActionType.REEVALUATE), null,
-        dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job0"),
+        ConfigFactory.empty());
     reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     int numOfLaunchedJobs = 1; // only the current job
@@ -223,6 +223,45 @@ public class ReevaluateDagProcTest {
         eq(DagActionStore.DagActionType.REEVALUATE));
 
     Assert.assertFalse(DagProcUtils.isDagFinished(this.dagManagementStateStore.getDag(dagId).get()));
+  }
+
+  @Test
+  public void testCurrentJobToRunReplacesStaleStoreInsertTimeMillis() throws Exception {
+    String flowName = "fn3-stamp";
+    long staleStoreInsertTimeMillis = 1730000000000L;
+    long freshStoreInsertTimeMillis = staleStoreInsertTimeMillis + 60000L;
+    Dag<JobExecutionPlan> dag = DagTestUtils.buildDag("1", flowExecutionId,
+        DagProcessingEngine.FailureOption.FINISH_ALL_POSSIBLE.name(), 2, "user5", ConfigFactory.empty()
+            .withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName))
+            .withValue(ConfigurationKeys.JOB_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup))
+            .withValue(ConfigurationKeys.SPECEXECUTOR_INSTANCE_URI_KEY, ConfigValueFactory.fromAnyRef(
+                MySqlDagManagementStateStoreTest.TEST_SPEC_EXECUTOR_URI)));
+    JobSpec jobSpec = dag.getNodes().get(0).getValue().getJobSpec();
+    Config staleJobConfig = jobSpec.getConfig().withValue(
+        ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY,
+        ConfigValueFactory.fromAnyRef(staleStoreInsertTimeMillis));
+    jobSpec.setConfig(staleJobConfig);
+    jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(staleJobConfig));
+    List<SpecProducer<Spec>> specProducers = getDagSpecProducers(dag);
+    dagManagementStateStore.addDag(dag);
+    doReturn(new ImmutablePair<>(Optional.of(dag.getNodes().get(0)), Optional.empty()))
+        .when(dagManagementStateStore).getDagNodeWithJobStatus(any());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(
+        buildReevaluateDagTask(flowName, "job0", freshStoreInsertTimeMillis), ConfigFactory.empty());
+
+    reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
+
+    ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
+    Mockito.verify(specProducers.get(0)).addSpec(specCaptor.capture());
+    JobSpec submittedJobSpec = (JobSpec) specCaptor.getValue();
+    Assert.assertEquals(
+        submittedJobSpec.getConfig().getLong(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        freshStoreInsertTimeMillis);
+    Assert.assertEquals(
+        submittedJobSpec.getConfigAsProperties()
+            .getProperty(ConfigurationKeys.DAG_ACTION_LAUNCH_STORE_INSERT_TIME_MILLIS_KEY),
+        String.valueOf(freshStoreInsertTimeMillis));
   }
 
   @Test
@@ -253,10 +292,8 @@ public class ReevaluateDagProcTest {
 
     doReturn(Optional.of(dag)).when(dagManagementStateStore).getDag(any());
 
-    ReevaluateDagProc
-        reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(new DagActionStore.DagAction(flowGroup, flowName,
-        flowExecutionId, "job3", DagActionStore.DagActionType.REEVALUATE), null,
-        dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job3"),
+        ConfigFactory.empty());
     List<SpecProducer<Spec>> specProducers = getDagSpecProducers(dag);
     // process 4th job
     reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
@@ -292,9 +329,8 @@ public class ReevaluateDagProcTest {
     doReturn(new ImmutablePair<>(Optional.of(dag.getNodes().get(0)), Optional.of(jobStatus)))
         .when(dagManagementStateStore).getDagNodeWithJobStatus(any());
 
-    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(new DagActionStore.DagAction(
-        flowGroup, flowName, flowExecutionId, "job0", DagActionStore.DagActionType.REEVALUATE), null,
-        dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+    ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job0"),
+        ConfigFactory.empty());
     reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
     int numOfLaunchedJobs = 1; // only the current job
@@ -318,10 +354,8 @@ public class ReevaluateDagProcTest {
         .when(dagManagementStateStore).getDagNodeWithJobStatus(any());
 
     try (MockedStatic<OrchestratorIssueEmitter> emitterMock = Mockito.mockStatic(OrchestratorIssueEmitter.class)) {
-      ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(new ReevaluateDagTask(
-          new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, "job0",
-              DagActionStore.DagActionType.REEVALUATE), null,
-          dagManagementStateStore, mockedDagProcEngineMetrics), ConfigFactory.empty());
+      ReevaluateDagProc reEvaluateDagProc = new ReevaluateDagProc(buildReevaluateDagTask(flowName, "job0"),
+          ConfigFactory.empty());
       reEvaluateDagProc.process(dagManagementStateStore, mockedDagProcEngineMetrics);
 
       // Verify that a service-layer issue was emitted for dag node not found
@@ -338,5 +372,19 @@ public class ReevaluateDagProcTest {
         throw new RuntimeException(e);
       }
     }).collect(Collectors.toList());
+  }
+
+  private ReevaluateDagTask buildReevaluateDagTask(String flowName, String jobName) {
+    return buildReevaluateDagTask(flowName, jobName, DagActionStore.LeaseParams.UNKNOWN_STORE_INSERT_TIME_MILLIS);
+  }
+
+  private ReevaluateDagTask buildReevaluateDagTask(String flowName, String jobName, long storeInsertTimeMillis) {
+    DagActionStore.DagAction dagAction = new DagActionStore.DagAction(flowGroup, flowName, flowExecutionId, jobName,
+        DagActionStore.DagActionType.REEVALUATE);
+    DagActionStore.LeaseParams consensusLeaseParams = new DagActionStore.LeaseParams(
+        dagAction, false, System.currentTimeMillis(), storeInsertTimeMillis);
+    LeaseAttemptStatus.LeaseObtainedStatus leaseObtainedStatus = new LeaseAttemptStatus.LeaseObtainedStatus(
+        consensusLeaseParams, System.currentTimeMillis(), 0L, Mockito.mock(MultiActiveLeaseArbiter.class));
+    return new ReevaluateDagTask(dagAction, leaseObtainedStatus, dagManagementStateStore, mockedDagProcEngineMetrics);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2263


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

GaaS launch latency is emitted when each job is submitted to the executor. The metric reads its anchor from `dagAction.launch.storeInsertTimeMillis` in the submitted `JobSpec`.

For multi-hop DAGs, downstream `REEVALUATE` DagActions already have fresh store-insert timestamps, but the downstream `JobSpec`s still carried the original flow `LAUNCH` timestamp from compilation time. As a result, downstream jobs reported `job submission time - original flow launch time`, which made normal long-running DAG progress look like multi-minute or multi-hour launch latency.

This PR refreshes `dagAction.launch.storeInsertTimeMillis` on the `JobSpec` immediately before each job submission using the current `DagTask` lease params. That makes the metric measure `job submission time - current DagAction insert time` for both initial LAUNCH jobs and downstream REEVALUATE/RESUME jobs.

Implementation details:
- `DagProcUtils` replaces stale `dagAction.launch.storeInsertTimeMillis` in both `JobSpec` config and `configAsProperties` before `producer.addSpec(jobSpec)`.
- `LaunchDagProc`, `ReevaluateDagProc`, and `ResumeDagProc` pass their current `LeaseParams` into the submission path.
- Existing overloads remain for callers that do not have DagAction lease metadata.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Added `DagProcUtilsTest.testSubmitJobToExecutorReplacesStaleStoreInsertTimeMillis` to verify stale anchors are replaced in both `JobSpec` config and properties before submission.
    - Added `ReevaluateDagProcTest.testCurrentJobToRunReplacesStaleStoreInsertTimeMillis` to cover the downstream REEVALUATE path.
    - `JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home" ./gradlew :gobblin-service:test --tests "org.apache.gobblin.service.modules.orchestration.proc.DagProcUtilsTest"`
    - `git diff --check origin/master...HEAD`
    - Previously attempted `JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home" ./gradlew :gobblin-service:test --tests "org.apache.gobblin.service.modules.orchestration.proc.DagProcUtilsTest" --tests "org.apache.gobblin.service.modules.orchestration.proc.ReevaluateDagProcTest" --tests "org.apache.gobblin.service.modules.orchestration.proc.LaunchDagProcTest"`; the suite compiled but failed during `TestMetastoreDatabaseFactory` setup because Docker/Testcontainers is not available in this environment.
    - `mint build` not applicable: this checkout is not a LinkedIn multiproduct directory.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

Made with [Cursor](https://cursor.com)