### PR TITLE
[GOBBLIN-2267] Block GobblinYarnAppLauncher launch() until the YARN application is terminal

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -236,6 +237,9 @@ public class GobblinYarnAppLauncher {
   // This flag tells if the Yarn application has already completed. This is used to
   // tell if it is necessary to send a shutdown message to the ApplicationMaster.
   private volatile boolean applicationCompleted = false;
+  // Released by the status monitor once the application reaches a terminal state (or the launcher is stopped);
+  // in attached mode launch()/run() blocks on this so it represents the full application lifecycle.
+  private final CountDownLatch applicationTerminalLatch = new CountDownLatch(1);
 
   private volatile boolean stopped = false;
 
@@ -408,6 +412,28 @@ public class GobblinYarnAppLauncher {
       handleApplicationLaunchFailure(e);
       throw e;
     }
+
+    // In attached mode, block the calling (launch()/run()) thread until the status monitor signals that the
+    // application has reached a terminal state (or the launcher was otherwise stopped), then tear down. Running
+    // stop() here -- on the calling thread rather than the monitor thread -- shuts the (non-daemon) status
+    // monitor and the launcher's services down before launch() returns, so no launcher-owned thread is left to
+    // keep the JVM alive. Detached launches return right after submission, leaving the application running.
+    if (!this.detachOnExitEnabled) {
+      LOGGER.info("Waiting for Gobblin Yarn application {} to reach a terminal state before exiting the launcher",
+          this.applicationId.get());
+      try {
+        this.applicationTerminalLatch.await();
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        LOGGER.info("Interrupted while waiting for Gobblin Yarn application {} to complete", this.applicationId.get());
+      }
+      LOGGER.info("Gobblin Yarn application monitoring complete; stopping the launcher");
+      try {
+        stop();
+      } catch (IOException | TimeoutException e) {
+        LOGGER.error("Failed to stop " + GobblinYarnAppLauncher.class.getSimpleName() + " after application monitoring", e);
+      }
+    }
   }
 
   public boolean isApplicationRunning() {
@@ -459,6 +485,10 @@ public class GobblinYarnAppLauncher {
     if (this.stopped) {
       return;
     }
+
+    // Release the launch()/run() thread if it is blocked waiting for the application to finish (e.g. on an
+    // external cancel/shutdown) so it can return.
+    this.applicationTerminalLatch.countDown();
 
     LOGGER.info("Stopping the " + GobblinYarnAppLauncher.class.getSimpleName());
 
@@ -522,17 +552,22 @@ public class GobblinYarnAppLauncher {
 
       handleTerminalAppStatus(applicationReport);
 
-      try {
-        GobblinYarnAppLauncher.this.stop();
-      } catch (IOException ioe) {
-        LOGGER.error("Failed to close the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
-      } catch (TimeoutException te) {
-        LOGGER.error("Timeout in stopping the service manager", te);
-      } finally {
-        if (this.emailNotificationOnShutdown) {
-          sendEmailOnShutdown(Optional.of(applicationReport));
+      // Detached launches have no caller blocked on the latch, so stop here as before. Attached launches are
+      // torn down by the launch()/run() thread once it is released by the latch below -- running stop() off this
+      // monitor thread avoids a self-shutdown of this executor.
+      if (this.detachOnExitEnabled) {
+        try {
+          GobblinYarnAppLauncher.this.stop();
+        } catch (IOException ioe) {
+          LOGGER.error("Failed to close the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
+        } catch (TimeoutException te) {
+          LOGGER.error("Timeout in stopping the service manager", te);
         }
       }
+      if (this.emailNotificationOnShutdown) {
+        sendEmailOnShutdown(Optional.of(applicationReport));
+      }
+      this.applicationTerminalLatch.countDown();
     }
   }
 
@@ -611,17 +646,21 @@ public class GobblinYarnAppLauncher {
 
       handleLostAmVisibility();
 
-      try {
-        stop();
-      } catch (IOException ioe) {
-        LOGGER.error("Failed to close the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
-      } catch (TimeoutException te) {
-        LOGGER.error("Timeout in stopping the service manager", te);
-      } finally {
-        if (this.emailNotificationOnShutdown) {
-          sendEmailOnShutdown(Optional.<ApplicationReport>absent());
+      // See handleApplicationReportArrivalEvent: detached launches stop here; attached launches are torn down by
+      // the launch()/run() thread once the latch below releases it (off this monitor thread).
+      if (this.detachOnExitEnabled) {
+        try {
+          stop();
+        } catch (IOException ioe) {
+          LOGGER.error("Failed to close the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
+        } catch (TimeoutException te) {
+          LOGGER.error("Timeout in stopping the service manager", te);
         }
       }
+      if (this.emailNotificationOnShutdown) {
+        sendEmailOnShutdown(Optional.<ApplicationReport>absent());
+      }
+      this.applicationTerminalLatch.countDown();
     }
   }
 

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTerminalGteTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTerminalGteTest.java
@@ -18,16 +18,23 @@
 package org.apache.gobblin.yarn;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.base.Optional;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.apache.gobblin.metrics.event.TimingEvent;
+import org.apache.gobblin.yarn.event.ApplicationReportArrivalEvent;
+import org.apache.gobblin.yarn.event.GetApplicationReportFailureEvent;
 
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -165,5 +172,62 @@ public class GobblinYarnAppLauncherTerminalGteTest {
     assertEquals(readExitCode(), 0);
     Mockito.verify(this.launcher, Mockito.times(1))
         .onTerminalApplicationStatus(Mockito.any(), Mockito.any());
+  }
+
+  // ---------- applicationTerminalLatch: monitor releases the launch()/run() thread, off the monitor thread ----------
+
+  private ApplicationReport terminalReport(FinalApplicationStatus status) {
+    ApplicationReport report = mockReport(status);
+    when(report.getYarnApplicationState()).thenReturn(YarnApplicationState.FINISHED);
+    when(report.getDiagnostics()).thenReturn("");
+    return report;
+  }
+
+  @Test
+  public void testTerminalReportReleasesLatchAndDoesNotStopWhenAttached() throws Exception {
+    // Attached (detachOnExitEnabled defaults to false): the monitor signals the latch and does NOT call stop()
+    // itself -- the blocked launch()/run() thread performs teardown, avoiding a self-shutdown of the monitor.
+    CountDownLatch latch = new CountDownLatch(1);
+    setField("applicationTerminalLatch", latch);
+    setField("getApplicationReportFailureCount", new AtomicInteger(0));
+    setField("helixClusterLifecycleManager", Optional.absent());
+
+    this.launcher.handleApplicationReportArrivalEvent(
+        new ApplicationReportArrivalEvent(terminalReport(FinalApplicationStatus.SUCCEEDED)));
+
+    assertEquals(latch.getCount(), 0);
+    Mockito.verify(this.launcher, Mockito.never()).stop();
+  }
+
+  @Test
+  public void testLostAmReleasesLatchAndDoesNotStopWhenAttached() throws Exception {
+    // Regression guard: the lost-AM-visibility path stops/releases without ever setting applicationCompleted, so
+    // the latch must still be released (otherwise launch()/run() would block forever).
+    CountDownLatch latch = new CountDownLatch(1);
+    setField("applicationTerminalLatch", latch);
+    setField("getApplicationReportFailureCount", new AtomicInteger(0)); // maxGetApplicationReportFailures defaults to 0
+
+    this.launcher.handleGetApplicationReportFailureEvent(
+        new GetApplicationReportFailureEvent(new RuntimeException("rm unreachable")));
+
+    assertEquals(latch.getCount(), 0);
+    Mockito.verify(this.launcher, Mockito.never()).stop();
+  }
+
+  @Test
+  public void testTerminalReportStopsDirectlyWhenDetached() throws Exception {
+    // Detached: no caller is blocked on the latch, so the monitor tears down here as before.
+    CountDownLatch latch = new CountDownLatch(1);
+    setField("applicationTerminalLatch", latch);
+    setField("getApplicationReportFailureCount", new AtomicInteger(0));
+    setField("helixClusterLifecycleManager", Optional.absent());
+    setField("detachOnExitEnabled", true);
+    Mockito.doNothing().when(this.launcher).stop();
+
+    this.launcher.handleApplicationReportArrivalEvent(
+        new ApplicationReportArrivalEvent(terminalReport(FinalApplicationStatus.SUCCEEDED)));
+
+    Mockito.verify(this.launcher, Mockito.times(1)).stop();
+    assertEquals(latch.getCount(), 0);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2267

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

#### Summary
`GobblinYarnAppLauncher.launch()` returned as soon as the YARN application was submitted, while the status monitor kept polling on a background **non-daemon** thread. For the Azkaban submitter path this meant `run()` returned at submission time and the launcher-owned non-daemon threads kept the JVM alive for the whole job, so the process hung after `run()` finished. This change makes `launch()` block (in attached mode) until the application reaches a terminal state, then tear down — so `run()` represents the full application lifecycle and the JVM exits cleanly once it returns.

#### Problem
- `launch()` scheduled the `applicationStatusMonitor` and returned immediately after submission; `AzkabanGobblinYarnAppLauncher.run()` therefore returned at submission time, and the launcher's non-daemon threads (the status monitor, the `ServiceManager`, the YARN client) kept the JVM alive for the entire job.
- The status monitor also invoked `stop()` from its own worker thread on a terminal report; `stop()` then called `shutdownExecutorService(applicationStatusMonitor)` — a thread cannot await termination of its own executor, so teardown stalled for the full `awaitTermination` window.
- `main()` called `launch()` then `System.exit(getExitCode())`; with a non-blocking `launch()` that exit raced submission.

#### Changes
- Add a `CountDownLatch applicationTerminalLatch` that the status monitor releases once the application reaches a terminal state, or the launcher is otherwise stopped (e.g. lost visibility of the AM).
- In **attached** mode, `launch()`/`run()` blocks on the latch and then runs `stop()` **on the calling thread**. Because teardown runs off the monitor thread, it shuts the (non-daemon) monitor and the launcher services down before `launch()` returns — no launcher-owned thread is left to keep the JVM alive, and the self-shutdown stall is gone. This also makes `main()`'s `System.exit(getExitCode())` correct.
- The two `@Subscribe` handlers (`handleApplicationReportArrivalEvent`, `handleGetApplicationReportFailureEvent`) now **signal the latch** instead of calling `stop()` from the monitor thread. **Detached** launches (which have no caller blocked on the latch) still stop directly in the handler, unchanged.
- The monitor thread is left **non-daemon** as before; nothing is force-killed — the threads are explicitly stopped by `stop()` on the calling thread.

#### Compatibility
The only callers of `launch()` are `main()` and `AzkabanGobblinYarnAppLauncher.run()`, both of which want blocking behaviour; there are no OSS subclasses of `GobblinYarnAppLauncher`. Detached-mode behaviour is preserved.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

**Unit** — adds three tests to `GobblinYarnAppLauncherTerminalGteTest`: a terminal report releases the latch without calling `stop()` on the monitor thread (attached); the lost-AM-visibility path releases the latch even though it never sets `applicationCompleted` (regression guard against an indefinite block); and a detached launch still stops directly in the handler. Existing tests continue to pass; `:gobblin-yarn` builds clean.

**E2E** — validated via a snapshot gobblin build wired into `gobblin-temporal-workers` and `carbon` copy flows on prod-ltx1 across the success, cancel, and failure paths; GGW-pod launcher logs confirm `launch()` blocks on the latch and tears down on the calling thread. (Results appended in a comment.)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters (not including Jira issue reference)
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
