### PR TITLE
[GOBBLIN-2268] Reconnect GobblinYarnAppLauncher to all YARN application states

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -190,14 +190,10 @@ public class GobblinYarnAppLauncher {
   // lookup the application this class has launched previously upon restarting.
   private static final Set<String> APPLICATION_TYPES = ImmutableSet.of(GOBBLIN_YARN_APPLICATION_TYPE);
 
-  // The set of Yarn application states under which the driver can reconnect to the Yarn application after restart
-  private static final EnumSet<YarnApplicationState> RECONNECTABLE_APPLICATION_STATES = EnumSet.of(
-      YarnApplicationState.NEW,
-      YarnApplicationState.NEW_SAVING,
-      YarnApplicationState.SUBMITTED,
-      YarnApplicationState.ACCEPTED,
-      YarnApplicationState.RUNNING
-  );
+  // The set of Yarn application states under which the driver can reconnect to the Yarn application after restart.
+  // Includes all Yarn application states so the driver can reconnect regardless of the application's current state.
+  private static final EnumSet<YarnApplicationState> RECONNECTABLE_APPLICATION_STATES =
+      EnumSet.allOf(YarnApplicationState.class);
 
   private final String applicationName;
   private final String appQueueName;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-2268] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-2268

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

RECONNECTABLE_APPLICATION_STATES only listed five of the eight YARN application states (NEW, NEW_SAVING, SUBMITTED, ACCEPTED, RUNNING), so getReconnectableApplicationId() -- which queries
yarnClient.getApplications(APPLICATION_TYPES, RECONNECTABLE_APPLICATION_STATES) -- could never rediscover an application that had already moved into a terminal state (FINISHED, FAILED, KILLED). On driver restart such an application was treated as absent and a brand new one was launched instead of reconnecting to the existing one.

Use EnumSet.allOf(YarnApplicationState.class) so the launcher considers applications in every state when searching for one to reconnect to. This also keeps the behavior correct if new YARN application states are added in the future.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

